### PR TITLE
Refactoring and hardening of security coordinator 

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -60,7 +60,6 @@ src/Datadog.Trace/Agent/TracesTransportType.cs
 src/Datadog.Trace/AppSec/AddressesConstants.cs
 src/Datadog.Trace/AppSec/AppSecRateLimiter.cs
 src/Datadog.Trace/AppSec/BlockingAction.cs
-src/Datadog.Trace/AppSec/CoreHttpContextStore.cs
 src/Datadog.Trace/AppSec/EventTrackingSdk.cs
 src/Datadog.Trace/AppSec/IDatadogSecurity.cs
 src/Datadog.Trace/AppSec/IEvent.cs

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -214,6 +214,7 @@
    <assembly fullname="System.Data.SqlClient" />
    <assembly fullname="System.Data.SQLite" />
    <assembly fullname="System.Diagnostics.Debug">
+      <type fullname="System.Diagnostics.Debug" />
       <type fullname="System.Diagnostics.Debugger" />
       <type fullname="System.Diagnostics.DebuggerBrowsableAttribute" />
       <type fullname="System.Diagnostics.DebuggerBrowsableState" />
@@ -546,6 +547,8 @@
       <type fullname="System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute" />
       <type fullname="System.Diagnostics.ConditionalAttribute" />
+      <type fullname="System.Diagnostics.Debug" />
+      <type fullname="System.Diagnostics.Debug/AssertInterpolatedStringHandler" />
       <type fullname="System.Diagnostics.DebuggableAttribute" />
       <type fullname="System.Diagnostics.DebuggableAttribute/DebuggingModes" />
       <type fullname="System.Diagnostics.Debugger" />

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -214,7 +214,6 @@
    <assembly fullname="System.Data.SqlClient" />
    <assembly fullname="System.Data.SQLite" />
    <assembly fullname="System.Diagnostics.Debug">
-      <type fullname="System.Diagnostics.Debug" />
       <type fullname="System.Diagnostics.Debugger" />
       <type fullname="System.Diagnostics.DebuggerBrowsableAttribute" />
       <type fullname="System.Diagnostics.DebuggerBrowsableState" />
@@ -547,8 +546,6 @@
       <type fullname="System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute" />
       <type fullname="System.Diagnostics.ConditionalAttribute" />
-      <type fullname="System.Diagnostics.Debug" />
-      <type fullname="System.Diagnostics.Debug/AssertInterpolatedStringHandler" />
       <type fullname="System.Diagnostics.DebuggableAttribute" />
       <type fullname="System.Diagnostics.DebuggableAttribute/DebuggingModes" />
       <type fullname="System.Diagnostics.Debugger" />

--- a/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
@@ -33,7 +33,7 @@ internal static class AttackerFingerprintHelper
         }
 
         // We need a context
-        if (!securityCoordinator.Value.IsAdditiveContextDisposed())
+        if (securityCoordinator.Value.IsAdditiveContextDisposed())
         {
             return;
         }

--- a/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
@@ -24,10 +24,16 @@ internal static class AttackerFingerprintHelper
             return;
         }
 
-        var securityCoordinator = new SecurityCoordinator(Security.Instance, span);
+        var securityCoordinator = SecurityCoordinator.TryGet(Security.Instance, span);
+
+        if (securityCoordinator is null)
+        {
+            Log.Warning("Security coordinator could not be instantiated, probably because of httpcontext null. AttackerFingerprintHelper.AddSpanTags won't be run");
+            return;
+        }
 
         // We need a context
-        if (!securityCoordinator.HasContext() || securityCoordinator.IsAdditiveContextDisposed())
+        if (!securityCoordinator.Value.IsAdditiveContextDisposed())
         {
             return;
         }

