### PR TITLE
Baggage part 1/3: change propagator signatures

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -301,13 +301,15 @@ namespace Datadog.Trace.Coverage.Collector
             _logger?.Warning($"Processed {numAssemblies} assemblies in folder: {folder}");
 
             // The following is just a best effort approach to indicate in the test session that
-            // we sucessfully instrumented all assemblies to collect code coverage.
+            // we successfully instrumented all assemblies to collect code coverage.
             // Is not part of the spec but useful for support tickets.
             // We try to extract session variables (from out of process sessions)
             // and try to send a message to the IPC server for setting the test.code_coverage.injected tag.
-            if (SpanContextPropagator.Instance.Extract(
-                    EnvironmentHelpers.GetEnvironmentVariables(),
-                    new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor)) is { } sessionContext)
+            var extractedContext = SpanContextPropagator.Instance.Extract(
+                EnvironmentHelpers.GetEnvironmentVariables(),
+                new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
+
+            if (extractedContext.SpanContext is { } sessionContext)
             {
                 try
                 {
@@ -323,7 +325,7 @@ namespace Datadog.Trace.Coverage.Collector
             }
             else
             {
-                _logger?.Debug($"CoverageCollector.Test session context cannot be found, skipping IPC client and sending injection tags");
+                _logger?.Debug("CoverageCollector.Test session context cannot be found, skipping IPC client and sending injection tags");
             }
         }
 

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -140,8 +140,7 @@ namespace Datadog.Trace.AspNet
                     {
                         // extract propagated http headers
                         headers = requestHeaders.Wrap();
-                        extractedContext = SpanContextPropagator.Instance.Extract(headers.Value);
-                        Baggage.Current.Merge(extractedContext.Baggage);
+                        extractedContext = SpanContextPropagator.Instance.Extract(headers.Value).MergeBaggageInto(Baggage.Current);
                     }
                     catch (Exception ex)
                     {

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -132,14 +132,16 @@ namespace Datadog.Trace.AspNet
                 HttpRequest httpRequest = httpContext.Request;
                 var requestHeaders = RequestDataHelper.GetHeaders(httpRequest) ?? new System.Collections.Specialized.NameValueCollection();
                 NameValueHeadersCollection? headers = null;
-                SpanContext propagatedContext = null;
+                PropagationContext extractedContext = default;
+
                 if (tracer.InternalActiveScope == null)
                 {
                     try
                     {
                         // extract propagated http headers
                         headers = requestHeaders.Wrap();
-                        propagatedContext = SpanContextPropagator.Instance.Extract(headers.Value);
+                        extractedContext = SpanContextPropagator.Instance.Extract(headers.Value);
+                        Baggage.Current.Merge(extractedContext.Baggage);
                     }
                     catch (Exception ex)
                     {
@@ -152,7 +154,7 @@ namespace Datadog.Trace.AspNet
                 string httpMethod = httpRequest.HttpMethod.ToUpperInvariant();
                 string url = httpContext.Request.GetUrlForSpan(tracer.TracerManager.QueryStringManager);
                 var tags = new WebTags();
-                scope = tracer.StartActiveInternal(_requestOperationName, propagatedContext, tags: tags);
+                scope = tracer.StartActiveInternal(_requestOperationName, extractedContext.SpanContext, tags: tags);
                 // Leave resourceName blank for now - we'll update it in OnEndRequest
                 scope.Span.DecorateWebServerSpan(resourceName: null, httpMethod, host, url, userAgent, tags);
                 if (headers is not null)
@@ -172,7 +174,8 @@ namespace Datadog.Trace.AspNet
                 // (e.g. WCF being hosted in IIS)
                 if (HttpRuntime.UsingIntegratedPipeline)
                 {
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, requestHeaders.Wrap());
+                    var injectedContext = new PropagationContext(scope.Span.Context, Baggage.Current);
+                    SpanContextPropagator.Instance.Inject(injectedContext, requestHeaders.Wrap());
                 }
 
                 httpContext.Items[_httpContextScopeKey] = scope;

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -225,7 +225,7 @@ internal class Baggage : IDictionary<string, string>
         return false;
     }
 
-    void IDictionary<string, string>.Add(string key, string value)
+    public void Add(string key, string value)
     {
         var items = EnsureListInitialized();
 
@@ -245,7 +245,7 @@ internal class Baggage : IDictionary<string, string>
 
     void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item)
     {
-        ((IDictionary<string, string>)this).Add(item.Key, item.Value);
+        Add(item.Key, item.Value);
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -340,13 +340,16 @@ internal class Baggage : IDictionary<string, string>
         if (baggage?.Count > 0)
         {
             var thisItems = EnsureListInitialized();
-            var otherItems = baggage._items!;
+            var newItems = baggage._items!;
 
             lock (thisItems)
             {
-                lock (otherItems)
+                lock (newItems)
                 {
-                    thisItems.AddRange(otherItems);
+                    foreach (var newItem in newItems)
+                    {
+                        AddOrReplace(newItem.Key, newItem.Value);
+                    }
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -338,29 +338,6 @@ internal class Baggage : IDictionary<string, string>
     }
 
     /// <summary>
-    /// Adds the baggage items from <paramref name="baggage"/> to this baggage.
-    /// </summary>
-    public void Merge(Baggage? baggage)
-    {
-        if (baggage?.Count > 0)
-        {
-            var thisItems = EnsureListInitialized();
-            var newItems = baggage._items!;
-
-            lock (thisItems)
-            {
-                lock (newItems)
-                {
-                    foreach (var newItem in newItems)
-                    {
-                        AddOrReplace(newItem.Key, newItem.Value);
-                    }
-                }
-            }
-        }
-    }
-
-    /// <summary>
     /// Adds the baggage items from this baggage instance into <paramref name="destination"/>.
     /// </summary>
     public void MergeInto(Baggage destination)

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace;
 /// <summary>
 /// Baggage is a collection of name-value pairs that are propagated to downstream services.
 /// </summary>
-internal class Baggage : IDictionary<string, string>
+internal sealed class Baggage : IDictionary<string, string>
 {
     private static readonly AsyncLocal<Baggage> AsyncStorage = new();
 
@@ -33,7 +33,7 @@ internal class Baggage : IDictionary<string, string>
     /// Initializes a new instance of the <see cref="Baggage"/> class using the specified items.
     /// </summary>
     /// <param name="items">The baggage items.</param>
-    public Baggage(IEnumerable<KeyValuePair<string, string>> items)
+    public Baggage(IEnumerable<KeyValuePair<string, string>>? items)
     {
         if (items != null!)
         {

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -1,0 +1,360 @@
+﻿// <copyright file="Baggage.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+#nullable enable
+
+namespace Datadog.Trace;
+
+/// <summary>
+/// Baggage is a collection of name-value pairs that are propagated to downstream services.
+/// </summary>
+internal class Baggage : IDictionary<string, string>
+{
+    private static readonly AsyncLocal<Baggage> AsyncStorage = new();
+
+    private static readonly List<KeyValuePair<string, string>> EmptyList = [];
+
+    private List<KeyValuePair<string, string>>? _items;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Baggage"/> class.
+    /// </summary>
+    public Baggage()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Baggage"/> class using the specified items.
+    /// </summary>
+    /// <param name="items">The baggage items.</param>
+    public Baggage(IEnumerable<KeyValuePair<string, string>> items)
+    {
+        if (items != null!)
+        {
+            _items = [..items];
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the baggage collection for the current execution context.
+    /// </summary>
+    public static Baggage Current
+    {
+        get => AsyncStorage.Value ??= new Baggage();
+        set => AsyncStorage.Value = value;
+    }
+
+    /// <summary>
+    /// Gets the count of items in this baggage instance.
+    /// </summary>
+    public int Count => _items?.Count ?? 0;
+
+    bool ICollection<KeyValuePair<string, string>>.IsReadOnly => false;
+
+    ICollection<string> IDictionary<string, string>.Keys
+    {
+        get
+        {
+            if (_items is { Count: > 0 } items)
+            {
+                var keys = new string[items.Count];
+
+                for (int i = 0; i < items.Count; i++)
+                {
+                    keys[i] = items[i].Key;
+                }
+
+                return keys;
+            }
+
+            return [];
+        }
+    }
+
+    ICollection<string> IDictionary<string, string>.Values
+    {
+        get
+        {
+            if (_items is { Count: > 0 } items)
+            {
+                var values = new string[items.Count];
+
+                for (int i = 0; i < items.Count; i++)
+                {
+                    values[i] = items[i].Value;
+                }
+
+                return values;
+            }
+
+            return [];
+        }
+    }
+
+    public string this[string key]
+    {
+        get
+        {
+            if (TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            ThrowHelper.ThrowKeyNotFoundException($"The key was not found: {key}");
+            return default!; // unreachable
+        }
+
+        set
+        {
+            Set(key, value);
+        }
+    }
+
+    private static List<KeyValuePair<string, string>>.Enumerator GetEmptyEnumerator() => EmptyList.GetEnumerator();
+
+    private List<KeyValuePair<string, string>> EnsureListInitialized()
+    {
+        if (_items == null)
+        {
+            Interlocked.CompareExchange(ref _items, [], null);
+        }
+
+        return _items;
+    }
+
+    bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item)
+    {
+        if (item.Key == null!)
+        {
+            ThrowHelper.ThrowArgumentException("The key cannot be null.", nameof(item));
+        }
+
+        if (_items is { Count: > 0 } list)
+        {
+            lock (list)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    // match both key and value
+                    if (list[i].Key == item.Key && list[i].Value == item.Value)
+                    {
+                        list.RemoveAt(i);
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sets the baggage value associated with the specified name.
+    /// </summary>
+    /// <param name="key">The baggage item name.</param>
+    /// <param name="value">The baggage item value.</param>
+    public void Set(string key, string value)
+    {
+        var list = EnsureListInitialized();
+
+        lock (list)
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i].Key == key)
+                {
+                    // key found, replace with new value
+                    list[i] = new KeyValuePair<string, string>(key, value);
+                    return;
+                }
+            }
+
+            // key not found, add new entry
+            list.Add(new KeyValuePair<string, string>(key, value));
+        }
+    }
+
+    public bool TryGetValue(string key, out string value)
+    {
+        if (_items is { Count: > 0 } list)
+        {
+            lock (list)
+            {
+                foreach (var pair in list)
+                {
+                    if (pair.Key == key)
+                    {
+                        value = pair.Value!;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        value = default!;
+        return false;
+    }
+
+    bool IDictionary<string, string>.ContainsKey(string key)
+    {
+        if (_items is { Count: > 0 } items)
+        {
+            lock (items)
+            {
+                foreach (var item in items)
+                {
+                    if (item.Key == key)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public void Add(string key, string value)
+    {
+        var items = EnsureListInitialized();
+
+        lock (items)
+        {
+            foreach (var item in items)
+            {
+                if (item.Key == key)
+                {
+                    ThrowHelper.ThrowArgumentException("An element with the same key already exists.", nameof(key));
+                }
+            }
+
+            items.Add(new KeyValuePair<string, string>(key, value));
+        }
+    }
+
+    void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item)
+    {
+        Add(item.Key, item.Value);
+    }
+
+    /// <summary>
+    /// Removes the baggage value associated with the specified name.
+    /// </summary>
+    /// <param name="name">The baggage item name.</param>
+    /// <returns><c>true</c> if the object was removed successfully; otherwise, <c>false</c>.</returns>
+    public bool Remove(string name)
+    {
+        if (name == null!)
+        {
+            ThrowHelper.ThrowArgumentNullException(nameof(name));
+        }
+
+        if (_items is { Count: > 0 } list)
+        {
+            lock (list)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    if (list[i].Key == name)
+                    {
+                        list.RemoveAt(i);
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public bool Contains(KeyValuePair<string, string> item)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <summary>
+    /// Gets the baggage value associated with the specified name.
+    /// </summary>
+    /// <param name="name">The baggage item name.</param>
+    /// <returns>Returns the baggage item value, or <c>null</c> if not found.</returns>
+    public string? Get(string name)
+    {
+        if (name == null!)
+        {
+            ThrowHelper.ThrowArgumentNullException(nameof(name));
+        }
+
+        return TryGetValue(name, out var value) ? value : null;
+    }
+
+    /// <summary>
+    /// Gets all baggage values.
+    /// </summary>
+    /// <returns>A new array that contains all baggage values.</returns>
+    public KeyValuePair<string, string>[] GetAll()
+    {
+        if (_items is { } list)
+        {
+            lock (list)
+            {
+                if (list.Count > 0)
+                {
+                    return _items.ToArray();
+                }
+            }
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Removes all baggage items.
+    /// </summary>
+    public void Clear()
+    {
+        if (_items is { } list)
+        {
+            lock (list)
+            {
+                _items?.Clear();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds the baggage items from <paramref name="baggage"/> to this baggage.
+    /// </summary>
+    public void Merge(Baggage? baggage)
+    {
+        if (baggage?.Count > 0)
+        {
+            var thisItems = EnsureListInitialized();
+            var otherItems = baggage._items!;
+
+            lock (thisItems)
+            {
+                lock (otherItems)
+                {
+                    thisItems.AddRange(otherItems);
+                }
+            }
+        }
+    }
+
+    public List<KeyValuePair<string, string>>.Enumerator GetEnumerator() => _items?.GetEnumerator() ?? GetEmptyEnumerator();
+
+    IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -167,7 +167,7 @@ internal class Baggage : IDictionary<string, string>
         }
     }
 
-    internal static void AddOrReplace(List<KeyValuePair<string, string>> list, string key, string value)
+    private static void AddOrReplace(List<KeyValuePair<string, string>> list, string key, string value)
     {
         for (int i = 0; i < list.Count; i++)
         {
@@ -366,7 +366,7 @@ internal class Baggage : IDictionary<string, string>
         }
     }
 
-    public List<KeyValuePair<string, string>>.Enumerator GetEnumerator() => _items?.GetEnumerator() ?? EmptyList.GetEnumerator();
+    private List<KeyValuePair<string, string>>.Enumerator GetEnumerator() => _items?.GetEnumerator() ?? EmptyList.GetEnumerator();
 
     IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => GetEnumerator();
 

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -116,8 +116,6 @@ internal class Baggage : IDictionary<string, string>
         }
     }
 
-    private static List<KeyValuePair<string, string>>.Enumerator GetEmptyEnumerator() => EmptyList.GetEnumerator();
-
     private List<KeyValuePair<string, string>> EnsureListInitialized()
     {
         if (_items == null)
@@ -368,7 +366,7 @@ internal class Baggage : IDictionary<string, string>
         }
     }
 
-    public List<KeyValuePair<string, string>>.Enumerator GetEnumerator() => _items?.GetEnumerator() ?? GetEmptyEnumerator();
+    public List<KeyValuePair<string, string>>.Enumerator GetEnumerator() => _items?.GetEnumerator() ?? EmptyList.GetEnumerator();
 
     IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => GetEnumerator();
 

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -150,11 +150,11 @@ internal sealed class Baggage : IDictionary<string, string>
 
         lock (items)
         {
-            AddOrReplace(items, key, value);
+            AddOrReplaceInternal(items, key, value);
         }
     }
 
-    private static void AddOrReplace(List<KeyValuePair<string, string>> items, string key, string value)
+    private static void AddOrReplaceInternal(List<KeyValuePair<string, string>> items, string key, string value)
     {
         for (int i = 0; i < items.Count; i++)
         {
@@ -410,7 +410,7 @@ internal sealed class Baggage : IDictionary<string, string>
             {
                 foreach (var sourceItem in sourceItems)
                 {
-                    AddOrReplace(destinationItems, sourceItem.Key, sourceItem.Value);
+                    AddOrReplaceInternal(destinationItems, sourceItem.Key, sourceItem.Value);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -295,9 +295,39 @@ internal sealed class Baggage : IDictionary<string, string>
         return false;
     }
 
-    public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+    void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
     {
-        throw new System.NotImplementedException();
+        if (array == null!)
+        {
+            ThrowHelper.ThrowArgumentNullException(nameof(array));
+        }
+
+        if (arrayIndex < 0 || arrayIndex >= array.Length)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(arrayIndex));
+        }
+
+        // check if items fit into the array
+        if (array.Length - arrayIndex < Count)
+        {
+            ThrowHelper.ThrowArgumentException(
+                """
+                The number of elements in the source collection is greater than 
+                the available space from arrayIndex to the end of the destination array.
+                """);
+        }
+
+        if (_items is { Count: > 0 } list)
+        {
+            lock (list)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var item = list[i];
+                    array[arrayIndex + i] = item;
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -197,6 +197,25 @@ internal sealed class Baggage : IDictionary<string, string>
         return false;
     }
 
+    bool ICollection<KeyValuePair<string, string>>.Contains(KeyValuePair<string, string> item)
+    {
+        if (_items is { Count: > 0 } items)
+        {
+            lock (items)
+            {
+                foreach (var existingItem in items)
+                {
+                    if (existingItem.Key == item.Key && existingItem.Value == item.Value)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
     public void Add(string key, string value)
     {
         var items = EnsureListInitialized();
@@ -274,11 +293,6 @@ internal sealed class Baggage : IDictionary<string, string>
         }
 
         return false;
-    }
-
-    public bool Contains(KeyValuePair<string, string> item)
-    {
-        throw new System.NotImplementedException();
     }
 
     public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -302,26 +302,6 @@ internal class Baggage : IDictionary<string, string>
     }
 
     /// <summary>
-    /// Gets all baggage values.
-    /// </summary>
-    /// <returns>A new array that contains all baggage values.</returns>
-    public KeyValuePair<string, string>[] GetAllItems()
-    {
-        if (_items is { } list)
-        {
-            lock (list)
-            {
-                if (list.Count > 0)
-                {
-                    return _items.ToArray();
-                }
-            }
-        }
-
-        return [];
-    }
-
-    /// <summary>
     /// Removes all baggage items.
     /// </summary>
     public void Clear()

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -112,7 +112,7 @@ internal class Baggage : IDictionary<string, string>
 
         set
         {
-            Set(key, value);
+            AddOrReplace(key, value);
         }
     }
 
@@ -159,7 +159,7 @@ internal class Baggage : IDictionary<string, string>
     /// </summary>
     /// <param name="key">The baggage item name.</param>
     /// <param name="value">The baggage item value.</param>
-    public void Set(string key, string value)
+    public void AddOrReplace(string key, string value)
     {
         var list = EnsureListInitialized();
 
@@ -220,7 +220,7 @@ internal class Baggage : IDictionary<string, string>
         return false;
     }
 
-    public void Add(string key, string value)
+    void IDictionary<string, string>.Add(string key, string value)
     {
         var items = EnsureListInitialized();
 
@@ -240,7 +240,7 @@ internal class Baggage : IDictionary<string, string>
 
     void ICollection<KeyValuePair<string, string>>.Add(KeyValuePair<string, string> item)
     {
-        Add(item.Key, item.Value);
+        ((IDictionary<string, string>)this).Add(item.Key, item.Value);
     }
 
     /// <summary>
@@ -288,7 +288,7 @@ internal class Baggage : IDictionary<string, string>
     /// </summary>
     /// <param name="name">The baggage item name.</param>
     /// <returns>Returns the baggage item value, or <c>null</c> if not found.</returns>
-    public string? Get(string name)
+    public string? GetValueOrDefault(string name)
     {
         if (name == null!)
         {
@@ -302,7 +302,7 @@ internal class Baggage : IDictionary<string, string>
     /// Gets all baggage values.
     /// </summary>
     /// <returns>A new array that contains all baggage values.</returns>
-    public KeyValuePair<string, string>[] GetAll()
+    public KeyValuePair<string, string>[] GetAllItems()
     {
         if (_items is { } list)
         {

--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -126,32 +126,6 @@ internal sealed class Baggage : IDictionary<string, string>
         return _items;
     }
 
-    bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item)
-    {
-        if (item.Key == null!)
-        {
-            ThrowHelper.ThrowArgumentException("The key cannot be null.", nameof(item));
-        }
-
-        if (_items is { Count: > 0 } list)
-        {
-            lock (list)
-            {
-                for (int i = 0; i < list.Count; i++)
-                {
-                    // match both key and value
-                    if (list[i].Key == item.Key && list[i].Value == item.Value)
-                    {
-                        list.RemoveAt(i);
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
     /// <summary>
     /// Sets the baggage value associated with the specified name.
     /// </summary>
@@ -265,6 +239,32 @@ internal sealed class Baggage : IDictionary<string, string>
                 for (int i = 0; i < list.Count; i++)
                 {
                     if (list[i].Key == name)
+                    {
+                        list.RemoveAt(i);
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    bool ICollection<KeyValuePair<string, string>>.Remove(KeyValuePair<string, string> item)
+    {
+        if (item.Key == null!)
+        {
+            ThrowHelper.ThrowArgumentException("The key cannot be null.", nameof(item));
+        }
+
+        if (_items is { Count: > 0 } list)
+        {
+            lock (list)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    // match both key and value
+                    if (list[i].Key == item.Key && list[i].Value == item.Value)
                     {
                         list.RemoveAt(i);
                         return true;

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -130,10 +130,10 @@ public sealed class TestModule
 
             // Extract session variables (from out of process sessions)
             var environmentVariables = EnvironmentHelpers.GetEnvironmentVariables();
-            var sessionContext = SpanContextPropagator.Instance.Extract(
+            var context = SpanContextPropagator.Instance.Extract(
                 environmentVariables, new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
 
-            if (sessionContext is not null)
+            if (context.SpanContext is { } sessionContext)
             {
                 tags.SessionId = sessionContext.SpanId;
                 if (environmentVariables.TryGetValue<string>(TestSuiteVisibilityTags.TestSessionCommandEnvironmentVariable, out var testSessionCommand))

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -549,7 +549,7 @@ public sealed class TestSession
         };
 
         SpanContextPropagator.Instance.Inject(
-            span.Context,
+            new PropagationContext(span.Context, Baggage.Current),
             (IDictionary)environmentVariables,
             new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
         private const int MaxSizeBytes = 256 * 1024; // 256 KB
 
         // Loops through all entries of the EventBridge event and tries to inject Datadog context into each.
-        public static void InjectTracingContext<TPutEventsRequest>(TPutEventsRequest request, SpanContext context)
+        public static void InjectContext<TPutEventsRequest>(TPutEventsRequest request, PropagationContext context)
             where TPutEventsRequest : IPutEventsRequest, IDuckType
         {
             var entries = request.Entries.Value;
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
 
         // Tries to add Datadog trace context under the `_datadog` key at the top level of the `detail` field.
         // `detail` is a string, so we have to manually modify it using a StringBuilder.
-        private static void InjectHeadersIntoDetail(IPutEventsRequestEntry entry, SpanContext context)
+        private static void InjectHeadersIntoDetail(IPutEventsRequestEntry entry, PropagationContext context)
         {
             var detail = entry.Detail?.Trim() ?? "{}";
             if (!detail.EndsWith("}"))
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
                 detailBuilder.Append(','); // Add comma if the original detail is not empty
             }
 
-            var traceContext = BuildTraceContextJson(context, entry.EventBusName);
+            var traceContext = BuildContextJson(context, entry.EventBusName);
             detailBuilder.Append($"\"{DatadogKey}\":{traceContext}").Append('}');
 
             // Check new detail size
@@ -77,11 +77,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
         }
 
         // Builds a JSON string containing Datadog trace context
-        private static string BuildTraceContextJson(SpanContext context, string? eventBusName)
+        private static string BuildContextJson(PropagationContext context, string? eventBusName)
         {
             // Inject trace context
             var jsonBuilder = Util.StringBuilderCache.Acquire(Util.StringBuilderCache.MaxBuilderSize);
             jsonBuilder.Append('{');
+
             SpanContextPropagator.Instance.Inject(context, jsonBuilder, new StringBuilderCarrierSetter());
 
             // Inject start time and bus name

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge;
 
@@ -61,10 +62,8 @@ public class PutEventsAsyncIntegration
             }
         }
 
-        if (scope?.Span.Context is { } context)
-        {
-            ContextPropagation.InjectTracingContext(request, context);
-        }
+        var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+        ContextPropagation.InjectContext(request, context);
 
         return new CallTargetState(scope);
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
@@ -8,6 +8,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge;
 
@@ -58,10 +59,8 @@ public class PutEventsIntegration
             }
         }
 
-        if (scope?.Span.Context is { } context)
-        {
-            ContextPropagation.InjectTracingContext(request, context);
-        }
+        var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+        ContextPropagation.InjectContext(request, context);
 
         return new CallTargetState(scope);
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/ContextPropagation.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
         private const int MaxKinesisDataSize = 1024 * 1024; // 1MB
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ContextPropagation));
 
-        public static void InjectTraceIntoRecords<TRecordsRequest>(TRecordsRequest request, SpanContext context)
+        public static void InjectTraceIntoRecords<TRecordsRequest>(TRecordsRequest request, PropagationContext context)
             where TRecordsRequest : IPutRecordsRequest
         {
             // request.Records is not null and has at least one element
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
             }
         }
 
-        public static void InjectTraceIntoData<TRecordRequest>(TRecordRequest record, SpanContext context)
+        public static void InjectTraceIntoData<TRecordRequest>(TRecordRequest record, PropagationContext context)
             where TRecordRequest : IContainsData
         {
             if (record.Data is null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
 {
@@ -54,10 +55,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 tags.StreamName = request.StreamName;
             }
 
-            if (scope?.Span.Context != null)
-            {
-                ContextPropagation.InjectTraceIntoData(request, scope.Span.Context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectTraceIntoData(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
@@ -9,6 +9,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
 {
@@ -52,10 +53,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 tags.StreamName = request.StreamName;
             }
 
-            if (scope?.Span.Context != null)
-            {
-                ContextPropagation.InjectTraceIntoData(request, scope.Span.Context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectTraceIntoData(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
 {
@@ -54,10 +55,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 tags.StreamName = request.StreamName;
             }
 
-            if (scope?.Span.Context != null)
-            {
-                ContextPropagation.InjectTraceIntoRecords(request, scope.Span.Context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectTraceIntoRecords(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
@@ -9,6 +9,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
 {
@@ -52,10 +53,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 tags.StreamName = request.StreamName;
             }
 
-            if (scope?.Span.Context != null)
-            {
-                ContextPropagation.InjectTraceIntoRecords(request, scope.Span.Context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectTraceIntoRecords(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -25,8 +25,7 @@ internal abstract class LambdaCommon
 
     internal static Scope CreatePlaceholderScope(Tracer tracer, NameValueHeadersCollection headers)
     {
-        var context = SpanContextPropagator.Instance.Extract(headers);
-        Baggage.Current.Merge(context.Baggage);
+        var context = SpanContextPropagator.Instance.Extract(headers).MergeBaggageInto(Baggage.Current);
 
         var span = tracer.StartSpan(
             PlaceholderOperationName,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -25,10 +25,15 @@ internal abstract class LambdaCommon
 
     internal static Scope CreatePlaceholderScope(Tracer tracer, NameValueHeadersCollection headers)
     {
-        var spanContext = SpanContextPropagator.Instance.Extract(headers);
-        TelemetryFactory.Metrics.RecordCountSpanCreated(MetricTags.IntegrationName.AwsLambda);
+        var context = SpanContextPropagator.Instance.Extract(headers);
+        Baggage.Current.Merge(context.Baggage);
 
-        var span = spanContext != null ? tracer.StartSpan(PlaceholderOperationName, tags: null, parent: spanContext, serviceName: PlaceholderServiceName, addToTraceContext: false) : tracer.StartSpan(PlaceholderOperationName, tags: null, serviceName: PlaceholderServiceName, addToTraceContext: false);
+        var span = tracer.StartSpan(
+            PlaceholderOperationName,
+            tags: null,
+            parent: context.SpanContext,
+            serviceName: PlaceholderServiceName,
+            addToTraceContext: false);
 
         TelemetryFactory.Metrics.RecordCountSpanCreated(MetricTags.IntegrationName.AwsLambda);
         return tracer.TracerManager.ScopeManager.Activate(span, false);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/ContextPropagation.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
     {
         private const string SnsKey = "_datadog";
 
-        private static void Inject<TMessageRequest>(SpanContext context, IDictionary messageAttributes)
+        private static void Inject<TMessageRequest>(PropagationContext context, IDictionary messageAttributes)
         {
             // Consolidate headers into one JSON object with <header_name>:<value>
             var sb = Util.StringBuilderCache.Acquire(Util.StringBuilderCache.MaxBuilderSize);
@@ -35,7 +35,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             messageAttributes[SnsKey] = CachedMessageHeadersHelper<TMessageRequest>.CreateMessageAttributeValue(stream);
         }
 
-        public static void InjectHeadersIntoBatch<TClientMarker, TBatchRequest>(TBatchRequest request, SpanContext context)
+        public static void InjectHeadersIntoBatch<TClientMarker, TBatchRequest>(
+            TBatchRequest request,
+            PropagationContext context)
             where TBatchRequest : IPublishBatchRequest
         {
             // Skip adding Trace Context if entries don't exist or empty.
@@ -55,7 +57,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             }
         }
 
-        public static void InjectHeadersIntoMessage<TClientMarker, TMessageRequest>(TMessageRequest carrier, SpanContext context)
+        public static void InjectHeadersIntoMessage<TClientMarker, TMessageRequest>(
+            TMessageRequest carrier,
+            PropagationContext context)
             where TMessageRequest : IContainsMessageAttributes
         {
             // Skip adding Trace Context if there is no more space left to inject.

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
@@ -56,10 +57,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
                 tags.TopicName = AwsSnsCommon.GetTopicName(request.TopicArn);
             }
 
-            if (scope?.Span.Context is { } context)
-            {
-                ContextPropagation.InjectHeadersIntoMessage<TTarget, TPublishRequest>(request, context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectHeadersIntoMessage<TTarget, TPublishRequest>(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishBatchAsyncIntegration.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
@@ -56,10 +57,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
                 tags.TopicName = AwsSnsCommon.GetTopicName(request.TopicArn);
             }
 
-            if (scope?.Span.Context is { } context)
-            {
-                ContextPropagation.InjectHeadersIntoBatch<TTarget, TPublishBatchRequest>(request, context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectHeadersIntoBatch<TTarget, TPublishBatchRequest>(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishBatchIntegration.cs
@@ -9,6 +9,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
@@ -54,10 +55,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
                 tags.TopicName = AwsSnsCommon.GetTopicName(request.TopicArn);
             }
 
-            if (scope?.Span.Context is { } context)
-            {
-                ContextPropagation.InjectHeadersIntoBatch<TTarget, TPublishBatchRequest>(request, context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectHeadersIntoBatch<TTarget, TPublishBatchRequest>(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishIntegration.cs
@@ -9,6 +9,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
@@ -54,10 +55,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
                 tags.TopicName = AwsSnsCommon.GetTopicName(request.TopicArn);
             }
 
-            if (scope?.Span.Context is { } context)
-            {
-                ContextPropagation.InjectHeadersIntoMessage<TTarget, TPublishRequest>(request, context);
-            }
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            ContextPropagation.InjectHeadersIntoMessage<TTarget, TPublishRequest>(request, context);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
@@ -21,13 +21,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
     {
         internal const string SqsKey = "_datadog";
 
-        private static void Inject<TMessageRequest>(SpanContext context, IDictionary messageAttributes, DataStreamsManager? dataStreamsManager)
+        private static void Inject<TMessageRequest>(PropagationContext context, IDictionary messageAttributes, DataStreamsManager? dataStreamsManager)
         {
             // Consolidate headers into one JSON object with <header_name>:<value>
             var sb = Util.StringBuilderCache.Acquire(Util.StringBuilderCache.MaxBuilderSize);
             sb.Append('{');
             SpanContextPropagator.Instance.Inject(context, sb, default(StringBuilderCarrierSetter));
-            dataStreamsManager?.InjectPathwayContext(context.PathwayContext, AwsSqsHeadersAdapters.GetInjectionAdapter(sb));
+
+            if (context.SpanContext?.PathwayContext is { } pathwayContext)
+            {
+                dataStreamsManager?.InjectPathwayContext(pathwayContext, AwsSqsHeadersAdapters.GetInjectionAdapter(sb));
+            }
+
             sb.Remove(startIndex: sb.Length - 1, length: 1); // Remove trailing comma
             sb.Append('}');
 
@@ -79,7 +84,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             // Only inject if there's room
             if (carrier.MessageAttributes.Count < 10)
             {
-                Inject<TMessageRequest>(spanContext, carrier.MessageAttributes, dataStreamsManager);
+                var context = new PropagationContext(spanContext, Baggage.Current);
+                Inject<TMessageRequest>(context, carrier.MessageAttributes, dataStreamsManager);
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -137,9 +137,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         {
                             // extract propagated http headers
                             headers = httpContext.Request.Headers.Wrap();
-                            extractedContext = SpanContextPropagator.Instance.Extract(headers.Value);
-
-                            Baggage.Current.Merge(extractedContext.Baggage);
+                            extractedContext = SpanContextPropagator.Instance.Extract(headers.Value).MergeBaggageInto(Baggage.Current);
                         }
                         catch (Exception ex)
                         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
                 var tracer = Tracer.Instance;
                 var request = controllerContext.Request;
-                SpanContext propagatedContext = null;
+                PropagationContext extractedContext = default;
                 HttpHeadersCollection? headersCollection = null;
                 tags = new AspNetTags();
 
@@ -59,7 +59,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         // extract propagated http headers
                         var headers = request.Headers;
                         headersCollection = new HttpHeadersCollection(headers);
-                        propagatedContext = SpanContextPropagator.Instance.Extract(headersCollection.Value);
+                        extractedContext = SpanContextPropagator.Instance.Extract(headersCollection.Value);
+
+                        Baggage.Current.Merge(extractedContext.Baggage);
                     }
                     catch (Exception ex)
                     {
@@ -82,9 +84,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                                     tags);
                             }
                         }
-                        else if (request.Properties.ContainsKey(httpContextKey))
+                        else if (request.Properties.TryGetValue(httpContextKey, out var property))
                         {
-                            if (request.Properties[httpContextKey] is HttpContextWrapper objectCtx)
+                            if (property is HttpContextWrapper objectCtx)
                             {
                                 Headers.Ip.RequestIpExtractor.AddIpToTags(
                                     objectCtx.Request.UserHostAddress,
@@ -97,8 +99,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     }
                 }
 
-                scope = tracer.StartActiveInternal(OperationName, propagatedContext, tags: tags);
+                scope = tracer.StartActiveInternal(OperationName, extractedContext.SpanContext, tags: tags);
                 UpdateSpan(controllerContext, scope.Span, tags);
+
                 if (headersCollection is not null)
                 {
                     SpanContextPropagator.Instance.AddHeadersToSpanAsTags(scope.Span, headersCollection.Value, tracer.Settings.HeaderTagsInternal, SpanContextPropagator.HttpRequestHeadersTagPrefix, request.Headers.UserAgent.ToString());

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -57,11 +57,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     try
                     {
                         // extract propagated http headers
-                        var headers = request.Headers;
-                        headersCollection = new HttpHeadersCollection(headers);
-                        extractedContext = SpanContextPropagator.Instance.Extract(headersCollection.Value);
-
-                        Baggage.Current.Merge(extractedContext.Baggage);
+                        headersCollection = new HttpHeadersCollection(request.Headers);
+                        extractedContext = SpanContextPropagator.Instance.Extract(headersCollection.Value).MergeBaggageInto(Baggage.Current);
                     }
                     catch (Exception ex)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
             {
                 // Try to work out which trigger type it is
                 var triggerType = "Unknown";
-                SpanContext? spanContext = null;
+                PropagationContext extractedContext = default;
 #pragma warning disable CS8605 // Unboxing a possibly null value. This is a lie, that only affects .NET Core 3.1
                 foreach (DictionaryEntry entry in context.FunctionDefinition.InputBindings)
 #pragma warning restore CS8605 // Unboxing a possibly null value.
@@ -231,7 +231,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                     // e.g. Cosmos + ServiceBus, so we should handle those too
                     if (triggerType == "Http")
                     {
-                        spanContext = ExtractPropagatedContextFromHttp(context, entry.Key as string);
+                        extractedContext = ExtractPropagatedContextFromHttp(context, entry.Key as string);
+                        Baggage.Current.Merge(extractedContext.Baggage);
                     }
 
                     break;
@@ -250,7 +251,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                 {
                     // This is the root scope
                     tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: false);
-                    scope = tracer.StartActiveInternal(OperationName, tags: tags, parent: spanContext);
+                    scope = tracer.StartActiveInternal(OperationName, tags: tags, parent: extractedContext.SpanContext);
                 }
                 else
                 {
@@ -295,11 +296,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                 // in the GRPC http request representation, which is what we're doing here by overwriting all
                 // the existing datadog headers
                 var useNullableHeaders = !string.IsNullOrEmpty(useNullableHeadersCapability);
-                SpanContextPropagator.Instance.Inject(span.Context, new RpcHttpHeadersCollection<TTarget>(typedData.Http, useNullableHeaders));
+                var context = new PropagationContext(span.Context, Baggage.Current);
+                SpanContextPropagator.Instance.Inject(context, new RpcHttpHeadersCollection<TTarget>(typedData.Http, useNullableHeaders));
             }
         }
 
-        private static SpanContext? ExtractPropagatedContextFromHttp<T>(T context, string? bindingName)
+        private static PropagationContext ExtractPropagatedContextFromHttp<T>(T context, string? bindingName)
             where T : IFunctionContext
         {
             // Need to try and grab the headers from the context
@@ -309,7 +311,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
             // the suggested approach in the docs.
             if (context.Features is null || string.IsNullOrEmpty(bindingName))
             {
-                return null;
+                return default;
             }
 
             try
@@ -326,19 +328,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 
                 if (feature is null || !feature.TryDuckCast<FunctionBindingsFeatureStruct>(out var bindingFeature))
                 {
-                    return null;
+                    return default;
                 }
 
                 if (bindingFeature.InputData is null
                  || !bindingFeature.InputData.TryGetValue(bindingName!, out var requestDataObject)
                  || requestDataObject is null)
                 {
-                    return null;
+                    return default;
                 }
 
                 if (!requestDataObject.TryDuckCast<HttpRequestDataStruct>(out var httpRequest))
                 {
-                    return null;
+                    return default;
                 }
 
                 return SpanContextPropagator.Instance.Extract(new HttpHeadersCollection(httpRequest.Headers));
@@ -346,7 +348,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
             catch (Exception ex)
             {
                 Log.Error(ex, "Error extracting propagated HTTP context from Http binding");
-                return null;
+                return default;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -231,8 +231,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                     // e.g. Cosmos + ServiceBus, so we should handle those too
                     if (triggerType == "Http")
                     {
-                        extractedContext = ExtractPropagatedContextFromHttp(context, entry.Key as string);
-                        Baggage.Current.Merge(extractedContext.Baggage);
+                        extractedContext = ExtractPropagatedContextFromHttp(context, entry.Key as string).MergeBaggageInto(Baggage.Current);
                     }
 
                     break;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
@@ -35,8 +35,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
                 var tags = new GrpcServerTags();
                 GrpcCommon.AddGrpcTags(tags, tracer, method.GrpcType, name: method.Name, path: method.FullName, serviceName: method.ServiceName);
 
-                var extractedContext = ExtractPropagatedContext(requestMessage);
-                Baggage.Current.Merge(extractedContext.Baggage);
+                var extractedContext = ExtractPropagatedContext(requestMessage).MergeBaggageInto(Baggage.Current);
 
                 // If we have a local span (e.g. from aspnetcore) then use that as the parent
                 // Otherwise, use the distributed context as the parent

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
@@ -35,14 +35,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
                 var tags = new GrpcServerTags();
                 GrpcCommon.AddGrpcTags(tags, tracer, method.GrpcType, name: method.Name, path: method.FullName, serviceName: method.ServiceName);
 
+                var extractedContext = ExtractPropagatedContext(requestMessage);
+                Baggage.Current.Merge(extractedContext.Baggage);
+
                 // If we have a local span (e.g. from aspnetcore) then use that as the parent
                 // Otherwise, use the distributed context as the parent
-                var spanContext = tracer.ActiveScope?.Span.Context;
-                if (spanContext is null)
-                {
-                    spanContext = ExtractPropagatedContext(requestMessage);
-                }
-
+                var spanContext = tracer.ActiveScope?.Span.Context ?? extractedContext.SpanContext;
                 var serviceName = tracer.DefaultServiceName ?? "grpc-server";
                 string operationName = tracer.CurrentTraceSettings.Schema.Server.GetOperationNameForProtocol("grpc");
                 scope = tracer.StartActiveInternal(operationName, parent: spanContext, tags: tags, serviceName: serviceName);
@@ -60,14 +58,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
             return scope;
         }
 
-        private static SpanContext? ExtractPropagatedContext(HttpRequest request)
+        private static PropagationContext ExtractPropagatedContext(HttpRequest request)
         {
             try
             {
                 // extract propagation details from http headers
-                var requestHeaders = request.Headers;
-
-                if (requestHeaders != null)
+                if (request.Headers is { } requestHeaders)
                 {
                     return SpanContextPropagator.Instance.Extract(new HeadersCollectionAdapter(requestHeaders));
                 }
@@ -77,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
                 Log.Error(ex, "Error extracting propagated HTTP headers.");
             }
 
-            return null;
+            return default;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
@@ -55,7 +55,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcNetC
 
                 // add distributed tracing headers to the HTTP request
                 // These will be overwritten by the HttpClient integration if that is enabled, per the RFC
-                SpanContextPropagator.Instance.Inject(span.Context, new HttpHeadersCollection(requestMessage.Headers));
+                var context = new PropagationContext(span.Context, Baggage.Current);
+                SpanContextPropagator.Instance.Inject(context, new HttpHeadersCollection(requestMessage.Headers));
 
                 // Add the request metadata as tags
                 if (grpcCall.Options.Headers is { Count: > 0 })

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
@@ -9,11 +9,8 @@ using System.Runtime.CompilerServices;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client.DuckTypes;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
-using Datadog.Trace.Sampling;
-using Datadog.Trace.Tagging;
 using Datadog.Trace.Util.Http;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
@@ -42,7 +39,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
             {
                 // try extracting all the details we need
                 var requestMetadataWrapper = new MetadataHeadersCollection(requestMetadata);
-                var existingSpanContext = SpanContextPropagator.Instance.Extract(requestMetadataWrapper);
+                var existingContext = SpanContextPropagator.Instance.Extract(requestMetadataWrapper);
+                var existingSpanContext = existingContext.SpanContext;
 
                 // If this operation creates the trace, then we will need to re-apply the sampling priority
                 bool setSamplingPriority = existingSpanContext?.SamplingPriority != null && tracer.ActiveScope == null;
@@ -146,7 +144,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
                     parentContext: span.Context.ParentInternal);
 
                 // Add the propagation headers
-                SpanContextPropagator.Instance.Inject(span.Context, collection);
+                var context = new PropagationContext(span.Context, Baggage.Current);
+                SpanContextPropagator.Instance.Inject(context, collection);
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/GrpcLegacyServerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/GrpcLegacyServerCommon.cs
@@ -35,10 +35,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
 
                 if (spanContext is null)
                 {
-                    var extractedContext = ExtractPropagatedContext(metadata);
+                    var extractedContext = ExtractPropagatedContext(metadata).MergeBaggageInto(Baggage.Current);
                     spanContext = extractedContext.SpanContext;
-
-                    Baggage.Current.Merge(extractedContext.Baggage);
                 }
 
                 var serviceName = tracer.DefaultServiceName ?? "grpc-server";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/GrpcLegacyServerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/GrpcLegacyServerCommon.cs
@@ -6,7 +6,6 @@
 using System;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
@@ -33,9 +32,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
                 // If we have a local span (e.g. from aspnetcore) then use that as the parent
                 // Otherwise, use the distributed context as the parent
                 var spanContext = tracer.ActiveScope?.Span.Context;
+
                 if (spanContext is null)
                 {
-                    spanContext = ExtractPropagatedContext(metadata);
+                    var extractedContext = ExtractPropagatedContext(metadata);
+                    spanContext = extractedContext.SpanContext;
+
+                    Baggage.Current.Merge(extractedContext.Baggage);
                 }
 
                 var serviceName = tracer.DefaultServiceName ?? "grpc-server";
@@ -61,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
             return scope;
         }
 
-        private static SpanContext? ExtractPropagatedContext(IMetadata? metadata)
+        private static PropagationContext ExtractPropagatedContext(IMetadata? metadata)
         {
             try
             {
@@ -75,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
                 Log.Error(ex, "Error extracting propagated HTTP headers.");
             }
 
-            return null;
+            return default;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -8,9 +8,7 @@ using System.Linq;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Propagators;
-using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
 {
@@ -26,19 +24,29 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
 
             var tracer = Tracer.Instance;
             var headers = requestMessage.Headers;
-            if (IsTracingEnabled(headers, implementationIntegrationId) &&
-                ScopeFactory.CreateOutboundHttpScope(tracer, requestMessage.Method.Method, requestMessage.RequestUri, integrationId, out var tags) is { } scope)
+            Scope scope = null;
+
+            if (IsTracingEnabled(headers, implementationIntegrationId))
             {
-                tags.HttpClientHandlerType = instance.GetType().FullName;
+                scope = ScopeFactory.CreateOutboundHttpScope(
+                    tracer,
+                    requestMessage.Method.Method,
+                    requestMessage.RequestUri,
+                    integrationId,
+                    out var tags);
 
-                // add distributed tracing headers to the HTTP request
-                SpanContextPropagator.Instance.Inject(scope.Span.Context, new HttpHeadersCollection(headers));
-
-                tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(implementationIntegrationId ?? integrationId);
-                return new CallTargetState(scope);
+                if (scope is not null)
+                {
+                    tags.HttpClientHandlerType = instance.GetType().FullName;
+                    tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(implementationIntegrationId ?? integrationId);
+                }
             }
 
-            return CallTargetState.GetDefault();
+            // add propagation headers to the HTTP request
+            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+            SpanContextPropagator.Instance.Inject(context, new HttpHeadersCollection(headers));
+
+            return scope is null ? CallTargetState.GetDefault() : new CallTargetState(scope);
         }
 
         public static TResponse OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse responseMessage, Exception exception, in CallTargetState state)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
@@ -7,7 +7,6 @@ using System;
 using System.ComponentModel;
 using System.Net;
 using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
@@ -66,17 +65,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         startTime: null,
                         addToTraceContext: false);
 
-                    if (span?.Context != null)
-                    {
-                        // Add distributed tracing headers to the HTTP request.
-                        // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
-                        // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
-                        // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
-                        // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
-                        // added by us, not the application
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
-                        HeadersInjectedCache.SetInjectedHeaders(request.Headers);
-                    }
+                    // Add distributed tracing headers to the HTTP request.
+                    // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
+                    // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
+                    // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
+                    // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
+                    // added by us, not the application
+                    var context = new PropagationContext(span?.Context, Baggage.Current);
+                    SpanContextPropagator.Instance.Inject(context, request.Headers.Wrap());
+                    HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -7,7 +7,6 @@ using System;
 using System.ComponentModel;
 using System.Net;
 using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
@@ -60,16 +59,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         startTime: null,
                         addToTraceContext: false);
 
-                    if (span?.Context != null)
-                    {
-                        // Add distributed tracing headers to the HTTP request.
-                        // We don't want to set an active scope now, because it's possible that EndGetResponse will never be called.
-                        // Instead, we generate a spancontext and inject it in the headers. EndGetResponse will fetch them and create an active scope with the right id.
-                        // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
-                        // added by us, not the application
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
-                        HeadersInjectedCache.SetInjectedHeaders(request.Headers);
-                    }
+                    // Add distributed tracing headers to the HTTP request.
+                    // We don't want to set an active scope now, because it's possible that EndGetResponse will never be called.
+                    // Instead, we generate a spancontext and inject it in the headers. EndGetResponse will fetch them and create an active scope with the right id.
+                    // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
+                    // added by us, not the application
+                    var context = new PropagationContext(span?.Context, Baggage.Current);
+                    SpanContextPropagator.Instance.Inject(context, request.Headers.Wrap());
+                    HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -72,7 +72,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 if (HeadersInjectedCache.TryGetInjectedHeaders(request.Headers))
                 {
                     var headers = request.Headers.Wrap();
-                    existingContext = SpanContextPropagator.Instance.Extract(headers).MergeBaggageInto(Baggage.Current);
+
+                    // We are intentionally not merging any extracted baggage here into Baggage.Current:
+                    // We've already propagated baggage through the HTTP headers at this point,
+                    // and when this method is called this is presumably the "bottom" of the call chain,
+                    // and it may have been called on an entirely different thread.
+                    existingContext = SpanContextPropagator.Instance.Extract(headers);
                 }
 
                 var existingSpanContext = existingContext.SpanContext;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -68,11 +68,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 // Since it is possible for users to manually propagate headers (which we should
                 // overwrite), check our cache which will be populated with header objects
                 // that we have injected context into
-                SpanContext existingSpanContext = null;
+                PropagationContext existingContext = default;
                 if (HeadersInjectedCache.TryGetInjectedHeaders(request.Headers))
                 {
-                    existingSpanContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
+                    existingContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
+                    Baggage.Current.Merge(existingContext.Baggage);
                 }
+
+                var existingSpanContext = existingContext.SpanContext;
 
                 // If this operation creates the trace, then we need to re-apply the sampling priority
                 bool setSamplingPriority = existingSpanContext?.SamplingPriority != null && Tracer.Instance.ActiveScope == null;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -71,8 +71,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 PropagationContext existingContext = default;
                 if (HeadersInjectedCache.TryGetInjectedHeaders(request.Headers))
                 {
-                    existingContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
-                    Baggage.Current.Merge(existingContext.Baggage);
+                    var headers = request.Headers.Wrap();
+                    existingContext = SpanContextPropagator.Instance.Extract(headers).MergeBaggageInto(Baggage.Current);
                 }
 
                 var existingSpanContext = existingContext.SpanContext;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
@@ -61,17 +61,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         startTime: null,
                         addToTraceContext: false);
 
-                    if (span?.Context != null)
-                    {
-                        // Add distributed tracing headers to the HTTP request.
-                        // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
-                        // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
-                        // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
-                        // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
-                        // added by us, not the application
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
-                        HeadersInjectedCache.SetInjectedHeaders(request.Headers);
-                    }
+                    // Add distributed tracing headers to the HTTP request.
+                    // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
+                    // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
+                    // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
+                    // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
+                    // added by us, not the application
+                    var context = new PropagationContext(span?.Context, Baggage.Current);
+                    SpanContextPropagator.Instance.Inject(context, request.Headers.Wrap());
+                    HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -5,13 +5,9 @@
 
 using System;
 using System.Net;
-using System.Runtime.CompilerServices;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Propagators;
-using Datadog.Trace.Sampling;
-using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 {
@@ -46,15 +42,23 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 // Since it is possible for users to manually propagate headers (which we should
                 // overwrite), check our cache which will be populated with header objects
                 // that we have injected context into
-                SpanContext spanContext = null;
+                PropagationContext cachedContext = default;
+
                 if (HeadersInjectedCache.TryGetInjectedHeaders(request.Headers))
                 {
-                    spanContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
+                    cachedContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
+                    Baggage.Current.Merge(cachedContext.Baggage);
                 }
 
-                // If this operation creates the trace, then we need to re-apply the sampling priority
+                var cachedSpanContext = cachedContext.SpanContext;
                 var tracer = Tracer.Instance;
-                bool setSamplingPriority = spanContext?.SamplingPriority != null && tracer.ActiveScope == null;
+                int? cachedSamplingPriority = null;
+
+                // If this operation creates the trace, then we need to re-apply the sampling priority
+                if (tracer.ActiveScope == null)
+                {
+                    cachedSamplingPriority = cachedSpanContext?.SamplingPriority;
+                }
 
                 Scope scope = null;
 
@@ -66,21 +70,21 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         request.RequestUri,
                         IntegrationId,
                         out _,
-                        spanContext?.TraceId128 ?? TraceId.Zero,
-                        spanContext?.SpanId ?? 0);
+                        cachedSpanContext?.TraceId128 ?? TraceId.Zero,
+                        cachedSpanContext?.SpanId ?? 0);
 
                     if (scope != null)
                     {
-                        if (setSamplingPriority)
+                        if (cachedSamplingPriority is { } samplingPriority)
                         {
-                            scope.Span.Context.TraceContext.SetSamplingPriority(spanContext.SamplingPriority.Value);
+                            scope.Span.Context.TraceContext.SetSamplingPriority(samplingPriority);
                         }
 
-                        // add distributed tracing headers to the HTTP request
-                        SpanContextPropagator.Instance.Inject(scope.Span.Context, request.Headers.Wrap());
+                        // add propagation headers to the HTTP request
+                        var context = new PropagationContext(scope.Span.Context, Baggage.Current);
+                        SpanContextPropagator.Instance.Inject(context, request.Headers.Wrap());
 
                         tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
-
                         return new CallTargetState(scope);
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -46,8 +46,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                 if (HeadersInjectedCache.TryGetInjectedHeaders(request.Headers))
                 {
-                    cachedContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
-                    Baggage.Current.Merge(cachedContext.Baggage);
+                    var headers = request.Headers.Wrap();
+                    cachedContext = SpanContextPropagator.Instance.Extract(headers).MergeBaggageInto(Baggage.Current);
                 }
 
                 var cachedSpanContext = cachedContext.SpanContext;
@@ -82,7 +82,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                         // add propagation headers to the HTTP request
                         var context = new PropagationContext(scope.Span.Context, Baggage.Current);
-                        SpanContextPropagator.Instance.Inject(context, request.Headers.Wrap());
+                        var headers = request.Headers.Wrap();
+                        SpanContextPropagator.Instance.Inject(context, headers);
 
                         tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
                         return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHeadersAdapterNoop.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHeadersAdapterNoop.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Datadog.Trace.Headers;
 
@@ -15,11 +16,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.IbmMq;
 /// </summary>
 internal readonly struct IbmMqHeadersAdapterNoop : IHeadersCollection
 {
-    private static readonly string[] EmptyValue = [];
-
     public IEnumerable<string> GetValues(string name)
     {
-        return EmptyValue;
+        return [];
     }
 
     public void Set(string name, string value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHelper.cs
@@ -57,7 +57,8 @@ internal static class IbmMqHelper
             span.ResourceName = resourceName;
             span.SetTag(Tags.SpanKind, SpanKinds.Producer);
 
-            SpanContextPropagator.Instance.Inject(span.Context, GetHeadersAdapter(message));
+            var context = new PropagationContext(span.Context, Baggage.Current);
+            SpanContextPropagator.Instance.Inject(context, GetHeadersAdapter(message));
         }
         catch (Exception ex)
         {
@@ -92,11 +93,12 @@ internal static class IbmMqHelper
                 return null;
             }
 
-            SpanContext? propagatedContext = null;
+            PropagationContext extractedContext = default;
 
             try
             {
-                propagatedContext = SpanContextPropagator.Instance.Extract(GetHeadersAdapter(message));
+                extractedContext = SpanContextPropagator.Instance.Extract(GetHeadersAdapter(message));
+                Baggage.Current.Merge(extractedContext.Baggage);
             }
             catch (Exception ex)
             {
@@ -109,7 +111,7 @@ internal static class IbmMqHelper
             scope = tracer.StartActiveInternal(
                 operationName,
                 tags: tags,
-                parent: propagatedContext,
+                parent: extractedContext.SpanContext,
                 serviceName: serviceName,
                 finishOnClose: true,
                 startTime: spanStartTime);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -165,8 +165,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                     try
                     {
-                        extractedContext = SpanContextPropagator.Instance.Extract(headers);
-                        Baggage.Current.Merge(extractedContext.Baggage);
+                        extractedContext = SpanContextPropagator.Instance.Extract(headers).MergeBaggageInto(Baggage.Current);
                     }
                     catch (Exception ex)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -155,7 +155,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                     return null;
                 }
 
-                SpanContext? propagatedContext = null;
+                PropagationContext extractedContext = default;
                 PathwayContext? pathwayContext = null;
 
                 // Try to extract propagated context from headers
@@ -165,7 +165,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                     try
                     {
-                        propagatedContext = SpanContextPropagator.Instance.Extract(headers);
+                        extractedContext = SpanContextPropagator.Instance.Extract(headers);
+                        Baggage.Current.Merge(extractedContext.Baggage);
                     }
                     catch (Exception ex)
                     {
@@ -188,7 +189,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 var serviceName = tracer.CurrentTraceSettings.Schema.Messaging.GetServiceName(MessagingType);
                 var tags = tracer.CurrentTraceSettings.Schema.Messaging.CreateKafkaTags(SpanKinds.Consumer);
 
-                scope = tracer.StartActiveInternal(operationName, parent: propagatedContext, tags: tags, serviceName: serviceName);
+                scope = tracer.StartActiveInternal(operationName, parent: extractedContext.SpanContext, tags: tags, serviceName: serviceName);
                 tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(KafkaConstants.IntegrationId);
 
                 string resourceName = $"Consume Topic {(string.IsNullOrEmpty(topic) ? "kafka" : topic)}";
@@ -323,7 +324,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                 var adapter = new KafkaHeadersCollectionAdapter(message.Headers);
 
-                SpanContextPropagator.Instance.Inject(span.Context, adapter);
+                var context = new PropagationContext(span.Context, Baggage.Current);
+                SpanContextPropagator.Instance.Inject(context, adapter);
 
                 if (dataStreamsManager.IsEnabled)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/SpanContextHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/SpanContextHelper.cs
@@ -34,7 +34,7 @@ internal static class SpanContextHelper
     {
         var context = parent.DuckCast<ISpanContextProxy>();
         return new SpanContext(
-            new TraceId(Upper: 0, Lower: context.TraceId),
+            (TraceId)context.TraceId,
             context.SpanId,
             samplingPriority: null,
             context.ServiceName,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -79,8 +79,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                     {
                         basicProperties = basicGetResult.BasicProperties;
 
-                        extractedContext = SpanContextPropagator.Instance.Extract(basicPropertiesHeaders, default(ContextPropagation));
-                        Baggage.Current.Merge(extractedContext.Baggage);
+                        extractedContext = SpanContextPropagator.Instance.Extract(basicPropertiesHeaders, default(ContextPropagation)).MergeBaggageInto(Baggage.Current);
                     }
                     catch (Exception ex)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -79,7 +79,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                         basicProperties.Headers = new Dictionary<string, object>();
                     }
 
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
+                    var context = new PropagationContext(scope.Span.Context, Baggage.Current);
+                    SpanContextPropagator.Instance.Inject(context, basicProperties.Headers, default(ContextPropagation));
+
                     RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(
                         Tracer.Instance,
                         scope.Span,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
@@ -204,7 +204,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             {
                 try
                 {
-                    extractedContext = SpanContextPropagator.Instance.Extract(basicProperties.Headers, default(ContextPropagation));
+                    extractedContext = SpanContextPropagator.Instance
+                                                            .Extract(basicProperties.Headers, default(ContextPropagation))
+                                                            .MergeBaggageInto(Baggage.Current);
                 }
                 catch (Exception ex)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
@@ -32,7 +32,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.RabbitMQ;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RabbitMQIntegration));
 
-        internal static Scope? CreateScope(Tracer tracer, out RabbitMQTags? tags, string command, string spanKind, string? host = null, ISpanContext? parentContext = null, DateTimeOffset? startTime = null, string? queue = null, string? exchange = null, string? routingKey = null)
+        internal static Scope? CreateScope(
+            Tracer tracer,
+            out RabbitMQTags? tags,
+            string command,
+            string spanKind,
+            string? host = null,
+            PropagationContext context = default,
+            DateTimeOffset? startTime = null,
+            string? queue = null,
+            string? exchange = null,
+            string? routingKey = null)
         {
             tags = null;
 
@@ -49,7 +59,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 tags = tracer.CurrentTraceSettings.Schema.Messaging.CreateRabbitMqTags(spanKind);
                 var serviceName = tracer.CurrentTraceSettings.Schema.Messaging.GetServiceName(MessagingType);
                 var operation = GetOperationName(tracer, spanKind);
-                scope = tracer.StartActiveInternal(operation, parent: parentContext, tags: tags, serviceName: serviceName, startTime: startTime);
+
+                scope = tracer.StartActiveInternal(
+                    operation,
+                    parent: context.SpanContext,
+                    tags: tags,
+                    serviceName: serviceName,
+                    startTime: startTime);
+
                 var span = scope.Span;
 
                 span.Type = SpanTypes.Queue;
@@ -180,14 +197,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 queue = queueInner;
             }
 
-            SpanContext? propagatedContext = null;
+            PropagationContext extractedContext = default;
 
             // try to extract propagated context values from headers
             if (basicProperties?.Headers != null)
             {
                 try
                 {
-                    propagatedContext = SpanContextPropagator.Instance.Extract(basicProperties.Headers, default(ContextPropagation));
+                    extractedContext = SpanContextPropagator.Instance.Extract(basicProperties.Headers, default(ContextPropagation));
                 }
                 catch (Exception ex)
                 {
@@ -195,7 +212,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out var tags, "basic.deliver", parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, exchange: exchange, routingKey: routingKey);
+            var scope = CreateScope(
+                Tracer.Instance,
+                out var tags,
+                "basic.deliver",
+                context: extractedContext,
+                spanKind: SpanKinds.Consumer,
+                queue: queue,
+                exchange: exchange,
+                routingKey: routingKey);
+
             if (scope is not null && tags != null)
             {
                 if (body.Instance is not null)
@@ -204,7 +230,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
 
                 var timeInQueue = basicProperties != null && basicProperties.Timestamp.UnixTime != 0 ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - basicProperties.Timestamp.UnixTime : 0;
-                RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(
+                SetDataStreamsCheckpointOnConsume(
                     Tracer.Instance,
                     scope.Span,
                     tags,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessMessageIntegration.cs
@@ -66,7 +66,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
                     // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
                     // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
                     // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, requestHeaders, (headers, key, value) => headers[key] = value);
+                    var context = new PropagationContext(scope.Span.Context, Baggage.Current);
+                    SpanContextPropagator.Instance.Inject(context, requestHeaders, (headers, key, value) => headers[key] = value);
 
                     // "Disable" tracing so that the regular WebRequest instrumentation does not fire for this request
                     requestHeaders["x-datadog-tracing-enabled"] = "false";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/IpcTcpProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/IpcTcpProcessMessageIntegration.cs
@@ -59,7 +59,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
             var tracer = Tracer.Instance;
             if (tracer.Settings.IsIntegrationEnabled(RemotingIntegration.IntegrationId) && tracer.InternalActiveScope is var scope)
             {
-                SpanContextPropagator.Instance.Inject(scope.Span.Context, requestHeaders, (headers, key, value) => headers[key] = value);
+                var context = new PropagationContext(scope.Span.Context, Baggage.Current);
+                SpanContextPropagator.Instance.Inject(context, requestHeaders, (headers, key, value) => headers[key] = value);
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/RemotingIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/RemotingIntegration.cs
@@ -11,6 +11,7 @@ using System;
 using System.Runtime.Remoting.Messaging;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting
@@ -28,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RemotingIntegration));
 
-        internal static Scope? CreateServerScope(IMessage msg, SpanContext? spanContext)
+        internal static Scope? CreateServerScope(IMessage msg, PropagationContext context)
         {
             var tracer = Tracer.Instance;
 
@@ -43,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting
             try
             {
                 var tags = new RemotingServerTags();
-                scope = tracer.StartActiveInternal(ServerOperationName, parent: spanContext, tags: tags);
+                scope = tracer.StartActiveInternal(ServerOperationName, parent: context.SpanContext, tags: tags);
                 var span = scope.Span;
 
                 var methodMessage = msg as IMethodMessage;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Server/ProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Server/ProcessMessageIntegration.cs
@@ -72,15 +72,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Server
 
             try
             {
-                extractedContext = SpanContextPropagator.Instance.Extract(requestHeaders, (headers, key) =>
-                {
-                    var value = headers[key];
-                    return value is null ?
-                        [] :
-                        new[] { value.ToString() };
-                });
-
-                Baggage.Current.Merge(extractedContext.Baggage);
+                extractedContext = SpanContextPropagator.Instance
+                                                        .Extract(requestHeaders, (headers, key) => headers[key] is { } value ? [value.ToString()] : [])
+                                                        .MergeBaggageInto(Baggage.Current);
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Server/ProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Server/ProcessMessageIntegration.cs
@@ -68,23 +68,26 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Server
             }
 
             // Extract span context
-            SpanContext? propagatedContext = null;
+            PropagationContext extractedContext = default;
+
             try
             {
-                propagatedContext = SpanContextPropagator.Instance.Extract(requestHeaders, (headers, key) =>
+                extractedContext = SpanContextPropagator.Instance.Extract(requestHeaders, (headers, key) =>
                 {
                     var value = headers[key];
                     return value is null ?
-                        Array.Empty<string>() :
-                        new string[] { value.ToString() };
+                        [] :
+                        new[] { value.ToString() };
                 });
+
+                Baggage.Current.Merge(extractedContext.Baggage);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error extracting propagated headers.");
             }
 
-            var scope = RemotingIntegration.CreateServerScope(requestMsg, propagatedContext);
+            var scope = RemotingIntegration.CreateServerScope(requestMsg, extractedContext);
             return new CallTargetState(scope);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/CoverageGetCoverageResultIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/CoverageGetCoverageResultIntegration.cs
@@ -65,9 +65,11 @@ public class CoverageGetCoverageResultIntegration
             DotnetCommon.Log.Information("CoverageGetCoverageResult.Percentage: {Value}", percentage);
 
             // Extract session variables (from out of process sessions)
-            if (SpanContextPropagator.Instance.Extract(
-                    EnvironmentHelpers.GetEnvironmentVariables(),
-                    new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor)) is { } sessionContext)
+            var context = SpanContextPropagator.Instance.Extract(
+                EnvironmentHelpers.GetEnvironmentVariables(),
+                new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
+
+            if (context.SpanContext is { } sessionContext)
             {
                 try
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
@@ -53,9 +53,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
             }
 
             // Let's detect if we already have a session for this test process
-            if (SpanContextPropagator.Instance.Extract(
-                    EnvironmentHelpers.GetEnvironmentVariables(),
-                    new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor)) is not null)
+            var context = SpanContextPropagator.Instance.Extract(
+                EnvironmentHelpers.GetEnvironmentVariables(),
+                new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
+
+            if (context.SpanContext is not null)
             {
                 // Session found in the environment variables
                 // let's bail-out

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/ManagedVanguardStopIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/ManagedVanguardStopIntegration.cs
@@ -51,9 +51,11 @@ public class ManagedVanguardStopIntegration
                     DotnetCommon.Log.Information("MicrosoftCodeCoverage.Percentage: {Value}", percentage);
 
                     // Extract session variables (from out of process sessions)
-                    if (SpanContextPropagator.Instance.Extract(
-                            EnvironmentHelpers.GetEnvironmentVariables(),
-                            new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor)) is { } sessionContext)
+                    var context = SpanContextPropagator.Instance.Extract(
+                        EnvironmentHelpers.GetEnvironmentVariables(),
+                        new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
+
+                    if (context.SpanContext is { } sessionContext)
                     {
                         try
                         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
@@ -82,8 +82,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                         try
                         {
                             headers = webHeaderCollection.Wrap();
-                            extractedContext = SpanContextPropagator.Instance.Extract(headers.Value);
-                            Baggage.Current.Merge(extractedContext.Baggage);
+
+                            extractedContext = SpanContextPropagator.Instance
+                                                                    .Extract(headers.Value)
+                                                                    .MergeBaggageInto(Baggage.Current);
                         }
                         catch (Exception ex)
                         {
@@ -97,8 +99,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                     Log.Debug("Extracting from WCF headers if any as http headers hadn't been found.");
                     try
                     {
-                        extractedContext = SpanContextPropagator.Instance.Extract(messageHeaders, GetHeaderValues);
-                        Baggage.Current.Merge(extractedContext.Baggage);
+                        extractedContext = SpanContextPropagator.Instance
+                                                                .Extract(messageHeaders, GetHeaderValues)
+                                                                .MergeBaggageInto(Baggage.Current);
 
                         static IEnumerable<string?> GetHeaderValues(IMessageHeaders headers, string name)
                         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -54,7 +54,8 @@ namespace Datadog.Trace.ClrProfiler
                 return spanContext;
             }
 
-            return SpanContextPropagator.Instance.Extract(value);
+            var context = SpanContextPropagator.Instance.Extract(value);
+            return context.SpanContext;
         }
 
         void IDistributedTracer.SetSpanContext(IReadOnlyDictionary<string, string> value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -72,7 +72,8 @@ namespace Datadog.Trace.ClrProfiler
             }
             else
             {
-                return SpanContextPropagator.Instance.Extract(values);
+                var context = SpanContextPropagator.Instance.Extract(values);
+                return context.SpanContext;
             }
         }
 

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -59,11 +59,9 @@ namespace Datadog.Trace.PlatformHelpers
             try
             {
                 // extract propagation details from http headers
-                var requestHeaders = request.Headers;
-
-                if (requestHeaders != null)
+                if (request.Headers is { } headers)
                 {
-                    return SpanContextPropagator.Instance.Extract(new HeadersCollectionAdapter(requestHeaders));
+                    return SpanContextPropagator.Instance.Extract(new HeadersCollectionAdapter(headers));
                 }
             }
             catch (Exception ex)
@@ -76,17 +74,20 @@ namespace Datadog.Trace.PlatformHelpers
 
         private void AddHeaderTagsToSpan(ISpan span, HttpRequest request, Tracer tracer)
         {
-            var settings = tracer.Settings;
+            var headerTagsInternal = tracer.Settings.HeaderTagsInternal;
 
-            if (!settings.HeaderTagsInternal.IsNullOrEmpty())
+            if (!headerTagsInternal.IsNullOrEmpty())
             {
                 try
                 {
                     // extract propagation details from http headers
-                    var requestHeaders = request.Headers;
-                    if (requestHeaders != null)
+                    if (request.Headers is { } requestHeaders)
                     {
-                        SpanContextPropagator.Instance.AddHeadersToSpanAsTags(span, new HeadersCollectionAdapter(requestHeaders), settings.HeaderTagsInternal, defaultTagPrefix: SpanContextPropagator.HttpRequestHeadersTagPrefix);
+                        SpanContextPropagator.Instance.AddHeadersToSpanAsTags(
+                            span,
+                            new HeadersCollectionAdapter(requestHeaders),
+                            headerTagsInternal,
+                            defaultTagPrefix: SpanContextPropagator.HttpRequestHeadersTagPrefix);
                     }
                 }
                 catch (Exception ex)

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -106,8 +106,7 @@ namespace Datadog.Trace.PlatformHelpers
             var userAgent = request.Headers[HttpHeaderNames.UserAgent];
             resourceName ??= GetDefaultResourceName(request);
 
-            var extractedContext = ExtractPropagatedContext(request);
-            Baggage.Current.Merge(extractedContext.Baggage);
+            var extractedContext = ExtractPropagatedContext(request).MergeBaggageInto(Baggage.Current);
 
             var routeTemplateResourceNames = tracer.Settings.RouteTemplateResourceNamesEnabled;
             var tags = routeTemplateResourceNames ? new AspNetCoreEndpointTags() : new AspNetCoreTags();

--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -37,21 +37,28 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
-        public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
+        public void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
+            if (context.SpanContext is not { } spanContext)
+            {
+                // nothing to inject
+                return;
+            }
+
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleInjected(MetricTags.ContextHeaderStyle.B3Multi);
-            CreateHeaders(context, out var traceId, out var spanId, out var sampled);
+
+            CreateHeaders(spanContext, out var traceId, out var spanId, out var sampled);
 
             carrierSetter.Set(carrier, TraceId, traceId);
             carrierSetter.Set(carrier, SpanId, spanId);
             carrierSetter.Set(carrier, Sampled, sampled);
         }
 
-        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
+        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out PropagationContext context)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {
-            spanContext = null;
+            context = default;
 
             var rawTraceId = ParseUtility.ParseString(carrier, carrierGetter, TraceId)?.Trim();
 
@@ -67,9 +74,11 @@ namespace Datadog.Trace.Propagators
                 return false;
             }
 
-            TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.B3Multi);
             var samplingPriority = ParseUtility.ParseInt32(carrier, carrierGetter, Sampled);
-            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId, isRemote: true);
+            var spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId, isRemote: true);
+            context = new PropagationContext(spanContext, baggage: null);
+
+            TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.B3Multi);
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -35,6 +35,8 @@ namespace Datadog.Trace.Propagators
         {
         }
 
+        public PropagatorType PropagatorType => PropagatorType.TraceContext;
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -27,18 +27,24 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
-        public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
+        public void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
+            if (context.SpanContext is not { } spanContext)
+            {
+                // nothing to inject
+                return;
+            }
+
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleInjected(MetricTags.ContextHeaderStyle.B3SingleHeader);
-            var header = CreateHeader(context);
+            var header = CreateHeader(spanContext);
             carrierSetter.Set(carrier, B3, header);
         }
 
-        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
+        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out PropagationContext context)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {
-            spanContext = null;
+            context = default;
 
             var brValue = ParseUtility.ParseString(carrier, carrierGetter, B3)?.Trim();
             if (!string.IsNullOrEmpty(brValue))
@@ -91,7 +97,7 @@ namespace Datadog.Trace.Propagators
                 }
 
                 var samplingPriority = rawSampled == '1' ? 1 : 0;
-                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId.ToString(), rawSpanId.ToString(), isRemote: true);
+                var spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId.ToString(), rawSpanId.ToString(), isRemote: true);
 #else
                 string? rawTraceId;
                 string? rawSpanId;
@@ -129,8 +135,10 @@ namespace Datadog.Trace.Propagators
                 }
 
                 var samplingPriority = rawSampled == '1' ? 1 : 0;
-                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId, isRemote: true);
+                var spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId, isRemote: true);
 #endif
+
+                context = new PropagationContext(spanContext, baggage: null);
 
                 TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.B3SingleHeader);
                 return true;

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -25,6 +25,8 @@ namespace Datadog.Trace.Propagators
         {
         }
 
+        public PropagatorType PropagatorType => PropagatorType.TraceContext;
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/ContextPropagationHeaderStyle.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ContextPropagationHeaderStyle.cs
@@ -5,8 +5,6 @@
 
 #nullable enable
 
-using Datadog.Trace.Configuration;
-
 namespace Datadog.Trace.Propagators;
 
 /// <summary>

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -21,6 +21,8 @@ namespace Datadog.Trace.Propagators
         {
         }
 
+        public PropagatorType PropagatorType => PropagatorType.TraceContext;
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -23,38 +23,44 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
-        public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
+        public void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
+            if (context.SpanContext is not { } spanContext)
+            {
+                // nothing to inject
+                return;
+            }
+
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleInjected(MetricTags.ContextHeaderStyle.Datadog);
             var invariantCulture = CultureInfo.InvariantCulture;
 
             // x-datadog-trace-id only supports 64-bit trace ids, truncate by using TraceId128.Lower
-            carrierSetter.Set(carrier, HttpHeaderNames.TraceId, context.TraceId128.Lower.ToString(invariantCulture));
-            carrierSetter.Set(carrier, HttpHeaderNames.ParentId, context.SpanId.ToString(invariantCulture));
+            carrierSetter.Set(carrier, HttpHeaderNames.TraceId, spanContext.TraceId128.Lower.ToString(invariantCulture));
+            carrierSetter.Set(carrier, HttpHeaderNames.ParentId, spanContext.SpanId.ToString(invariantCulture));
 
-            if (!string.IsNullOrEmpty(context.Origin))
+            if (!string.IsNullOrEmpty(spanContext.Origin))
             {
-                carrierSetter.Set(carrier, HttpHeaderNames.Origin, context.Origin!);
+                carrierSetter.Set(carrier, HttpHeaderNames.Origin, spanContext.Origin!);
             }
 
-            if (context.GetOrMakeSamplingDecision() is { } samplingPriority)
+            if (spanContext.GetOrMakeSamplingDecision() is { } samplingPriority)
             {
                 var samplingPriorityString = SamplingPriorityValues.ToString(samplingPriority);
                 carrierSetter.Set(carrier, HttpHeaderNames.SamplingPriority, samplingPriorityString);
             }
 
-            var propagatedTagsHeader = context.PrepareTagsHeaderForPropagation();
+            var propagatedTagsHeader = spanContext.PrepareTagsHeaderForPropagation();
             if (!string.IsNullOrEmpty(propagatedTagsHeader))
             {
                 carrierSetter.Set(carrier, HttpHeaderNames.PropagatedTags, propagatedTagsHeader!);
             }
         }
 
-        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
+        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out PropagationContext context)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {
-            spanContext = null;
+            context = default;
 
             var traceIdLower = ParseUtility.ParseUInt64(carrier, carrierGetter, HttpHeaderNames.TraceId);
 
@@ -75,10 +81,12 @@ namespace Datadog.Trace.Propagators
             // and the upper 64 bits in "_dd.p.tid"
             var traceId = GetFullTraceId((ulong)traceIdLower, traceTags);
 
-            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, isRemote: true)
-                          {
-                              PropagatedTags = traceTags,
-                          };
+            var spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, isRemote: true)
+                              {
+                                  PropagatedTags = traceTags,
+                              };
+
+            context = new PropagationContext(spanContext, baggage: null);
 
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.Datadog);
             return true;

--- a/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
@@ -19,6 +19,8 @@ namespace Datadog.Trace.Propagators
         {
         }
 
+        public PropagatorType PropagatorType => PropagatorType.TraceContext;
+
         public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
@@ -21,10 +21,10 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
-        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
+        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out PropagationContext context)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {
-            spanContext = null;
+            context = default;
 
             if (carrier is not IReadOnlyDictionary<string, string?>)
             {
@@ -61,12 +61,13 @@ namespace Datadog.Trace.Propagators
             }
 
             // we don't consider contexts coming from this as "remote" as it could be from a version conflict scenario
-            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, rawTraceId, rawSpanId, isRemote: false)
-                          {
-                              PropagatedTags = traceTags,
-                              AdditionalW3CTraceState = w3CTraceState,
-                          };
+            var spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, rawTraceId, rawSpanId, isRemote: false)
+                              {
+                                  PropagatedTags = traceTags,
+                                  AdditionalW3CTraceState = w3CTraceState,
+                              };
 
+            context = new PropagationContext(spanContext, baggage: null);
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Propagators/IContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/IContextExtractor.cs
@@ -7,16 +7,17 @@
 
 using System.Collections.Generic;
 
-namespace Datadog.Trace.Propagators
-{
-    internal interface IContextExtractor
-    {
-        bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
-            where TCarrierGetter : struct, ICarrierGetter<TCarrier>;
-    }
+namespace Datadog.Trace.Propagators;
 
-    internal interface ICarrierGetter<in TCarrier>
-    {
-        IEnumerable<string?> Get(TCarrier carrier, string key);
-    }
+internal interface IContextExtractor
+{
+    PropagatorType PropagatorType { get; }
+
+    bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? context)
+        where TCarrierGetter : struct, ICarrierGetter<TCarrier>;
+}
+
+internal interface ICarrierGetter<in TCarrier>
+{
+    IEnumerable<string?> Get(TCarrier carrier, string key);
 }

--- a/tracer/src/Datadog.Trace/Propagators/IContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/IContextExtractor.cs
@@ -13,7 +13,7 @@ internal interface IContextExtractor
 {
     PropagatorType PropagatorType { get; }
 
-    bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? context)
+    bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out PropagationContext context)
         where TCarrierGetter : struct, ICarrierGetter<TCarrier>;
 }
 

--- a/tracer/src/Datadog.Trace/Propagators/IContextInjector.cs
+++ b/tracer/src/Datadog.Trace/Propagators/IContextInjector.cs
@@ -11,7 +11,7 @@ internal interface IContextInjector
 {
     PropagatorType PropagatorType { get; }
 
-    void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
+    void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
         where TCarrierSetter : struct, ICarrierSetter<TCarrier>;
 }
 

--- a/tracer/src/Datadog.Trace/Propagators/IContextInjector.cs
+++ b/tracer/src/Datadog.Trace/Propagators/IContextInjector.cs
@@ -5,16 +5,17 @@
 
 #nullable enable
 
-namespace Datadog.Trace.Propagators
-{
-    internal interface IContextInjector
-    {
-        void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
-            where TCarrierSetter : struct, ICarrierSetter<TCarrier>;
-    }
+namespace Datadog.Trace.Propagators;
 
-    internal interface ICarrierSetter<in TCarrier>
-    {
-        void Set(TCarrier carrier, string key, string value);
-    }
+internal interface IContextInjector
+{
+    PropagatorType PropagatorType { get; }
+
+    void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
+        where TCarrierSetter : struct, ICarrierSetter<TCarrier>;
+}
+
+internal interface ICarrierSetter<in TCarrier>
+{
+    void Set(TCarrier carrier, string key, string value);
 }

--- a/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
+++ b/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="PropagationContext.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Propagators;
+
+internal readonly struct PropagationContext
+{
+    public readonly SpanContext? SpanContext;
+
+    public readonly Baggage? Baggage;
+
+    public PropagationContext(SpanContext? spanContext, Baggage? baggage)
+    {
+        SpanContext = spanContext;
+        Baggage = baggage;
+    }
+
+    public bool IsEmpty => SpanContext is null && Baggage is null;
+}

--- a/tracer/src/Datadog.Trace/Propagators/PropagationContextExtensions.cs
+++ b/tracer/src/Datadog.Trace/Propagators/PropagationContextExtensions.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="PropagationContextExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Propagators;
+
+internal static class PropagationContextExtensions
+{
+    public static PropagationContext MergeBaggageInto(this PropagationContext context, Baggage destination)
+    {
+        context.Baggage?.MergeInto(destination);
+        return context;
+    }
+}

--- a/tracer/src/Datadog.Trace/Propagators/PropagatorType.cs
+++ b/tracer/src/Datadog.Trace/Propagators/PropagatorType.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="PropagatorType.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Propagators;
+
+#nullable enable
+
+internal enum PropagatorType
+{
+    Undefined = 0,
+
+    /// <summary>
+    /// A propagator that extracts and injects trace context as <see cref="Datadog.Trace.SpanContext"/>.
+    /// </summary>
+    TraceContext,
+
+    /// <summary>
+    /// A propagator that extracts and injects baggage as <see cref="Datadog.Trace.Baggage"/>.
+    /// </summary>
+    Baggage,
+}

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -9,9 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
-using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 
@@ -30,11 +28,14 @@ namespace Datadog.Trace.Propagators
         private readonly IContextExtractor[] _extractors;
         private readonly bool _propagationExtractFirstOnly;
 
-        internal SpanContextPropagator(IEnumerable<IContextInjector>? injectors, IEnumerable<IContextExtractor>? extractors, bool propagationExtractFirsValue)
+        internal SpanContextPropagator(
+            IEnumerable<IContextInjector>? injectors,
+            IEnumerable<IContextExtractor>? extractors,
+            bool propagationExtractFirstValue)
         {
-            _propagationExtractFirstOnly = propagationExtractFirsValue;
-            _injectors = injectors?.ToArray() ?? Array.Empty<IContextInjector>();
-            _extractors = extractors?.ToArray() ?? Array.Empty<IContextExtractor>();
+            _propagationExtractFirstOnly = propagationExtractFirstValue;
+            _injectors = injectors?.ToArray() ?? [];
+            _extractors = extractors?.ToArray() ?? [];
         }
 
         public static SpanContextPropagator Instance
@@ -54,13 +55,9 @@ namespace Datadog.Trace.Propagators
                     }
 
                     _instance = new SpanContextPropagator(
-                        new IContextInjector[] { DatadogContextPropagator.Instance },
-                        new IContextExtractor[]
-                        {
-                            DistributedContextExtractor.Instance,
-                            DatadogContextPropagator.Instance
-                        },
-                        false);
+                        [DatadogContextPropagator.Instance],
+                        [DistributedContextExtractor.Instance, DatadogContextPropagator.Instance],
+                        propagationExtractFirstValue: false);
 
                     return _instance;
                 }
@@ -87,47 +84,54 @@ namespace Datadog.Trace.Propagators
         /// <param name="context">A <see cref="SpanContext"/> value that will be propagated into <paramref name="headers"/>.</param>
         /// <param name="headers">A <see cref="IHeadersCollection"/> to add new headers to.</param>
         /// <typeparam name="TCarrier">Type of header collection</typeparam>
-        public void Inject<TCarrier>(SpanContext context, TCarrier headers)
+        public void Inject<TCarrier>(PropagationContext context, TCarrier headers)
             where TCarrier : IHeadersCollection
         {
             Inject(context, headers, default(HeadersCollectionGetterAndSetter<TCarrier>));
         }
 
         /// <summary>
-        /// Propagates the specified context by adding new headers to a <see cref="IHeadersCollection"/>.
-        /// This locks the sampling priority for <paramref name="context"/>.
+        /// Propagates the specified context by adding new headers to a <paramref name="carrier"/>.
         /// </summary>
-        /// <param name="context">A <see cref="SpanContext"/> value that will be propagated into <paramref name="carrier"/>.</param>
+        /// <param name="context">A <see cref="PropagationContext"/> with values that will be propagated into <paramref name="carrier"/>.</param>
         /// <param name="carrier">The headers to add to.</param>
         /// <param name="setter">The action that can set a header in the carrier.</param>
-        /// <typeparam name="TCarrier">Type of header collection</typeparam>
-        public void Inject<TCarrier>(SpanContext context, TCarrier carrier, Action<TCarrier, string, string> setter)
+        /// <typeparam name="TCarrier">Type of header collection.</typeparam>
+        public void Inject<TCarrier>(PropagationContext context, TCarrier carrier, Action<TCarrier, string, string> setter)
         {
-            if (context == null!) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
             if (setter == null!) { ThrowHelper.ThrowArgumentNullException(nameof(setter)); }
 
             Inject(context, carrier, new ActionSetter<TCarrier>(setter));
         }
 
-        internal void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
+        internal void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
-            if (context == null!) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
 
-            // If appsec standalone is enabled and appsec propagation is disabled (no ASM events) -> stop propagation
-            if (context.TraceContext?.Tracer.Settings?.AppsecStandaloneEnabledInternal == true && context.TraceContext.Tags.GetTag(Tags.Propagated.AppSec) != "1")
+            if (context.IsEmpty)
             {
+                // nothing to inject
                 return;
             }
 
-            // trigger a sampling decision if it hasn't happened yet
-            _ = context.GetOrMakeSamplingDecision();
-
-            for (var i = 0; i < _injectors.Length; i++)
+            if (context.SpanContext is { } spanContext)
             {
-                _injectors[i].Inject(context, carrier, carrierSetter);
+                // If appsec standalone is enabled and appsec propagation is disabled (no ASM events) -> stop propagation
+                if (spanContext.TraceContext is { Tracer.Settings.AppsecStandaloneEnabledInternal: true } trace &&
+                    trace.Tags.GetTag(Tags.Propagated.AppSec) != "1")
+                {
+                    return;
+                }
+
+                // trigger a sampling decision if it hasn't happened yet
+                _ = spanContext.GetOrMakeSamplingDecision();
+            }
+
+            foreach (var injector in _injectors)
+            {
+                injector.Inject(context, carrier, carrierSetter);
             }
         }
 
@@ -137,7 +141,7 @@ namespace Datadog.Trace.Propagators
         /// <param name="headers">The headers that contain the values to be extracted.</param>
         /// <typeparam name="TCarrier">Type of header collection</typeparam>
         /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="headers"/>.</returns>
-        public SpanContext? Extract<TCarrier>(TCarrier headers)
+        public PropagationContext Extract<TCarrier>(TCarrier headers)
             where TCarrier : IHeadersCollection
         {
             return Extract(headers, default(HeadersCollectionGetterAndSetter<TCarrier>));
@@ -150,7 +154,7 @@ namespace Datadog.Trace.Propagators
         /// <param name="getter">The function that can extract a list of values for a given header name.</param>
         /// <typeparam name="TCarrier">Type of header collection</typeparam>
         /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="carrier"/>.</returns>
-        public SpanContext? Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
+        public PropagationContext Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
         {
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
             if (getter == null!) { ThrowHelper.ThrowArgumentNullException(nameof(getter)); }
@@ -158,68 +162,93 @@ namespace Datadog.Trace.Propagators
             return Extract(carrier, new FuncGetter<TCarrier>(getter));
         }
 
-        internal SpanContext? Extract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter)
+        internal PropagationContext Extract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {
             if (carrier is null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
 
-            SpanContext? localSpanContext = null;
+            // as we extract values from the carrier using multiple extractors,
+            // we will accumulate them in this context
+            SpanContext? cumulativeSpanContext = null;
+            Baggage? cumulativeBaggage = null;
 
-            for (var i = 0; i < _extractors.Length; i++)
+            foreach (var extractor in _extractors)
             {
-                if (_extractors[i].TryExtract(carrier, carrierGetter, out var spanContext))
+                if (_propagationExtractFirstOnly &&
+                    cumulativeSpanContext is not null &&
+                    extractor.PropagatorType == PropagatorType.TraceContext)
                 {
-                    if (_propagationExtractFirstOnly)
-                    {
-                        return spanContext;
-                    }
+                    // skip this extractor if
+                    // - we are configured to extract only the first trace context (aka SpanContext)
+                    // - we already extracted trace context
+                    // - this extractor is a trace context extractor
+                    continue;
+                }
 
-                    if (localSpanContext is not null && spanContext is not null && _extractors[i] is W3CTraceContextPropagator)
-                    {
-                        if (localSpanContext.RawTraceId == spanContext.RawTraceId)
-                        {
-                            localSpanContext.AdditionalW3CTraceState += spanContext.AdditionalW3CTraceState;
+                if (!extractor.TryExtract(carrier, carrierGetter, out var currentExtractedContext))
+                {
+                    // extractor failed to extract
+                    continue;
+                }
 
-                            if (localSpanContext.RawSpanId != spanContext.RawSpanId)
-                            {
-                                if (!string.IsNullOrEmpty(spanContext.LastParentId) && spanContext.LastParentId != W3CTraceContextPropagator.ZeroLastParent)
-                                {
-                                    localSpanContext.LastParentId = spanContext.LastParentId;
-                                }
-                                else
-                                {
-                                    localSpanContext.LastParentId = HexString.ToHexString(localSpanContext.SpanId);
-                                }
+                if (cumulativeBaggage is null)
+                {
+                    cumulativeBaggage = currentExtractedContext.Baggage;
+                }
+                else if (currentExtractedContext.Baggage is { Count: > 0 } extractedBaggage)
+                {
+                    cumulativeBaggage.Merge(extractedBaggage);
+                }
 
-                                localSpanContext.SpanId = spanContext.SpanId;
-                                localSpanContext.RawSpanId = spanContext.RawSpanId;
-                            }
-                        }
-                    }
-
-                    if (localSpanContext is null)
-                    {
-                        localSpanContext = spanContext;
-                    }
+                if (cumulativeSpanContext == null)
+                {
+                    cumulativeSpanContext = currentExtractedContext.SpanContext;
+                }
+                else if (extractor is W3CTraceContextPropagator && currentExtractedContext.SpanContext is { } extractedSpanContext)
+                {
+                    FixUpSpanContext(cumulativeSpanContext, extractedSpanContext);
                 }
             }
 
-            return localSpanContext;
+            return new PropagationContext(cumulativeSpanContext, cumulativeBaggage);
+        }
+
+        private static void FixUpSpanContext(SpanContext cumulativeSpanContext, SpanContext extractedSpanContext)
+        {
+            if (cumulativeSpanContext.RawTraceId == extractedSpanContext.RawTraceId)
+            {
+                cumulativeSpanContext.AdditionalW3CTraceState += extractedSpanContext.AdditionalW3CTraceState;
+
+                if (cumulativeSpanContext.RawSpanId != extractedSpanContext.RawSpanId)
+                {
+                    if (!string.IsNullOrEmpty(extractedSpanContext.LastParentId) && extractedSpanContext.LastParentId != W3CTraceContextPropagator.ZeroLastParent)
+                    {
+                        cumulativeSpanContext.LastParentId = extractedSpanContext.LastParentId;
+                    }
+                    else
+                    {
+                        cumulativeSpanContext.LastParentId = HexString.ToHexString(cumulativeSpanContext.SpanId);
+                    }
+
+                    cumulativeSpanContext.SpanId = extractedSpanContext.SpanId;
+                    cumulativeSpanContext.RawSpanId = extractedSpanContext.RawSpanId;
+                }
+            }
         }
 
         /// <summary>
-        /// Extracts a <see cref="SpanContext"/> from its serialized dictionary.
+        /// Extracts a <see cref="PropagationContext"/> from its serialized dictionary.
         /// </summary>
         /// <param name="serializedSpanContext">The serialized dictionary.</param>
-        /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from the serialized dictionary.</returns>
-        internal SpanContext? Extract(IReadOnlyDictionary<string, string?>? serializedSpanContext)
+        /// <returns>A new <see cref="PropagationContext"/> that contains the values obtained from the serialized dictionary.</returns>
+        internal PropagationContext Extract(IReadOnlyDictionary<string, string?>? serializedSpanContext)
         {
-            if (serializedSpanContext == null)
+            if (serializedSpanContext is { Count: > 0 })
             {
-                return null;
+                return Extract(serializedSpanContext, default(ReadOnlyDictionaryGetter));
             }
 
-            return Extract(serializedSpanContext, default(ReadOnlyDictionaryGetter));
+            return default;
         }
 
         public void AddHeadersToSpanAsTags<THeaders>(ISpan span, THeaders headers, IEnumerable<KeyValuePair<string, string?>> headerToTagMap, string defaultTagPrefix)

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Propagators
         /// Propagates the specified context by adding new headers to a <see cref="IHeadersCollection"/>.
         /// This locks the sampling priority for <paramref name="context"/>.
         /// </summary>
-        /// <param name="context">A <see cref="SpanContext"/> value that will be propagated into <paramref name="headers"/>.</param>
+        /// <param name="context">A <see cref="PropagationContext"/> that will be propagated into <paramref name="headers"/>.</param>
         /// <param name="headers">A <see cref="IHeadersCollection"/> to add new headers to.</param>
         /// <typeparam name="TCarrier">Type of header collection</typeparam>
         public void Inject<TCarrier>(PropagationContext context, TCarrier headers)
@@ -136,11 +136,11 @@ namespace Datadog.Trace.Propagators
         }
 
         /// <summary>
-        /// Extracts a <see cref="SpanContext"/> from the values found in the specified headers.
+        /// Extracts a <see cref="PropagationContext"/> from the values found in the specified headers.
         /// </summary>
         /// <param name="headers">The headers that contain the values to be extracted.</param>
         /// <typeparam name="TCarrier">Type of header collection</typeparam>
-        /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="headers"/>.</returns>
+        /// <returns>A new <see cref="PropagationContext"/> that contains the values obtained from <paramref name="headers"/>.</returns>
         public PropagationContext Extract<TCarrier>(TCarrier headers)
             where TCarrier : IHeadersCollection
         {
@@ -148,12 +148,12 @@ namespace Datadog.Trace.Propagators
         }
 
         /// <summary>
-        /// Extracts a <see cref="SpanContext"/> from the values found in the specified headers.
+        /// Extracts a <see cref="PropagationContext"/> from the values found in the specified headers.
         /// </summary>
         /// <param name="carrier">The headers that contain the values to be extracted.</param>
         /// <param name="getter">The function that can extract a list of values for a given header name.</param>
         /// <typeparam name="TCarrier">Type of header collection</typeparam>
-        /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="carrier"/>.</returns>
+        /// <returns>A new <see cref="PropagationContext"/> that contains the values obtained from <paramref name="carrier"/>.</returns>
         public PropagationContext Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
         {
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -208,6 +208,21 @@ namespace Datadog.Trace.Propagators
             return new PropagationContext(cumulativeSpanContext, cumulativeBaggage);
         }
 
+        /// <summary>
+        /// Extracts a <see cref="PropagationContext"/> from its serialized dictionary.
+        /// </summary>
+        /// <param name="serializedSpanContext">The serialized dictionary.</param>
+        /// <returns>A new <see cref="PropagationContext"/> that contains the values obtained from the serialized dictionary.</returns>
+        internal PropagationContext Extract(IReadOnlyDictionary<string, string?>? serializedSpanContext)
+        {
+            if (serializedSpanContext is { Count: > 0 })
+            {
+                return Extract(serializedSpanContext, default(ReadOnlyDictionaryGetter));
+            }
+
+            return default;
+        }
+
         private static void MergeExtractedW3CSpanContext(SpanContext cumulativeSpanContext, SpanContext extractedSpanContext)
         {
             if (cumulativeSpanContext.RawTraceId == extractedSpanContext.RawTraceId)
@@ -229,21 +244,6 @@ namespace Datadog.Trace.Propagators
                     cumulativeSpanContext.RawSpanId = extractedSpanContext.RawSpanId;
                 }
             }
-        }
-
-        /// <summary>
-        /// Extracts a <see cref="PropagationContext"/> from its serialized dictionary.
-        /// </summary>
-        /// <param name="serializedSpanContext">The serialized dictionary.</param>
-        /// <returns>A new <see cref="PropagationContext"/> that contains the values obtained from the serialized dictionary.</returns>
-        internal PropagationContext Extract(IReadOnlyDictionary<string, string?>? serializedSpanContext)
-        {
-            if (serializedSpanContext is { Count: > 0 })
-            {
-                return Extract(serializedSpanContext, default(ReadOnlyDictionaryGetter));
-            }
-
-            return default;
         }
 
         public void AddHeadersToSpanAsTags<THeaders>(ISpan span, THeaders headers, IEnumerable<KeyValuePair<string, string?>> headerToTagMap, string defaultTagPrefix)

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -170,7 +170,7 @@ namespace Datadog.Trace.Propagators
             // as we extract values from the carrier using multiple extractors,
             // we will accumulate them in this context
             SpanContext? cumulativeSpanContext = null;
-            Baggage? cumulativeBaggage = null;
+            Baggage cumulativeBaggage = new();
 
             foreach (var extractor in _extractors)
             {
@@ -191,14 +191,9 @@ namespace Datadog.Trace.Propagators
                     continue;
                 }
 
-                if (cumulativeBaggage is null)
-                {
-                    cumulativeBaggage = currentExtractedContext.Baggage;
-                }
-                else if (currentExtractedContext.Baggage is { Count: > 0 } extractedBaggage)
-                {
-                    cumulativeBaggage.Merge(extractedBaggage);
-                }
+                // in practice, there should only ever be zero or one baggage extractors, but since we're treating this as
+                // a list of generic extractors, we handle the possibility of multiple baggage extractors by merging all baggage
+                cumulativeBaggage.Merge(currentExtractedContext.Baggage);
 
                 if (cumulativeSpanContext == null)
                 {

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -201,14 +201,14 @@ namespace Datadog.Trace.Propagators
                 }
                 else if (extractor is W3CTraceContextPropagator && currentExtractedContext.SpanContext is { } extractedSpanContext)
                 {
-                    FixUpSpanContext(cumulativeSpanContext, extractedSpanContext);
+                    MergeExtractedW3CSpanContext(cumulativeSpanContext, extractedSpanContext);
                 }
             }
 
             return new PropagationContext(cumulativeSpanContext, cumulativeBaggage);
         }
 
-        private static void FixUpSpanContext(SpanContext cumulativeSpanContext, SpanContext extractedSpanContext)
+        private static void MergeExtractedW3CSpanContext(SpanContext cumulativeSpanContext, SpanContext extractedSpanContext)
         {
             if (cumulativeSpanContext.RawTraceId == extractedSpanContext.RawTraceId)
             {

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -193,7 +193,7 @@ namespace Datadog.Trace.Propagators
 
                 // in practice, there should only ever be zero or one baggage extractors, but since we're treating this as
                 // a list of generic extractors, we handle the possibility of multiple baggage extractors by merging all baggage
-                cumulativeBaggage.Merge(currentExtractedContext.Baggage);
+                currentExtractedContext.Baggage?.MergeInto(cumulativeBaggage);
 
                 if (cumulativeSpanContext == null)
                 {

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -114,6 +114,8 @@ namespace Datadog.Trace.Propagators
             Sampled = 1,
         }
 
+        public PropagatorType PropagatorType => PropagatorType.TraceContext;
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
@@ -67,8 +67,10 @@ namespace Datadog.Trace.ServiceFabric
                     // inject propagation context into message headers for distributed tracing
                     if (messageHeaders != null)
                     {
+                        var context = new PropagationContext(span.Context, Baggage.Current);
+
                         SpanContextPropagator.Instance.Inject(
-                            span.Context,
+                            context,
                             messageHeaders,
                             default(ServiceRemotingRequestMessageHeaderSetter));
                     }

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingService.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingService.cs
@@ -63,8 +63,9 @@ namespace Datadog.Trace.ServiceFabric
                 // extract propagation context from message headers for distributed tracing
                 if (messageHeaders != null)
                 {
-                    extractedContext = SpanContextPropagator.Instance.Extract(messageHeaders, default(ServiceRemotingRequestMessageHeaderGetter));
-                    Baggage.Current.Merge(extractedContext.Baggage);
+                    extractedContext = SpanContextPropagator.Instance
+                                                            .Extract(messageHeaders, default(ServiceRemotingRequestMessageHeaderGetter))
+                                                            .MergeBaggageInto(Baggage.Current);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -80,10 +80,12 @@ namespace Datadog.Trace
             if (messageType != null && source == null) { ThrowHelper.ThrowArgumentNullException(nameof(source)); }
             else if (messageType == null && source != null) { ThrowHelper.ThrowArgumentNullException(nameof(messageType)); }
 
-            var spanContext = SpanContextPropagator.Instance.Extract(carrier, getter);
+            var context = SpanContextPropagator.Instance.Extract(carrier, getter);
+            Baggage.Current.Merge(context.Baggage);
 
-            if (spanContext is not null
-             && Tracer.Instance.TracerManager.DataStreamsManager is { IsEnabled: true } dsm)
+            // DSM
+            if (context.SpanContext is { } spanContext
+                && Tracer.Instance.TracerManager.DataStreamsManager is { IsEnabled: true } dsm)
             {
                 if (getter(carrier, DataStreamsPropagationHeaders.TemporaryBase64PathwayContext).FirstOrDefault() is { Length: > 0 } base64PathwayContext)
                 {
@@ -101,7 +103,7 @@ namespace Datadog.Trace
                 }
             }
 
-            return spanContext;
+            return context.SpanContext;
         }
 
         private static PathwayContext? TryGetPathwayContext(string? base64PathwayContext)

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -81,7 +81,6 @@ namespace Datadog.Trace
             else if (messageType == null && source != null) { ThrowHelper.ThrowArgumentNullException(nameof(messageType)); }
 
             var context = SpanContextPropagator.Instance.Extract(carrier, getter);
-            Baggage.Current.Merge(context.Baggage);
 
             // DSM
             if (context.SpanContext is { } spanContext

--- a/tracer/src/Datadog.Trace/SpanContextInjector.cs
+++ b/tracer/src/Datadog.Trace/SpanContextInjector.cs
@@ -70,16 +70,18 @@ namespace Datadog.Trace
             if (messageType != null && target == null) { ThrowHelper.ThrowArgumentNullException(nameof(target)); }
             else if (messageType == null && target != null) { ThrowHelper.ThrowArgumentNullException(nameof(messageType)); }
 
-            var spanContext = context as SpanContext;
+            if (context is not SpanContext spanContext)
+            {
+                return;
+            }
 
             SpanContextPropagator.Instance.Inject(
-                    new PropagationContext(spanContext, Baggage.Current),
-                    carrier,
-                    setter);
+                new PropagationContext(spanContext, baggage: null),
+                carrier,
+                setter);
 
             // DSM
-            if (spanContext is not null &&
-                !string.IsNullOrEmpty(messageType) &&
+            if (!string.IsNullOrEmpty(messageType) &&
                 !string.IsNullOrEmpty(target) &&
                 Tracer.Instance.TracerManager.DataStreamsManager is { IsEnabled: true } dsm)
             {

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -149,7 +149,7 @@ namespace Datadog.Trace
                     _instance = instance;
                     _globalInstanceInitialized = true;
 
-                    // ensure Baggage's AsyncLocal<T> has a value if the user can't user it yet,
+                    // ensure Baggage's AsyncLocal<T> has a value as soon as we can,
                     // since it can only flow down the async call chain, not up
                     _ = Baggage.Current;
                 }

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -148,6 +148,10 @@ namespace Datadog.Trace
                     instance = new Tracer(tracerManager: null); // don't replace settings, use existing
                     _instance = instance;
                     _globalInstanceInitialized = true;
+
+                    // ensure Baggage's AsyncLocal<T> has a value if the user can't user it yet,
+                    // since it can only flow down the async call chain, not up
+                    _ = Baggage.Current;
                 }
 
                 instance.TracerManager.Start();

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Amazon.EventBridge.Model;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
@@ -46,7 +47,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -79,7 +80,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -113,7 +114,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -146,7 +147,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -165,7 +166,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(2);
@@ -201,7 +202,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -235,7 +236,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -255,7 +256,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
-        ContextPropagation.InjectTracingContext(proxy, _spanContext);
+        ContextPropagation.InjectContext(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/Kinesis/ContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/Kinesis/ContextPropagationTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Amazon.Kinesis.Model;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Xunit;
@@ -74,7 +75,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutRecordsRequest>();
 
-        ContextPropagation.InjectTraceIntoRecords(proxy, _spanContext);
+        ContextPropagation.InjectTraceIntoRecords(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var firstRecord = proxy.Records[0].DuckCast<IContainsData>();
 
@@ -105,7 +106,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutRecordsRequest>();
 
-        ContextPropagation.InjectTraceIntoRecords(proxy, _spanContext);
+        ContextPropagation.InjectTraceIntoRecords(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var firstRecord = proxy.Records[0].DuckCast<IContainsData>();
 
@@ -124,7 +125,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutRecordRequest>();
 
-        ContextPropagation.InjectTraceIntoData(proxy, _spanContext);
+        ContextPropagation.InjectTraceIntoData(proxy, new PropagationContext(_spanContext, baggage: null));
 
         // Naively deserialize in order to not use tracer extraction logic
         var jsonString = Encoding.UTF8.GetString(proxy.Data.ToArray());
@@ -155,7 +156,7 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPutRecordRequest>();
 
-        ContextPropagation.InjectTraceIntoData(proxy, _spanContext);
+        ContextPropagation.InjectTraceIntoData(proxy, new PropagationContext(_spanContext, baggage: null));
 
         var data = proxy.Data;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SNS/ContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SNS/ContextPropagationTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Amazon.SimpleNotificationService.Model;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
@@ -81,7 +82,9 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPublishBatchRequest>();
 
-        ContextPropagation.InjectHeadersIntoBatch<PublishBatchRequest, IPublishBatchRequest>(proxy, _spanContext);
+        ContextPropagation.InjectHeadersIntoBatch<PublishBatchRequest, IPublishBatchRequest>(
+            proxy,
+            new PropagationContext(_spanContext, baggage: null));
 
         for (int i = 0; i < proxy.PublishBatchRequestEntries.Count; i++)
         {
@@ -126,7 +129,9 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPublishBatchRequest>();
 
-        ContextPropagation.InjectHeadersIntoBatch<PublishBatchRequest, IPublishBatchRequest>(proxy, _spanContext);
+        ContextPropagation.InjectHeadersIntoBatch<PublishBatchRequest, IPublishBatchRequest>(
+            proxy,
+            new PropagationContext(_spanContext, baggage: null));
 
         for (int i = 0; i < proxy.PublishBatchRequestEntries.Count; i++)
         {
@@ -170,7 +175,9 @@ public class ContextPropagationTests
             });
 
         var proxy = request.DuckCast<IPublishBatchRequest>();
-        ContextPropagation.InjectHeadersIntoBatch<PublishBatchRequest, IPublishBatchRequest>(proxy, _spanContext);
+        ContextPropagation.InjectHeadersIntoBatch<PublishBatchRequest, IPublishBatchRequest>(
+            proxy,
+            new PropagationContext(_spanContext, baggage: null));
 
         for (int i = 0; i < proxy.PublishBatchRequestEntries.Count; i++)
         {
@@ -199,7 +206,9 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPublishRequest>();
 
-        ContextPropagation.InjectHeadersIntoMessage<PublishRequest, IPublishRequest>(proxy, _spanContext);
+        ContextPropagation.InjectHeadersIntoMessage<PublishRequest, IPublishRequest>(
+            proxy,
+            new PropagationContext(_spanContext, baggage: null));
 
         // Hard-casting into PublishBatchRequestEntry because trace context assertion is needed
         var messageAttributes = (Dictionary<string, MessageAttributeValue>)proxy.MessageAttributes;
@@ -229,7 +238,9 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPublishRequest>();
 
-        ContextPropagation.InjectHeadersIntoMessage<PublishRequest, IPublishRequest>(proxy, _spanContext);
+        ContextPropagation.InjectHeadersIntoMessage<PublishRequest, IPublishRequest>(
+            proxy,
+            new PropagationContext(_spanContext, baggage: null));
 
         // Hard-casting into PublishBatchRequestEntry because trace context assertion is needed
         var messageAttributes = (Dictionary<string, MessageAttributeValue>)proxy.MessageAttributes;
@@ -259,7 +270,9 @@ public class ContextPropagationTests
 
         var proxy = request.DuckCast<IPublishRequest>();
 
-        ContextPropagation.InjectHeadersIntoMessage<PublishRequest, IPublishRequest>(proxy, _spanContext);
+        ContextPropagation.InjectHeadersIntoMessage<PublishRequest, IPublishRequest>(
+            proxy,
+            new PropagationContext(_spanContext, baggage: null));
 
         // Hard-casting into PublishBatchRequestEntry because trace context assertion is needed
         var messageAttributes = (Dictionary<string, MessageAttributeValue>)proxy.MessageAttributes;

--- a/tracer/test/Datadog.Trace.IntegrationTests/Sampling/DelaySamplingDecisionTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Sampling/DelaySamplingDecisionTests.cs
@@ -77,7 +77,9 @@ public class DelaySamplingDecisionTests
             traceContext.SamplingPriority.Should().BeNull();
 
             var headers = new NameValueCollection();
-            SpanContextPropagator.Instance.Inject(scope1.Span.Context, headers.Wrap());
+            SpanContextPropagator.Instance.Inject(
+                new PropagationContext(scope1.Span.Context, baggage: null),
+                headers.Wrap());
 
             // sampling decision IS taken before propagating
             sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Once);

--- a/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
@@ -98,12 +98,21 @@ public class BaggageTests
     [Fact]
     public void Merge_AddsItemsToExistingBaggage()
     {
-        var baggage1 = new Baggage(new Dictionary<string, string> { { "key1", "value1" } });
-        var baggage2 = new Baggage(new Dictionary<string, string> { { "key2", "value2" } });
+        var baggage1 = new Baggage(new Dictionary<string, string>
+        {
+            { "key1", "value1" }
+        });
+
+        // replace "key1" and add "key2"
+        var baggage2 = new Baggage(new Dictionary<string, string>
+        {
+            { "key1", "new value" },
+            { "key2", "value2" }
+        });
 
         baggage1.Merge(baggage2);
 
-        baggage1.GetValueOrDefault("key1").Should().Be("value1");
+        baggage1.GetValueOrDefault("key1").Should().Be("new value");
         baggage1.GetValueOrDefault("key2").Should().Be("value2");
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
@@ -21,7 +22,7 @@ public class BaggageTests
     [Fact]
     public void Count_ReturnsCount_WhenBaggageHasItems()
     {
-        var baggage = new Baggage(new Dictionary<string, string> { { "key1", "value1" } });
+        var baggage = new Baggage { { "key1", "value1" } };
         baggage.Count.Should().Be(1);
 
         baggage.AddOrReplace("key2", "value2");
@@ -29,7 +30,27 @@ public class BaggageTests
     }
 
     [Fact]
-    public void Get_ReturnsNull_WhenItemDoesNotExist()
+    public void TryGetValue_ReturnsTrue_WhenItemExists()
+    {
+        var baggage = new Baggage { { "key", "value" } };
+        var exists = baggage.TryGetValue("key", out var value);
+
+        exists.Should().BeTrue();
+        value.Should().Be("value");
+    }
+
+    [Fact]
+    public void TryGetValue_ReturnsFalse_WhenItemDoesNotExist()
+    {
+        var baggage = new Baggage { { "key", "value" } };
+        var exists = baggage.TryGetValue("nonexistent", out var value);
+
+        exists.Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetValueOrDefault_ReturnsNull_WhenItemDoesNotExist()
     {
         var baggage = new Baggage();
         var value = baggage.GetValueOrDefault("nonexistent");
@@ -37,15 +58,32 @@ public class BaggageTests
     }
 
     [Fact]
-    public void Get_ReturnsValue_WhenItemExists()
+    public void GetValueOrDefault_ReturnsValue_WhenItemExists()
     {
-        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
+        var baggage = new Baggage { { "key", "value" } };
         var value = baggage.GetValueOrDefault("key");
         value.Should().Be("value");
     }
 
     [Fact]
-    public void Set_AddsNewItem_WhenItemDoesNotExist()
+    public void Indexer_ReturnsValue_WhenItemExists()
+    {
+        var baggage = new Baggage { { "key", "value" } };
+        var value = baggage["key"];
+        value.Should().Be("value");
+    }
+
+    [Fact]
+    public void Indexer_Throws_WhenItemDoesNotExist()
+    {
+        var baggage = new Baggage { { "key", "value" } };
+
+        FluentActions.Invoking(() => baggage["nonexistent"])
+                     .Should().Throw<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public void Add_AddsNewItem_WhenItemDoesNotExist()
     {
         var baggage = new Baggage();
         baggage.AddOrReplace("key", "value");
@@ -55,9 +93,28 @@ public class BaggageTests
     }
 
     [Fact]
-    public void Set_UpdatesItem_WhenItemExists()
+    public void Add_Throws_WhenItemExists()
     {
-        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value1" } });
+        var baggage = new Baggage { { "key", "value1" } };
+
+        FluentActions.Invoking(() => baggage.Add("key", "value2"))
+                     .Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddOrReplace_AddsNewItem_WhenItemDoesNotExist()
+    {
+        var baggage = new Baggage();
+        baggage.AddOrReplace("key", "value");
+
+        var value = baggage.GetValueOrDefault("key");
+        value.Should().Be("value");
+    }
+
+    [Fact]
+    public void AddOrReplace_UpdatesItem_WhenItemExists()
+    {
+        var baggage = new Baggage { { "key", "value1" } };
         baggage.AddOrReplace("key", "value2");
 
         var value = baggage.GetValueOrDefault("key");
@@ -67,7 +124,7 @@ public class BaggageTests
     [Fact]
     public void Remove_ReturnsFalse_WhenItemDoesNotExist()
     {
-        var baggage = new Baggage();
+        var baggage = new Baggage { { "key", "value" } };
         var result = baggage.Remove("nonexistent");
         result.Should().BeFalse();
     }
@@ -75,7 +132,7 @@ public class BaggageTests
     [Fact]
     public void Remove_ReturnsTrue_WhenItemExists()
     {
-        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
+        var baggage = new Baggage { { "key", "value" } };
         baggage.GetValueOrDefault("key").Should().Be("value");
 
         var result = baggage.Remove("key");
@@ -87,7 +144,7 @@ public class BaggageTests
     [Fact]
     public void Clear_RemovesAllItems()
     {
-        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
+        var baggage = new Baggage { { "key", "value" } };
         baggage.GetValueOrDefault("key").Should().Be("value");
         baggage.Count.Should().Be(1);
 
@@ -96,21 +153,17 @@ public class BaggageTests
     }
 
     [Fact]
-    public void Merge_AddsItemsToExistingBaggage()
+    public void MergeInto_AddsAndReplacesItems()
     {
-        var baggage1 = new Baggage(new Dictionary<string, string>
-        {
-            { "key1", "value1" }
-        });
+        var baggage1 = new Baggage { { "key1", "value1" } };
 
-        // replace "key1" and add "key2"
-        var baggage2 = new Baggage(new Dictionary<string, string>
+        var baggage2 = new Baggage
         {
-            { "key1", "new value" },
-            { "key2", "value2" }
-        });
+            { "key1", "new value" }, // replace "key1"
+            { "key2", "value2" }     // add "key2"
+        };
 
-        baggage1.Merge(baggage2);
+        baggage2.MergeInto(baggage1);
 
         baggage1.GetValueOrDefault("key1").Should().Be("new value");
         baggage1.GetValueOrDefault("key2").Should().Be("value2");

--- a/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
@@ -24,7 +24,7 @@ public class BaggageTests
         var baggage = new Baggage(new Dictionary<string, string> { { "key1", "value1" } });
         baggage.Count.Should().Be(1);
 
-        baggage.Set("key2", "value2");
+        baggage.AddOrReplace("key2", "value2");
         baggage.Count.Should().Be(2);
     }
 
@@ -32,7 +32,7 @@ public class BaggageTests
     public void Get_ReturnsNull_WhenItemDoesNotExist()
     {
         var baggage = new Baggage();
-        var value = baggage.Get("nonexistent");
+        var value = baggage.GetValueOrDefault("nonexistent");
         value.Should().BeNull();
     }
 
@@ -40,7 +40,7 @@ public class BaggageTests
     public void Get_ReturnsValue_WhenItemExists()
     {
         var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
-        var value = baggage.Get("key");
+        var value = baggage.GetValueOrDefault("key");
         value.Should().Be("value");
     }
 
@@ -48,9 +48,9 @@ public class BaggageTests
     public void Set_AddsNewItem_WhenItemDoesNotExist()
     {
         var baggage = new Baggage();
-        baggage.Set("key", "value");
+        baggage.AddOrReplace("key", "value");
 
-        var value = baggage.Get("key");
+        var value = baggage.GetValueOrDefault("key");
         value.Should().Be("value");
     }
 
@@ -58,9 +58,9 @@ public class BaggageTests
     public void Set_UpdatesItem_WhenItemExists()
     {
         var baggage = new Baggage(new Dictionary<string, string> { { "key", "value1" } });
-        baggage.Set("key", "value2");
+        baggage.AddOrReplace("key", "value2");
 
-        var value = baggage.Get("key");
+        var value = baggage.GetValueOrDefault("key");
         value.Should().Be("value2");
     }
 
@@ -76,19 +76,19 @@ public class BaggageTests
     public void Remove_ReturnsTrue_WhenItemExists()
     {
         var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
-        baggage.Get("key").Should().Be("value");
+        baggage.GetValueOrDefault("key").Should().Be("value");
 
         var result = baggage.Remove("key");
 
         result.Should().BeTrue();
-        baggage.Get("key").Should().BeNull();
+        baggage.GetValueOrDefault("key").Should().BeNull();
     }
 
     [Fact]
     public void Clear_RemovesAllItems()
     {
         var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
-        baggage.Get("key").Should().Be("value");
+        baggage.GetValueOrDefault("key").Should().Be("value");
         baggage.Count.Should().Be(1);
 
         baggage.Clear();
@@ -103,7 +103,7 @@ public class BaggageTests
 
         baggage1.Merge(baggage2);
 
-        baggage1.Get("key1").Should().Be("value1");
-        baggage1.Get("key2").Should().Be("value2");
+        baggage1.GetValueOrDefault("key1").Should().Be("value1");
+        baggage1.GetValueOrDefault("key2").Should().Be("value2");
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
@@ -1,0 +1,109 @@
+﻿// <copyright file="BaggageTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests;
+
+public class BaggageTests
+{
+    [Fact]
+    public void Count_ReturnsZero_WhenBaggageIsEmpty()
+    {
+        var baggage = new Baggage();
+        baggage.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Count_ReturnsCount_WhenBaggageHasItems()
+    {
+        var baggage = new Baggage(new Dictionary<string, string> { { "key1", "value1" } });
+        baggage.Count.Should().Be(1);
+
+        baggage.Set("key2", "value2");
+        baggage.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void Get_ReturnsNull_WhenItemDoesNotExist()
+    {
+        var baggage = new Baggage();
+        var value = baggage.Get("nonexistent");
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Get_ReturnsValue_WhenItemExists()
+    {
+        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
+        var value = baggage.Get("key");
+        value.Should().Be("value");
+    }
+
+    [Fact]
+    public void Set_AddsNewItem_WhenItemDoesNotExist()
+    {
+        var baggage = new Baggage();
+        baggage.Set("key", "value");
+
+        var value = baggage.Get("key");
+        value.Should().Be("value");
+    }
+
+    [Fact]
+    public void Set_UpdatesItem_WhenItemExists()
+    {
+        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value1" } });
+        baggage.Set("key", "value2");
+
+        var value = baggage.Get("key");
+        value.Should().Be("value2");
+    }
+
+    [Fact]
+    public void Remove_ReturnsFalse_WhenItemDoesNotExist()
+    {
+        var baggage = new Baggage();
+        var result = baggage.Remove("nonexistent");
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Remove_ReturnsTrue_WhenItemExists()
+    {
+        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
+        baggage.Get("key").Should().Be("value");
+
+        var result = baggage.Remove("key");
+
+        result.Should().BeTrue();
+        baggage.Get("key").Should().BeNull();
+    }
+
+    [Fact]
+    public void Clear_RemovesAllItems()
+    {
+        var baggage = new Baggage(new Dictionary<string, string> { { "key", "value" } });
+        baggage.Get("key").Should().Be("value");
+        baggage.Count.Should().Be(1);
+
+        baggage.Clear();
+        baggage.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Merge_AddsItemsToExistingBaggage()
+    {
+        var baggage1 = new Baggage(new Dictionary<string, string> { { "key1", "value1" } });
+        var baggage2 = new Baggage(new Dictionary<string, string> { { "key2", "value2" } });
+
+        baggage1.Merge(baggage2);
+
+        baggage1.Get("key1").Should().Be("value1");
+        baggage1.Get("key2").Should().Be("value2");
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
@@ -89,7 +89,8 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             using (var scope = Tracer.Instance.StartActive("Test"))
             {
-                var spanContext = SpanContextPropagator.Instance.Extract(automaticTracer.GetDistributedTrace());
+                var context = SpanContextPropagator.Instance.Extract(automaticTracer.GetDistributedTrace());
+                var spanContext = context.SpanContext!;
 
                 spanContext.Should().NotBeNull();
                 spanContext.TraceId128.Should().Be(((Scope)scope).Span.TraceId128);

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -186,6 +186,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Theory]
@@ -234,6 +236,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -255,12 +259,14 @@ namespace Datadog.Trace.Tests.Propagators
             const ulong expectedSpanId = 0x00f067aa0ba902b7UL;
 
             var context = B3Propagator.Extract(headers.Object);
-            var spanContext = context.SpanContext!;
+            var result = context.SpanContext!;
 
-            spanContext.Should().NotBeNull();
-            spanContext.TraceId128.Should().Be(expectedTraceId);
-            spanContext.TraceId.Should().Be(expectedTraceId.Lower);
-            spanContext.SpanId.Should().Be(expectedSpanId);
+            result.Should().NotBeNull();
+            result.TraceId128.Should().Be(expectedTraceId);
+            result.TraceId.Should().Be(expectedTraceId.Lower);
+            result.SpanId.Should().Be(expectedSpanId);
+
+            context.Baggage.Should().BeNull();
 
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>(MockBehavior.Strict);
@@ -294,6 +300,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -314,6 +321,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -334,6 +342,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -355,6 +364,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -375,6 +385,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never()); // extractor doesn't get this far
 
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -395,6 +406,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -25,13 +25,11 @@ namespace Datadog.Trace.Tests.Propagators
                 [ContextPropagationHeaderStyle.B3MultipleHeaders],
                 false);
 
-            var baggageItems = new KeyValuePair<string, string>[]
+            TestBaggage = new Baggage
             {
-                new("key1", "value1"),
-                new("key2", "value2")
+                { "key1", "value1" },
+                { "key2", "value2" },
             };
-
-            TestBaggage = new Baggage(baggageItems);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using FluentAssertions;
@@ -15,12 +16,22 @@ namespace Datadog.Trace.Tests.Propagators
     {
         private static readonly SpanContextPropagator B3Propagator;
 
+        private static readonly Baggage TestBaggage;
+
         static B3MultipleHeadersPropagatorTests()
         {
             B3Propagator = SpanContextPropagatorFactory.GetSpanContextPropagator(
                 [ContextPropagationHeaderStyle.B3MultipleHeaders],
                 [ContextPropagationHeaderStyle.B3MultipleHeaders],
                 false);
+
+            var baggageItems = new KeyValuePair<string, string>[]
+            {
+                new("key1", "value1"),
+                new("key2", "value2")
+            };
+
+            TestBaggage = new Baggage(baggageItems);
         }
 
         [Fact]
@@ -29,10 +40,10 @@ namespace Datadog.Trace.Tests.Propagators
             var traceId = new TraceId(0x0123456789abcdef, 0x1122334455667788); // 0x0123456789abcdef1122334455667788
             ulong spanId = 0x000000003ade68b1;
             var samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, null);
+            var spanContext1 = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, null);
             var headers = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(context, headers.Object);
+            B3Propagator.Inject(new PropagationContext(spanContext1, TestBaggage), headers.Object);
 
             headers.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             headers.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
@@ -40,10 +51,10 @@ namespace Datadog.Trace.Tests.Propagators
             headers.VerifyNoOtherCalls();
 
             // Extract default (no sampler) sampling from trace context
-            var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
+            var spanContext2 = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(newContext, newHeaders.Object);
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object);
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
@@ -51,10 +62,10 @@ namespace Datadog.Trace.Tests.Propagators
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
+            spanContext2.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(newContext, newHeaders.Object);
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object);
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
@@ -68,12 +79,12 @@ namespace Datadog.Trace.Tests.Propagators
             var traceId = new TraceId(0x0123456789abcdef, 0x1122334455667788); // 0x0123456789abcdef1122334455667788
             ulong spanId = 0x000000003ade68b1;
             var samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, null);
+            var spanContext1 = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, null);
 
             // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(context, headers.Object, (carrier, name, value) => carrier.Set(name, value));
+            B3Propagator.Inject(new PropagationContext(spanContext1, TestBaggage), headers.Object, (carrier, name, value) => carrier.Set(name, value));
 
             headers.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             headers.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
@@ -81,10 +92,10 @@ namespace Datadog.Trace.Tests.Propagators
             headers.VerifyNoOtherCalls();
 
             // Extract default (no sampler) sampling from trace context
-            var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
+            var spanContext2 = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
@@ -92,10 +103,10 @@ namespace Datadog.Trace.Tests.Propagators
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
+            spanContext2.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
@@ -159,19 +170,22 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Once());
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Once());
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(traceIdUpper, traceIdLower),
-                           TraceId = traceIdLower,
-                           SpanId = spanId,
-                           RawTraceId = rawTraceId,
-                           RawSpanId = rawSpanId,
-                           Origin = null,
-                           SamplingPriority = samplingPriority,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(traceIdUpper, traceIdLower),
+                          TraceId = traceIdLower,
+                          SpanId = spanId,
+                          RawTraceId = rawTraceId,
+                          RawSpanId = rawSpanId,
+                          Origin = null,
+                          SamplingPriority = samplingPriority,
+                          IsRemote = true,
+                      });
         }
 
         [Theory]
@@ -204,19 +218,22 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Once());
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Once());
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(traceIdUpper, traceIdLower),
-                           TraceId = traceIdLower,
-                           SpanId = spanId,
-                           RawTraceId = rawTraceId,
-                           RawSpanId = rawSpanId,
-                           Origin = null,
-                           SamplingPriority = samplingPriority,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(traceIdUpper, traceIdLower),
+                          TraceId = traceIdLower,
+                          SpanId = spanId,
+                          RawTraceId = rawTraceId,
+                          RawSpanId = rawSpanId,
+                          Origin = null,
+                          SamplingPriority = samplingPriority,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -237,12 +254,13 @@ namespace Datadog.Trace.Tests.Propagators
             var expectedTraceId = new TraceId(0x0af7651916cd43dd, 0x8448eb211c80319c);
             const ulong expectedSpanId = 0x00f067aa0ba902b7UL;
 
-            var result = B3Propagator.Extract(headers.Object);
+            var context = B3Propagator.Extract(headers.Object);
+            var spanContext = context.SpanContext!;
 
-            result.Should().NotBeNull();
-            result!.TraceId128.Should().Be(expectedTraceId);
-            result.TraceId.Should().Be(expectedTraceId.Lower);
-            result.SpanId.Should().Be(expectedSpanId);
+            spanContext.Should().NotBeNull();
+            spanContext.TraceId128.Should().Be(expectedTraceId);
+            spanContext.TraceId.Should().Be(expectedTraceId.Lower);
+            spanContext.SpanId.Should().Be(expectedSpanId);
 
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>(MockBehavior.Strict);
@@ -250,7 +268,7 @@ namespace Datadog.Trace.Tests.Propagators
             headersForInjection.Setup(h => h.Set("x-b3-spanid", spanId));
             headersForInjection.Setup(h => h.Set("x-b3-sampled", sampled));
 
-            B3Propagator.Inject(result, headersForInjection.Object);
+            B3Propagator.Inject(context, headersForInjection.Object);
 
             headersForInjection.Verify(h => h.Set("x-b3-traceid", traceId), Times.Once());
             headersForInjection.Verify(h => h.Set("x-b3-spanid", spanId), Times.Once());
@@ -275,7 +293,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Never);  // extractor doesn't get this far
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -295,7 +313,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Never);  // extractor doesn't get this far
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -315,7 +333,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Never);  // extractor doesn't get this far
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -336,7 +354,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Once());
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -356,7 +374,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Never());  // extractor doesn't get this far
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never()); // extractor doesn't get this far
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -376,7 +394,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Once());
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Never); // extractor doesn't get this far
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -25,13 +25,11 @@ namespace Datadog.Trace.Tests.Propagators
                 [ContextPropagationHeaderStyle.B3SingleHeader],
                 false);
 
-            var baggageItems = new KeyValuePair<string, string>[]
+            TestBaggage = new Baggage
             {
-                new("key1", "value1"),
-                new("key2", "value2")
+                { "key1", "value1" },
+                { "key2", "value2" },
             };
-
-            TestBaggage = new Baggage(baggageItems);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -149,6 +149,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Theory]
@@ -182,6 +184,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -204,6 +208,8 @@ namespace Datadog.Trace.Tests.Propagators
             spanContext.TraceId.Should().Be(traceId.Lower);
             spanContext.SpanId.Should().Be(expectedSpanId);
 
+            result.Baggage.Should().BeNull();
+
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>();
             headersForInjection.Setup(h => h.Set("b3", expectedTraceParent));
@@ -224,6 +230,7 @@ namespace Datadog.Trace.Tests.Propagators
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -233,10 +240,11 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Setup(h => h.GetValues("b3"))
                    .Returns(new[] { "00000000075bcd15=000000003ade68b1=1" });
 
-            var context = B3Propagator.Extract(headers.Object);
+            var result = B3Propagator.Extract(headers.Object);
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
-            context.SpanContext.Should().BeNull();
+            result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -250,6 +258,7 @@ namespace Datadog.Trace.Tests.Propagators
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using FluentAssertions;
@@ -15,12 +16,22 @@ namespace Datadog.Trace.Tests.Propagators
     {
         private static readonly SpanContextPropagator B3Propagator;
 
+        private static readonly Baggage TestBaggage;
+
         static B3SingleHeaderPropagatorTests()
         {
             B3Propagator = SpanContextPropagatorFactory.GetSpanContextPropagator(
                 [ContextPropagationHeaderStyle.B3SingleHeader],
                 [ContextPropagationHeaderStyle.B3SingleHeader],
                 false);
+
+            var baggageItems = new KeyValuePair<string, string>[]
+            {
+                new("key1", "value1"),
+                new("key2", "value2")
+            };
+
+            TestBaggage = new Baggage(baggageItems);
         }
 
         [Fact]
@@ -28,25 +39,25 @@ namespace Datadog.Trace.Tests.Propagators
         {
             var traceId = new TraceId(0x0123456789abcdef, 0x1122334455667788);
             const ulong spanId = 987654321;
-            var context = new SpanContext(traceId, spanId, SamplingPriorityValues.UserKeep, serviceName: null, origin: null);
+            var spanContext1 = new SpanContext(traceId, spanId, SamplingPriorityValues.UserKeep, serviceName: null, origin: null);
             var headers = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(context, headers.Object);
+            B3Propagator.Inject(new PropagationContext(spanContext1, TestBaggage), headers.Object);
 
             headers.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-1"), Times.Once());
             headers.VerifyNoOtherCalls();
 
             // Extract default (no sampler) sampling from trace context
-            var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
+            var spanContext2 = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
-            B3Propagator.Inject(newContext, newHeaders.Object);
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object);
             newHeaders.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-1"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
+            spanContext2.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
-            B3Propagator.Inject(newContext, newHeaders.Object);
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object);
             newHeaders.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
         }
@@ -57,27 +68,27 @@ namespace Datadog.Trace.Tests.Propagators
             var traceId = (TraceId)0x00000000075bcd15; // 123456789
             ulong spanId = 0x000000003ade68b1; // 987654321;
             var samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, origin: null);
+            var spanContext1 = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, origin: null);
 
             // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>();
 
-            B3Propagator.Inject(context, headers.Object, (carrier, name, value) => carrier.Set(name, value));
+            B3Propagator.Inject(new PropagationContext(spanContext1, TestBaggage), headers.Object, (carrier, name, value) => carrier.Set(name, value));
 
             headers.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-1"), Times.Once());
             headers.VerifyNoOtherCalls();
 
             // Extract default (no sampler) sampling from trace context
-            var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
+            var spanContext2 = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
-            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
             newHeaders.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-1"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
+            spanContext2.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
-            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            B3Propagator.Inject(new PropagationContext(spanContext2, TestBaggage), newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
             newHeaders.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
         }
@@ -122,19 +133,22 @@ namespace Datadog.Trace.Tests.Propagators
             var result = B3Propagator.Extract(headers.Object);
             headers.Verify(h => h.GetValues("b3"), Times.Once());
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(traceIdUpper, traceIdLower),
-                           TraceId = traceIdLower,
-                           SpanId = spanId,
-                           RawTraceId = rawTraceId,
-                           RawSpanId = rawSpanId,
-                           Origin = null,
-                           SamplingPriority = samplingPriority,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(traceIdUpper, traceIdLower),
+                          TraceId = traceIdLower,
+                          SpanId = spanId,
+                          RawTraceId = rawTraceId,
+                          RawSpanId = rawSpanId,
+                          Origin = null,
+                          SamplingPriority = samplingPriority,
+                          IsRemote = true,
+                      });
         }
 
         [Theory]
@@ -152,19 +166,22 @@ namespace Datadog.Trace.Tests.Propagators
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(traceIdUpper, traceIdLower),
-                           TraceId = traceIdLower,
-                           SpanId = spanId,
-                           RawTraceId = rawTraceId,
-                           RawSpanId = rawSpanId,
-                           Origin = null,
-                           SamplingPriority = samplingPriority,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(traceIdUpper, traceIdLower),
+                          TraceId = traceIdLower,
+                          SpanId = spanId,
+                          RawTraceId = rawTraceId,
+                          RawSpanId = rawSpanId,
+                          Origin = null,
+                          SamplingPriority = samplingPriority,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -178,19 +195,20 @@ namespace Datadog.Trace.Tests.Propagators
                    .Returns(new[] { expectedTraceParent });
 
             var result = B3Propagator.Extract(headers.Object);
+            var spanContext = result.SpanContext!;
 
             var expectedSpanId = 0x00f067aa0ba902b7UL;
 
-            result.Should().NotBeNull();
-            result!.TraceId128.Should().Be(traceId);
-            result!.TraceId.Should().Be(traceId.Lower);
-            result.SpanId.Should().Be(expectedSpanId);
+            spanContext.Should().NotBeNull();
+            spanContext.TraceId128.Should().Be(traceId);
+            spanContext.TraceId.Should().Be(traceId.Lower);
+            spanContext.SpanId.Should().Be(expectedSpanId);
 
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>();
             headersForInjection.Setup(h => h.Set("b3", expectedTraceParent));
 
-            B3Propagator.Inject(result, headersForInjection.Object);
+            B3Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headersForInjection.Object);
 
             headersForInjection.Verify(h => h.Set("b3", expectedTraceParent), Times.Once());
         }
@@ -205,7 +223,7 @@ namespace Datadog.Trace.Tests.Propagators
             var result = B3Propagator.Extract(headers.Object);
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
-            Assert.Null(result);
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -215,10 +233,10 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Setup(h => h.GetValues("b3"))
                    .Returns(new[] { "00000000075bcd15=000000003ade68b1=1" });
 
-            var result = B3Propagator.Extract(headers.Object);
+            var context = B3Propagator.Extract(headers.Object);
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
-            Assert.Null(result);
+            context.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -231,7 +249,7 @@ namespace Datadog.Trace.Tests.Propagators
             var result = B3Propagator.Extract(headers.Object);
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
-            Assert.Null(result);
+            result.SpanContext.Should().BeNull();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -50,12 +50,22 @@ namespace Datadog.Trace.Tests.Propagators
 
         private static readonly TraceTagCollection EmptyPropagatedTags = new();
 
+        private static readonly Baggage TestBaggage;
+
         static DatadogPropagatorTests()
         {
             Propagator = SpanContextPropagatorFactory.GetSpanContextPropagator(
-                new[] { ContextPropagationHeaderStyle.Datadog },
-                new[] { ContextPropagationHeaderStyle.Datadog },
+                [ContextPropagationHeaderStyle.Datadog],
+                [ContextPropagationHeaderStyle.Datadog],
                 false);
+
+            var baggageItems = new KeyValuePair<string, string>[]
+            {
+                new("key1", "value1"),
+                new("key2", "value2")
+            };
+
+            TestBaggage = new Baggage(baggageItems);
         }
 
         public static TheoryData<string> GetInvalidIds() => new()
@@ -70,10 +80,10 @@ namespace Datadog.Trace.Tests.Propagators
         [Fact]
         public void Inject_IHeadersCollection()
         {
-            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
+            var spanContext = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             VerifySetCalls(headers, DefaultHeaderValues);
         }
@@ -97,9 +107,9 @@ namespace Datadog.Trace.Tests.Propagators
             traceContext.Origin = Origin;
             traceContext.Tags.SetTags(PropagatedTagsCollection);
 
-            var context = new SpanContext(parent: null, traceContext, serviceName: null, TraceId, SpanId);
+            var spanContext = new SpanContext(parent: null, traceContext, serviceName: null, TraceId, SpanId);
             var headers = new Mock<IHeadersCollection>();
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             VerifySetCalls(headers, expectedHeaders);
         }
@@ -121,10 +131,10 @@ namespace Datadog.Trace.Tests.Propagators
                 new("x-datadog-tags", @"_dd.p.tid=1234567890abcdef"),
             };
 
-            var context = new SpanContext(traceId, spanId, SamplingPriority, serviceName: null, Origin);
+            var spanContext = new SpanContext(traceId, spanId, SamplingPriority, serviceName: null, Origin);
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             VerifySetCalls(headers, expectedHeaders);
         }
@@ -144,10 +154,10 @@ namespace Datadog.Trace.Tests.Propagators
                 // verify that "_dd.p.tid" tag is not injected for 64-bit trace ids
             };
 
-            var context = new SpanContext(traceId, spanId, SamplingPriority, serviceName: null, Origin);
+            var spanContext = new SpanContext(traceId, spanId, SamplingPriority, serviceName: null, Origin);
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             VerifySetCalls(headers, expectedHeaders);
         }
@@ -155,12 +165,15 @@ namespace Datadog.Trace.Tests.Propagators
         [Fact]
         public void Inject_CarrierAndDelegate()
         {
-            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
+            var spanContext = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
 
             // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object, (carrier, name, value) => carrier.Set(name, value));
+            Propagator.Inject(
+                new PropagationContext(spanContext, TestBaggage),
+                headers.Object,
+                (carrier, name, value) => carrier.Set(name, value));
 
             VerifySetCalls(headers, DefaultHeaderValues);
         }
@@ -168,10 +181,10 @@ namespace Datadog.Trace.Tests.Propagators
         [Fact]
         public void Inject_TraceIdSpanIdOnly()
         {
-            var context = new SpanContext(TraceId, SpanId, samplingPriority: null, serviceName: null, origin: null) { PropagatedTags = null };
+            var spanContext = new SpanContext(TraceId, SpanId, samplingPriority: null, serviceName: null, origin: null) { PropagatedTags = null };
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             // null values are not set, so only traceId and spanId (the first two in the list) should be set
             headers.Verify(h => h.Set("x-datadog-trace-id", TraceId.Lower.ToString(InvariantCulture)), Times.Once());
@@ -182,10 +195,10 @@ namespace Datadog.Trace.Tests.Propagators
         [Fact]
         public void Inject_InvalidSampling()
         {
-            var context = new SpanContext(TraceId, SpanId, samplingPriority: 12, serviceName: null, origin: null);
+            var spanContext = new SpanContext(TraceId, SpanId, samplingPriority: 12, serviceName: null, origin: null);
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             // null values are not set, so only traceId and spanId (the first two in the list) should be set
             headers.Verify(h => h.Set("x-datadog-trace-id", TraceId.Lower.ToString(InvariantCulture)), Times.Once());
@@ -202,20 +215,23 @@ namespace Datadog.Trace.Tests.Propagators
 
             VerifyGetCalls(headers);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = TraceId,
-                           TraceId = TraceId.Lower,
-                           RawTraceId = RawTraceId,
-                           SpanId = SpanId,
-                           RawSpanId = RawSpanId,
-                           Origin = Origin,
-                           SamplingPriority = SamplingPriority,
-                           PropagatedTags = PropagatedTagsCollection,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = TraceId,
+                          TraceId = TraceId.Lower,
+                          RawTraceId = RawTraceId,
+                          SpanId = SpanId,
+                          RawSpanId = RawSpanId,
+                          Origin = Origin,
+                          SamplingPriority = SamplingPriority,
+                          PropagatedTags = PropagatedTagsCollection,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -227,20 +243,23 @@ namespace Datadog.Trace.Tests.Propagators
 
             VerifyGetCalls(headers);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = TraceId,
-                           TraceId = TraceId.Lower,
-                           RawTraceId = RawTraceId,
-                           SpanId = SpanId,
-                           RawSpanId = RawSpanId,
-                           Origin = Origin,
-                           SamplingPriority = SamplingPriority,
-                           PropagatedTags = PropagatedTagsCollection,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = TraceId,
+                          TraceId = TraceId.Lower,
+                          RawTraceId = RawTraceId,
+                          SpanId = SpanId,
+                          RawSpanId = RawSpanId,
+                          Origin = Origin,
+                          SamplingPriority = SamplingPriority,
+                          PropagatedTags = PropagatedTagsCollection,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -251,20 +270,23 @@ namespace Datadog.Trace.Tests.Propagators
 
             VerifyGetCalls(headers);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = TraceId,
-                           TraceId = TraceId.Lower,
-                           RawTraceId = RawTraceId,
-                           SpanId = SpanId,
-                           RawSpanId = RawSpanId,
-                           Origin = Origin,
-                           SamplingPriority = SamplingPriority,
-                           PropagatedTags = PropagatedTagsCollection,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = TraceId,
+                          TraceId = TraceId.Lower,
+                          RawTraceId = RawTraceId,
+                          SpanId = SpanId,
+                          RawSpanId = RawSpanId,
+                          Origin = Origin,
+                          SamplingPriority = SamplingPriority,
+                          PropagatedTags = PropagatedTagsCollection,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -273,7 +295,7 @@ namespace Datadog.Trace.Tests.Propagators
             var headers = new Mock<IHeadersCollection>();
             var result = Propagator.Extract(headers.Object);
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -285,40 +307,43 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Setup(h => h.GetValues("x-datadog-trace-id")).Returns(new[] { TraceId.Lower.ToString(InvariantCulture) });
             var result = Propagator.Extract(headers.Object);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = TraceId,
-                           TraceId = TraceId.Lower,
-                           RawTraceId = RawTraceId,
-                           RawSpanId = "0000000000000000",
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = TraceId,
+                          TraceId = TraceId.Lower,
+                          RawTraceId = RawTraceId,
+                          RawSpanId = "0000000000000000",
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
         public void SpanContextRoundTrip()
         {
-            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
-            var result = Propagator.Extract(context);
+            var spanContext = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
+            var result = Propagator.Extract(spanContext);
 
-            result.Should().NotBeSameAs(context);
-            result.Should().BeEquivalentTo(context);
+            result.SpanContext.Should().NotBeSameAs(spanContext);
+            result.SpanContext.Should().BeEquivalentTo(spanContext);
         }
 
         [Fact]
         public void Identity()
         {
-            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
+            var spanContext = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { PropagatedTags = PropagatedTagsCollection };
             var headers = new NameValueHeadersCollection(new NameValueCollection());
 
-            Propagator.Inject(context, headers);
-            var result = Propagator.Extract(headers);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers);
+            var extractedContext = Propagator.Extract(headers);
 
-            result.Should().NotBeSameAs(context);
-            result.Should().BeEquivalentTo(context);
+            extractedContext.SpanContext.Should().NotBeSameAs(spanContext);
+            extractedContext.SpanContext.Should().BeEquivalentTo(spanContext);
         }
 
         [Theory]
@@ -333,7 +358,7 @@ namespace Datadog.Trace.Tests.Propagators
             var result = Propagator.Extract(headers.Object);
 
             // invalid traceId should return a null context even if other values are set
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Theory]
@@ -347,20 +372,23 @@ namespace Datadog.Trace.Tests.Propagators
 
             var result = Propagator.Extract(headers.Object);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           // SpanId has default value
-                           TraceId128 = TraceId,
-                           TraceId = TraceId.Lower,
-                           RawTraceId = RawTraceId,
-                           RawSpanId = "0000000000000000",
-                           Origin = Origin,
-                           SamplingPriority = SamplingPriority,
-                           PropagatedTags = PropagatedTagsCollection,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          // SpanId has default value
+                          TraceId128 = TraceId,
+                          TraceId = TraceId.Lower,
+                          RawTraceId = RawTraceId,
+                          RawSpanId = "0000000000000000",
+                          Origin = Origin,
+                          SamplingPriority = SamplingPriority,
+                          PropagatedTags = PropagatedTagsCollection,
+                          IsRemote = true,
+                      });
         }
 
         [Theory]
@@ -380,22 +408,25 @@ namespace Datadog.Trace.Tests.Propagators
             // replace SamplingPriority setup
             headers.Setup(h => h.GetValues("x-datadog-sampling-priority")).Returns(new[] { samplingPriority });
 
-            object result = Propagator.Extract(headers.Object);
+            var result = Propagator.Extract(headers.Object);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = TraceId,
-                           TraceId = TraceId.Lower,
-                           RawTraceId = RawTraceId,
-                           SpanId = SpanId,
-                           RawSpanId = RawSpanId,
-                           Origin = Origin,
-                           SamplingPriority = expectedSamplingPriority,
-                           PropagatedTags = PropagatedTagsCollection,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = TraceId,
+                          TraceId = TraceId.Lower,
+                          RawTraceId = RawTraceId,
+                          SpanId = SpanId,
+                          RawSpanId = RawSpanId,
+                          Origin = Origin,
+                          SamplingPriority = expectedSamplingPriority,
+                          PropagatedTags = PropagatedTagsCollection,
+                          IsRemote = true,
+                      });
         }
 
         private static Mock<IHeadersCollection> SetupMockHeadersCollection()
@@ -412,7 +443,8 @@ namespace Datadog.Trace.Tests.Propagators
 
         private static Mock<IReadOnlyDictionary<string, string>> SetupMockReadOnlyDictionary()
         {
-            var headers = new Mock<IReadOnlyDictionary<string, string>>();
+            var headers = new Mock<IReadOnlyDictionary<string, string>>(MockBehavior.Strict);
+            headers.Setup(h => h.Count).Returns(DefaultHeaderValues.Length);
 
             foreach (var pair in DefaultHeaderValues)
             {
@@ -451,6 +483,8 @@ namespace Datadog.Trace.Tests.Propagators
         {
             var once = Times.Once();
             string value;
+
+            headers.Verify(h => h.Count, once);
 
             foreach (var pair in DefaultHeaderValues)
             {

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -232,6 +232,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -260,6 +262,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -296,6 +300,7 @@ namespace Datadog.Trace.Tests.Propagators
             var result = Propagator.Extract(headers.Object);
 
             result.SpanContext.Should().BeNull();
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -321,6 +326,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = EmptyPropagatedTags,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -340,10 +347,12 @@ namespace Datadog.Trace.Tests.Propagators
             var headers = new NameValueHeadersCollection(new NameValueCollection());
 
             Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers);
-            var extractedContext = Propagator.Extract(headers);
+            var result = Propagator.Extract(headers);
 
-            extractedContext.SpanContext.Should().NotBeSameAs(spanContext);
-            extractedContext.SpanContext.Should().BeEquivalentTo(spanContext);
+            result.SpanContext.Should().NotBeSameAs(spanContext);
+            result.SpanContext.Should().BeEquivalentTo(spanContext);
+
+            result.Baggage.Should().BeNull();
         }
 
         [Theory]
@@ -389,6 +398,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Theory]
@@ -427,6 +438,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         private static Mock<IHeadersCollection> SetupMockHeadersCollection()

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -291,6 +291,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -59,13 +59,11 @@ namespace Datadog.Trace.Tests.Propagators
                 [ContextPropagationHeaderStyle.Datadog],
                 false);
 
-            var baggageItems = new KeyValuePair<string, string>[]
+            TestBaggage = new Baggage
             {
-                new("key1", "value1"),
-                new("key2", "value2")
+                { "key1", "value1" },
+                { "key2", "value2" },
             };
-
-            TestBaggage = new Baggage(baggageItems);
         }
 
         public static TheoryData<string> GetInvalidIds() => new()

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
@@ -53,8 +53,8 @@ public class DistributedPropagatorTests
     static DistributedPropagatorTests()
     {
         Propagator = new SpanContextPropagator(
-            injectors: null,
-            extractors: new IContextExtractor[] { DistributedContextExtractor.Instance },
+            injectors: [],
+            extractors: [DistributedContextExtractor.Instance],
             false);
     }
 
@@ -78,20 +78,23 @@ public class DistributedPropagatorTests
 
         VerifyGetCalls(headers);
 
-        result.Should()
+        result.SpanContext
+              .Should()
+              .NotBeNull()
+              .And
               .BeEquivalentTo(
-                   new SpanContextMock
-                   {
-                       TraceId128 = TraceId,
-                       TraceId = TraceId.Lower,
-                       SpanId = SpanId,
-                       RawTraceId = RawTraceId,
-                       RawSpanId = RawSpanId,
-                       Origin = Origin,
-                       SamplingPriority = SamplingPriority,
-                       PropagatedTags = PropagatedTagsCollection,
-                       AdditionalW3CTraceState = AdditionalW3CTraceState,
-                   });
+                  new SpanContextMock
+                  {
+                      TraceId128 = TraceId,
+                      TraceId = TraceId.Lower,
+                      SpanId = SpanId,
+                      RawTraceId = RawTraceId,
+                      RawSpanId = RawSpanId,
+                      Origin = Origin,
+                      SamplingPriority = SamplingPriority,
+                      PropagatedTags = PropagatedTagsCollection,
+                      AdditionalW3CTraceState = AdditionalW3CTraceState,
+                  });
     }
 
     [Fact]
@@ -103,7 +106,7 @@ public class DistributedPropagatorTests
         // extract SpanContext
         var result = Propagator.Extract(headers.Object);
 
-        result.Should().BeNull();
+        result.SpanContext.Should().BeNull();
     }
 
     [Fact]
@@ -113,20 +116,28 @@ public class DistributedPropagatorTests
 
         // only setup TraceId, other properties remain null/empty
         var headers = new Mock<IReadOnlyDictionary<string, string>>();
+        headers.Setup(h => h.Count).Returns(1);
         headers.Setup(h => h.TryGetValue("__DistributedKey-TraceId", out value)).Returns(true);
 
         // extract SpanContext
         var result = Propagator.Extract(headers.Object);
 
-        result.Should().BeEquivalentTo(
-            new SpanContextMock
-            {
-                TraceId128 = TraceId,
-                TraceId = TraceId.Lower,
-                RawTraceId = RawTraceId,
-                RawSpanId = "0000000000000000",
-                PropagatedTags = EmptyPropagatedTags,
-            });
+        result.SpanContext
+              .Should()
+              .NotBeNull()
+              .And
+              .BeEquivalentTo(
+                  new SpanContextMock
+                  {
+                      TraceId128 = TraceId,
+                      TraceId = TraceId.Lower,
+                      RawTraceId = RawTraceId,
+                      RawSpanId = "0000000000000000",
+                      PropagatedTags = EmptyPropagatedTags,
+                  });
+
+        // TODO: add this to all tests
+        result.Baggage.Should().BeNull();
     }
 
     [Fact]
@@ -155,10 +166,10 @@ public class DistributedPropagatorTests
         var result = Propagator.Extract(context);
 
         // they are not the same SpanContext instance...
-        result.Should().NotBeSameAs(context);
+        result.SpanContext.Should().NotBeSameAs(context);
 
         // ...but they contain the same values
-        result.Should().BeEquivalentTo(context);
+        result.SpanContext.Should().BeEquivalentTo(context);
     }
 
     [Theory]
@@ -176,7 +187,7 @@ public class DistributedPropagatorTests
         var result = Propagator.Extract(headers.Object);
 
         // invalid traceId should return a null context even if other values are set
-        result.Should().BeNull();
+        result.SpanContext.Should().BeNull();
     }
 
     [Theory]
@@ -193,20 +204,23 @@ public class DistributedPropagatorTests
         // extract SpanContext
         var result = Propagator.Extract(headers.Object);
 
-        result.Should()
+        result.SpanContext
+              .Should()
+              .NotBeNull()
+              .And
               .BeEquivalentTo(
-                   new SpanContextMock
-                   {
-                       // SpanId has default value
-                       TraceId128 = TraceId,
-                       TraceId = TraceId.Lower,
-                       Origin = Origin,
-                       RawTraceId = RawTraceId,
-                       RawSpanId = RawSpanId,
-                       SamplingPriority = SamplingPriority,
-                       PropagatedTags = PropagatedTagsCollection,
-                       AdditionalW3CTraceState = AdditionalW3CTraceState,
-                   });
+                  new SpanContextMock
+                  {
+                      // SpanId has default value
+                      TraceId128 = TraceId,
+                      TraceId = TraceId.Lower,
+                      Origin = Origin,
+                      RawTraceId = RawTraceId,
+                      RawSpanId = RawSpanId,
+                      SamplingPriority = SamplingPriority,
+                      PropagatedTags = PropagatedTagsCollection,
+                      AdditionalW3CTraceState = AdditionalW3CTraceState,
+                  });
     }
 
     [Theory]
@@ -229,27 +243,31 @@ public class DistributedPropagatorTests
         headers.Setup(h => h.TryGetValue("__DistributedKey-SamplingPriority", out value)).Returns(true);
 
         // extract SpanContext
-        object result = Propagator.Extract(headers.Object);
+        var result = Propagator.Extract(headers.Object);
 
-        result.Should()
+        result.SpanContext
+              .Should()
+              .NotBeNull()
+              .And
               .BeEquivalentTo(
-                   new SpanContextMock
-                   {
-                       TraceId128 = TraceId,
-                       TraceId = TraceId.Lower,
-                       SpanId = SpanId,
-                       RawTraceId = RawTraceId,
-                       RawSpanId = RawSpanId,
-                       Origin = Origin,
-                       SamplingPriority = expectedSamplingPriority,
-                       PropagatedTags = PropagatedTagsCollection,
-                       AdditionalW3CTraceState = AdditionalW3CTraceState,
-                   });
+                  new SpanContextMock
+                  {
+                      TraceId128 = TraceId,
+                      TraceId = TraceId.Lower,
+                      SpanId = SpanId,
+                      RawTraceId = RawTraceId,
+                      RawSpanId = RawSpanId,
+                      Origin = Origin,
+                      SamplingPriority = expectedSamplingPriority,
+                      PropagatedTags = PropagatedTagsCollection,
+                      AdditionalW3CTraceState = AdditionalW3CTraceState,
+                  });
     }
 
     private static Mock<IReadOnlyDictionary<string, string>> SetupMockReadOnlyDictionary()
     {
-        var headers = new Mock<IReadOnlyDictionary<string, string>>();
+        var headers = new Mock<IReadOnlyDictionary<string, string>>(MockBehavior.Strict);
+        headers.Setup(h => h.Count).Returns(DefaultHeaderValues.Length);
 
         foreach (var pair in DefaultHeaderValues)
         {
@@ -264,6 +282,8 @@ public class DistributedPropagatorTests
     {
         var once = Times.Once();
         string value;
+
+        headers.Verify(h => h.Count, once);
 
         foreach (var pair in DefaultHeaderValues)
         {

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -348,6 +348,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = SamplingPriorityValues.AutoKeep,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -378,6 +380,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = SamplingPriorityValues.AutoKeep,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -411,6 +415,8 @@ namespace Datadog.Trace.Tests.Propagators
                           IsRemote = true,
                           LastParentId = ZeroLastParentId,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -450,6 +456,8 @@ namespace Datadog.Trace.Tests.Propagators
                           IsRemote = true,
                           LastParentId = ZeroLastParentId,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -493,6 +501,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]
@@ -515,6 +525,8 @@ namespace Datadog.Trace.Tests.Propagators
             result.TraceId128.Should().Be(expectedTraceId);
             result.TraceId.Should().Be(expectedTraceId.Lower);
             result.SpanId.Should().Be(expectedSpanId);
+
+            context.Baggage.Should().BeNull();
 
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>();
@@ -550,6 +562,8 @@ namespace Datadog.Trace.Tests.Propagators
             result.TraceId.Should().Be(expectedTraceId.Lower);
             result.SpanId.Should().Be(expectedSpanId);
 
+            context.Baggage.Should().BeNull();
+
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>();
             headersForInjection.Setup(h => h.Set("x-b3-traceid", traceId));
@@ -581,6 +595,8 @@ namespace Datadog.Trace.Tests.Propagators
 
             result.TraceId128.Should().Be(expectedTraceId);
             result.SpanId.Should().Be(expectedSpanId);
+
+            context.Baggage.Should().BeNull();
 
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>();

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -42,6 +42,8 @@ namespace Datadog.Trace.Tests.Propagators
         private static readonly SpanContextPropagator DatadogB3PropagatorExtractFirstFalse;
         private static readonly SpanContextPropagator B3W3CPropagatorExtractFirstFalse;
 
+        private static readonly Baggage TestBaggage;
+
         static MultiSpanContextPropagatorTests()
         {
             var names = new[]
@@ -52,7 +54,7 @@ namespace Datadog.Trace.Tests.Propagators
                             ContextPropagationHeaderStyle.B3SingleHeader,
                         };
 
-            Propagator = SpanContextPropagatorFactory.GetSpanContextPropagator(names, names, true);
+            Propagator = SpanContextPropagatorFactory.GetSpanContextPropagator(names, names, propagationExtractFirst: true);
 
             // W3CTraceContext-Datadog Extracts first header only
             W3CDatadogPropagatorExtractFirstTrue = SpanContextPropagatorFactory.GetSpanContextPropagator(
@@ -66,7 +68,7 @@ namespace Datadog.Trace.Tests.Propagators
                     ContextPropagationHeaderStyle.W3CTraceContext,
                     ContextPropagationHeaderStyle.Datadog,
                 },
-                true);
+                propagationExtractFirst: true);
 
             // Datadog-W3CTraceContext Extracts first header only
             DatadogW3CPropagatorExtractFirstTrue = SpanContextPropagatorFactory.GetSpanContextPropagator(
@@ -80,7 +82,7 @@ namespace Datadog.Trace.Tests.Propagators
                     ContextPropagationHeaderStyle.Datadog,
                     ContextPropagationHeaderStyle.W3CTraceContext,
                 },
-                true);
+                propagationExtractFirst: true);
 
             // W3CTraceContext-Datadog
             W3CDatadogPropagatorExtractFirstFalse = SpanContextPropagatorFactory.GetSpanContextPropagator(
@@ -94,7 +96,7 @@ namespace Datadog.Trace.Tests.Propagators
                     ContextPropagationHeaderStyle.W3CTraceContext,
                     ContextPropagationHeaderStyle.Datadog,
                 },
