### PR TITLE
Inject startup hook preferentially into static constructor when available

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
@@ -13,257 +13,272 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Samples;
 
-await Task.Yield();
-
-// Do this before anything else to hit ready-to-run issues
-using (Tracer.Instance.StartActive("initial"))
+internal class Program
 {
-}
+    private static readonly Tracer _initialTracer;
 
-// Moving this to a separate
-await OtherStuff();
-
-async Task OtherStuff()
-{
-    var shouldBeAttached = Environment.GetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED") == "1";
-    var runInstrumentationChecks = shouldBeAttached;
-
-    var isManualOnly = (bool)typeof(Tracer)
-                            .Assembly
-                            .GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: true)
-                             !.GetMethod("IsManualInstrumentationOnly")
-                             !.Invoke(null, null)!;
-
-    // It's... weird... but reflection doesn't work with the rewriting in r2r for some reason...
-    var hasCorrectValueAfterRewrite = Environment.GetEnvironmentVariable("READY2RUN_ENABLED") != "1";
-    if (hasCorrectValueAfterRewrite)
+    static Program()
     {
-        Expect(isManualOnly != shouldBeAttached);
+        // Ensure we initialize the tracer before any other code
+        // to test that the automatic startup hook handles this correctly
+        _initialTracer = Tracer.Instance;
     }
 
