### PR TITLE
Backport #6041 to v2

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -50,7 +50,6 @@ internal abstract class LambdaCommon
         WriteRequestHeaders(request, context);
         var response = (HttpWebResponse)request.GetResponse();
 
-        // response.Headers is a WebHeaderCollection, which is not convertable to IHeadersCollection, so we have to make it into a dictionary.
         var headers = response.Headers;
         if (!ValidateOkStatus(response))
         {

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -48,6 +48,22 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
+        public async Task TestCreatePlaceholderScopeSuccessWith128BitTraceIdContext()
+        {
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
+            var myHeaders = new Dictionary<string, string>
+            {
+                { HttpHeaderNames.TraceId, "5744042798732701615" }, { HttpHeaderNames.SamplingPriority, "-1" }, { HttpHeaderNames.PropagatedTags, "_dd.p.tid=1914fe7789eb32be" }
+            };
+            var scope = LambdaCommon.NewCreatePlaceholderScope(tracer, myHeaders);
+
+            scope.Should().NotBeNull();
+            scope.Span.TraceId128.ToString().Should().Be("1914fe7789eb32be4fb6f07e011a6faf");
+            scope.Span.SpanId.Should().BeGreaterThan(0);
+            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(-1);
+        }
+
+        [Fact]
         [Trait("Category", "ArmUnsupported")]
         public async Task TestCreatePlaceholderScopeSuccessWithoutContext()
         {

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -25,8 +25,9 @@ namespace Datadog.Trace.Tests
         public async Task TestCreatePlaceholderScopeSuccessWithTraceIdOnly()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", null);
 
+            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().Be((TraceId)1234);
             ((ISpan)scope.Span).TraceId.Should().Be(1234);
@@ -34,11 +35,14 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-
         public async Task TestCreatePlaceholderScopeSuccessWith64BitTraceIdContext()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
+            var myHeaders = new Dictionary<string, string>
+            {
+                { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" }
+            };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().Be((TraceId)1234);
@@ -55,7 +59,7 @@ namespace Datadog.Trace.Tests
             {
                 { HttpHeaderNames.TraceId, "5744042798732701615" }, { HttpHeaderNames.SamplingPriority, "-1" }, { HttpHeaderNames.PropagatedTags, "_dd.p.tid=1914fe7789eb32be" }
             };
-            var scope = LambdaCommon.NewCreatePlaceholderScope(tracer, myHeaders);
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.ToString().Should().Be("1914fe7789eb32be4fb6f07e011a6faf");
@@ -68,26 +72,12 @@ namespace Datadog.Trace.Tests
         public async Task TestCreatePlaceholderScopeSuccessWithoutContext()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, new Dictionary<string, string>());
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().BeGreaterThan((TraceId.Zero));
             ((ISpan)scope.Span).TraceId.Should().BeGreaterThan(0);
             scope.Span.SpanId.Should().BeGreaterThan(0);
-        }
-
-        [Fact]
-        public async Task TestCreatePlaceholderScopeInvalidTraceId()
-        {
-            await using var tracer = TracerHelper.CreateWithFakeAgent();
-            Assert.Throws<FormatException>(() => LambdaCommon.CreatePlaceholderScope(tracer, "invalid-trace-id", "-1"));
-        }
-
-        [Fact]
-        public async Task TestCreatePlaceholderScopeInvalidSamplingPriority()
-        {
-            await using var tracer = TracerHelper.CreateWithFakeAgent();
-            Assert.Throws<FormatException>(() => LambdaCommon.CreatePlaceholderScope(tracer, "1234", "invalid-sampling-priority"));
         }
 
         [Fact]
@@ -150,7 +140,8 @@ namespace Datadog.Trace.Tests
         public async Task TestSendEndInvocationFailure()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
+            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
             var responseStream = new Mock<Stream>(MockBehavior.Loose);
@@ -170,7 +161,8 @@ namespace Datadog.Trace.Tests
         public async Task TestSendEndInvocationSuccess()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
+            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
             var responseStream = new Mock<Stream>(MockBehavior.Loose);
@@ -193,7 +185,8 @@ namespace Datadog.Trace.Tests
         public async Task TestSendEndInvocationFalse()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
+            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
             var responseStream = new Mock<Stream>(MockBehavior.Loose);

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -34,20 +34,8 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public async Task TestCreatePlaceholderScopeSuccessWithSamplingPriorityOnly()
-        {
-            await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, "-1");
 
-            scope.Should().NotBeNull();
-            scope.Span.TraceId128.Should().BeGreaterThan(TraceId.Zero);
-            ((ISpan)scope.Span).TraceId.Should().BeGreaterThan(0);
-            scope.Span.SpanId.Should().BeGreaterThan(0);
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(-1);
-        }
-
-        [Fact]
-        public async Task TestCreatePlaceholderScopeSuccessWithFullContext()
+        public async Task TestCreatePlaceholderScopeSuccessWith64BitTraceIdContext()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -26,8 +26,8 @@ namespace Datadog.Trace.Tests
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
 