-                false);
+                propagationExtractFirst: false);
 
             // Datadog-W3CTraceContext
             DatadogW3CPropagatorExtractFirstFalse = SpanContextPropagatorFactory.GetSpanContextPropagator(
@@ -122,7 +124,7 @@ namespace Datadog.Trace.Tests.Propagators
                     ContextPropagationHeaderStyle.Datadog,
                     ContextPropagationHeaderStyle.B3MultipleHeaders,
                 },
-                false);
+                propagationExtractFirst: false);
 
             // B3MultipleHeaders-W3CTraceContext
             B3W3CPropagatorExtractFirstFalse = SpanContextPropagatorFactory.GetSpanContextPropagator(
@@ -136,7 +138,15 @@ namespace Datadog.Trace.Tests.Propagators
                     ContextPropagationHeaderStyle.B3MultipleHeaders,
                     ContextPropagationHeaderStyle.W3CTraceContext,
                 },
-                false);
+                propagationExtractFirst: false);
+
+            var baggageItems = new KeyValuePair<string, string>[]
+            {
+                new("key1", "value1"),
+                new("key2", "value2")
+            };
+
+            TestBaggage = new Baggage(baggageItems);
         }
 
         [Fact]
@@ -147,7 +157,7 @@ namespace Datadog.Trace.Tests.Propagators
             traceContext.Origin = "rum";
             traceContext.Tags.SetTags(PropagatedTagsCollection);
 
