### PR TITLE
[Crashtracking] Disable crashtracking on Windows by default

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
@@ -80,7 +80,7 @@ EXTERN_C BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_cal
         bool telemetry_enabled = true;
         shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(L"DD_INSTRUMENTATION_TELEMETRY_ENABLED"), telemetry_enabled);
 
-        bool crashtracking_enabled = true;
+        bool crashtracking_enabled = false;
         shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(L"DD_CRASHTRACKING_ENABLED"), crashtracking_enabled);
 
         if (telemetry_enabled && crashtracking_enabled)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -35,6 +35,11 @@ public class CreatedumpTests : ConsoleTestHelper
         SetEnvironmentVariable("COMPlus_DbgMiniDumpType", string.Empty);
         SetEnvironmentVariable("COMPlus_DbgEnableMiniDump", string.Empty);
         SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", string.Empty);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            SetEnvironmentVariable("DD_CRASHTRACKING_ENABLED", "1");
+        }
     }
 
     private static (string Key, string Value) LdPreloadConfig


### PR DESCRIPTION
## Summary of changes

Disable crashtracking on Windows by default.

## Reason for change

The next version of the tracer will be released before we implement proper support for the PDBs in crashtracking, so change it to opt-in for now (effectively disabling it since nobody is going to manually enable it).

## Implementation details

Changed the default value of `DD_CRASHTRACKING_ENABLED`.

## Test coverage

Had to update the tests to account for the new default value on Windows.