-            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, };
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().Be((TraceId)1234);
             ((ISpan)scope.Span).TraceId.Should().Be(1234);
@@ -38,11 +38,8 @@ namespace Datadog.Trace.Tests
         public async Task TestCreatePlaceholderScopeSuccessWith64BitTraceIdContext()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string>
-            {
-                { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" }
-            };
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().Be((TraceId)1234);
@@ -55,11 +52,8 @@ namespace Datadog.Trace.Tests
         public async Task TestCreatePlaceholderScopeSuccessWith128BitTraceIdContext()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string>
-            {
-                { HttpHeaderNames.TraceId, "5744042798732701615" }, { HttpHeaderNames.SamplingPriority, "-1" }, { HttpHeaderNames.PropagatedTags, "_dd.p.tid=1914fe7789eb32be" }
-            };
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "5744042798732701615" }, { HttpHeaderNames.SamplingPriority, "-1" }, { HttpHeaderNames.PropagatedTags, "_dd.p.tid=1914fe7789eb32be" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.ToString().Should().Be("1914fe7789eb32be4fb6f07e011a6faf");
@@ -72,7 +66,7 @@ namespace Datadog.Trace.Tests
         public async Task TestCreatePlaceholderScopeSuccessWithoutContext()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, new Dictionary<string, string>());
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, new WebHeaderCollection());
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().BeGreaterThan((TraceId.Zero));
@@ -140,8 +134,8 @@ namespace Datadog.Trace.Tests
         public async Task TestSendEndInvocationFailure()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
             var responseStream = new Mock<Stream>(MockBehavior.Loose);
@@ -161,8 +155,8 @@ namespace Datadog.Trace.Tests
         public async Task TestSendEndInvocationSuccess()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
             var responseStream = new Mock<Stream>(MockBehavior.Loose);
@@ -185,8 +179,8 @@ namespace Datadog.Trace.Tests
         public async Task TestSendEndInvocationFalse()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string> { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
             var responseStream = new Mock<Stream>(MockBehavior.Loose);

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 #if NET6_0_OR_GREATER
-using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Lambda;
 using Datadog.Trace.TestHelpers;
@@ -21,8 +21,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithError()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string>();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, isError: true);
@@ -37,8 +37,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithoutError()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string>();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, isError: false);
@@ -53,12 +53,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithScope()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string>
-            {
-                { HttpHeaderNames.TraceId, "1234" },
-                { HttpHeaderNames.SamplingPriority, "-1" }
-            };
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, isError: false);
@@ -85,8 +81,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithErrorTags()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string>();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
             scope.Span.SetTag("error.msg", "Exception");
             scope.Span.SetTag("error.type", "Exception");
             scope.Span.SetTag("error.stack", "everything is " + System.Environment.NewLine + "fine");
@@ -107,8 +103,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithoutErrorTags()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var myHeaders = new Dictionary<string, string>();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
+            var headers = new WebHeaderCollection();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 #if NET6_0_OR_GREATER
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Lambda;
 using Datadog.Trace.TestHelpers;
@@ -20,7 +21,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithError()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: null, samplingPriority: null);
+            var myHeaders = new Dictionary<string, string>();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, isError: true);
@@ -35,7 +37,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithoutError()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: null, samplingPriority: null);
+            var myHeaders = new Dictionary<string, string>();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, isError: false);
@@ -50,7 +53,12 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithScope()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: "1234", samplingPriority: "-1");
+            var myHeaders = new Dictionary<string, string>
+            {
+                { HttpHeaderNames.TraceId, "1234" },
+                { HttpHeaderNames.SamplingPriority, "-1" }
+            };
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, isError: false);
@@ -77,7 +85,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithErrorTags()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: null, samplingPriority: null);
+            var myHeaders = new Dictionary<string, string>();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
             scope.Span.SetTag("error.msg", "Exception");
             scope.Span.SetTag("error.type", "Exception");
             scope.Span.SetTag("error.stack", "everything is " + System.Environment.NewLine + "fine");