-            var context = new SpanContext(
+            var spanContext = new SpanContext(
                 parent: SpanContext.None,
                 traceContext,
                 serviceName: null,
@@ -156,7 +166,7 @@ namespace Datadog.Trace.Tests.Propagators
 
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             headers.Verify(h => h.Set("x-datadog-trace-id", "123456789"), Times.Once());
             headers.Verify(h => h.Set("x-datadog-parent-id", "987654321"), Times.Once());
@@ -187,7 +197,7 @@ namespace Datadog.Trace.Tests.Propagators
             var traceId = new TraceId(0x1234567890abcdef, 0x1122334455667788);
             var spanId = 1UL;
 
-            var context = new SpanContext(
+            var spanContext = new SpanContext(
                 parent: SpanContext.None,
                 traceContext,
                 serviceName: null,
@@ -198,7 +208,7 @@ namespace Datadog.Trace.Tests.Propagators
 
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object);
+            Propagator.Inject(new PropagationContext(spanContext, TestBaggage), headers.Object);
 
             headers.Verify(h => h.Set("x-datadog-trace-id", traceId.Lower.ToString(InvariantCulture)), Times.Once());
             headers.Verify(h => h.Set("x-datadog-parent-id", spanId.ToString(InvariantCulture)), Times.Once());
@@ -226,7 +236,7 @@ namespace Datadog.Trace.Tests.Propagators
             traceContext.Origin = "rum";
             traceContext.Tags.SetTags(PropagatedTagsCollection);
 
-            var context = new SpanContext(
+            var spanContext = new SpanContext(
                 parent: SpanContext.None,
                 traceContext,
                 serviceName: null,
@@ -236,7 +246,10 @@ namespace Datadog.Trace.Tests.Propagators
             // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object, (carrier, name, value) => carrier.Set(name, value));
+            Propagator.Inject(
+                new PropagationContext(spanContext, TestBaggage),
+                headers.Object,
+                (carrier, name, value) => carrier.Set(name, value));
 
             headers.Verify(h => h.Set("x-datadog-trace-id", "123456789"), Times.Once());
             headers.Verify(h => h.Set("x-datadog-parent-id", "987654321"), Times.Once());
@@ -267,7 +280,7 @@ namespace Datadog.Trace.Tests.Propagators
             var traceId = new TraceId(0x1234567890abcdef, 0x1122334455667788);
             var spanId = 1UL;
 
-            var context = new SpanContext(
+            var spanContext = new SpanContext(
                 parent: SpanContext.None,
                 traceContext,
                 serviceName: null,
@@ -278,7 +291,10 @@ namespace Datadog.Trace.Tests.Propagators
 
             var headers = new Mock<IHeadersCollection>();
 
-            Propagator.Inject(context, headers.Object, (carrier, name, value) => carrier.Set(name, value));
+            Propagator.Inject(
+                new PropagationContext(spanContext, TestBaggage),
+                headers.Object,
+                (carrier, name, value) => carrier.Set(name, value));
 
             headers.Verify(h => h.Set("x-datadog-trace-id", traceId.Lower.ToString(InvariantCulture)), Times.Once());
             headers.Verify(h => h.Set("x-datadog-parent-id", spanId.ToString(InvariantCulture)), Times.Once());
@@ -316,19 +332,22 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-b3-spanid"), Times.Once());
             headers.Verify(h => h.GetValues("x-b3-sampled"), Times.Once());
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           Origin = null,
-                           SamplingPriority = SamplingPriorityValues.AutoKeep,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          Origin = null,
+                          SamplingPriority = SamplingPriorityValues.AutoKeep,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -342,19 +361,23 @@ namespace Datadog.Trace.Tests.Propagators
             var result = Propagator.Extract(headers.Object);
 
             headers.Verify(h => h.GetValues("b3"), Times.Once());
-            result.Should()
+
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "00000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           Origin = null,
-                           SamplingPriority = SamplingPriorityValues.AutoKeep,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "00000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          Origin = null,
+                          SamplingPriority = SamplingPriorityValues.AutoKeep,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -370,23 +393,24 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("traceparent"), Times.Once());
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           Origin = null,
-                           SamplingPriority = SamplingPriorityValues.AutoKeep,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          Origin = null,
+                          SamplingPriority = SamplingPriorityValues.AutoKeep,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -406,25 +430,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = SamplingPriorityValues.UserKeep,
-                           Origin = "rum",
-                           PropagatedTags = PropagatedTagsCollection,
-                           Parent = null,
-                           ParentId = null,
-                           IsRemote = true,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = SamplingPriorityValues.UserKeep,
+                          Origin = "rum",
+                          PropagatedTags = PropagatedTagsCollection,
+                          Parent = null,
+                          ParentId = null,
+                          IsRemote = true,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -451,20 +476,23 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("x-datadog-origin"), Times.Once());
             headers.Verify(h => h.GetValues("x-datadog-tags"), Times.Once());
 
-            result.Should()
+            result.SpanContext
+                  .Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           SpanId = 987654321,
-                           RawSpanId = "000000003ade68b1",
-                           Origin = "rum",
-                           SamplingPriority = SamplingPriorityValues.AutoKeep,
-                           PropagatedTags = PropagatedTagsCollection,
-                           IsRemote = true,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          SpanId = 987654321,
+                          RawSpanId = "000000003ade68b1",
+                          Origin = "rum",
+                          SamplingPriority = SamplingPriorityValues.AutoKeep,
+                          PropagatedTags = PropagatedTagsCollection,
+                          IsRemote = true,
+                      });
         }
 
         [Fact]
@@ -480,10 +508,11 @@ namespace Datadog.Trace.Tests.Propagators
             var expectedTraceId = new TraceId(0x0af7651916cd43dd, 0x8448eb211c80319c);
             const ulong expectedSpanId = 0x00f067aa0ba902b7UL;
 
-            var result = Propagator.Extract(headers.Object);
+            var context = Propagator.Extract(headers.Object);
+            var result = context.SpanContext!;
 
             result.Should().NotBeNull();
-            result!.TraceId128.Should().Be(expectedTraceId);
+            result.TraceId128.Should().Be(expectedTraceId);
             result.TraceId.Should().Be(expectedTraceId.Lower);
             result.SpanId.Should().Be(expectedSpanId);
 
@@ -491,7 +520,7 @@ namespace Datadog.Trace.Tests.Propagators
             var headersForInjection = new Mock<IHeadersCollection>();
             headersForInjection.Setup(h => h.Set("traceparent", expectedTraceParent));
 
-            Propagator.Inject(result, headersForInjection.Object);
+            Propagator.Inject(new PropagationContext(result, TestBaggage), headersForInjection.Object);
 
             headersForInjection.Verify(h => h.Set("traceparent", expectedTraceParent), Times.Once());
         }
@@ -513,10 +542,11 @@ namespace Datadog.Trace.Tests.Propagators
             var expectedTraceId = new TraceId(0x0af7651916cd43dd, 0x8448eb211c80319c);
             const ulong expectedSpanId = 0x00f067aa0ba902b7UL;
 
-            var result = Propagator.Extract(headers.Object);
+            var context = Propagator.Extract(headers.Object);
+            var result = context.SpanContext!;
 
             result.Should().NotBeNull();
-            result!.TraceId128.Should().Be(expectedTraceId);
+            result.TraceId128.Should().Be(expectedTraceId);
             result.TraceId.Should().Be(expectedTraceId.Lower);
             result.SpanId.Should().Be(expectedSpanId);
 
@@ -526,7 +556,7 @@ namespace Datadog.Trace.Tests.Propagators
             headersForInjection.Setup(h => h.Set("x-b3-spanid", spanId));
             headersForInjection.Setup(h => h.Set("x-b3-sampled", "1"));
 
-            Propagator.Inject(result, headersForInjection.Object);
+            Propagator.Inject(new PropagationContext(result, TestBaggage), headersForInjection.Object);
 
             headersForInjection.Verify(h => h.Set("x-b3-traceid", traceId), Times.Once());
             headersForInjection.Verify(h => h.Set("x-b3-spanid", spanId), Times.Once());
@@ -543,23 +573,25 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Setup(h => h.GetValues("b3"))
                    .Returns(new[] { expectedTraceParent });
 
-            var result = Propagator.Extract(headers.Object);
+            var context = Propagator.Extract(headers.Object);
+            var result = context.SpanContext!;
 
             var expectedTraceId = new TraceId(0x0af7651916cd43ddUL, 0x8448eb211c80319cUL);
             const ulong expectedSpanId = 0x00f067aa0ba902b7UL;
-            Assert.Equal(expectedTraceId, result!.TraceId128);
-            Assert.Equal(expectedSpanId, result.SpanId);
+
+            result.TraceId128.Should().Be(expectedTraceId);
+            result.SpanId.Should().Be(expectedSpanId);
 
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>();
             headersForInjection.Setup(h => h.Set("b3", expectedTraceParent));
 
-            Propagator.Inject(result, headersForInjection.Object);
+            Propagator.Inject(new PropagationContext(result, TestBaggage), headersForInjection.Object);
 
             headersForInjection.Verify(h => h.Set("b3", expectedTraceParent), Times.Once());
         }
 