-    Expect(SampleHelpers.IsProfilerAttached() == shouldBeAttached);
-
-    var count = 0;
-    var port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
-    Console.WriteLine($"Port {port}");
-    var server = WebServer.Start(port, out var url);
-    var client = new HttpClient();
-    server.RequestHandler = HandleHttpRequests;
-
-// Manually enable debug logs
-    GlobalSettings.SetDebugEnabled(true);
-    LogCurrentSettings(Tracer.Instance, "Initial");
-
-// verify instrumentation
-    ThrowIf(string.IsNullOrEmpty(Tracer.Instance.DefaultServiceName));
-
-// Manual + automatic before reconfiguration
-    var firstOperationName = $"Manual-{++count}.Initial";
-    using (var scope = Tracer.Instance.StartActive(firstOperationName))
+    public static async Task Main(string[] args)
     {
-        // All these should be satisfied when we're instrumented
-        Expect(Tracer.Instance.ActiveScope is not null);
-        Expect(scope.Span.OperationName == firstOperationName);
-        Expect(scope.Span.SpanId != 0);
-        Expect(scope.Span.TraceId != 0);
-        scope.Span.SetTag("Temp", "TempTest");
-        Expect(scope.Span.GetTag("Temp") == "TempTest");
-        scope.Span.SetTag("Temp", null);
+        await Task.Yield();
 
-        await SendHttpRequest("Initial");
-    }
-
-    await Tracer.Instance.ForceFlushAsync();
-
-// Reconfigure the tracer
-    var settings = TracerSettings.FromDefaultSources();
-    settings.ServiceName = "updated-name";
-    settings.Environment = "updated-env";
-    settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
-    Tracer.Configure(settings);
-    LogCurrentSettings(Tracer.Instance, "Reconfigured");
-
-// Manual + automatic
-    using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
-    {
-        await SendHttpRequest("Reconfigured");
-    }
-
-    await Tracer.Instance.ForceFlushAsync();
-
-// reconfigure with Http disabled
-    settings = TracerSettings.FromDefaultSources();
-// net core
-    var httpIntegration = settings.Integrations["HttpMessageHandler"];
-    httpIntegration.Enabled = false;
-    httpIntegration.AnalyticsEnabled = false; // just setting them because why not
-    httpIntegration.AnalyticsSampleRate = 1.0;
-// net FX
-    httpIntegration = settings.Integrations["WebRequest"];
-    httpIntegration.Enabled = false;
-    httpIntegration.AnalyticsEnabled = false; // just setting them because why not
-    httpIntegration.AnalyticsSampleRate = 1.0;
-    Tracer.Configure(settings);
-    LogCurrentSettings(Tracer.Instance, "HttpDisabled");
-
-// send a trace with it disabled
-    using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
-    {
-        await SendHttpRequest("HttpDisabled");
-    }
-
-    await Tracer.Instance.ForceFlushAsync();
-
-// go back to the defaults
-    Tracer.Configure(TracerSettings.FromDefaultSources());
-    LogCurrentSettings(Tracer.Instance, "DefaultsReinstated");
-    using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
-    {
-        await SendHttpRequest("DefaultsReinstated");
-    }
-
-    await Tracer.Instance.ForceFlushAsync();
-
-// nested manual + extensions
-    using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))
-    {
-        s1.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
-
-        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.Ext.Inner");
-        s2.Span.SetException(new CustomException());
-        s2.Span.SetTag("Custom", "Some-Value");
-        s2.Span.SetTag("Some-Number", 123);
-        s2.Span.SetUser(
-            new UserDetails("my-id")
-            {
-                Email = "test@example.com",
-                Name = "Bits",
-                Role = "Mascot",
-                Scope = "test-scope",
-                PropagateId = true,
-                SessionId = "abc123"
-            });
-
-        await SendHttpRequest("Ext");
-    }
-
-// nested manual + eventSDK
-    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Custom.Outer"))
-    {
-        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Custom.Inner");
-        EventTrackingSdk.TrackCustomEvent("custom-event");
-        EventTrackingSdk.TrackCustomEvent("custom-event-meta", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-        await SendHttpRequest("Ext");
-    }
-
-    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Success.Outer"))
-    {
-        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Success.Inner");
-        EventTrackingSdk.TrackUserLoginSuccessEvent("my-id");
-        EventTrackingSdk.TrackUserLoginSuccessEvent("my-id", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-        await SendHttpRequest("Ext");
-    }
-
-    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Failure.Outer"))
-    {
-        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Failure.Inner");
-        EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true);
-        EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true, new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-        await SendHttpRequest("Ext");
-    }
-
-// Custom context
-    var parent = new SpanContext(traceId: 1234567, 7654321, SamplingPriority.AutoKeep, "manual-parent");
-    var createSpan = new SpanCreationSettings { FinishOnClose = false, StartTime = DateTimeOffset.Now.AddHours(-1), Parent = parent, };
-    using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.CustomContext", createSpan))
-    {
-        s1.Span.ServiceName = Tracer.Instance.DefaultServiceName;
-        await SendHttpRequest("CustomContext");
-    }
-
-// Manually disable debug logs
-    GlobalSettings.SetDebugEnabled(false);
-
-// Force flush
-    await Tracer.Instance.ForceFlushAsync();
-
-// Force process to end, otherwise the background listener thread lives forever in .NET Core.
-// Apparently listener.GetContext() doesn't throw an exception if listener.Stop() is called,
-// like it does in .NET Framework.
-    server.Dispose();
-    Environment.Exit(0);
-    return;
-
-    async Task SendHttpRequest(string name)
-    {
-        var q = $"{count}.{name}";
-        using var scope = Tracer.Instance.StartActive($"Manual-{q}.HttpClient");
-        await client.GetAsync(url + $"?q={q}");
-        Console.WriteLine("Received response for client.GetAsync(String)");
-    }
-
-    void HandleHttpRequests(HttpListenerContext context)
-    {
-        try
+        // Do this before anything else to hit ready-to-run issues
+        using (_initialTracer.StartActive("initial"))
         {
-            var query = context.Request.QueryString["q"];
-            using var scope = Tracer.Instance.StartActive($"Manual-{query}.HttpListener");
-            Console.WriteLine("[HttpListener] received request");
+        }
 
-            // read request content and headers
-            using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+        // Moving this to a separate method to hit the r2r issue
+        await OtherStuff();
+
+        async Task OtherStuff()
+        {
+            var shouldBeAttached = Environment.GetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED") == "1";
+            var runInstrumentationChecks = shouldBeAttached;
+
+            var isManualOnly = (bool)typeof(Tracer)
+                                    .Assembly
+                                    .GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: true)
+                                     !.GetMethod("IsManualInstrumentationOnly")
+                                     !.Invoke(null, null)!;
+
+            // It's... weird... but reflection doesn't work with the rewriting in r2r for some reason...
+            var hasCorrectValueAfterRewrite = Environment.GetEnvironmentVariable("READY2RUN_ENABLED") != "1";
+            if (hasCorrectValueAfterRewrite)
             {
-                string requestContent = reader.ReadToEnd();
-                Console.WriteLine($"[HttpListener] request content: {requestContent}");
+                Expect(isManualOnly != shouldBeAttached);
             }
 
-            // write response content
-            scope.Span.SetTag("content", "PONG");
-            var responseBytes = Encoding.UTF8.GetBytes("PONG");
-            context.Response.ContentEncoding = Encoding.UTF8;
-            context.Response.ContentLength64 = responseBytes.Length;
-            context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
-            // we must close the response
-            context.Response.Close();
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-            context.Response.Close();
-            throw;
-        }
-    }
+            Expect(SampleHelpers.IsProfilerAttached() == shouldBeAttached);
 
