### PR TITLE
[ASM] Remove httpcontext from context store at the end of the request

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/CoreHttpContextStore.cs
+++ b/tracer/src/Datadog.Trace/AppSec/CoreHttpContextStore.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.AppSec
 
         public static readonly CoreHttpContextStore Instance = new();
 
-        private readonly AsyncLocal<HttpContext> _localStore = new();
+        private readonly AsyncLocal<HttpContext?> _localStore = new();
 
         public HttpContext? Get()
         {
@@ -36,6 +36,8 @@ namespace Datadog.Trace.AppSec
         }
 
         public void Set(HttpContext context) => _localStore.Value = context;
+
+        public void Remove() => _localStore.Value = null;
     }
 }
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -670,6 +670,8 @@ namespace Datadog.Trace.DiagnosticListeners
                 AspNetCoreRequestHandler.StopAspNetCorePipelineScope(tracer, CurrentSecurity, rootScope, httpContext);
             }
 
+            CoreHttpContextStore.Instance.Remove();
+
             // If we don't have a scope, no need to call Stop pipeline
         }
 
@@ -688,6 +690,8 @@ namespace Datadog.Trace.DiagnosticListeners
             {
                 AspNetCoreRequestHandler.HandleAspNetCoreException(tracer, CurrentSecurity, rootSpan, httpContext, unhandledStruct.Exception);
             }
+
+            CoreHttpContextStore.Instance.Remove();
 
             // If we don't have a span, no need to call Handle exception
         }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -671,7 +671,6 @@ namespace Datadog.Trace.DiagnosticListeners
             }
 
             CoreHttpContextStore.Instance.Remove();
-
             // If we don't have a scope, no need to call Stop pipeline
         }
 
@@ -690,8 +689,6 @@ namespace Datadog.Trace.DiagnosticListeners
             {
                 AspNetCoreRequestHandler.HandleAspNetCoreException(tracer, CurrentSecurity, rootSpan, httpContext, unhandledStruct.Exception);
             }
-
-            CoreHttpContextStore.Instance.Remove();
 
             // If we don't have a span, no need to call Handle exception
         }

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -178,6 +178,7 @@ namespace Datadog.Trace.PlatformHelpers
                     new SecurityCoordinator.HttpTransport(httpContext).DisposeAdditiveContext();
                 }
 
+                CoreHttpContextStore.Instance.Remove();
                 rootScope.Dispose();
             }
         }


### PR DESCRIPTION
## Summary of changes

Some logs show that we're accessing HttpContext properties when it has already been disposed. Stacktrace shows that it's at the beginning of running the waf, so this might be a simple fix for now

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