--- a/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
@@ -28,7 +28,6 @@ internal static class AttackerFingerprintHelper
 
         if (securityCoordinator is null)
         {
-            Log.Warning("Security coordinator could not be instantiated, probably because of httpcontext null. AttackerFingerprintHelper.AddSpanTags won't be run");
             return;
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
@@ -9,6 +9,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.AspNet;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet;
 using Datadog.Trace.Iast;
@@ -78,7 +79,7 @@ namespace Datadog.Trace.AppSec
 
             if (security.Enabled)
             {
-                var securityTransport = new Coordinator.SecurityCoordinator(security, scope.Span!);
+                var securityTransport = SecurityCoordinator.Get(security, scope.Span!, context);
                 if (!securityTransport.IsBlocked)
                 {
                     var inputData = new Dictionary<string, object>();

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #nullable enable
+using System;
 using System.Collections.Generic;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Headers;

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -20,14 +20,30 @@ namespace Datadog.Trace.AppSec.Coordinator;
 
 internal readonly partial struct SecurityCoordinator
 {
-    internal SecurityCoordinator(Security security, Span span, HttpTransport? transport = null)
+    private SecurityCoordinator(Security security, Span span, HttpTransport transport)
     {
         _security = security;
         _localRootSpan = TryGetRoot(span);
-        _httpTransport = transport ?? new HttpTransport(CoreHttpContextStore.Instance.Get());
+        _httpTransport = transport;
     }
 
     private static bool CanAccessHeaders => true;
+
+    internal static SecurityCoordinator? TryGet(Security security, Span span)
+    {
+        var context = CoreHttpContextStore.Instance.Get();
+        if (context is null)
+        {
+            Log.Warning("Can't instantiate SecurityCoordinator.Core as no transport has been provided and CoreHttpContextStore.Instance.Get() returned null, make sure HttpContext is available");
+            return null;
+        }
+
+        return new SecurityCoordinator(security, span, new(context));
+    }
+
+    internal static SecurityCoordinator Get(Security security, Span span, HttpContext context) => new(security, span, new HttpTransport(context));
+
+    internal static SecurityCoordinator Get(Security security, Span span, HttpTransport transport) => new(security, span, transport);
 
     public static Dictionary<string, object> ExtractHeadersFromRequest(IHeaderDictionary headers)
     {
@@ -162,7 +178,7 @@ internal readonly partial struct SecurityCoordinator
             {
                 if (Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out var value))
                 {
-                    return value is bool boolValue && boolValue;
+                    return value is true;
                 }
 
                 return false;

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -54,23 +54,22 @@ internal readonly partial struct SecurityCoordinator
 
     private bool CanAccessHeaders => UsingIntegratedPipeline is true or null;
 
-    internal static SecurityCoordinator? TryGet(Security security, Span span, HttpTransport? transport = null)
+    internal static SecurityCoordinator? TryGet(Security security, Span span)
     {
-        if (transport == null)
+        if (HttpContext.Current is null)
         {
-            if (HttpContext.Current is null)
-            {
-                Log.Warning("Can't instantiate SecurityCoordinator.Framework as no transport has been provided and HttpContext.Current null, make sure HttpContext is available");
-                return null;
-            }
-
-            transport = new HttpTransport(HttpContext.Current);
+            Log.Warning("Can't instantiate SecurityCoordinator.Framework as no transport has been provided and HttpContext.Current null, make sure HttpContext is available");
+            return null;
         }
+
+        var transport = new HttpTransport(HttpContext.Current);
 
         return new SecurityCoordinator(security, span, transport);
     }
 
     internal static SecurityCoordinator Get(Security security, Span span, HttpContext context) => new(security, span, new HttpTransport(context));
+
+    internal static SecurityCoordinator Get(Security security, Span span, HttpTransport transport) => new(security, span, transport);
 
     private static Action<IResult, HttpStatusCode, string, string>? CreateThrowHttpResponseExceptionDynMeth()
     {

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -56,13 +56,13 @@ internal readonly partial struct SecurityCoordinator
 
     internal static SecurityCoordinator? TryGet(Security security, Span span)
     {
-        if (HttpContext.Current is null)
+        if (HttpContext.Current is not { } current)
         {
             Log.Warning("Can't instantiate SecurityCoordinator.Framework as no transport has been provided and HttpContext.Current null, make sure HttpContext is available");
             return null;
         }
 
-        var transport = new HttpTransport(HttpContext.Current);
+        var transport = new HttpTransport(current);
 
         return new SecurityCoordinator(security, span, transport);
     }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -25,7 +25,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, span, transport);
+                var securityCoordinator = SecurityCoordinator.Get(security, span, context);
                 var result = securityCoordinator.Scan();
                 securityCoordinator.BlockAndReport(result);
             }
@@ -41,7 +41,8 @@ internal static class SecurityCoordinatorHelpers
                 var transport = new SecurityCoordinator.HttpTransport(httpContext);
                 if (!transport.IsBlocked)
                 {
-                    var securityCoordinator = new SecurityCoordinator(security, span, transport);
+                    var securityCoordinator = SecurityCoordinator.Get(security, span, transport);
+
                     var args = new Dictionary<string, object>
                     {
                         {
@@ -73,7 +74,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, span, transport);
+                var securityCoordinator = SecurityCoordinator.Get(security, span, transport);
                 var args = new Dictionary<string, object> { { AddressesConstants.RequestPathParams, pathParams } };
                 var result = securityCoordinator.RunWaf(args);
                 securityCoordinator.BlockAndReport(result);
@@ -88,7 +89,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, span, transport);
+                var securityCoordinator = SecurityCoordinator.Get(security, span, transport);
                 var args = new Dictionary<string, object> { { AddressesConstants.UserId, userId } };
                 var result = securityCoordinator.RunWaf(args);
                 securityCoordinator.BlockAndReport(result);
@@ -103,7 +104,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, span, transport);
+                var securityCoordinator = SecurityCoordinator.Get(security, span, transport);
                 var pathParams = new Dictionary<string, object>(actionPathParams.Count);
                 for (var i = 0; i < actionPathParams.Count; i++)
                 {
@@ -131,7 +132,7 @@ internal static class SecurityCoordinatorHelpers
         var transport = new SecurityCoordinator.HttpTransport(context);
         if (!transport.IsBlocked)
         {
-            var securityCoordinator = new SecurityCoordinator(security, span, transport);
+            var securityCoordinator = SecurityCoordinator.Get(security, span, transport);
             var keysAndValues = ObjectExtractor.Extract(body);
 
             if (keysAndValues is not null)

--- a/tracer/src/Datadog.Trace/AppSec/CoreHttpContextStore.cs
+++ b/tracer/src/Datadog.Trace/AppSec/CoreHttpContextStore.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 #if !NETFRAMEWORK
 
 using System;
@@ -10,19 +11,31 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.AppSec.Coordinator;
+using Datadog.Trace.Logging;
 using Microsoft.AspNetCore.Http;
 
 namespace Datadog.Trace.AppSec
 {
     internal class CoreHttpContextStore
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CoreHttpContextStore>();
+
         public static readonly CoreHttpContextStore Instance = new();
 
-        private AsyncLocal<HttpContext> localStore = new();
+        private readonly AsyncLocal<HttpContext> _localStore = new();
 
-        public HttpContext Get() => localStore.Value;
+        public HttpContext? Get()
+        {
+            if (_localStore.Value is null)
+            {
+                Log.Debug("CoreHttpContextStore.Get called but returning null for HttpContext");
+            }
 
-        public void Set(HttpContext context) => localStore.Value = context;
+            return _localStore.Value;
+        }
+
+        public void Set(HttpContext context) => _localStore.Value = context;
     }
 }
 

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -107,15 +107,16 @@ internal static class RaspModule
 
     private static void RunWafRasp(Dictionary<string, object> arguments, Span rootSpan, string address)
     {
-        var securityCoordinator = new SecurityCoordinator(Security.Instance, rootSpan);
+        var securityCoordinator = SecurityCoordinator.TryGet(Security.Instance, rootSpan);
 
         // We need a context for RASP
-        if (!securityCoordinator.HasContext() || securityCoordinator.IsAdditiveContextDisposed())
+        if (securityCoordinator is null)
         {
+            Log.Warning("Tried to run Rasp but security coordinator couldn't be instantiated, probably because of httpcontext missing");
             return;
         }
 
-        var result = securityCoordinator.RunWaf(arguments, runWithEphemeral: true, isRasp: true);
+        var result = securityCoordinator.Value.RunWaf(arguments, runWithEphemeral: true, isRasp: true);
 
         if (result is not null)
         {
@@ -139,7 +140,7 @@ internal static class RaspModule
                 }
             }
         }
-        catch (System.Exception ex)
+        catch (Exception ex)
         {
             Log.Error(ex, "RASP: Error while sending stack.");
         }
@@ -148,7 +149,7 @@ internal static class RaspModule
 
         // we want to report first because if we are inside a try{} catch(Exception ex){} block, we will not report
         // the blockings, so we report first and then block
-        securityCoordinator.ReportAndBlock(result);
+        securityCoordinator.Value.ReportAndBlock(result);
     }
 
     private static void AddSpanId(IResult? result)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -184,7 +184,7 @@ namespace Datadog.Trace.AspNet
                 if (security.Enabled)
                 {
                     SecurityCoordinator.ReportWafInitInfoOnce(security, scope.Span);
-                    var securityCoordinator = new SecurityCoordinator(security, scope.Span);
+                    var securityCoordinator = SecurityCoordinator.Get(security, scope.Span, httpContext);
 
                     // request args
                     var args = securityCoordinator.GetBasicRequestArgsForWaf();
@@ -245,7 +245,7 @@ namespace Datadog.Trace.AspNet
                         var security = Security.Instance;
                         if (security.Enabled)
                         {
-                            var securityCoordinator = new SecurityCoordinator(security, rootSpan);
+                            var securityCoordinator = SecurityCoordinator.Get(security, rootSpan, app.Context);
                             var args = securityCoordinator.GetBasicRequestArgsForWaf();
                             args.Add(AddressesConstants.RequestPathParams, securityCoordinator.GetPathParams());
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ControllerActionInvoker_InvokeAction_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ControllerActionInvoker_InvokeAction_Integration.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         var scope = SharedItems.TryPeekScope(HttpContext.Current, AspNetMvcIntegration.HttpContextKey);
                         if (scope is not null)
                         {
-                            var securityTransport = new SecurityCoordinator(security, scope.Span);
+                            var securityTransport = SecurityCoordinator.Get(security, scope.Span, HttpContext.Current);
                             if (!securityTransport.IsBlocked)
                             {
                                 var extractedObject = ObjectExtractor.Extract(responseObject);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ReflectedHttpActionDescriptor_ExecuteAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ReflectedHttpActionDescriptor_ExecuteAsync_Integration.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         var scope = SharedItems.TryPeekScope(HttpContext.Current, AspNetWebApi2Integration.HttpContextKey);
                         if (scope is not null)
                         {
-                            var securityTransport = new SecurityCoordinator(security, scope.Span);
+                            var securityTransport = SecurityCoordinator.Get(security, scope.Span, HttpContext.Current);
                             if (!securityTransport.IsBlocked)
                             {
                                 var extractedObj = ObjectExtractor.Extract(responseObject);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
@@ -80,7 +80,7 @@ internal class BlockingMiddleware
         {
             if (Tracer.Instance?.ActiveScope?.Span is Span span)
             {
-                var securityCoordinator = new SecurityCoordinator(security, span, new SecurityCoordinator.HttpTransport(context));
+                var securityCoordinator = SecurityCoordinator.Get(security, span, new SecurityCoordinator.HttpTransport(context));
                 if (_endPipeline && !context.Response.HasStarted)
                 {
                     context.Response.StatusCode = 404;
@@ -123,7 +123,7 @@ internal class BlockingMiddleware
                 {
                     if (Tracer.Instance?.ActiveScope?.Span is Span span)
                     {
-                        var securityCoordinator = new SecurityCoordinator(security, span, new SecurityCoordinator.HttpTransport(context));
+                        var securityCoordinator = SecurityCoordinator.Get(security, span, new SecurityCoordinator.HttpTransport(context));
                         if (!blockException.Reported)
                         {
                             securityCoordinator.TryReport(blockException.Result, endedResponse);

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -423,7 +423,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (arg.TryDuckCast<HttpRequestInStartStruct>(out var requestStruct))
             {
-                HttpContext httpContext = requestStruct.HttpContext;
+                var httpContext = requestStruct.HttpContext;
                 if (shouldTrace)
                 {
                     // Use an empty resource name here, as we will likely replace it as part of the request

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.PlatformHelpers
                 span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), tracer.Settings.HeaderTagsInternal, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 if (security.Enabled)
                 {
-                    var transport = new SecurityCoordinator(security, span, new SecurityCoordinator.HttpTransport(httpContext));
+                    var transport = SecurityCoordinator.Get(security, span, new SecurityCoordinator.HttpTransport(httpContext));
                     transport.AddResponseHeadersToSpanAndCleanup();
                 }
                 else

--- a/tracer/src/Datadog.Trace/SpanExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.Framework.cs
@@ -26,14 +26,18 @@ namespace Datadog.Trace
 
             if (security.Enabled)
             {
-                var securityCoordinator = new SecurityCoordinator(Security.Instance, span);
+                var securityCoordinator = SecurityCoordinator.TryGet(Security.Instance, span);
+                if (securityCoordinator is null)
+                {
+                    return;
+                }
 
                 var wafArgs = new Dictionary<string, object>
                 {
                     { AddressesConstants.UserId, userId },
                 };
 
-                securityCoordinator.BlockAndReport(wafArgs);
+                securityCoordinator.Value.BlockAndReport(wafArgs);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
@@ -5,7 +5,6 @@
 
 using Datadog.Trace.AppSec.Coordinator;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests
@@ -16,7 +15,8 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void DefaultBehavior()
         {
             var target = new AppSec.Security();
-            var secCoord = SecurityCoordinator.TryGet(target, new Mock<Span>().Object);
+            var span = new Span(new SpanContext(1, 1), new System.DateTimeOffset());
+            var secCoord = SecurityCoordinator.TryGet(target, span);
             secCoord.Should().BeNull();
         }
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
@@ -1,0 +1,23 @@
+// <copyright file="SecurityCoordinatorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.AppSec.Coordinator;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests
+{
+    public class SecurityCoordinatorTests
+    {
+        [Fact]
+        public void DefaultBehavior()
+        {
+            var target = new AppSec.Security();
+            var secCoord = SecurityCoordinator.TryGet(target, new Mock<Span>().Object);
+            secCoord.Should().BeNull();
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
@@ -14,7 +14,6 @@ using Datadog.Trace.Util;
 using FluentAssertions;
 using Moq;
 using Xunit;
-using static Datadog.Trace.AppSec.Coordinator.SecurityCoordinator;
 
 namespace Datadog.Trace.Tests.Util;
 
@@ -79,8 +78,8 @@ public class RequestDataHelperTests
         scope.Span.ServiceName = "service";
         HttpContext context = new HttpContext(request, new HttpResponse(new System.IO.StringWriter()));
         request.ValidateInput();
-        HttpTransport transport = new HttpTransport(context);
-        var securityCoordinator = new SecurityCoordinator(security, scope.Span, transport);
+        var transport = new SecurityCoordinator.HttpTransport(context);
+        var securityCoordinator = SecurityCoordinator.Get(security, scope.Span, transport);
         // We should not launch any exception here
         var result = securityCoordinator.GetBasicRequestArgsForWaf();
         var iastContext = new IastRequestContext();

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -80,8 +80,8 @@ namespace Benchmarks.Trace.Asm
             context?.Dispose();
             _httpContext.Features.Set<IContext>(null);
 #else
-            var securityTransport = new SecurityCoordinator(_security, span, new SecurityCoordinator.HttpTransport(_httpContext));
-            securityTransport.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestBody, ObjectExtractor.Extract(body) } });
+            var securityTransport = SecurityCoordinator.Get(_security, span, new SecurityCoordinator.HttpTransport(_httpContext));
+            securityTransport!.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestBody, ObjectExtractor.Extract(body) } });
             var context = _httpContext.Items["waf"] as IContext;
             context?.Dispose();
             _httpContext.Items["waf"] = null;


### PR DESCRIPTION
## Summary of changes

Security coordinator should NEVER be able to be instantiated if http context is null 

## Reason for change

Refering to several errors at customers with NullReferenceException or waf additive contexts disposed 

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