@@ -98,7 +107,8 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithoutErrorTags()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
+            var myHeaders = new Dictionary<string, string>();
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, myHeaders);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -577,10 +577,7 @@
       runtime-id: Guid_10
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
@@ -595,10 +592,7 @@
       runtime-id: Guid_11
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
@@ -613,10 +607,7 @@
       runtime-id: Guid_12
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
@@ -667,10 +658,7 @@
       runtime-id: Guid_15
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
@@ -883,10 +871,7 @@
       runtime-id: Guid_27
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
@@ -901,10 +886,7 @@
       runtime-id: Guid_28
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
@@ -919,10 +901,7 @@
       runtime-id: Guid_29
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
@@ -1102,7 +1081,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamSync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1123,7 +1103,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamSync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_2,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1144,7 +1125,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsSync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_3,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1165,7 +1147,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamAsync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_4,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1186,7 +1169,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamAsync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_5,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1207,7 +1191,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsAsync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_6,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1228,7 +1213,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamVoid,
       out.host: serverless-dummy-api,
       runtime-id: Guid_7,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1249,7 +1235,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamVoid,
       out.host: serverless-dummy-api,
       runtime-id: Guid_8,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1270,7 +1257,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsVoid,
       out.host: serverless-dummy-api,
       runtime-id: Guid_9,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1291,7 +1279,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamSyncWithContext,
       out.host: serverless-dummy-api,
       runtime-id: Guid_10,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1312,7 +1301,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamSyncWithContext,
       out.host: serverless-dummy-api,
       runtime-id: Guid_11,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1333,7 +1323,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsSyncWithContext,
       out.host: serverless-dummy-api,
       runtime-id: Guid_12,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1354,7 +1345,8 @@
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerNoParamSync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_13,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1375,7 +1367,8 @@
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerTwoParamsSync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_14,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1396,7 +1389,8 @@
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerOneParamSyncWithContext,
       out.host: serverless-dummy-api,
       runtime-id: Guid_15,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1417,7 +1411,8 @@
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerOneParamAsync,
       out.host: serverless-dummy-api,
       runtime-id: Guid_16,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1438,7 +1433,8 @@
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerTwoParamsVoid,
       out.host: serverless-dummy-api,
       runtime-id: Guid_17,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1459,7 +1455,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerStructParam,
       out.host: serverless-dummy-api,
       runtime-id: Guid_18,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1480,7 +1477,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerNestedClassParam,
       out.host: serverless-dummy-api,
       runtime-id: Guid_19,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1501,7 +1499,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerNestedStructParam,
       out.host: serverless-dummy-api,
       runtime-id: Guid_20,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1522,7 +1521,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
       out.host: serverless-dummy-api,
       runtime-id: Guid_21,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1543,7 +1543,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerNestedGenericDictionaryParam,
       out.host: serverless-dummy-api,
       runtime-id: Guid_22,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1564,7 +1565,8 @@
       http.url: http://serverless-dummy-api:9005/function/HandlerDoublyNestedGenericDictionaryParam,
       out.host: serverless-dummy-api,
       runtime-id: Guid_23,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1588,7 +1590,8 @@
       http.url: http://localhost/function/ThrowingHandler,
       out.host: localhost,
       runtime-id: Guid_24,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1612,7 +1615,8 @@
       http.url: http://localhost/function/ThrowingHandlerAsync,
       out.host: localhost,
       runtime-id: Guid_25,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1636,7 +1640,8 @@
       http.url: http://localhost/function/ThrowingHandlerAsyncTask,
       out.host: localhost,
       runtime-id: Guid_26,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1660,7 +1665,8 @@
       http.url: http://localhost/function/ThrowingHandler,
       out.host: localhost,
       runtime-id: Guid_27,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1684,7 +1690,8 @@
       http.url: http://localhost/function/ThrowingHandlerAsync,
       out.host: localhost,
       runtime-id: Guid_28,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1708,7 +1715,8 @@
       http.url: http://localhost/function/ThrowingHandlerAsyncTask,
       out.host: localhost,
       runtime-id: Guid_29,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1729,7 +1737,8 @@
       http.url: http://serverless-dummy-api:9005/function/GenericBaseType1,
       out.host: serverless-dummy-api,
       runtime-id: Guid_30,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1750,7 +1759,8 @@
       http.url: http://serverless-dummy-api:9005/function/GenericBaseType2,
       out.host: serverless-dummy-api,
       runtime-id: Guid_31,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1771,7 +1781,8 @@
       http.url: http://serverless-dummy-api:9005/function/VirtualGenericBaseType3,
       out.host: serverless-dummy-api,
       runtime-id: Guid_32,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1792,7 +1803,8 @@
       http.url: http://serverless-dummy-api:9005/function/VirtualGenericBaseType4,
       out.host: serverless-dummy-api,
       runtime-id: Guid_33,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1813,7 +1825,8 @@
       http.url: http://serverless-dummy-api:9005/function/AbstractGenericBaseType5,
       out.host: serverless-dummy-api,
       runtime-id: Guid_34,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1834,7 +1847,8 @@
       http.url: http://serverless-dummy-api:9005/function/AbstractGenericBaseType6,
       out.host: serverless-dummy-api,
       runtime-id: Guid_35,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1855,7 +1869,8 @@
       http.url: http://serverless-dummy-api:9005/function/ComplexNestedGeneric,
       out.host: serverless-dummy-api,
       runtime-id: Guid_36,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1876,7 +1891,8 @@
       http.url: http://serverless-dummy-api:9005/function/ComplexNestedGeneric,
       out.host: serverless-dummy-api,
       runtime-id: Guid_37,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.AWS.Lambda
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1897,10 +1913,149 @@
       http.url: http://serverless-dummy-api:9005/function/ToplevelStatements,
       out.host: serverless-dummy-api,
       runtime-id: Guid_38,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.Amazon.Lambda.RuntimeSupport
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_19,
+    SpanId: Id_20,
+    Name: placeholder-operation,
+    Resource: placeholder-operation,
+    Service: placeholder-service,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_10,
+      _dd.base_service: Samples.AWS.Lambda
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_21,
+    SpanId: Id_22,
+    Name: placeholder-operation,
+    Resource: placeholder-operation,
+    Service: placeholder-service,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_11,
+      _dd.base_service: Samples.AWS.Lambda
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_24,
+    Name: placeholder-operation,
+    Resource: placeholder-operation,
+    Service: placeholder-service,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_12,
+      _dd.base_service: Samples.AWS.Lambda
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_29,
+    SpanId: Id_30,
+    Name: placeholder-operation,
+    Resource: placeholder-operation,
+    Service: placeholder-service,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_15,
+      _dd.base_service: Samples.AWS.Lambda
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_53,
+    SpanId: Id_54,
+    Name: placeholder-operation,
+    Resource: placeholder-operation,
+    Service: placeholder-service,
+    Error: 1,
+    Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
+      language: dotnet,
+      runtime-id: Guid_27,
+      _dd.base_service: Samples.AWS.Lambda
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_55,
+    SpanId: Id_56,
+    Name: placeholder-operation,
+    Resource: placeholder-operation,
+    Service: placeholder-service,
+    Error: 1,
+    Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
+      language: dotnet,
+      runtime-id: Guid_28,
+      _dd.base_service: Samples.AWS.Lambda
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_58,
+    Name: placeholder-operation,
+    Resource: placeholder-operation,
+    Service: placeholder-service,
+    Error: 1,
+    Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
+      language: dotnet,
+      runtime-id: Guid_29,
+      _dd.base_service: Samples.AWS.Lambda
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]


