### PR TITLE
Add support for the "new" dev.azure.com style URLs in SourceLink URL parsing logic

### DIFF
--- a/tracer/src/Datadog.Trace/PDBs/SourceLink/AzureDevOpsSourceLinkUrlParser.cs
+++ b/tracer/src/Datadog.Trace/PDBs/SourceLink/AzureDevOpsSourceLinkUrlParser.cs
@@ -15,15 +15,16 @@ namespace Datadog.Trace.Pdb.SourceLink;
 internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
 {
     /// <summary>
-    /// Extract the git commit sha and repository url from a Azure DevOps SourceLink mapping string.
-    /// For example, for the following SourceLink mapping string:
-    ///     https://test.visualstudio.com/test-org/_apis/git/repositories/my-repo/items?api-version=1.0&amp;versionType=commit&amp;version=dd35903c688a74b62d1c6a9e4f41371c65704db8&amp;path=/*
-    /// It will return:
+    ///     Extract the git commit sha and repository url from a Azure DevOps SourceLink mapping string.
+    ///     For example, for the following SourceLink mapping string:
+    ///     https://test.visualstudio.com/test-org/_apis/git/repositories/my-repo/items?api-version=1.0&amp;versionType=commit
+    ///     &amp;version=dd35903c688a74b62d1c6a9e4f41371c65704db8&amp;path=/*
+    ///     It will return:
     ///     - commit sha: dd35903c688a74b62d1c6a9e4f41371c65704db8
     ///     - repository URL: https://test.visualstudio.com/test-org/_git/my-repo
-    /// 
-	/// Likewise, for the following SourceLink mapping string:
-    ///     https://dev.azure.com/organisation/project/_apis/git/repositories/example.shopping.api/items?api-version=1.0&amp;versionType=commit&amp;version=0e4d29442102e6cef1c271025d513c8b2187bcd6&amp;path=/*
+    ///     Likewise, for the following SourceLink mapping string:
+    ///     https://dev.azure.com/organisation/project/_apis/git/repositories/example.shopping.api/items?api-version=1.0&amp;
+    ///     versionType=commit&amp;version=0e4d29442102e6cef1c271025d513c8b2187bcd6&amp;path=/*
     /// It will return:
     ///     - commit sha: 0e4d29442102e6cef1c271025d513c8b2187bcd6
     ///     - repository URL: https://dev.azure.com/organisation/project/_git/example.shopping.api
@@ -52,7 +53,7 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
                 return false;
             }
 
-            var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var segments = uri.AbsolutePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             if (segments.Length < 5)
             {
                 return false;
@@ -72,7 +73,7 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
 
     private static string? BuildRepositoryUrl(Uri uri)
     {
-        var segments = uri.AbsolutePath.Split(['/'], StringSplitOptions.RemoveEmptyEntries);
+        var segments = uri.AbsolutePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length < 5)
         {
             return null;
@@ -85,7 +86,8 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
             var repoName = segments[4];
             return $"https://{uri.Host}/{project}/_git/{repoName}";
         }
-        else if (uri.Host.EndsWith("dev.azure.com", StringComparison.OrdinalIgnoreCase))
+
+        if (uri.Host.EndsWith("dev.azure.com", StringComparison.OrdinalIgnoreCase))
         {
             // New format: https://dev.azure.com/{organization}
             var organization = segments[0];
@@ -93,10 +95,9 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
             var repoName = segments[5];
             return $"https://{uri.Host}/{organization}/{project}/_git/{repoName}";
         }
-        else
-        {
-            throw new NotSupportedException($"Unsupported Azure DevOps host: {uri.Host}");
-        }
+
+        Log.Error("Unsupported Azure DevOps host: {Host}", uri.Host);
+        return null;
     }
 
     private static NameValueCollection ParseQueryString(string queryString)
@@ -108,7 +109,7 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
         var pairs = queryString.Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
         foreach (var pair in pairs)
         {
-            var parts = pair.Split(new[] { '=' }, 2);
+            var parts = pair.Split(new char[] { '=' }, 2);
             if (parts.Length == 2)
             {
                 query.Add(parts[0], parts[1]);

--- a/tracer/src/Datadog.Trace/PDBs/SourceLink/AzureDevOpsSourceLinkUrlParser.cs
+++ b/tracer/src/Datadog.Trace/PDBs/SourceLink/AzureDevOpsSourceLinkUrlParser.cs
@@ -53,12 +53,6 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
                 return false;
             }
 
-            var segments = uri.AbsolutePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-            if (segments.Length < 5)
-            {
-                return false;
-            }
-
             repositoryUrl = BuildRepositoryUrl(uri);
 
             return repositoryUrl != null;

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/SourceLinkUriParserTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/SourceLinkUriParserTests.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 yield return new object[] { "https://api.bitbucket.org/2.0/repositories/test-org/test-repo/src/dd35903c688a74b62d1c6a9e4f41371c65704db8/*", "dd35903c688a74b62d1c6a9e4f41371c65704db8", "https://bitbucket.org/test-org/test-repo", typeof(BitBucketSourceLinkUrlParser) };
                 yield return new object[] { "https://test.visualstudio.com/test-org/_apis/git/repositories/my-repo/items?api-version=1.0&versionType=commit&version=dd35903c688a74b62d1c6a9e4f41371c65704db8&path=/*", "dd35903c688a74b62d1c6a9e4f41371c65704db8", "https://test.visualstudio.com/test-org/_git/my-repo", typeof(AzureDevOpsSourceLinkUrlParser) };
                 yield return new object[] { "https://test-gitlab-domain.com/test-org/test-repo/raw/dd35903c688a74b62d1c6a9e4f41371c65704db8/*", "dd35903c688a74b62d1c6a9e4f41371c65704db8", "https://test-gitlab-domain.com/test-org/test-repo", typeof(GitLabSourceLinkUrlParser) };
+                yield return new object[] { "https://dev.azure.com/organisation/project/_apis/git/repositories/example.shopping.api/items?api-version=1.0&versionType=commit&version=0e4d29442102e6cef1c271025d513c8b2187bcd6&path=/*", "0e4d29442102e6cef1c271025d513c8b2187bcd6", "https://dev.azure.com/organisation/project/_git/example.shopping.api", typeof(AzureDevOpsSourceLinkUrlParser) };
             }
         }
 


### PR DESCRIPTION
## Summary of changes

Fixes #6146

## Reason for change
Customer reported an issue where the tracer reports incorrect `git.repository_url` as a result of this bug.


## Test coverage
Add a new test case.