-        // Tests for making sure the behaviour of either copying the valid tracecontext or not is accurate
+        // Tests for making sure the behavior of either copying the valid tracecontext or not is accurate
         [Theory]
         [InlineData(false, false)]
         [InlineData(false, true)]
@@ -594,26 +626,27 @@ namespace Datadog.Trace.Tests.Propagators
                 },
                 null);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(0x1111111111111111, 1),
-                           TraceId = 1,
-                           SpanId = 987654321,
-                           RawTraceId = "11111111111111110000000000000001",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = SamplingPriorityValues.UserKeep,
-                           PropagatedTags = propagatedTags,
-                           Origin = "rum",
-                           AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
-                           Parent = null,
-                           ParentId = null,
-                           IsRemote = true,
-                           LastParentId = w3CHeaderFirst ? "0123456789abcdef" : null, // if we have Datadog headers don't use p
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(0x1111111111111111, 1),
+                          TraceId = 1,
+                          SpanId = 987654321,
+                          RawTraceId = "11111111111111110000000000000001",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = SamplingPriorityValues.UserKeep,
+                          PropagatedTags = propagatedTags,
+                          Origin = "rum",
+                          AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
+                          Parent = null,
+                          ParentId = null,
+                          IsRemote = true,
+                          LastParentId = w3CHeaderFirst ? "0123456789abcdef" : null, // if we have Datadog headers don't use p
+                      });
         }
 
         [Theory]