-    static void LogCurrentSettings(Tracer tracer, string step)
-    {
-        var settings = tracer.Settings;
-        Console.WriteLine($"Current tracer settings for {step}: ");
+            var count = 0;
+            var port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
+            Console.WriteLine($"Port {port}");
+            var server = WebServer.Start(port, out var url);
+            var client = new HttpClient();
+            server.RequestHandler = HandleHttpRequests;
 
-        WriteLog(settings.Environment);
-        WriteLog(settings.ServiceName);
-        WriteLog(settings.ServiceVersion);
-        var globalTags = string.Join(". ", settings.GlobalTags.Select(x => $"{x.Key}:{x.Value}"));
-        WriteLog(globalTags);
+            // Manually enable debug logs
+            GlobalSettings.SetDebugEnabled(true);
+            LogCurrentSettings(_initialTracer, "Initial");
 
-        static void WriteLog(object argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
-        {
-            Console.WriteLine($"  {paramName}: {argument}");
-        }
-    }
+            // verify instrumentation
+            ThrowIf(string.IsNullOrEmpty(_initialTracer.DefaultServiceName));
 
-    void Expect(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
-    {
-        if (runInstrumentationChecks && !condition)
-        {
-            throw new InstrumentationErrorException(description, expected: true);
-        }
-    }
+            // Manual + automatic before reconfiguration
+            var firstOperationName = $"Manual-{++count}.Initial";
+            using (var scope = _initialTracer.StartActive(firstOperationName))
+            {
+                // All these should be satisfied when we're instrumented
+                Expect(_initialTracer.ActiveScope is not null);
+                Expect(scope.Span.OperationName == firstOperationName);
+                Expect(scope.Span.SpanId != 0);
+                Expect(scope.Span.TraceId != 0);
+                scope.Span.SetTag("Temp", "TempTest");
+                Expect(scope.Span.GetTag("Temp") == "TempTest");
+                scope.Span.SetTag("Temp", null);
 
-    void ThrowIf(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
-    {
-        if (runInstrumentationChecks && condition)
-        {
-            throw new InstrumentationErrorException(description, expected: false);
+                await SendHttpRequest("Initial");
+            }
+
+            await _initialTracer.ForceFlushAsync();
+
+            // Reconfigure the tracer
+            var settings = TracerSettings.FromDefaultSources();
+            settings.ServiceName = "updated-name";
+            settings.Environment = "updated-env";
+            settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
+            Tracer.Configure(settings);
+            LogCurrentSettings(Tracer.Instance, "Reconfigured");
+
+            // Manual + automatic
+            using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
+            {
+                await SendHttpRequest("Reconfigured");
+            }
+
+            await Tracer.Instance.ForceFlushAsync();
+
+            // reconfigure with Http disabled
+            settings = TracerSettings.FromDefaultSources();
+            // net core
+            var httpIntegration = settings.Integrations["HttpMessageHandler"];
+            httpIntegration.Enabled = false;
+            httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+            httpIntegration.AnalyticsSampleRate = 1.0;
+            // net FX
+            httpIntegration = settings.Integrations["WebRequest"];
+            httpIntegration.Enabled = false;
+            httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+            httpIntegration.AnalyticsSampleRate = 1.0;
+            Tracer.Configure(settings);
+            LogCurrentSettings(Tracer.Instance, "HttpDisabled");
+
+            // send a trace with it disabled
+            using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
+            {
+                await SendHttpRequest("HttpDisabled");
+            }
+
+            await Tracer.Instance.ForceFlushAsync();
+
+            // go back to the defaults
+            Tracer.Configure(TracerSettings.FromDefaultSources());
+            LogCurrentSettings(Tracer.Instance, "DefaultsReinstated");
+            using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
+            {
+                await SendHttpRequest("DefaultsReinstated");
+            }
+
+            await Tracer.Instance.ForceFlushAsync();
+
+            // nested manual + extensions
+            using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))
+            {
+                s1.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+
+                using var s2 = Tracer.Instance.StartActive($"Manual-{count}.Ext.Inner");
+                s2.Span.SetException(new CustomException());
+                s2.Span.SetTag("Custom", "Some-Value");
+                s2.Span.SetTag("Some-Number", 123);
+                s2.Span.SetUser(
+                    new UserDetails("my-id")
+                    {
+                        Email = "test@example.com",
+                        Name = "Bits",
+                        Role = "Mascot",
+                        Scope = "test-scope",
+                        PropagateId = true,
+                        SessionId = "abc123"
+                    });
+
+                await SendHttpRequest("Ext");
+            }
+
+            // nested manual + eventSDK
+            using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Custom.Outer"))
+            {
+                using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Custom.Inner");
+                EventTrackingSdk.TrackCustomEvent("custom-event");
+                EventTrackingSdk.TrackCustomEvent("custom-event-meta", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+                await SendHttpRequest("Ext");
+            }
+
+            using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Success.Outer"))
+            {
+                using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Success.Inner");
+                EventTrackingSdk.TrackUserLoginSuccessEvent("my-id");
+                EventTrackingSdk.TrackUserLoginSuccessEvent("my-id", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+                await SendHttpRequest("Ext");
+            }
+
+            using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Failure.Outer"))
+            {
+                using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Failure.Inner");
+                EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true);
+                EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true, new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+                await SendHttpRequest("Ext");
+            }
+
+            // Custom context
+            var parent = new SpanContext(traceId: 1234567, 7654321, SamplingPriority.AutoKeep, "manual-parent");
+            var createSpan = new SpanCreationSettings { FinishOnClose = false, StartTime = DateTimeOffset.Now.AddHours(-1), Parent = parent, };
+            using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.CustomContext", createSpan))
+            {
+                s1.Span.ServiceName = Tracer.Instance.DefaultServiceName;
+                await SendHttpRequest("CustomContext");
+            }
+
+            // Manually disable debug logs
+            GlobalSettings.SetDebugEnabled(false);
+
+            // Force flush
+            await Tracer.Instance.ForceFlushAsync();
+
+            // Force process to end, otherwise the background listener thread lives forever in .NET Core.
+            // Apparently listener.GetContext() doesn't throw an exception if listener.Stop() is called,
+            // like it does in .NET Framework.
+            server.Dispose();
+            Environment.Exit(0);
+            return;
+
+            async Task SendHttpRequest(string name)
+            {
+                var q = $"{count}.{name}";
+                using var scope = Tracer.Instance.StartActive($"Manual-{q}.HttpClient");
+                await client.GetAsync(url + $"?q={q}");
+                Console.WriteLine("Received response for client.GetAsync(String)");
+            }
+
+            void HandleHttpRequests(HttpListenerContext context)
+            {
+                try
+                {
+                    var query = context.Request.QueryString["q"];
+                    using var scope = Tracer.Instance.StartActive($"Manual-{query}.HttpListener");
+                    Console.WriteLine("[HttpListener] received request");
+
+                    // read request content and headers
+                    using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+                    {
+                        string requestContent = reader.ReadToEnd();
+                        Console.WriteLine($"[HttpListener] request content: {requestContent}");
+                    }
+
+                    // write response content
+                    scope.Span.SetTag("content", "PONG");
+                    var responseBytes = Encoding.UTF8.GetBytes("PONG");
+                    context.Response.ContentEncoding = Encoding.UTF8;
+                    context.Response.ContentLength64 = responseBytes.Length;
+                    context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+                    // we must close the response
+                    context.Response.Close();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    context.Response.Close();
+                    throw;
+                }
+            }
+
+            static void LogCurrentSettings(Tracer tracer, string step)
+            {
+                var settings = tracer.Settings;
+                Console.WriteLine($"Current tracer settings for {step}: ");
+
+                WriteLog(settings.Environment);
+                WriteLog(settings.ServiceName);
+                WriteLog(settings.ServiceVersion);
+                var globalTags = string.Join(". ", settings.GlobalTags.Select(x => $"{x.Key}:{x.Value}"));
+                WriteLog(globalTags);
+
+                static void WriteLog(object argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+                {
+                    Console.WriteLine($"  {paramName}: {argument}");
+                }
+            }
+
+            void Expect(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
+            {
+                if (runInstrumentationChecks && !condition)
+                {
+                    throw new InstrumentationErrorException(description, expected: true);
+                }
+            }
+
+            void ThrowIf(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
+            {
+                if (runInstrumentationChecks && condition)
+                {
+                    throw new InstrumentationErrorException(description, expected: false);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Before injecting the startup hook, check if the type has an explicit static constructor. If so, skip injecting.

## Reason for change

This fixes an issue with manual instrumentation in v3 when the entrypoint contains an explicit static constructor. A simple reproduction is the following:

```csharp
public static class Program
{
    private static readonly Datadog.Trace.Tracer _tracer = Datadog.Trace.Tracer.Instance;
    static Program()
    {
        _ = _tracer;
    }

    public static void Main(string[] args)
    {
        var builder = WebApplication.CreateBuilder(args);
        var app = builder.Build();

        app.MapGet("/", () => {
            using var scope = _tracer.StartActive("custom-operation-name");
            return "Hello World!";
        });

        app.Run();
    }
}
```

In this example, we inject into the entrypoint `Program.Main()`. We add the startup hook which initializes the instrumentation. However, the JIT sees that there is a static constructor and manually inserts a call to a static field to trigger its execution. This is inserted at the start of `Program.Main` i.e. _before_ our startup hook.

> Note that this _only_ happens in .NET Core - in .NET Framework the `.cctor` is re-jitted before the entrypoint, so the problem doesn't exist. So we limit this implementation to .NET Core to reduce the blast radius.

In this situation, we don't see the initialization of the tracer, so we miss the ReJit calls, and the manual instrumentation library ends up in a half-instrumented state.

This is particularly noticeable for the manual instrumentation case, because we have a lot of instrumentation, but technically it applies to anything that is called from a static constructor in the entrypoint.


## Implementation details

When choosing whether to inject the startup hook, check whether the entrypoint type contains a static constructor. If it does, _and the constructor is not an implicit constructor_, then skip instrumenting, on the basis that the JIT will subsequently inject a call to the static constructor, which we will then instrument, ensuring we _are_ the first call in the app.

In some cases (i.e. IIS) we're specifically choosing where we want to instrument (`System.Web.Compilation.BuildManager.InvokePreStartInitMethods()`) so we don't try to change anything in that case.

The implicit static constructor is annoying. If there's a static field, but no explicit static constructor, then the profiling API will return a static constructor. However, we _shouldn't_ skip on the basis of this implicit constructor, because `JITCompilationStarted` is never called for it, so we would end up initializing too late. To detect this, [we check whether `beforefieldinit` is set](https://csharpindepth.com/Articles/BeforeFieldInit) to try to decide whether to rely on the static constructor actually being called or not.

There's obviously a risk with all this; causing things to initialize in the wrong order is a perennial problem. If for some (strange) reason the static constructor is _not_ invoked next, then we may end up injection somewhere else, which would be... strange... but also Bad™😅 At least we're not doing this behavior in .NET FX which is often the source of weirdness!

## Test coverage

Added a reproduction to `Samples.ManualInstrumentation`. Without the change to startup hook injection the tests fail at `ThrowIf(string.IsNullOrEmpty(Tracer.Instance.DefaultServiceName))` (because it _is_ empty) and also at `Tracer.Instance.StartActive()`

## Other details

Discovered this behaviour while trying to solve #6124
#6184 actually resolved the issue, so this is just an edge case
