### PR TITLE
Opt Datadog.Trace.Manual out of NGEN

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1488,11 +1488,24 @@ partial class Build
                         .SetProjectFile(project)));
 
                 var projectsToPublish = includeIntegration
-                   .Select(x => Solution.GetProject(x))
-                   .Where(x => x.Name switch
+                   .Select(x =>
                     {
-                        "Samples.Trimming" => Framework.IsGreaterThanOrEqualTo(TargetFramework.NET6_0),
-                        _ => false,
+                        var project = Solution.GetProject(x);
+                        return project?.Name switch
+                        {
+                            "Samples.Trimming" => (project, include: Framework.IsGreaterThanOrEqualTo(TargetFramework.NET6_0), r2r: false),
+                            "Samples.ManualInstrumentation" => (project, include: Framework.IsGreaterThanOrEqualTo(TargetFramework.NETCOREAPP2_1), r2r: false),
+                            _ => (project, include: false, r2r: false),
+                        };
+                    })
+                   .Where(x => (x, x.project.TryGetTargetFrameworks(), x.project.RequiresDockerDependency()) switch
+                    {
+                        ({include: false }, _, _) => false,
+                        _ when exclude.Contains(x.project.Path) => false,
+                        _ when !string.IsNullOrWhiteSpace(SampleName) => x.project.Path.ToString().Contains(SampleName, StringComparison.OrdinalIgnoreCase),
+                        (_, _, DockerDependencyType.All) => false, // can't use docker on Windows
+                        (_, { } targets, _) => targets.Contains(Framework),
+                        _ => true,
                     });
 
                 var rid = IsArm64 ? "win-arm64" : "win-x64";
@@ -1500,7 +1513,9 @@ partial class Build
                    .SetConfiguration(BuildConfiguration)
                    .SetFramework(Framework)
                    .SetRuntime(rid)
-                   .CombineWith(projectsToPublish, (s, project) => s.SetProject(project)));
+                   .CombineWith(projectsToPublish, (s, project) => s
+                      .SetProject(project.project)
+                      .When(project.r2r, x => x.SetPublishReadyToRun(true))));
             }
         });
 
@@ -1912,20 +1927,25 @@ partial class Build
 
             // We have to explicitly publish the trimming sample separately (written so we can add to this later if needs be)
             var projectsToPublish = sampleProjects
-               .Select(x => Solution.GetProject(x))
-               .Where(x => x?.Name switch
+               .Select(x =>
                 {
-                    "Samples.Trimming" => x.TryGetTargetFrameworks().Contains(Framework),
-                    _ => false,
+                    var project = Solution.GetProject(x);
+                    return project?.Name switch
+                    {
+                        "Samples.Trimming" => (project, include: Framework.IsGreaterThanOrEqualTo(TargetFramework.NET6_0), r2r: false),
+                        "Samples.ManualInstrumentation" => (project, include: Framework.IsGreaterThanOrEqualTo(TargetFramework.NETCOREAPP2_1), r2r: false),
+                        _ => (project, include: false, r2r: false),
+                    };
                 })
                .Where(x => (IncludeTestsRequiringDocker, x) switch
                 {
                     // filter out or to integration tests that have docker dependencies
+                    (_, {include: false }) => false,
                     (null, _) => true,
-                    (_, null) => true,
-                    (_, { } p) when !string.IsNullOrWhiteSpace(SampleName) => p.Name.Contains(SampleName, StringComparison.OrdinalIgnoreCase),
-                    (false, { } p) => p.RequiresDockerDependency() == DockerDependencyType.None,
-                    (true, { } p) => p.RequiresDockerDependency() != DockerDependencyType.None,
+                    (_, { project: null}) => true,
+                    (_, { } p) when !string.IsNullOrWhiteSpace(SampleName) => p.project.Name.Contains(SampleName, StringComparison.OrdinalIgnoreCase),
+                    (false, { } p) => p.project.RequiresDockerDependency() == DockerDependencyType.None,
+                    (true, { } p) => p.project.RequiresDockerDependency() != DockerDependencyType.None,
                 });
 
             var rid = (IsLinux, IsArm64) switch
@@ -1939,7 +1959,9 @@ partial class Build
                .SetConfiguration(BuildConfiguration)
                .SetFramework(Framework)
                .SetRuntime(rid)
-               .CombineWith(projectsToPublish, (s, project) => s.SetProject(project)));
+               .CombineWith(projectsToPublish, (s, project) => s
+                  .SetProject(project.project)
+                  .When(project.r2r, x => x.SetPublishReadyToRun(true))));
         });
 
     Target CompileMultiApiPackageVersionSamples => _ => _

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -4309,6 +4309,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
         return S_OK;
     }
 