### PR DESCRIPTION
This is a backport of #6041  to V2.

## Summary of changes

I've updated the Lambda extension so it is capable of returning a 128 bit trace ID when a tracer calls the `/lambda/start-invocation` endpoint [in this PR](https://github.com/DataDog/datadog-agent/pull/27988)

As per [the RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3545630931/RFC+Support+128+bit+trace+IDs+in+RUM+SDKs#:~:text=For%20Datadog%20headers%2C%20the%20128%20bit%20trace%20id%20is%20sent%20in%20two%20parts%2C%20lower%2064%20bits%20in%20x%2Ddatadog%2Dtrace%2Did%20(decimal)%20and%20the%20higher%2064%20bits%20in%20x%2Ddatadog%2Dtags%20header%20under%20_dd.p.tid%20(hex)%20tag), the

> lower 64 bits in `x-datadog-trace-id` (decimal) and the higher 64 bits in `x-datadog-tags` header under `_dd.p.tid` (hex) tag.

This change modifies the function that calls `/lambda/start-invocation`, allowing it to pick out the upper 64 bits of the trace ID and set the resulting 128-bit trace ID in the extracted context.


## Reason for change

The Lambda Extension may now return a 128 bit trace ID when a Step Function invokes a Lambda Function.

## Implementation details

I rewrote LambdaCommon's `CreatePlaceholderScope` so it uses `SpanContextPropagator.Instance.Extract` rather than extracting trace context elements one by one. 

## Test coverage

Added a unit test for 128 bit trace IDs. Fixed existing unit tests so they pass a dictionary of headers to CreatePlaceholderScope. Removed a unit test that only passes SamplingPriority, since a distributed trace with only a sampling priority is hardly a distributed trace at all.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
