### PR TITLE
Make DD_TRACE_<INTEGRATION>_ENABLED Case Insensitive 

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -49,6 +49,7 @@ namespace Datadog.Trace.Configuration
             var config = new ConfigurationBuilder(source, NullConfigurationTelemetry.Instance);
             EnabledInternal = config
                      .WithKeys(
+                          string.Format(ConfigurationKeys.Integrations.Enabled, integrationName.ToUpper()),
                           string.Format(ConfigurationKeys.Integrations.Enabled, integrationName),
                           string.Format("DD_{0}_ENABLED", integrationName))
                      .AsBool();

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Configuration
             var config = new ConfigurationBuilder(source, NullConfigurationTelemetry.Instance);
             EnabledInternal = config
                      .WithKeys(
-                          string.Format(ConfigurationKeys.Integrations.Enabled, integrationName.ToUpper()),
+                          string.Format(ConfigurationKeys.Integrations.Enabled, integrationName.ToUpperInvariant()),
                           string.Format(ConfigurationKeys.Integrations.Enabled, integrationName),
                           string.Format("DD_{0}_ENABLED", integrationName))
                      .AsBool();

--- a/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
@@ -33,6 +33,8 @@ namespace Datadog.Trace.Tests.Configuration
         [Theory]
         [InlineData("DD_TRACE_MYSQL_ENABLED", "false", false)]
         [InlineData("DD_TRACE_MySql_ENABLED", "false", false)]
+        [InlineData("DD_TRACE_MYSQL_ENABLED", "true", true)]
+        [InlineData("DD_TRACE_MySql_ENABLED", "true", true)]
         public void CaseInsenstiveIntegrationEnabled(string settingName, string settingValue, bool expected)
         {
             var dict = new Dictionary<string, string>(StringComparer.Ordinal)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
@@ -31,18 +31,15 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [InlineData("false", "true", true)]
-        [InlineData("true", null, true)]
-        [InlineData(null, "false", false)]
-        public void CaseInsenstiveIntegrationEnabled(string sensitiveCaseValue, string upperCasedValue, bool expected)
+        [InlineData("DD_TRACE_MYSQL_ENABLED", "false", false)]
+        [InlineData("DD_TRACE_MySql_ENABLED", "false", false)]
+        public void CaseInsenstiveIntegrationEnabled(string settingName, string settingValue, bool expected)
         {
             var dict = new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                { "DD_TRACE_MYSQL_ENABLED", upperCasedValue },
-                { "DD_TRACE_MySql_ENABLED", sensitiveCaseValue }
+                { settingName, settingValue },
             };
             var src = new DictionaryConfigurationSource(dict);
-
             var settings = new IntegrationSettings(nameof(IntegrationId.MySql), src);
 
             settings.EnabledInternal.Should().Be(expected);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
@@ -3,8 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Configuration
@@ -25,6 +28,24 @@ namespace Datadog.Trace.Tests.Configuration
 
             var settings = new IntegrationSettings("FOO", source);
             Assert.Equal(expected, settings.Enabled);
+        }
+
+        [Theory]
+        [InlineData("false", "true", true)]
+        [InlineData("true", null, true)]
+        [InlineData(null, "false", false)]
+        public void CaseInsenstiveIntegrationEnabled(string sensitiveCaseValue, string upperCasedValue, bool expected)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { "DD_TRACE_MYSQL_ENABLED", upperCasedValue },
+                { "DD_TRACE_MySql_ENABLED", sensitiveCaseValue }
+            };
+            var src = new DictionaryConfigurationSource(dict);
+
+            var settings = new IntegrationSettings(nameof(IntegrationId.MySql), src);
+
+            settings.EnabledInternal.Should().Be(expected);
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes
Added a option to check for upper cased integration names and moved the case sensitive option as fallback 1.

## Reason for change
Currently for Linux `DD_TRACE_<INTEGRATION>_ENABLED` needs to have an integration name that matches the name's casing on the existing dictionary we check but need to make it case insensitive like all other languages:
 
https://datadoghq.atlassian.net/browse/APMAPI-476

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
