### PR TITLE
Fix crashes on .NET Core 2.1 CI

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -197,7 +197,13 @@ namespace Datadog.Trace.TestHelpers
 
             // In some scenarios (.NET 6, SSI run enabled) enabling procdump makes
             // grabbing a stack trace _crazy_ expensive (10s). Setting this "fixes" it.
-            environmentVariables["_NO_DEBUG_HEAP"] = "1";
+            // But for some reason, .NET Core 2.1 gets _very_ unhappy about it -
+            // given we don't really support .NET Core 2.1 anyway, and this _only_ happens
+            // when procdump is attached, just skip in that
+            if (_major > 2)
+            {
+                environmentVariables["_NO_DEBUG_HEAP"] = "1";
+            }
 
             // Set a canary variable that should always be ignored
             // and check that it doesn't appear in the logs


### PR DESCRIPTION
## Summary of changes

Fix failing .NET Core 2.1 Windows integration tests

## Reason for change

The .NET Core 2.1 Windows Integration tests are failing

## Implementation details

After merging #6117 (to fix a weird issue in the .NET 6 windows integration tests related to procdump), we started getting failures in .NET Core 2.1. This is almost certainly a bug in the runtime, and as it's a CI-only issue, trivially fixing by not setting the variable

## Test coverage

[Ran a full test here and all ok](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=165403&view=results)
