### PR TITLE
Ensure we don't throw a null reference exception in Manual instrumentation

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Proxies/ITracerProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Proxies/ITracerProxy.cs
@@ -15,5 +15,5 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Pr
 [DuckType("Datadog.Trace.Tracer", "Datadog.Trace.Manual")]
 internal interface ITracerProxy
 {
-    public object AutomaticTracer { get; }
+    public object? AutomaticTracer { get; }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/ForceFlushAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/ForceFlushAsyncIntegration.cs
@@ -35,7 +35,11 @@ public class ForceFlushAsyncIntegration
     {
         TelemetryFactory.Metrics.Record(PublicApiUsage.Tracer_ForceFlushAsync);
 
-        var tracer = (Datadog.Trace.Tracer)instance.AutomaticTracer;
-        return new CallTargetReturn<Task>(tracer.FlushAsync());
+        if (instance.AutomaticTracer is Datadog.Trace.Tracer tracer)
+        {
+            return new CallTargetReturn<Task>(tracer.FlushAsync());
+        }
+
+        return new CallTargetReturn<Task>(returnValue);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/GetActiveScopeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/GetActiveScopeIntegration.cs
@@ -32,9 +32,12 @@ public class GetActiveScopeIntegration
         where TTarget : ITracerProxy
     {
         // TODO: Add telemetry for public API?
-        var tracer = (Datadog.Trace.Tracer)instance.AutomaticTracer;
-        var scope = tracer.ActiveScope;
+        if (instance.AutomaticTracer is Datadog.Trace.Tracer tracer)
+        {
+            var scope = tracer.ActiveScope;
+            return new CallTargetReturn<TReturn>(scope.DuckCast<TReturn>());
+        }
 
-        return new CallTargetReturn<TReturn>(scope.DuckCast<TReturn>());
+        return new CallTargetReturn<TReturn>(returnValue);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/GetDefaultServiceNameIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/GetDefaultServiceNameIntegration.cs
@@ -31,7 +31,11 @@ public class GetDefaultServiceNameIntegration
         where TTarget : ITracerProxy
     {
         // TODO: Add telemetry?
-        var tracer = (Datadog.Trace.Tracer)instance.AutomaticTracer;
-        return new CallTargetReturn<string>(tracer.DefaultServiceName);
+        if (instance.AutomaticTracer is Datadog.Trace.Tracer tracer)
+        {
+            return new CallTargetReturn<string>(tracer.DefaultServiceName);
+        }
+
+        return new CallTargetReturn<string>(returnValue);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
@@ -34,6 +34,9 @@ public class StartSpanIntegration
         // This is only used by the OpenTracing public API
         if (instance.AutomaticTracer is not Datadog.Trace.Tracer tracer)
         {
+            Log.Error(
+                "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
+                instance.AutomaticTracer?.GetType());
             return CallTargetState.GetDefault();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
@@ -28,6 +28,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tr
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class StartSpanIntegration
 {
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StartSpanIntegration>();
+
     internal static CallTargetState OnMethodBegin<TTarget, TSpanContext>(TTarget instance, string operationName, TSpanContext parent, string serviceName, DateTimeOffset? startTime, bool ignoreActiveScope)
         where TTarget : ITracerProxy
     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Proxies;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer;
 


### PR DESCRIPTION
## Summary of changes

Check `instance.AutomaticTracer` for `null` before using it instead of casting 

## Reason for change

In #6124, we were seeing null reference exceptions. This was indicative of a separate (major) issue related to r2r (see #6168), but we still shouldn't have been throwing null refs in this case.

## Implementation details

- Mark the property as nullable
- Stop casting directly with `(Datadog.Trace.Tracer)instance.AutomaticTracer`
- Use pattern matching to check for `null`
- Log an error in `StartActiveImplementationIntegration` if we can't match, so that we still have visibility that _something_ went wrong on the managed side.

## Test coverage

Tested locally to confirm it fixes the error in the tests introduced in #6168, but as those fix the root cause anyway, we won't be able to easily test for this invalid scenario

## Other details

Relates to #6124
