### PR TITLE
Add support for the "new" dev.azure.com style URLs in SourceLink URL parsing logic (#6159 => v2)

### DIFF
--- a/tracer/src/Datadog.Trace/PDBs/SourceLink/AzureDevOpsSourceLinkUrlParser.cs
+++ b/tracer/src/Datadog.Trace/PDBs/SourceLink/AzureDevOpsSourceLinkUrlParser.cs
@@ -15,12 +15,19 @@ namespace Datadog.Trace.Pdb.SourceLink;
 internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
 {
     /// <summary>
-    /// Extract the git commit sha and repository url from a Azure DevOps SourceLink mapping string.
-    /// For example, for the following SourceLink mapping string:
-    ///     https://test.visualstudio.com/test-org/_apis/git/repositories/my-repo/items?api-version=1.0&amp;versionType=commit&amp;version=dd35903c688a74b62d1c6a9e4f41371c65704db8&amp;path=/*
-    /// It will return:
+    ///     Extract the git commit sha and repository url from a Azure DevOps SourceLink mapping string.
+    ///     For example, for the following SourceLink mapping string:
+    ///     https://test.visualstudio.com/test-org/_apis/git/repositories/my-repo/items?api-version=1.0&amp;versionType=commit
+    ///     &amp;version=dd35903c688a74b62d1c6a9e4f41371c65704db8&amp;path=/*
+    ///     It will return:
     ///     - commit sha: dd35903c688a74b62d1c6a9e4f41371c65704db8
     ///     - repository URL: https://test.visualstudio.com/test-org/_git/my-repo
+    ///     Likewise, for the following SourceLink mapping string:
+    ///     https://dev.azure.com/organisation/project/_apis/git/repositories/example.shopping.api/items?api-version=1.0&amp;
+    ///     versionType=commit&amp;version=0e4d29442102e6cef1c271025d513c8b2187bcd6&amp;path=/*
+    /// It will return:
+    ///     - commit sha: 0e4d29442102e6cef1c271025d513c8b2187bcd6
+    ///     - repository URL: https://dev.azure.com/organisation/project/_git/example.shopping.api
     /// </summary>
     internal override bool TryParseSourceLinkUrl(Uri uri, [NotNullWhen(true)] out string? commitSha, [NotNullWhen(true)] out string? repositoryUrl)
     {
@@ -46,15 +53,9 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
                 return false;
             }
 
-            var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-            if (segments.Length < 5)
-            {
-                return false;
-            }
+            repositoryUrl = BuildRepositoryUrl(uri);
 
-            repositoryUrl = $"https://{uri.Host}/{segments[0]}/_git/{segments[4]}";
-
-            return true;
+            return repositoryUrl != null;
         }
         catch (Exception ex)
         {
@@ -62,6 +63,35 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
         }
 
         return false;
+    }
+
+    private static string? BuildRepositoryUrl(Uri uri)
+    {
+        var segments = uri.AbsolutePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 5)
+        {
+            return null;
+        }
+
+        if (uri.Host.EndsWith("visualstudio.com", StringComparison.OrdinalIgnoreCase))
+        {
+            // Legacy format: https://{organization}.visualstudio.com
+            var project = segments[0];
+            var repoName = segments[4];
+            return $"https://{uri.Host}/{project}/_git/{repoName}";
+        }
+
+        if (uri.Host.EndsWith("dev.azure.com", StringComparison.OrdinalIgnoreCase))
+        {
+            // New format: https://dev.azure.com/{organization}
+            var organization = segments[0];
+            var project = segments[1];
+            var repoName = segments[5];
+            return $"https://{uri.Host}/{organization}/{project}/_git/{repoName}";
+        }
+
+        Log.Error("Unsupported Azure DevOps host: {Host}", uri.Host);
+        return null;
     }
 
     private static NameValueCollection ParseQueryString(string queryString)
@@ -73,7 +103,7 @@ internal class AzureDevOpsSourceLinkUrlParser : SourceLinkUrlParser
         var pairs = queryString.Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
         foreach (var pair in pairs)
         {
-            var parts = pair.Split(new[] { '=' }, 2);
+            var parts = pair.Split(new char[] { '=' }, 2);
             if (parts.Length == 2)
             {
                 query.Add(parts[0], parts[1]);

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/SourceLinkUriParserTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/SourceLinkUriParserTests.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 yield return new object[] { "https://api.bitbucket.org/2.0/repositories/test-org/test-repo/src/dd35903c688a74b62d1c6a9e4f41371c65704db8/*", "dd35903c688a74b62d1c6a9e4f41371c65704db8", "https://bitbucket.org/test-org/test-repo", typeof(BitBucketSourceLinkUrlParser) };
                 yield return new object[] { "https://test.visualstudio.com/test-org/_apis/git/repositories/my-repo/items?api-version=1.0&versionType=commit&version=dd35903c688a74b62d1c6a9e4f41371c65704db8&path=/*", "dd35903c688a74b62d1c6a9e4f41371c65704db8", "https://test.visualstudio.com/test-org/_git/my-repo", typeof(AzureDevOpsSourceLinkUrlParser) };
                 yield return new object[] { "https://test-gitlab-domain.com/test-org/test-repo/raw/dd35903c688a74b62d1c6a9e4f41371c65704db8/*", "dd35903c688a74b62d1c6a9e4f41371c65704db8", "https://test-gitlab-domain.com/test-org/test-repo", typeof(GitLabSourceLinkUrlParser) };
+                yield return new object[] { "https://dev.azure.com/organisation/project/_apis/git/repositories/example.shopping.api/items?api-version=1.0&versionType=commit&version=0e4d29442102e6cef1c271025d513c8b2187bcd6&path=/*", "0e4d29442102e6cef1c271025d513c8b2187bcd6", "https://dev.azure.com/organisation/project/_git/example.shopping.api", typeof(AzureDevOpsSourceLinkUrlParser) };
             }
         }
 


### PR DESCRIPTION
## Summary of changes

Fixes #6146

2.x backport of #6159

## Reason for change
Customer reported an issue where the tracer reports incorrect `git.repository_url` as a result of this bug.

## Test coverage
Add a new test case.