@@ -648,25 +681,26 @@ namespace Datadog.Trace.Tests.Propagators
                 },
                 null);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(0x1111111111111111, 2),
-                           TraceId = 2,
-                           SpanId = 987654321,
-                           RawTraceId = "11111111111111110000000000000002",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = w3CHeaderFirst ? 1 : 2,
-                           PropagatedTags = propagatedTags,
-                           AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
-                           Parent = null,
-                           ParentId = null,
-                           IsRemote = true,
-                           LastParentId = w3CHeaderFirst ? "0123456789abcdef" : null, // if we have Datadog headers don't use p
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(0x1111111111111111, 2),
+                          TraceId = 2,
+                          SpanId = 987654321,
+                          RawTraceId = "11111111111111110000000000000002",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = w3CHeaderFirst ? 1 : 2,
+                          PropagatedTags = propagatedTags,
+                          AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
+                          Parent = null,
+                          ParentId = null,
+                          IsRemote = true,
+                          LastParentId = w3CHeaderFirst ? "0123456789abcdef" : null, // if we have Datadog headers don't use p
+                      });
         }
 
         [Theory]
@@ -701,25 +735,26 @@ namespace Datadog.Trace.Tests.Propagators
                 },
                 null);
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(0x1111111111111111, 3),
-                           TraceId = 3,
-                           SpanId = 987654321,
-                           RawTraceId = "11111111111111110000000000000003",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = w3CHeaderFirst ? 1 : 2,
-                           PropagatedTags = !w3CHeaderFirst ? propagatedTags : new TraceTagCollection(),
-                           AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
-                           Parent = null,
-                           ParentId = null,
-                           IsRemote = true,
-                           LastParentId = w3CHeaderFirst ? ZeroLastParentId : null,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(0x1111111111111111, 3),
+                          TraceId = 3,
+                          SpanId = 987654321,
+                          RawTraceId = "11111111111111110000000000000003",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = w3CHeaderFirst ? 1 : 2,
+                          PropagatedTags = !w3CHeaderFirst ? propagatedTags : new TraceTagCollection(),
+                          AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
+                          Parent = null,
+                          ParentId = null,
+                          IsRemote = true,
+                          LastParentId = w3CHeaderFirst ? ZeroLastParentId : null,
+                      });
         }
 
         [Theory]