+    const auto& module_info = GetModuleInfo(this->info_, module_id);
+    // if this is Datadog.Trace.Manual, don't allow inlining as it causes... issues
+    if(module_info.assembly.name == WStr("Datadog.Trace.Manual"))
+    {
+        Logger::Debug("Disabling NGEN for Datadog.Trace.Manual");
+        *pbUseCachedFunction = false;
+        return S_OK;
+    }
+
     // Verify that we have the metadata for this module
     if (!shared::Contains(modules.Ref(), module_id))
     {
@@ -4318,7 +4327,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
         return S_OK;
     }
 
-    const auto& module_info = GetModuleInfo(this->info_, module_id);
     const auto& appDomainId = module_info.assembly.app_domain_id;
 
     const bool has_loader_injected_in_appdomain =

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -23,22 +24,13 @@ public class ManualInstrumentationTests : TestHelper
 
     [SkippableFact]
     [Trait("RunOnWindows", "True")]
-    public async Task ManualAndAutomatic()
-    {
-        SetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED", "1");
-        const int expectedSpans = 36;
-        using var telemetry = this.ConfigureTelemetry();
-        using var agent = EnvironmentHelper.GetMockAgent();
-        using var assert = new AssertionScope();
-        using var process = await RunSampleAndWaitForExit(agent);
+    public async Task ManualAndAutomatic() => await RunTest(usePublishWithRID: false);
 
-        var spans = agent.WaitForSpans(expectedSpans);
-        spans.Should().HaveCount(expectedSpans);
-
-        var settings = VerifyHelper.GetSpanVerifierSettings();
-
-        await VerifyHelper.VerifySpans(spans, settings);
-    }
+#if !NETFRAMEWORK
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task ReadyToRunManualAndAutomatic() => await RunTest(usePublishWithRID: true);
+#endif
 
     [SkippableFact]
     [Trait("RunOnWindows", "True")]
@@ -54,5 +46,22 @@ public class ManualInstrumentationTests : TestHelper
 
         var spans = agent.WaitForSpans(0, timeoutInMilliseconds: 500);
         spans.Should().BeEmpty();
