### PR TITLE
Add workaround for ASP.NET ConfigBuilder issue

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
@@ -8,6 +8,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet;
 using Datadog.Trace.ClrProfiler.CallTarget.Handlers;
 
 namespace Datadog.Trace.ClrProfiler.CallTarget;
@@ -66,7 +67,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget>(TTarget? instance)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget>.Invoke(instance);
@@ -87,7 +88,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget? instance, TArg1? arg1)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1>.Invoke(instance, ref arg1);
@@ -110,7 +111,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2>(TTarget? instance, TArg1? arg1, TArg2? arg2)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2>.Invoke(instance, ref arg1, ref arg2);
@@ -135,7 +136,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(TTarget? instance, TArg1? arg1, TArg2? arg2, TArg3? arg3)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3>.Invoke(instance, ref arg1, ref arg2, ref arg3);
@@ -162,7 +163,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(TTarget? instance, TArg1? arg1, TArg2? arg2, TArg3? arg3, TArg4? arg4)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4);
@@ -191,7 +192,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(TTarget? instance, TArg1? arg1, TArg2? arg2, TArg3? arg3, TArg4? arg4, TArg5? arg5)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5);
@@ -222,7 +223,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget? instance, TArg1? arg1, TArg2? arg2, TArg3? arg3, TArg4? arg4, TArg5? arg5, TArg6? arg6)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6);
@@ -255,7 +256,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget? instance, TArg1? arg1, TArg2? arg2, TArg3? arg3, TArg4? arg4, TArg5? arg5, TArg6? arg6, TArg7? arg7)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7);
@@ -290,7 +291,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget? instance, TArg1? arg1, TArg2? arg2, TArg3? arg3, TArg4? arg4, TArg5? arg5, TArg6? arg6, TArg7? arg7, TArg8? arg8)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8);
@@ -311,7 +312,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget? instance, ref TArg1? arg1)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1>.Invoke(instance, ref arg1);
@@ -334,7 +335,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2>(TTarget? instance, ref TArg1? arg1, ref TArg2? arg2)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2>.Invoke(instance, ref arg1, ref arg2);
@@ -359,7 +360,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(TTarget? instance, ref TArg1? arg1, ref TArg2? arg2, ref TArg3? arg3)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3>.Invoke(instance, ref arg1, ref arg2, ref arg3);
@@ -386,7 +387,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(TTarget? instance, ref TArg1? arg1, ref TArg2? arg2, ref TArg3? arg3, ref TArg4? arg4)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4);
@@ -415,7 +416,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(TTarget? instance, ref TArg1? arg1, ref TArg2? arg2, ref TArg3? arg3, ref TArg4? arg4, ref TArg5? arg5)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5);
@@ -446,7 +447,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget? instance, ref TArg1? arg1, ref TArg2? arg2, ref TArg3? arg3, ref TArg4? arg4, ref TArg5? arg5, ref TArg6? arg6)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6);
@@ -479,7 +480,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget? instance, ref TArg1? arg1, ref TArg2? arg2, ref TArg3? arg3, ref TArg4? arg4, ref TArg5? arg5, ref TArg6? arg6, ref TArg7? arg7)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7);
@@ -514,7 +515,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget? instance, ref TArg1? arg1, ref TArg2? arg2, ref TArg3? arg3, ref TArg4? arg4, ref TArg5? arg5, ref TArg6? arg6, ref TArg7? arg7, ref TArg8? arg8)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8);
@@ -534,7 +535,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetState BeginMethod<TIntegration, TTarget>(TTarget? instance, object[] arguments)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return BeginMethodSlowHandler<TIntegration, TTarget>.Invoke(instance, arguments);
@@ -555,7 +556,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetReturn EndMethod<TIntegration, TTarget>(TTarget? instance, Exception? exception, CallTargetState state)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             EndMethodHandler<TIntegration, TTarget>.Invoke(instance, exception, in state);
@@ -578,7 +579,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetReturn<TReturn> EndMethod<TIntegration, TTarget, TReturn>(TTarget? instance, TReturn? returnValue, Exception? exception, CallTargetState state)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             var result = EndMethodHandler<TIntegration, TTarget, TReturn>.Invoke(instance, returnValue, exception, in state);
@@ -600,7 +601,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetReturn EndMethod<TIntegration, TTarget>(TTarget? instance, Exception? exception, in CallTargetState state)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return EndMethodHandler<TIntegration, TTarget>.Invoke(instance, exception, in state);
@@ -623,7 +624,7 @@ public static class CallTargetInvoker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static CallTargetReturn<TReturn> EndMethod<TIntegration, TTarget, TReturn>(TTarget? instance, TReturn? returnValue, Exception? exception, in CallTargetState state)
     {
-        if (IsIisPreStartComplete() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+        if (IsIisPreStartComplete<TIntegration>() && IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
         {
             IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
             return EndMethodHandler<TIntegration, TTarget, TReturn>.Invoke(instance, returnValue, exception, in state);
@@ -665,7 +666,7 @@ public static class CallTargetInvoker
     }
 
 #if NETFRAMEWORK
-    private static bool IsIisPreStartComplete()
+    private static bool IsIisPreStartComplete<TIntegration>()
     {
         if (_isIisPreStartInitComplete)
         {
@@ -673,12 +674,17 @@ public static class CallTargetInvoker
         }
 
         _isIisPreStartInitComplete = AppDomain.CurrentDomain.GetData(NamedSlotName) is false;
-        return _isIisPreStartInitComplete;
+
+        // We _have_ to allow the HttpModule_Integration inocation through, even if we're in the Iis PreStart phase
+        // that integration is specifically designed to run in this phase. We considered other options
+        // such as moving it to Instrumentation.Initialise, or rewriting directly with the profiling API
+        // but this was the simplest, easiest, and safest approach we could see generally.
+        return _isIisPreStartInitComplete || typeof(TIntegration) == typeof(HttpModule_Integration);
     }
 
 #else
     // Compiler should inline this out of the condition checks completely
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsIisPreStartComplete() => true;
+    private static bool IsIisPreStartComplete<TIntegration>() => true;
 #endif
 }


### PR DESCRIPTION
## Summary of changes

Adds a check that IisPreStartInit has completed before we run any automatic instrumentations

## Reason for change

We recently had a case where a customer was [using `AzureKeyVaultConfigBuilder`](https://github.com/aspnet/MicrosoftConfigurationBuilders/blob/main/src/Azure/AzureKeyVaultConfigBuilder.cs) with ASP.NET's web.config to load configuration into `AppSettings`, which was causing the  application to deadlock on startup.

After some investigation, we isolated the problem as happening specifically when there are 2 apps running inside an app pool:

- App 1 starts
  - The config builder populates and loads from key vault
  - We initialize the tracer, and set up instrumentation
  - App1 works fine 👍 
- App 2 starts
  - The config builder tries to populate and load from key vault
    - This requires making HTTP requests
    - Due to the instrumentation run for app 1, we instrument the HTTP request
    - This invokes `CallTargetInvoker` which tries to initialize the tracer
    - Initializing the tracer [requires reading `AppSettings` so that we can populate configuration](https://github.com/DataDog/dd-trace-dotnet/blob/c8399df44468f83c22a978418e0cfc314f9c3542/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/GlobalConfigurationSource.cs#L39)
      - The config builder tries to populate and load from key vault 
      - ♻️re-entry 💥

![boom](https://github.com/user-attachments/assets/725ec7ba-a1ff-4069-aa15-f5dd3d28c314)

So the key thing is that we need to make sure we _don't_ run our automatic instrumentation until _after_ the IIS pre-init stage is completely, to avoid re-entry and recursion during setup.

## Implementation details

The implementation is leveraging work we did years ago to fix essentially the same problem: https://github.com/DataDog/dd-trace-dotnet/pull/1157. The problem back then was with Liblog and NLog, but we did all the work to inject flags for tracking when it is safe to make changes.

Given the native work already exists, we can piggy-pack on those hooks and make sure we don't run any automatic instrumentations unless the domain as finished pre-initialization.

This is still _relatively_ fragile, as things like adding a static reference to IDatadogLogger would cause a static initialization to happen too early, and ultimately deadlock/crash the app, so added a bunch of comments to try to highlight the issue

## Test coverage

This is kind of a pain to test because it requires a custom config builder, plus two applications running in an app pool. I tested manually by

- Created a custom `ConfigBuilder` based on the `AzureKeyVaultConfigBuilder` implementation. The custom builder simply makes a generic HTTP request when a value is requested
- Create a generic .NET 472 asp.net app
- Add to the `web.config` to set up the builder (see below)
- Publish the app
- Create two asp.net apps in IIS, using the same app pool
- Hit the first app - all good 👍 
- Hit the second app - 💥 `The configBuilder 'CustomBuilder' failed while processing the configuration section 'appSettings'.: The ConfigurationBuilder 'CustomBuilder[Microsoft.Configuration.ConfigurationBuilders.CustomConfigBuilder]' has recursively re-entered processing of the 'appSettings' section` (I based my implementation on v3 which specifically detects re-entry)
- Made the fix, now it works 🎉 

web.config for my dummy test:
```xml
<configuration>
  <configSections>
    <section name="configBuilders"
      type="System.Configuration.ConfigurationBuildersSection, 
      System.Configuration, Version=4.0.0.0, Culture=neutral, 
      PublicKeyToken=b03f5f7f11d50a3a"
      restartOnExternalChanges="false" requirePermission="false" />
  </configSections>

  <configBuilders>
    <builders>
      <add name="CustomBuilder" preloadSecretNames="false" Uri="https://some-value-prd.vault.azure.net/"
      type="Microsoft.Configuration.ConfigurationBuilders.CustomConfigBuilder, CustomConfigBuilder, Version=1.0.0.0, Culture=neutral" />
    </builders>
  </configBuilders>

  <appSettings configBuilders="CustomBuilder">
    <add key="DummyKey1" value="DummyKey1 value from web.config" />
    <add key="DummyKey2" value="DummyKey2 value from web.config" />
  </appSettings>
```

Complete test solution is here:
[ConfigBuilderIssueRepro.zip](https://github.com/user-attachments/files/17343990/ConfigBuilderIssueRepro.zip)

## Other details

Fixes: https://datadoghq.atlassian.net/browse/APMS-13426
