### PR TITLE
Include pID in managed logs filename

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -104,16 +104,6 @@ internal static class DatadogLoggingFactory
         {
             var managedLogPath = Path.Combine(fileConfig.LogDirectory, $"dotnet-tracer-managed-{domainMetadata.ProcessName}-{domainMetadata.ProcessId.ToString(CultureInfo.InvariantCulture)}.log");
 
-#if NETFRAMEWORK
-            // In IIS, the log file is shared between all app domains, so we need this setup
-            var shared = true;
-            var buffered = false;
-#else
-            // In .NET Core, we always have one tracer per process, so we can yolo this a bit more
-            var shared = false;
-            var buffered = true;
-#endif
-
             loggerConfiguration
                .WriteTo.File(
                     managedLogPath,
@@ -121,9 +111,7 @@ internal static class DatadogLoggingFactory
                     rollingInterval: RollingInterval.Infinite, // don't do daily rolling, rely on the file size limit for rolling instead
                     rollOnFileSizeLimit: true,
                     fileSizeLimitBytes: fileConfig.MaxLogFileSizeBytes,
-                    shared: shared,
-                    buffered: buffered,
-                    flushToDiskInterval: buffered ? TimeSpan.FromSeconds(1) : null); // make sure we still flush to disk if we're buffered
+                    shared: true);
         }
 
         try


### PR DESCRIPTION
## Summary of changes

- Adds the process ID to the managed logs filename
- ~Enables buffering in .NET Core~ Reverted this change, as not required and caused test failures. Should be invetigated later

## Reason for change

While investigating #6147, we discovered that if you have two app pools, running under different users, the second app domain is unable to write managed logs. This is because it's unable to hold the shared mutex that's used to synchronize access to the file.

## Implementation details

Include the pID in the filename, so each process writes to a separate file.

<details><summary>I originally enabled buffering, but removed it</summary>
<p>
As a consequence, if we only have one tracer instance writing to a managed file, then we no longer need to have a shared logger, and can enable buffering, which should improve performance by buffering writes to the file.
</p>
<ul>
<li>We can't assume this in .NET Framework, as we can have multiple app domains writing to the same file, so this is only enabled for .NET Core.</li>
<li>_Theoretically_ this is a problem in version conflict, where we could have a v2 tracer loaded at the same time as a v3 tracer. However, as this PR changes the file name to differ from v2, that's not an issue, so we should still be safe</li>
<li>For the buffering, we need to choose a flush interval. I plucked 1s out of the sky - any other suggestions?</li>

</details> 

However, I reverted this change as it broke the dynamic instrumentation tests, because they ended up reading partial lines. We _should_ fix this so that we can get the perf benefit of buffering etc, but it's tangential to the bug fix, so removed for now.



## Test coverage

Yeah... the existing integration tests obviously write a bunch of logs... any suggestion for additional tests we should add would be gratefully received...

## Other details

I also updated the file-rolling behaviour. Having daily file rolling _in addition_ to split by pid _and_ file size limit seemed more confusing than anything else.

- For customers that have multi-day-long processes with high log volume, the results should be broadly the same, as they're limited by rolling file size
- For customers that have multi-day-long processes with low log volume, log volume overall may increase, as they won't roll _until_ they hit the log limit? I think, this one I'm struggling to visualize
- For customers with short-lived processes, they will have more _files_ but these will use the same amount of space.