+    }
+
+    private async Task RunTest(bool usePublishWithRID = false)
+    {
+        SetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED", "1");
+        const int expectedSpans = 37;
+        using var telemetry = this.ConfigureTelemetry();
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var assert = new AssertionScope();
+        using var process = await RunSampleAndWaitForExit(agent, usePublishWithRID: usePublishWithRID);
+
+        var spans = agent.WaitForSpans(expectedSpans);
+        spans.Should().HaveCount(expectedSpans);
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+
+        await VerifyHelper.VerifySpans(spans, settings);
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs
@@ -24,7 +24,7 @@ public class SourceCodeIntegrationGitMetadataTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ManualAndAutomatic()
     {
-        const int expectedSpans = 36;
+        const int expectedSpans = 37;
         using var telemetry = this.ConfigureTelemetry();
         using var agent = EnvironmentHelper.GetMockAgent();
         using var assert = new AssertionScope();

--- a/tracer/test/snapshots/ManualInstrumentationTests.ReadyToRunManualAndAutomatic.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ReadyToRunManualAndAutomatic.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
@@ -13,239 +13,251 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Samples;
 
-var shouldBeAttached = Environment.GetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED") == "1";
-var runInstrumentationChecks = shouldBeAttached;
+await Task.Yield();
 
-var isManualOnly = (bool)typeof(Tracer)
-                          .Assembly
-                          .GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: true)
-                           !.GetMethod("IsManualInstrumentationOnly")
-                           !.Invoke(null, null)!;
-Expect(isManualOnly != shouldBeAttached);
-Expect(SampleHelpers.IsProfilerAttached() == shouldBeAttached);
+// Do this before anything else to hit ready-to-run issues
+using (Tracer.Instance.StartActive("initial"))
+{
+}
 
-var count = 0;
-var port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
-Console.WriteLine($"Port {port}");
-var server = WebServer.Start(port, out var url);
-var client = new HttpClient();
-server.RequestHandler = HandleHttpRequests;
+// Moving this to a separate
+await OtherStuff();
+
+async Task OtherStuff()
+{
+    var shouldBeAttached = Environment.GetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED") == "1";
+    var runInstrumentationChecks = shouldBeAttached;
+
+    var isManualOnly = (bool)typeof(Tracer)
+                            .Assembly
+                            .GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: true)
+                             !.GetMethod("IsManualInstrumentationOnly")
+                             !.Invoke(null, null)!;
+    Expect(isManualOnly != shouldBeAttached);
+    Expect(SampleHelpers.IsProfilerAttached() == shouldBeAttached);
+
+    var count = 0;
+    var port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
+    Console.WriteLine($"Port {port}");
+    var server = WebServer.Start(port, out var url);
+    var client = new HttpClient();
+    server.RequestHandler = HandleHttpRequests;
 
 // Manually enable debug logs
-GlobalSettings.SetDebugEnabled(true);
-LogCurrentSettings(Tracer.Instance, "Initial");
+    GlobalSettings.SetDebugEnabled(true);
+    LogCurrentSettings(Tracer.Instance, "Initial");
 
 // verify instrumentation
-ThrowIf(string.IsNullOrEmpty(Tracer.Instance.DefaultServiceName));
+    ThrowIf(string.IsNullOrEmpty(Tracer.Instance.DefaultServiceName));
 
 // Manual + automatic before reconfiguration
-var firstOperationName = $"Manual-{++count}.Initial";
-using (var scope = Tracer.Instance.StartActive(firstOperationName))
-{
-    // All these should be satisfied when we're instrumented
-    Expect(Tracer.Instance.ActiveScope is not null);
-    Expect(scope.Span.OperationName == firstOperationName);
-    Expect(scope.Span.SpanId != 0);
-    Expect(scope.Span.TraceId != 0);
-    scope.Span.SetTag("Temp", "TempTest");
-    Expect(scope.Span.GetTag("Temp") == "TempTest");
-    scope.Span.SetTag("Temp", null);
+    var firstOperationName = $"Manual-{++count}.Initial";
+    using (var scope = Tracer.Instance.StartActive(firstOperationName))
+    {
+        // All these should be satisfied when we're instrumented
+        Expect(Tracer.Instance.ActiveScope is not null);
+        Expect(scope.Span.OperationName == firstOperationName);
+        Expect(scope.Span.SpanId != 0);
+        Expect(scope.Span.TraceId != 0);
+        scope.Span.SetTag("Temp", "TempTest");
+        Expect(scope.Span.GetTag("Temp") == "TempTest");
+        scope.Span.SetTag("Temp", null);
 
-    await SendHttpRequest("Initial");
-}
-await Tracer.Instance.ForceFlushAsync();
+        await SendHttpRequest("Initial");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // Reconfigure the tracer
-var settings = TracerSettings.FromDefaultSources();
-settings.ServiceName = "updated-name";
-settings.Environment = "updated-env";
-settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
-Tracer.Configure(settings);
-LogCurrentSettings(Tracer.Instance, "Reconfigured");
+    var settings = TracerSettings.FromDefaultSources();
+    settings.ServiceName = "updated-name";
+    settings.Environment = "updated-env";
+    settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
+    Tracer.Configure(settings);
+    LogCurrentSettings(Tracer.Instance, "Reconfigured");
 
 // Manual + automatic
-using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
-{
-    await SendHttpRequest("Reconfigured");
-}
-await Tracer.Instance.ForceFlushAsync();
+    using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
+    {
+        await SendHttpRequest("Reconfigured");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // reconfigure with Http disabled
-settings = TracerSettings.FromDefaultSources();
+    settings = TracerSettings.FromDefaultSources();
 // net core
-var httpIntegration = settings.Integrations["HttpMessageHandler"];
-httpIntegration.Enabled = false;
-httpIntegration.AnalyticsEnabled = false; // just setting them because why not
-httpIntegration.AnalyticsSampleRate = 1.0;
+    var httpIntegration = settings.Integrations["HttpMessageHandler"];
+    httpIntegration.Enabled = false;
+    httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+    httpIntegration.AnalyticsSampleRate = 1.0;
 // net FX
-httpIntegration = settings.Integrations["WebRequest"];
-httpIntegration.Enabled = false;
-httpIntegration.AnalyticsEnabled = false; // just setting them because why not
-httpIntegration.AnalyticsSampleRate = 1.0;
-Tracer.Configure(settings);
-LogCurrentSettings(Tracer.Instance, "HttpDisabled");
+    httpIntegration = settings.Integrations["WebRequest"];
+    httpIntegration.Enabled = false;
+    httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+    httpIntegration.AnalyticsSampleRate = 1.0;
+    Tracer.Configure(settings);
+    LogCurrentSettings(Tracer.Instance, "HttpDisabled");
 
 // send a trace with it disabled
-using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
-{
-    await SendHttpRequest("HttpDisabled");
-}
-await Tracer.Instance.ForceFlushAsync();
+    using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
+    {
+        await SendHttpRequest("HttpDisabled");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // go back to the defaults
-Tracer.Configure(TracerSettings.FromDefaultSources());
-LogCurrentSettings(Tracer.Instance, "DefaultsReinstated");
-using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
-{
-    await SendHttpRequest("DefaultsReinstated");
-}
-await Tracer.Instance.ForceFlushAsync();
+    Tracer.Configure(TracerSettings.FromDefaultSources());
+    LogCurrentSettings(Tracer.Instance, "DefaultsReinstated");
+    using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
+    {
+        await SendHttpRequest("DefaultsReinstated");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // nested manual + extensions
-using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))
-{
-    s1.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+    using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))
+    {
+        s1.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
 
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.Ext.Inner");
-    s2.Span.SetException(new CustomException());
-    s2.Span.SetTag("Custom", "Some-Value");
-    s2.Span.SetTag("Some-Number", 123);
-    s2.Span.SetUser(
-        new UserDetails("my-id")
-        {
-            Email = "test@example.com",
-            Name = "Bits",
-            Role = "Mascot",
-            Scope = "test-scope",
-            PropagateId = true,
-            SessionId = "abc123"
-        });
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.Ext.Inner");
+        s2.Span.SetException(new CustomException());
+        s2.Span.SetTag("Custom", "Some-Value");
+        s2.Span.SetTag("Some-Number", 123);
+        s2.Span.SetUser(
+            new UserDetails("my-id")
+            {
+                Email = "test@example.com",
+                Name = "Bits",
+                Role = "Mascot",
+                Scope = "test-scope",
+                PropagateId = true,
+                SessionId = "abc123"
+            });
 
-    await SendHttpRequest("Ext");
-}
+        await SendHttpRequest("Ext");
+    }
 
 // nested manual + eventSDK
-using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Custom.Outer"))
-{
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Custom.Inner");
-    EventTrackingSdk.TrackCustomEvent("custom-event");
-    EventTrackingSdk.TrackCustomEvent("custom-event-meta", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-    await SendHttpRequest("Ext");
-}
+    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Custom.Outer"))
+    {
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Custom.Inner");
+        EventTrackingSdk.TrackCustomEvent("custom-event");
+        EventTrackingSdk.TrackCustomEvent("custom-event-meta", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+        await SendHttpRequest("Ext");
+    }
 
-using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Success.Outer"))
-{
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Success.Inner");
-    EventTrackingSdk.TrackUserLoginSuccessEvent("my-id");
-    EventTrackingSdk.TrackUserLoginSuccessEvent("my-id", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-    await SendHttpRequest("Ext");
-}
+    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Success.Outer"))
+    {
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Success.Inner");
+        EventTrackingSdk.TrackUserLoginSuccessEvent("my-id");
+        EventTrackingSdk.TrackUserLoginSuccessEvent("my-id", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+        await SendHttpRequest("Ext");
+    }
 
-using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Failure.Outer"))
-{
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Failure.Inner");
-    EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true);
-    EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true, new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-    await SendHttpRequest("Ext");
-}
+    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Failure.Outer"))
+    {
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Failure.Inner");
+        EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true);
+        EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true, new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+        await SendHttpRequest("Ext");
+    }
 
 // Custom context
-var parent = new SpanContext(traceId: 1234567, 7654321, SamplingPriority.AutoKeep, "manual-parent");
-var createSpan = new SpanCreationSettings
-{
-    FinishOnClose = false,
-    StartTime = DateTimeOffset.Now.AddHours(-1),
-    Parent = parent,
-};
-using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.CustomContext", createSpan))
-{
-    s1.Span.ServiceName = Tracer.Instance.DefaultServiceName;
-    await SendHttpRequest("CustomContext");
-}
+    var parent = new SpanContext(traceId: 1234567, 7654321, SamplingPriority.AutoKeep, "manual-parent");
+    var createSpan = new SpanCreationSettings { FinishOnClose = false, StartTime = DateTimeOffset.Now.AddHours(-1), Parent = parent, };
+    using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.CustomContext", createSpan))
+    {
+        s1.Span.ServiceName = Tracer.Instance.DefaultServiceName;
+        await SendHttpRequest("CustomContext");
+    }
 
 // Manually disable debug logs
-GlobalSettings.SetDebugEnabled(false);
+    GlobalSettings.SetDebugEnabled(false);
 
 // Force flush
-await Tracer.Instance.ForceFlushAsync();
-    
+    await Tracer.Instance.ForceFlushAsync();
+
 // Force process to end, otherwise the background listener thread lives forever in .NET Core.
 // Apparently listener.GetContext() doesn't throw an exception if listener.Stop() is called,
 // like it does in .NET Framework.
-server.Dispose();
-Environment.Exit(0);
-return;
+    server.Dispose();
+    Environment.Exit(0);
+    return;
 
-async Task SendHttpRequest(string name)
-{
-    var q = $"{count}.{name}";
-    using var scope = Tracer.Instance.StartActive($"Manual-{q}.HttpClient");
-    await client.GetAsync(url + $"?q={q}");
-    Console.WriteLine("Received response for client.GetAsync(String)");
-}
-
-void HandleHttpRequests(HttpListenerContext context)
-{
-    try
+    async Task SendHttpRequest(string name)
     {
-        var query = context.Request.QueryString["q"];
-        using var scope = Tracer.Instance.StartActive($"Manual-{query}.HttpListener");
-        Console.WriteLine("[HttpListener] received request");
+        var q = $"{count}.{name}";
+        using var scope = Tracer.Instance.StartActive($"Manual-{q}.HttpClient");
+        await client.GetAsync(url + $"?q={q}");
+        Console.WriteLine("Received response for client.GetAsync(String)");
+    }
 
-        // read request content and headers
-        using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+    void HandleHttpRequests(HttpListenerContext context)
+    {
+        try
         {
-            string requestContent = reader.ReadToEnd();
-            Console.WriteLine($"[HttpListener] request content: {requestContent}");
+            var query = context.Request.QueryString["q"];
+            using var scope = Tracer.Instance.StartActive($"Manual-{query}.HttpListener");
+            Console.WriteLine("[HttpListener] received request");
+
+            // read request content and headers
+            using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+            {
+                string requestContent = reader.ReadToEnd();
+                Console.WriteLine($"[HttpListener] request content: {requestContent}");
+            }
+
+            // write response content
+            scope.Span.SetTag("content", "PONG");
+            var responseBytes = Encoding.UTF8.GetBytes("PONG");
+            context.Response.ContentEncoding = Encoding.UTF8;
+            context.Response.ContentLength64 = responseBytes.Length;
+            context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+            // we must close the response
+            context.Response.Close();
         }
-
-        // write response content
-        scope.Span.SetTag("content", "PONG");
-        var responseBytes = Encoding.UTF8.GetBytes("PONG");
-        context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.ContentLength64 = responseBytes.Length;
-        context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
-        // we must close the response
-        context.Response.Close();
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            context.Response.Close();
+            throw;
+        }
     }
-    catch (Exception e)
+
+    static void LogCurrentSettings(Tracer tracer, string step)
     {
-        Console.WriteLine(e);
-        context.Response.Close();
-        throw;
+        var settings = tracer.Settings;
+        Console.WriteLine($"Current tracer settings for {step}: ");
+
+        WriteLog(settings.Environment);
+        WriteLog(settings.ServiceName);
+        WriteLog(settings.ServiceVersion);
+        var globalTags = string.Join(". ", settings.GlobalTags.Select(x => $"{x.Key}:{x.Value}"));
+        WriteLog(globalTags);
+
+        static void WriteLog(object argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+        {
+            Console.WriteLine($"  {paramName}: {argument}");
+        }
     }
-}
 
-static void LogCurrentSettings(Tracer tracer, string step)
-{
-    var settings = tracer.Settings;
-    Console.WriteLine($"Current tracer settings for {step}: ");
-
-    WriteLog(settings.Environment);
-    WriteLog(settings.ServiceName);
-    WriteLog(settings.ServiceVersion);
-    var globalTags = string.Join(". ", settings.GlobalTags.Select(x => $"{x.Key}:{x.Value}"));
-    WriteLog(globalTags);
-
-    static void WriteLog(object argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+    void Expect(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
     {
-        Console.WriteLine($"  {paramName}: {argument}");
+        if (runInstrumentationChecks && !condition)
+        {
+            throw new InstrumentationErrorException(description, expected: true);
+        }
     }
-}
 
-void Expect(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
-{
-    if (runInstrumentationChecks && !condition)
+    void ThrowIf(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
     {
-        throw new InstrumentationErrorException(description, expected: true);
-    }
-}
-
-void ThrowIf(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
-{
-    if (runInstrumentationChecks && condition)
-    {
-        throw new InstrumentationErrorException(description, expected: false);
+        if (runInstrumentationChecks && condition)
+        {
+            throw new InstrumentationErrorException(description, expected: false);
+        }
     }
 }
 

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
@@ -1,8 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Just temporary, until v3 -->
-    <AllowDatadogTraceReference>true</AllowDatadogTraceReference>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj" />


### PR DESCRIPTION
## Summary of changes

- Adds a test that uses manual instrumentation with Ready-to-run (r2r)
- Disable using the ngen images of Datadog.Trace.Manual

## Reason for change

In #6124 we have narrowed down the root cause of a failure to get manual instrumentation to an interaction with r2r images. In this scenario, _some_ of the methods in Datadog.Trace.Manual (`GetAutomaticTracer()` specifically) do not get rejitted, even though a rejit is requested _and_ we request rejitting of the inliner (`Tracer.Instance`). This causes manual instrumenation in v3 to break in this scenario).

It's still not clear exactly why this is happening. It only happens in some scenarios. For example the following Program.cs (compiled with r2r for any platform) reproduces the issue

```csharp
await Task.Yield();

using(Tracer.Instance.StartActive("manual"))
{
}
```

Omitting the `Task.Yield()` means the problem does not reproduce. Adding additional methods at the end of this also can cause the method to not reproduce.

Additionally, we rewrite some methods directly (rather than using calltarget rewriting) in `TryRejitModule` (we rewrite `IsManualInstrumentationOnly()`). However, the rewritten method is _not_ used. This is likely because `JITCachedFunctionSearchStarted` runs after this, and we return `useCachedMethod=true` for the method, so the rewritten method is never used.

## Implementation details

We have explored various approaches (@tonyredondo is actively exploring in #6165), but the simplest is to simply disable NGEN for the Datadog.Trace.Manual module. The vast majority of this assembly is rewritten anyway (for v3 manual instrumentation) so the perf impact will be low, and it solves all of the reproduction cases. 

We're pretty sure there's a more generic problem/solution here, but as it's not clear exactly what that is, this is the simplest solution to the immediate issue.

## Test coverage

Added a new test that uses an r2r version of _Samples.ManualInstrumentation_. Prior to this fix, the test fails. With the fix, the test passes.

## Other details

Fixes #6124 

We briefly looked into reenabling `RequestReJITWithInliners` as in [here](https://github.com/DataDog/dd-trace-dotnet/blob/ff51ea93c1782317b4dc112e72129354a3241080/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp#L265) (which was removed due to a crashing bug https://github.com/dotnet/runtime/issues/77973), as [this has been fixed in .NET 7+](https://github.com/dotnet/runtime/issues/88924), however that simple change didn't resolve the problem + the problem exists on earlier runtimes anyway, so we need a fix that works everywhere.
