### PR TITLE
Build against macos-13 as macos-12 is going to be deprecated

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -978,7 +978,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-12
+      vmImage: macos-13
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -998,7 +998,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-12
+      vmImage: macos-13
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -1023,7 +1023,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [native_tracer, native_loader_and_managed ]
     pool:
-      vmImage: macos-12
+      vmImage: macos-13
     steps:
     - checkout: none
 
@@ -1325,7 +1325,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-12
+      vmImage: macos-13
     steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1392,7 +1392,7 @@ stages:
   - job: managed
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-12
+      vmImage: macos-13
     steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1897,7 +1897,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-12
+      vmImage: macos-13
     steps:
     - template: steps/clone-repo.yml
       parameters:


### PR DESCRIPTION
## Summary of changes

Changes CI to build using macos-13 instead of macos-12

## Reason for change

Azure Devops are removing macos-12 images and will start running brownouts from November, so we _have_ to update.

## Implementation details

`macos-12` -> `macos-13`

## Test coverage

This is the test - I will also do a full installer tests run