@@ -756,25 +791,26 @@ namespace Datadog.Trace.Tests.Propagators
 
             bool expectW3cParentIds = w3CHeaderFirst || !extractFirst;
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(0x1111111111111111, 4),
-                           TraceId = 4,
-                           SpanId = (ulong)(expectW3cParentIds ? 987654321 : 3540),
-                           RawTraceId = "11111111111111110000000000000004",
-                           RawSpanId = expectW3cParentIds ? "000000003ade68b1" : "0000000000000dd4",
-                           SamplingPriority = 2,
-                           PropagatedTags = propagatedTags,
-                           AdditionalW3CTraceState = expectW3cParentIds ? "foo=1" : null,
-                           Parent = null,
-                           ParentId = null,
-                           IsRemote = true,
-                           LastParentId =  expectW3cParentIds ? "0123456789abcdef" : null,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(0x1111111111111111, 4),
+                          TraceId = 4,
+                          SpanId = (ulong)(expectW3cParentIds ? 987654321 : 3540),
+                          RawTraceId = "11111111111111110000000000000004",
+                          RawSpanId = expectW3cParentIds ? "000000003ade68b1" : "0000000000000dd4",
+                          SamplingPriority = 2,
+                          PropagatedTags = propagatedTags,
+                          AdditionalW3CTraceState = expectW3cParentIds ? "foo=1" : null,
+                          Parent = null,
+                          ParentId = null,
+                          IsRemote = true,
+                          LastParentId = expectW3cParentIds ? "0123456789abcdef" : null,
+                      });
         }
 
         [Theory]
