### PR TITLE
Add SSI denylist and tests (#5928 => v2)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,10 +101,18 @@ download-single-step-artifacts:
       start_in: 15 minutes
   script:
     - .gitlab/download-single-step-artifacts.sh
+    - cp tracer/build/artifacts/requirements.json artifacts/requirements.json
   artifacts:
     expire_in: 2 weeks
     paths:
       - artifacts
+
+requirements_json_test:
+  rules:
+    - when: on_success
+  variables:
+    REQUIREMENTS_BLOCK_JSON_PATH: "tracer/build/artifacts/requirements_block.json"
+    REQUIREMENTS_ALLOW_JSON_PATH: "tracer/build/artifacts/requirements_allow.json"
 
 package-oci:
   needs: [ download-single-step-artifacts ]

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -50,3 +50,5 @@ else
 fi
 
 echo -n $VERSION > sources/version
+
+cp ../artifacts/requirements.json sources/requirements.json

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -159,6 +159,7 @@ namespace datadog::shared::nativeloader
             // We don't want to instrument _build_ processes in dotnet by default, as they generally
             // don't give useful information, add latency, and risk triggering bugs in the runtime,
             // particularly around shutdown, like this one: https://github.com/dotnet/runtime/issues/55441
+            // Note that you should also consider adding to the SSI tracer/build/artifacts/requirements.json file
            const auto [process_command_line , tokenized_command_line]  = GetCurrentProcessCommandLine();
             Log::Info("Process CommandLine: ", process_command_line);
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -22,6 +22,7 @@ const ::shared::WSTRING cfg_copying_originals_modules_env = WStr("DD_COPY_ORIGIN
 const ::shared::WSTRING cfg_log_directory_env = WStr("DD_TRACE_LOG_DIRECTORY");
 
 // Note that this list should be kept in sync with the values in tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+// Note that you should also consider adding to the SSI tracer/build/artifacts/requirements.json file
 const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace"),
     WStr("dd-trace.exe"),

--- a/tracer/build/artifacts/requirements.json
+++ b/tracer/build/artifacts/requirements.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DataDog/auto_inject/refs/heads/main/preload_go/cmd/library_requirements_tester/testdata/requirements_schema.json",
+  "version": 1,
+  "native_deps": {
+    "glibc": [{
+      "arch": "x64",
+      "supported": true,
+      "description": "From centOS 7",
+      "min": "2.17"
+    },
+    {
+      "arch": "arm64",
+      "supported": true,
+      "description": "From debian buster (10), which is 2.28, but we verify we don't exceed 2.23",
+      "min": "2.23"
+    }],
+    "musl": [{
+      "arch": "x64",
+      "supported": true,
+      "description": "From alpine 3.14"
+    },{
+      "arch": "arm64",
+      "supported": true,
+      "description": "From alpine 3.18"
+    }]
+  },
+  "deny": [
+    {
+      "id": "dotnet_core_uninstall",
+      "description": "Ignore dotnet-core-uninstall which is self-contained app",
+      "os": null,
+      "cmds": [
+        "**/dotnet-core-uninstall"
+      ],
+      "args": [],
+      "envars": null
+    },
+    {
+      "id": "vsdbg",
+      "description": "Ignore vsdbg Visual Studio debug bridge",
+      "os": null,
+      "cmds": [
+        "**/vsdbg"
+      ],
+      "args": [],
+      "envars": null
+    },
+    {
+      "id": "dd_trace",
+      "description": "Ignore our own dd-trace runner",
+      "os": null,
+      "cmds": [
+        "**/dd-trace"
+      ],
+      "args": [],
+      "envars": null
+    },
+    {
+      "id": "dd_dotnet",
+      "description": "Ignore our own dd-dotnet runner",
+      "os": null,
+      "cmds": [
+        "**/dd-dotnet"
+      ],
+      "args": [],
+      "envars": null
+    },
+    {
+      "id": "dotnet_build",
+      "description": "Ignore dotnet build",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["build"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_build_server",
+      "description": "Ignore dotnet build-server",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["build-server"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_clean",
+      "description": "Ignore dotnet clean",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["clean"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_msbuild",
+      "description": "Ignore dotnet msbuild",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["msbuild"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_new",
+      "description": "Ignore dotnet new",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["new"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_nuget",
+      "description": "Ignore dotnet nuget",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["nuget"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_pack",
+      "description": "Ignore dotnet pack",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["pack"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_publish",
+      "description": "Ignore dotnet publish",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["publish"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_restore",
+      "description": "Ignore dotnet restore",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["restore"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_tool",
+      "description": "Ignore dotnet tool",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["tool"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_workload",
+      "description": "Ignore dotnet workload",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [{ "args":  ["workload"], "position": 1}],
+      "envars": null
+    },
+    {
+      "id": "dotnet_exec_csc",
+      "description": "Ignore dotnet exec **/csc.dll",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [
+        { "args":  ["exec"], "position": 1},
+        { "args":  ["*csc.dll"], "position": null}
+      ],
+      "envars": null
+    },
+    {
+      "id": "dotnet_exec_vbcscompiler",
+      "description": "Ignore dotnet exec **/VBCSCompiler.dll",
+      "os": null,
+      "cmds": [ "**/dotnet"],
+      "args": [
+        { "args":  ["exec"], "position": 1},
+        { "args":  ["*VBCSCompiler.dll"], "position": null}
+      ],
+      "envars": null
+    },
+    {
+      "id": "already_instrumented",
+      "description": "Ignore if the process is already has automatic instrumentation",
+      "os": null,
+      "cmds": [ ],
+      "args": [],
+      "envars": { "CORECLR_PROFILER_PATH*":  null, "CORECLR_ENABLE_PROFILING": "1" }
+    }
+  ]
+}

--- a/tracer/build/artifacts/requirements.json
+++ b/tracer/build/artifacts/requirements.json
@@ -20,8 +20,8 @@
       "description": "From alpine 3.14"
     },{
       "arch": "arm64",
-      "supported": true,
-      "description": "From alpine 3.18"
+      "supported": false,
+      "description": "Not supported in v2"
     }]
   },
   "deny": [

--- a/tracer/build/artifacts/requirements_allow.json
+++ b/tracer/build/artifacts/requirements_allow.json
@@ -1,0 +1,16 @@
+[
+  {"name": "min glibc x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.17"}},
+  {"name": "ok glibc x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.23"}},
+  {"name": "high glibc x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:3.0"}},
+  {"name": "musl x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "musl:1.2.2"}},
+  {"name": "min glibc arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.23"}},
+  {"name": "ok glibc arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.27"}},
+  {"name": "musl arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "musl:1.2.2"}},
+  {"name": "windows", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet run", "filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "run", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet test", "filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "test", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet exec path", "filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "exec", "/some/path"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet exec flag", "filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "exec", "-flag", "/some/path"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "not-dotnet build", "filepath":  "/pathto/not-dotnet", "args": ["/pathto/not-dotnet", "build"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet buildme", "filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "buildme"], "envars":  [], "host": {"os": "windows", "arch": "x64"}}
+]

--- a/tracer/build/artifacts/requirements_allow.json
+++ b/tracer/build/artifacts/requirements_allow.json
@@ -5,7 +5,6 @@
   {"name": "musl x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "musl:1.2.2"}},
   {"name": "min glibc arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.23"}},
   {"name": "ok glibc arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.27"}},
-  {"name": "musl arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "musl:1.2.2"}},
   {"name": "windows", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
   {"name": "dotnet run", "filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "run", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
   {"name": "dotnet test", "filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "test", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},

--- a/tracer/build/artifacts/requirements_block.json
+++ b/tracer/build/artifacts/requirements_block.json
@@ -1,0 +1,22 @@
+[
+  {"name": "unsupported 2.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.16"}},
+  {"name": "unsupported 1.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:1.22"}},
+  {"name": "unsupported 2.x.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.16.9"}},
+  {"name": "unsupported 2.x glibc arm64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.22"}},
+  {"name": "unsupported 2.x.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.22.9"}},
+  {"name": "glibx x86","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x86", "libc":  "glibc:2.23"}},
+  {"name": "musl x86","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x86", "libc":  "musl:1.2.2"}},
+  {"name": "dotnet-core-uninstall","filepath":  "/some/path/to/dotnet-core-uninstall", "args": ["/some/path/to/dotnet-core-uninstall"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet-core-uninstall with flags","filepath":  "/some/path/to/dotnet-core-uninstall", "args": ["/some/path/to/dotnet-core-uninstall", "-a", "--force"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet msbuild","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "msbuild", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet nuget","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "nuget", "restore", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet restore","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "restore", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet build","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "build"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet tool","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "tool", "install", "dd-trace"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet exec csc.dl","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "exec","/usr/share/dotnet/sdk/6.0.400/Roslyn/bincore/csc.dll", "/noconfig", "@/tmp/tmp8895f601306443a6a54388ecc6dcfc44.rsp"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet exec flags csc.dl","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "exec", "-framework", "net7.0", "/usr/share/dotnet/sdk/6.0.400/Roslyn/bincore/csc.dll", "/noconfig", "@/tmp/tmp8895f601306443a6a54388ecc6dcfc44.rsp"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dotnet exec VBCSCompiler.dll","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "exec", "-framework", "net7.0", "/usr/share/dotnet/sdk/6.0.400/Roslyn/bincore/VBCSCompiler.dll", "/noconfig", "@/tmp/tmp8895f601306443a6a54388ecc6dcfc44.rsp"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dd-dotnet run myapp","filepath":  "/pathto/dd-dotnet", "args": ["/pathto/dd-dotnet", "run", "myapp"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dd-trace run -- myapp","filepath":  "/pathto/dd-trace", "args": ["/pathto/dd-trace", "run", "--", "myapp"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
+  {"name": "dd-trace ci -- myapp","filepath":  "/pathto/dd-trace", "args": ["/pathto/dd-trace", "ci", "--", "myapp"], "envars":  [], "host": {"os": "windows", "arch": "x64"}}
+]

--- a/tracer/build/artifacts/requirements_block.json
+++ b/tracer/build/artifacts/requirements_block.json
@@ -6,6 +6,7 @@
   {"name": "unsupported 2.x.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.22.9"}},
   {"name": "glibx x86","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x86", "libc":  "glibc:2.23"}},
   {"name": "musl x86","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x86", "libc":  "musl:1.2.2"}},
+  {"name": "musl arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "musl:1.2.2"}},
   {"name": "dotnet-core-uninstall","filepath":  "/some/path/to/dotnet-core-uninstall", "args": ["/some/path/to/dotnet-core-uninstall"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
   {"name": "dotnet-core-uninstall with flags","filepath":  "/some/path/to/dotnet-core-uninstall", "args": ["/some/path/to/dotnet-core-uninstall", "-a", "--force"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},
   {"name": "dotnet msbuild","filepath":  "/pathto/dotnet", "args": ["/pathto/dotnet", "msbuild", "myproj.csproj"], "envars":  [], "host": {"os": "windows", "arch": "x64"}},

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -64,6 +64,7 @@ const shared::WSTRING include_assemblies[]{
 };
 
 // Note that this list should be kept in sync with the values in shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+// Note that you also consider adding to the SSI tracer/build/artifacts/requirements.json file
 const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace"),
     WStr("dd-trace.exe"),


### PR DESCRIPTION
## Summary of changes

Adds the SSI denylist and initial testing

## Reason for change

We want to bail out early if we don't support the platform.

## Implementation details

Add a requirements.json file that specifies supported hosts and some of the patterns we expect to block or allow injection on

## Test coverage

This includes a `requirements_json_test` stage. This will be ported to the one-pipeline once the `auto_inject` code is merged, this is a PoC that proves it works atm

## Other details

Backport of #5928 