@@ -811,25 +847,26 @@ namespace Datadog.Trace.Tests.Propagators
 
             var traceId = new TraceId(0x1111111111111111, (ulong)(w3CHeaderFirst ? 5 : 0xdd5));
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = traceId,
-                           TraceId = (ulong)(w3CHeaderFirst ? 5 : 0xdd5),
-                           SpanId = 987654321,
-                           RawTraceId = traceId.ToString(),
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = w3CHeaderFirst ? 1 : 2,
-                           PropagatedTags = !w3CHeaderFirst ? propagatedTags : new TraceTagCollection(),
-                           AdditionalW3CTraceState = w3CHeaderFirst ? "foo=1" : null,
-                           Parent = null,
-                           ParentId = null,
-                           IsRemote = true,
-                           LastParentId = w3CHeaderFirst ? ZeroLastParentId : null,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = traceId,
+                          TraceId = (ulong)(w3CHeaderFirst ? 5 : 0xdd5),
+                          SpanId = 987654321,
+                          RawTraceId = traceId.ToString(),
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = w3CHeaderFirst ? 1 : 2,
+                          PropagatedTags = !w3CHeaderFirst ? propagatedTags : new TraceTagCollection(),
+                          AdditionalW3CTraceState = w3CHeaderFirst ? "foo=1" : null,
+                          Parent = null,
+                          ParentId = null,
+                          IsRemote = true,
+                          LastParentId = w3CHeaderFirst ? ZeroLastParentId : null,
+                      });
         }
 
         [Theory]
@@ -854,23 +891,23 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Add("x-b3-spanid", $"{HexString.ToHexString(uLongParentId)}");
             headers.Add("x-b3-sampled", "1");
 
-            var resultDatadogW3C = DatadogW3CPropagatorExtractFirstFalse.Extract(headers);
+            var resultDatadogW3C = DatadogW3CPropagatorExtractFirstFalse.Extract(headers).SpanContext!;
             resultDatadogW3C.Should().NotBeNull();
-            resultDatadogW3C?.SpanId.Should().Be(expectedSpanId);
-            resultDatadogW3C?.LastParentId.Should().Be(expectedParentTag);
+            resultDatadogW3C.SpanId.Should().Be(expectedSpanId);
+            resultDatadogW3C.LastParentId.Should().Be(expectedParentTag);
 
-            var resultDatadogB3 = DatadogB3PropagatorExtractFirstFalse.Extract(headers);
+            var resultDatadogB3 = DatadogB3PropagatorExtractFirstFalse.Extract(headers).SpanContext!;
             resultDatadogB3.Should().NotBeNull();
-            resultDatadogB3?.SpanId.Should().Be(uLongParentId);
-            resultDatadogB3?.LastParentId.Should().Be(null);
+            resultDatadogB3.SpanId.Should().Be(uLongParentId);
+            resultDatadogB3.LastParentId.Should().Be(null);
 
-            var resultB3W3C = B3W3CPropagatorExtractFirstFalse.Extract(headers);
+            var resultB3W3C = B3W3CPropagatorExtractFirstFalse.Extract(headers).SpanContext!;
             resultB3W3C.Should().NotBeNull();
-            resultB3W3C?.SpanId.Should().Be(expectedSpanId);
-            resultB3W3C?.LastParentId.Should().Be(expectedParentTag);
+            resultB3W3C.SpanId.Should().Be(expectedSpanId);
+            resultB3W3C.LastParentId.Should().Be(expectedParentTag);
         }
 
-        private SpanContextPropagator GetPropagatorToTest(bool extractFirst, bool w3CHeaderFirst)
+        private static SpanContextPropagator GetPropagatorToTest(bool extractFirst, bool w3CHeaderFirst)
             => (w3CHeaderFirst, extractFirst) switch
         {
             (true, true) => W3CDatadogPropagatorExtractFirstTrue,

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -140,13 +140,11 @@ namespace Datadog.Trace.Tests.Propagators
                 },
                 propagationExtractFirst: false);
 
-            var baggageItems = new KeyValuePair<string, string>[]
+            TestBaggage = new Baggage
             {
-                new("key1", "value1"),
-                new("key2", "value2")
+                { "key1", "value1" },
+                { "key2", "value2" },
             };
-
-            TestBaggage = new Baggage(baggageItems);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -31,12 +31,22 @@ namespace Datadog.Trace.Tests.Propagators
 
         private static readonly SpanContextPropagator W3CPropagator;
 
+        private static readonly Baggage TestBaggage;
+
         static W3CTraceContextPropagatorTests()
         {
             W3CPropagator = SpanContextPropagatorFactory.GetSpanContextPropagator(
-                new[] { ContextPropagationHeaderStyle.W3CTraceContext },
-                new[] { ContextPropagationHeaderStyle.W3CTraceContext },
+                [ContextPropagationHeaderStyle.W3CTraceContext],
+                [ContextPropagationHeaderStyle.W3CTraceContext],
                 false);
+
+            var baggageItems = new KeyValuePair<string, string>[]
+            {
+                new("key1", "value1"),
+                new("key2", "value2")
+            };
+
+            TestBaggage = new Baggage(baggageItems);
         }
 
         [Theory]
@@ -152,7 +162,8 @@ namespace Datadog.Trace.Tests.Propagators
             var spanContext = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, traceId: (TraceId)123456789, spanId: 987654321, rawTraceId: null, rawSpanId: null);
             var headers = new Mock<IHeadersCollection>();
 
-            W3CPropagator.Inject(spanContext, headers.Object);
+            var context = new PropagationContext(spanContext, TestBaggage);
+            W3CPropagator.Inject(context, headers.Object);
 
             headers.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-01"), Times.Once());
             headers.Verify(h => h.Set("tracestate", "dd=s:2;o:origin;p:000000003ade68b1,key1=value1"), Times.Once());
@@ -175,7 +186,8 @@ namespace Datadog.Trace.Tests.Propagators
             var spanContext = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, traceId, spanId, rawTraceId: traceId.ToString(), rawSpanId: spanId.ToString("x16"));
             var headers = new Mock<IHeadersCollection>();
 
-            W3CPropagator.Inject(spanContext, headers.Object);
+            var context = new PropagationContext(spanContext, TestBaggage);
+            W3CPropagator.Inject(context, headers.Object);
 
             headers.Verify(h => h.Set("traceparent", "00-1234567890abcdef1122334455667788-0000000000000001-01"), Times.Once());
             headers.Verify(h => h.Set("tracestate", "dd=s:2;o:origin;p:0000000000000001,key1=value1"), Times.Once());
@@ -195,7 +207,8 @@ namespace Datadog.Trace.Tests.Propagators
             var spanContext = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, traceId: (TraceId)123456789, spanId: 987654321, rawTraceId: null, rawSpanId: null);
             var headers = new Mock<IHeadersCollection>();
 
-            W3CPropagator.Inject(spanContext, headers.Object, (carrier, name, value) => carrier.Set(name, value));
+            var context = new PropagationContext(spanContext, TestBaggage);
+            W3CPropagator.Inject(context, headers.Object, (carrier, name, value) => carrier.Set(name, value));
 
             headers.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-01"), Times.Once());
             headers.Verify(h => h.Set("tracestate", "dd=s:2;o:origin;p:000000003ade68b1,key1=value1"), Times.Once());
@@ -340,7 +353,8 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
@@ -386,7 +400,8 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.AtMost(1));
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
@@ -424,25 +439,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = SamplingPriorityValues.UserKeep,
-                           Origin = "rum",
-                           PropagatedTags = PropagatedTagsCollection,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = SamplingPriorityValues.UserKeep,
+                          Origin = "rum",
+                          PropagatedTags = PropagatedTagsCollection,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId
+                      });
         }
 
         [Fact]
@@ -468,7 +484,7 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Never());
             headers.VerifyNoOtherCalls();
 
-            result.Should().BeNull();
+            result.SpanContext.Should().BeNull();
         }
 
         [Fact]
@@ -495,26 +511,27 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = SamplingPriorityValues.UserKeep,
-                           Origin = "rum",
-                           PropagatedTags = PropagatedTagsCollection,
-                           AdditionalW3CTraceState = "abc=123,foo=bar",
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = "0123456789abcdef",
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = SamplingPriorityValues.UserKeep,
+                          Origin = "rum",
+                          PropagatedTags = PropagatedTagsCollection,
+                          AdditionalW3CTraceState = "abc=123,foo=bar",
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = "0123456789abcdef",
+                      });
         }
 
         [Fact]
@@ -534,25 +551,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = SamplingPriorityValues.AutoKeep,
-                           Origin = null,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = SamplingPriorityValues.AutoKeep,
+                          Origin = null,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -670,25 +688,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = samplingPriority,
-                           Origin = null,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = samplingPriority,
+                          Origin = null,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Theory]
@@ -711,25 +730,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = samplingPriority,
-                           Origin = null,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = samplingPriority,
+                          Origin = null,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -749,30 +769,31 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = 1,
-                           Origin = null,
-                           PropagatedTags = new(
-                               new List<KeyValuePair<string, string>>
-                               {
-                                   new("_dd.p.dm", "-0"),
-                               },
-                               cachedPropagationHeader: null),
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = 1,
+                          Origin = null,
+                          PropagatedTags = new(
+                              new List<KeyValuePair<string, string>>
+                              {
+                                  new("_dd.p.dm", "-0"),
+                              },
+                              cachedPropagationHeader: null),
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -792,30 +813,31 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(0x0000000000000000, 0x00000000075bcd15),
-                           TraceId = 0x00000000075bcd15,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = 1,
-                           Origin = null,
-                           PropagatedTags = new(
-                               new List<KeyValuePair<string, string>>
-                               {
-                                   new("_dd.p.dm", "-0"),
-                               },
-                               cachedPropagationHeader: null),
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(0x0000000000000000, 0x00000000075bcd15),
+                          TraceId = 0x00000000075bcd15,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = 1,
+                          Origin = null,
+                          PropagatedTags = new(
+                              new List<KeyValuePair<string, string>>
+                              {
+                                  new("_dd.p.dm", "-0"),
+                              },
+                              cachedPropagationHeader: null),
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -835,25 +857,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = 0,
-                           Origin = null,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = 0,
+                          Origin = null,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -873,25 +896,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = new TraceId(0x0000000000000000, 0x00000000075bcd15),
-                           TraceId = 0x00000000075bcd15,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = 0,
-                           Origin = null,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = new TraceId(0x0000000000000000, 0x00000000075bcd15),
+                          TraceId = 0x00000000075bcd15,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = 0,
+                          Origin = null,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -911,25 +935,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = 1,
-                           Origin = null,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = 1,
+                          Origin = null,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
 
         [Fact]
@@ -949,25 +974,26 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.GetValues("tracestate"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            result.Should()
+            result.SpanContext
+                  .Should()
                   .NotBeNull()
                   .And
                   .BeEquivalentTo(
-                       new SpanContextMock
-                       {
-                           TraceId128 = (TraceId)123456789,
-                           TraceId = 123456789,
-                           SpanId = 987654321,
-                           RawTraceId = "000000000000000000000000075bcd15",
-                           RawSpanId = "000000003ade68b1",
-                           SamplingPriority = 0,
-                           Origin = null,
-                           PropagatedTags = EmptyPropagatedTags,
-                           IsRemote = true,
-                           Parent = null,
-                           ParentId = null,
-                           LastParentId = ZeroLastParentId,
-                       });
+                      new SpanContextMock
+                      {
+                          TraceId128 = (TraceId)123456789,
+                          TraceId = 123456789,
+                          SpanId = 987654321,
+                          RawTraceId = "000000000000000000000000075bcd15",
+                          RawSpanId = "000000003ade68b1",
+                          SamplingPriority = 0,
+                          Origin = null,
+                          PropagatedTags = EmptyPropagatedTags,
+                          IsRemote = true,
+                          Parent = null,
+                          ParentId = null,
+                          LastParentId = ZeroLastParentId,
+                      });
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -459,6 +459,8 @@ namespace Datadog.Trace.Tests.Propagators
                           ParentId = null,
                           LastParentId = ZeroLastParentId
                       });
+
+            result.Baggage.Should().BeNull();
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -40,13 +40,11 @@ namespace Datadog.Trace.Tests.Propagators
                 [ContextPropagationHeaderStyle.W3CTraceContext],
                 false);
 
-            var baggageItems = new KeyValuePair<string, string>[]
+            TestBaggage = new Baggage
             {
-                new("key1", "value1"),
-                new("key2", "value2")
+                { "key1", "value1" },
+                { "key2", "value2" },
             };
-
-            TestBaggage = new Baggage(baggageItems);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -501,13 +501,14 @@ namespace Datadog.Trace.Tests
 
             IHeadersCollection headers = WebRequest.CreateHttp("http://localhost").Headers.Wrap();
 
-            SpanContextPropagator.Instance.Inject(secondSpan.Context, headers);
-            var resultContext = SpanContextPropagator.Instance.Extract(headers);
+            SpanContextPropagator.Instance.Inject(new PropagationContext(secondSpan.Context, baggage: null), headers);
+            var context = SpanContextPropagator.Instance.Extract(headers);
+            var spanContext = context.SpanContext!;
 
-            Assert.NotNull(resultContext);
-            Assert.Equal(firstSpan.Context.Origin, resultContext.Origin);
-            Assert.Equal(secondSpan.Context.Origin, resultContext.Origin);
-            Assert.Equal(origin, resultContext.Origin);
+            spanContext.Should().NotBeNull();
+            spanContext.Origin.Should().Be(firstSpan.Context.Origin);
+            spanContext.Origin.Should().Be(secondSpan.Context.Origin);
+            spanContext.Origin.Should().Be(origin);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

First of multiple PRs to add OpenTelemetry baggage support.

This PR prepares propagators to support baggage. Since all propagators are currently _trace_ propagators and work on `SpanContext`, this PR changes all propagator signatures to accept or return a new `PropationContext` instead. `PropationContext` is a light container for both the existing `SpanContext` and the new `Baggage` type.

Baggage progpation across services is _not_ implemented in this PR.

## Reason for change

Adding support for OpenTelemetry baggage.

## Implementation details

- Add `Baggage` class
- Add `PropagationContext`, which contains `SpanContext` and `Baggage`
- Modify all propagator signatures (and usages) to replace `SpanContext` with `PropagationContext`

## Test coverage

- added unit tests for `Baggage` (get, set, remove, etc)
- existing propagators are already covered by extensive tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
