### PR TITLE
Reject method NGEN image if there's a rejit request for that method.

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -4340,7 +4340,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
     // In .NET Core if we don't reject the image, the image will be used and the rejit callback will never get called
     // (this was confirmed on issue-6124).
     // The following code handle both scenarios.
-    if (runtime_information_.is_core()) 
+    *pbUseCachedFunction = true;
+    if (runtime_information_.is_core())
     {
         // Check if this method has been rejitted, if that's the case we don't accept the image
         bool hasBeenRejitted = this->rejit_handler->HasBeenRejitted(module_id, function_token);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -4333,31 +4333,40 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
         return S_OK;
     }
 
-    // Check if this method has been rejitted, if that's the case we don't accept the image
-    bool hasBeenRejitted = this->rejit_handler->HasBeenRejitted(module_id, function_token);
-    *pbUseCachedFunction = !hasBeenRejitted;
-
-    // If we are in debug mode and the image is rejected because has been rejitted then let's write a couple of logs
-    if (Logger::IsDebugEnabled() && hasBeenRejitted)
+    // JITCachedFunctionSearchStarted has a different behaviour between .NET Framework and .NET Core
+    // On .NET Framework when we reject bcl images the rejit calls of the integrations for those bcl assemblies
+    // are not resolved (is not clear why, maybe a bug). So we end up missing spans.
+    // Also in .NET Framework  we don't need to reject the ngen image, the rejit will always do the right job.
+    // In .NET Core if we don't reject the image, the image will be used and the rejit callback will never get called
+    // (this was confirmed in issue-6124).
+    // The following code handle both scenarios.
+    if (runtime_information_.is_core()) 
     {
-        ComPtr<IUnknown> metadata_interfaces;
-        hr = this->info_->GetModuleMetaData(module_id, ofRead,IID_IMetaDataImport2, metadata_interfaces.GetAddressOf());
-        if (hr == S_OK)
+        // Check if this method has been rejitted, if that's the case we don't accept the image
+        bool hasBeenRejitted = this->rejit_handler->HasBeenRejitted(module_id, function_token);
+        *pbUseCachedFunction = !hasBeenRejitted;
+
+        // If we are in debug mode and the image is rejected because has been rejitted then let's write a couple of logs
+        if (Logger::IsDebugEnabled() && hasBeenRejitted)
         {
-            const auto& metadata_import = metadata_interfaces.As<IMetaDataImport2>(IID_IMetaDataImport);
-            auto functionInfo = GetFunctionInfo(metadata_import, function_token);
-            Logger::Debug("NGEN Image: Rejected (because rejitted) for Module: ",
-                         module_info.assembly.name,
-                         ", Method:",
-                         functionInfo.type.name, ".", functionInfo.name,
-                         "()");
-        }
-        else
-        {
-            Logger::Debug("NGEN Image: Rejected (because rejitted) for Module: ",
-                          module_info.assembly.name,
-                          ", Function: ",
-                          HexStr(function_token));
+            ComPtr<IUnknown> metadata_interfaces;
+            if (this->info_->GetModuleMetaData(module_id, ofRead, IID_IMetaDataImport2,
+                                               metadata_interfaces.GetAddressOf()) == S_OK)
+            {
+                const auto& metadata_import = metadata_interfaces.As<IMetaDataImport2>(IID_IMetaDataImport);
+                auto functionInfo = GetFunctionInfo(metadata_import, function_token);
+
+                Logger::Debug("NGEN Image: Rejected (because rejitted) for Module: ", module_info.assembly.name,
+                              ", Method:", functionInfo.type.name, ".", functionInfo.name,
+                              "() previous value =  ", *pbUseCachedFunction ? "true" : "false", "[moduleId=", module_id,
+                              ", methodDef=", HexStr(function_token), "]");
+            }
+            else
+            {
+                Logger::Debug("NGEN Image: Rejected (because rejitted) for Module: ", module_info.assembly.name,
+                              ", Function: ", HexStr(function_token),
+                              " previous value = ", *pbUseCachedFunction ? "true" : "false");
+            }          
         }
     }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -255,6 +255,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     rejit_handler = info10 != nullptr
                         ? std::make_shared<RejitHandler>(info10, work_offloader)
                         : std::make_shared<RejitHandler>(this->info_, work_offloader);
+    rejit_handler->SetRejitTracking(runtime_information_.is_core());
+
     tracer_integration_preprocessor = std::make_unique<TracerRejitPreprocessor>(this, rejit_handler, work_offloader);
 
     fault_tolerant_method_duplicator = std::make_shared<fault_tolerant::FaultTolerantMethodDuplicator>(this, rejit_handler, work_offloader);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -4352,6 +4352,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
                          functionInfo.type.name, ".", functionInfo.name,
                          "()");
         }
+        else
+        {
+            Logger::Debug("NGEN Image: Rejected (because rejitted) for Module: ",
+                          module_info.assembly.name,
+                          ", Function: ",
+                          HexStr(function_token));
+        }
     }
 
     return S_OK;

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -4333,7 +4333,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
         return S_OK;
     }
 
-    *pbUseCachedFunction = true;
+    // Check if this method has been rejitted, if that's the case we don't accept the image
+    bool hasBeenRejitted = this->rejit_handler->HasBeenRejitted(module_id, function_token);
+    *pbUseCachedFunction = !hasBeenRejitted;
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -4338,7 +4338,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
     // are not resolved (is not clear why, maybe a bug). So we end up missing spans.
     // Also in .NET Framework  we don't need to reject the ngen image, the rejit will always do the right job.
     // In .NET Core if we don't reject the image, the image will be used and the rejit callback will never get called
-    // (this was confirmed in issue-6124).
+    // (this was confirmed on issue-6124).
     // The following code handle both scenarios.
     if (runtime_information_.is_core()) 
     {

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -280,6 +280,12 @@ void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector, std::vecto
         if (SUCCEEDED(hr))
         {
             Logger::Info("Request ReJIT done for ", modulesVector.size(), " methods");
+
+            WriteLock wlock(m_rejit_history_lock);
+            for (auto i = 0; i < modulesVector.size(); i++)
+            {
+                m_rejit_history.push_back({modulesVector[i], modulesMethodDef[i]});
+            }
         }
         else
         {
@@ -491,6 +497,25 @@ void RejitHandler::AddNGenInlinerModule(ModuleID moduleId)
     {
         rejitter->AddNGenInlinerModule(moduleId);
     }
+}
+
+bool RejitHandler::HasBeenRejitted(ModuleID moduleId, mdMethodDef methodDef) {
+    if (IsShutdownRequested())
+    {
+        return false;
+    }
+
+    ReadLock rlock(m_rejit_history_lock);
+    for (auto i = 0; i < m_rejit_history.size(); i++)
+    {
+        const auto mod_met_pair = m_rejit_history[i];
+        if (get<0>(mod_met_pair) == moduleId && get<1>(mod_met_pair) == methodDef)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 } // namespace trace

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -116,6 +116,7 @@ private:
 
     Lock m_rejit_history_lock;
     std::vector<std::tuple<ModuleID, mdMethodDef>> m_rejit_history;
+    bool enable_rejit_tracking = false;
 public:
     RejitHandler(ICorProfilerInfo7* pInfo, std::shared_ptr<RejitWorkOffloader> work_offloader);
     RejitHandler(ICorProfilerInfo10* pInfo, std::shared_ptr<RejitWorkOffloader> work_offloader);
@@ -146,6 +147,7 @@ public:
     void RemoveModule(ModuleID moduleId);
     void AddNGenInlinerModule(ModuleID moduleId);
 
+    void SetRejitTracking(bool enabled);
     bool HasBeenRejitted(ModuleID moduleId, mdMethodDef methodDef);
 };
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -114,6 +114,8 @@ private:
 
     std::vector<Rejitter*> m_rejitters;
 
+    Lock m_rejit_history_lock;
+    std::vector<std::tuple<ModuleID, mdMethodDef>> m_rejit_history;
 public:
     RejitHandler(ICorProfilerInfo7* pInfo, std::shared_ptr<RejitWorkOffloader> work_offloader);
     RejitHandler(ICorProfilerInfo10* pInfo, std::shared_ptr<RejitWorkOffloader> work_offloader);
@@ -143,6 +145,8 @@ public:
     bool HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef);
     void RemoveModule(ModuleID moduleId);
     void AddNGenInlinerModule(ModuleID moduleId);
+
+    bool HasBeenRejitted(ModuleID moduleId, mdMethodDef methodDef);
 };
 
 } // namespace trace

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -26,7 +27,24 @@ public class ManualInstrumentationTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ManualAndAutomatic() => await RunTest(usePublishWithRID: false);
 
-#if !NETFRAMEWORK
+#if NETFRAMEWORK
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task NGenRunManualAndAutomatic()
+    {
+        SetEnvironmentVariable("READY2RUN_ENABLED", "1");
+        var sampleAppPath = EnvironmentHelper.GetSampleApplicationPath();
+        NgenHelper.InstallToNativeImageCache(Output, sampleAppPath);
+        try
+        {
+            await RunTest(usePublishWithRID: false);
+        }
+        finally
+        {
+            NgenHelper.UninstallFromNativeImageCache(Output, sampleAppPath);
+        }
+    }
+#else
     [SkippableFact]
     [Trait("RunOnWindows", "True")]
     public async Task ReadyToRunManualAndAutomatic()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs
@@ -24,7 +24,7 @@ public class SourceCodeIntegrationGitMetadataTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ManualAndAutomatic()
     {
-        const int expectedSpans = 36;
+        const int expectedSpans = 37;
         using var telemetry = this.ConfigureTelemetry();
         using var agent = EnvironmentHelper.GetMockAgent();
         using var assert = new AssertionScope();

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -487,12 +487,10 @@ namespace Datadog.Trace.TestHelpers
 
             string GetPivot()
             {
-                var rid = (usePublishWithRID, IsAlpine()) switch
-                {
-                    (false, _) => string.Empty,
-                    (true, false) => $"_{EnvironmentTools.GetOS()}-{(EnvironmentTools.GetPlatform() == "Arm64" ? "arm64" : "x64")}",
-                    (true, true) => $"_{EnvironmentTools.GetOS()}-musl-{(EnvironmentTools.GetPlatform() == "Arm64" ? "arm64" : "x64")}",
-                };
+                var rid = usePublishWithRID
+                              ? $"_{EnvironmentTools.GetOS()}{(IsAlpine() ? "-musl" : string.Empty)}-{EnvironmentTools.GetPlatform().ToLowerInvariant()}"
+                              : string.Empty;
+
                 var config = EnvironmentTools.GetBuildConfiguration().ToLowerInvariant();
                 var packageVersionPivot = string.IsNullOrEmpty(packageVersion) ? string.Empty : $"_{packageVersion}";
                 return $"{config}_{targetFramework}{packageVersionPivot}{rid}";

--- a/tracer/test/Datadog.Trace.TestHelpers/NgenHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/NgenHelper.cs
@@ -21,6 +21,9 @@ public static class NgenHelper
 
         var install = $"install \"{appFilename}\"";
         RunNgen(output, workingDirectory, install);
+
+        // display NGEN'd assemblies
+        RunNgen(output, workingDirectory, "display");
     }
 
     public static void UninstallFromNativeImageCache(ITestOutputHelper output, string applicationPath)
@@ -28,8 +31,11 @@ public static class NgenHelper
         var appFilename = Path.GetFileName(applicationPath);
         var workingDirectory = Path.GetDirectoryName(applicationPath);
 
-        var install = $"install \"{appFilename}\"";
+        var install = $"uninstall \"{appFilename}\"";
         RunNgen(output, workingDirectory, install);
+
+        // display NGEN'd assemblies
+        RunNgen(output, workingDirectory, "display");
     }
 
     private static void RunNgen(ITestOutputHelper output, string workingDirectory, string arguments)

--- a/tracer/test/Datadog.Trace.TestHelpers/NgenHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/NgenHelper.cs
@@ -1,0 +1,98 @@
+﻿// <copyright file="NgenHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if NETFRAMEWORK
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.TestHelpers;
+
+public static class NgenHelper
+{
+    public static void InstallToNativeImageCache(ITestOutputHelper output, string applicationPath)
+    {
+        var appFilename = Path.GetFileName(applicationPath);
+        var workingDirectory = Path.GetDirectoryName(applicationPath);
+
+        var install = $"install \"{appFilename}\"";
+        RunNgen(output, workingDirectory, install);
+    }
+
+    public static void UninstallFromNativeImageCache(ITestOutputHelper output, string applicationPath)
+    {
+        var appFilename = Path.GetFileName(applicationPath);
+        var workingDirectory = Path.GetDirectoryName(applicationPath);
+
+        var install = $"install \"{appFilename}\"";
+        RunNgen(output, workingDirectory, install);
+    }
+
+    private static void RunNgen(ITestOutputHelper output, string workingDirectory, string arguments)
+    {
+        var frameworkDirectory = RuntimeEnvironment.GetRuntimeDirectory();
+        var ngenPath = Path.Combine(frameworkDirectory, "ngen.exe");
+        var startInfo = new ProcessStartInfo(ngenPath, arguments)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = false,
+            WorkingDirectory = workingDirectory
+        };
+
+        output.WriteLine($"Running {ngenPath} {arguments}");
+        var process = Process.Start(startInfo);
+
+        using var helper = new ProcessHelper(process);
+        var timeoutMs = 30_000;
+
+        var ranToCompletion = process.WaitForExit(timeoutMs) && helper.Drain(timeoutMs / 2);
+        var standardOutput = helper.StandardOutput;
+        var standardError = helper.ErrorOutput;
+
+        if (!ranToCompletion)
+        {
+            if (!process.HasExited)
+            {
+                try
+                {
+                    process.Kill();
+                }
+                catch
+                {
+                    // Do nothing
+                }
+            }
+
+            output.WriteLine("NGEN was running for too long or was lost.");
+            output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+            output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+
+            throw new TimeoutException("The smoke test is running for too long or was lost.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(standardOutput))
+        {
+            output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(standardError))
+        {
+            output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+        }
+
+        if (process.ExitCode != 0)
+        {
+            throw new Exception($"Error executing {ngenPath} {arguments} - are you running with admin priviliges?");
+        }
+
+        output.WriteLine("NGEN command completed successfully.");
+    }
+}
+#endif

--- a/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
@@ -2,6 +2,24 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
+    Name: initial,
+    Resource: initial,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
     Name: Manual-1.Initial,
     Resource: Manual-1.Initial,
     Service: Samples.ManualInstrumentation,
@@ -18,25 +36,25 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_3,
+    TraceId: Id_3,
+    SpanId: Id_5,
     Name: Manual-1.Initial.HttpClient,
     Resource: Manual-1.Initial.HttpClient,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_2,
+    ParentId: Id_4,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_4,
+    TraceId: Id_3,
+    SpanId: Id_6,
     Name: http.request,
     Resource: GET localhost:00000/?/,
     Service: Samples.ManualInstrumentation-http-client,
     Type: http,
-    ParentId: Id_3,
+    ParentId: Id_5,
     Tags: {
       component: HttpMessageHandler,
       env: integration_tests,
@@ -55,8 +73,8 @@
     }
   },
   {
-    TraceId: Id_5,
-    SpanId: Id_6,
+    TraceId: Id_7,
+    SpanId: Id_8,
     Name: Manual-1.Initial.HttpListener,
     Resource: Manual-1.Initial.HttpListener,
     Service: Samples.ManualInstrumentation,
@@ -74,8 +92,8 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_8,
+    TraceId: Id_9,
+    SpanId: Id_10,
     Name: Manual-2.Reconfigured,
     Resource: Manual-2.Reconfigured,
     Service: updated-name,
@@ -93,12 +111,12 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_9,
+    TraceId: Id_9,
+    SpanId: Id_11,
     Name: Manual-2.Reconfigured.HttpClient,
     Resource: Manual-2.Reconfigured.HttpClient,
     Service: updated-name,
-    ParentId: Id_8,
+    ParentId: Id_10,
     Tags: {
       env: updated-env,
       language: dotnet,
@@ -106,13 +124,13 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_10,
+    TraceId: Id_9,
+    SpanId: Id_12,
     Name: http.request,
     Resource: GET localhost:00000/?/,
     Service: updated-name-http-client,
     Type: http,
-    ParentId: Id_9,
+    ParentId: Id_11,
     Tags: {
       component: HttpMessageHandler,
       env: updated-env,
@@ -132,8 +150,8 @@
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_12,
+    TraceId: Id_13,
+    SpanId: Id_14,
     Name: Manual-2.Reconfigured.HttpListener,
     Resource: Manual-2.Reconfigured.HttpListener,
     Service: updated-name,
@@ -152,8 +170,8 @@
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_14,
+    TraceId: Id_15,
+    SpanId: Id_16,
     Name: Manual-3.HttpDisabled,
     Resource: Manual-3.HttpDisabled,
     Service: Samples.ManualInstrumentation,
@@ -170,20 +188,20 @@
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_15,
+    TraceId: Id_15,
+    SpanId: Id_17,
     Name: Manual-3.HttpDisabled.HttpClient,
     Resource: Manual-3.HttpDisabled.HttpClient,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_14,
+    ParentId: Id_16,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_16,
-    SpanId: Id_17,
+    TraceId: Id_18,
+    SpanId: Id_19,
     Name: Manual-3.HttpDisabled.HttpListener,
     Resource: Manual-3.HttpDisabled.HttpListener,
     Service: Samples.ManualInstrumentation,
@@ -201,8 +219,8 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_19,
+    TraceId: Id_20,
+    SpanId: Id_21,
     Name: Manual-4.DefaultsReinstated,
     Resource: Manual-4.DefaultsReinstated,
     Service: Samples.ManualInstrumentation,
@@ -219,25 +237,25 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_20,
+    TraceId: Id_20,
+    SpanId: Id_22,
     Name: Manual-4.DefaultsReinstated.HttpClient,
     Resource: Manual-4.DefaultsReinstated.HttpClient,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_19,
+    ParentId: Id_21,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_21,
+    TraceId: Id_20,
+    SpanId: Id_23,
     Name: http.request,
     Resource: GET localhost:00000/?/,
     Service: Samples.ManualInstrumentation-http-client,
     Type: http,
-    ParentId: Id_20,
+    ParentId: Id_22,
     Tags: {
       component: HttpMessageHandler,
       env: integration_tests,
@@ -256,8 +274,8 @@
     }
   },
   {
-    TraceId: Id_22,
-    SpanId: Id_23,
+    TraceId: Id_24,
+    SpanId: Id_25,
     Name: Manual-4.DefaultsReinstated.HttpListener,
     Resource: Manual-4.DefaultsReinstated.HttpListener,
     Service: Samples.ManualInstrumentation,
@@ -275,8 +293,8 @@
     }
   },
   {
-    TraceId: Id_24,
-    SpanId: Id_25,
+    TraceId: Id_26,
+    SpanId: Id_27,
     Name: Manual-5.Ext.HttpListener,
     Resource: Manual-5.Ext.HttpListener,
     Service: Samples.ManualInstrumentation,
@@ -294,8 +312,8 @@
     }
   },
   {
-    TraceId: Id_26,
-    SpanId: Id_27,
+    TraceId: Id_28,
+    SpanId: Id_29,
     Name: Manual-5.Ext.Outer,
     Resource: Manual-5.Ext.Outer,
     Service: Samples.ManualInstrumentation,
@@ -318,12 +336,12 @@
     }
   },
   {
-    TraceId: Id_26,
-    SpanId: Id_28,
+    TraceId: Id_28,
+    SpanId: Id_30,
     Name: Manual-5.Ext.Inner,
     Resource: Manual-5.Ext.Inner,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_27,
+    ParentId: Id_29,
     Error: 1,
     Tags: {
       Custom: Some-Value,
@@ -340,25 +358,25 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_26,
-    SpanId: Id_29,
+    TraceId: Id_28,
+    SpanId: Id_31,
     Name: Manual-5.Ext.HttpClient,
     Resource: Manual-5.Ext.HttpClient,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_28,
+    ParentId: Id_30,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_26,
-    SpanId: Id_30,
+    TraceId: Id_28,
+    SpanId: Id_32,
     Name: http.request,
     Resource: GET localhost:00000/?/,
     Service: Samples.ManualInstrumentation-http-client,
     Type: http,
-    ParentId: Id_29,
+    ParentId: Id_31,
     Tags: {
       component: HttpMessageHandler,
       env: integration_tests,
@@ -377,8 +395,8 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_31,
-    SpanId: Id_32,
+    TraceId: Id_33,
+    SpanId: Id_34,
     Name: Manual-6.EventSdk.Custom.Outer,
     Resource: Manual-6.EventSdk.Custom.Outer,
     Service: Samples.ManualInstrumentation,
@@ -401,37 +419,37 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_31,
-    SpanId: Id_33,
+    TraceId: Id_33,
+    SpanId: Id_35,
     Name: Manual-6.EventSdk.Custom.Inner,
     Resource: Manual-6.EventSdk.Custom.Inner,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_32,
+    ParentId: Id_34,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_31,
-    SpanId: Id_34,
+    TraceId: Id_33,
+    SpanId: Id_36,
     Name: Manual-6.Ext.HttpClient,
     Resource: Manual-6.Ext.HttpClient,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_33,
+    ParentId: Id_35,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_31,
-    SpanId: Id_35,
+    TraceId: Id_33,
+    SpanId: Id_37,
     Name: http.request,
     Resource: GET localhost:00000/?/,
     Service: Samples.ManualInstrumentation-http-client,
     Type: http,
-    ParentId: Id_34,
+    ParentId: Id_36,
     Tags: {
       component: HttpMessageHandler,
       env: integration_tests,
@@ -450,8 +468,8 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_36,
-    SpanId: Id_37,
+    TraceId: Id_38,
+    SpanId: Id_39,
     Name: Manual-6.Ext.HttpListener,
     Resource: Manual-6.Ext.HttpListener,
     Service: Samples.ManualInstrumentation,
@@ -469,8 +487,8 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_38,
-    SpanId: Id_39,
+    TraceId: Id_40,
+    SpanId: Id_41,
     Name: Manual-7.EventSdk.Success.Outer,
     Resource: Manual-7.EventSdk.Success.Outer,
     Service: Samples.ManualInstrumentation,
@@ -492,37 +510,37 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_38,
-    SpanId: Id_40,
+    TraceId: Id_40,
+    SpanId: Id_42,
     Name: Manual-7.EventSdk.Success.Inner,
     Resource: Manual-7.EventSdk.Success.Inner,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_39,
+    ParentId: Id_41,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_38,
-    SpanId: Id_41,
+    TraceId: Id_40,
+    SpanId: Id_43,
     Name: Manual-7.Ext.HttpClient,
     Resource: Manual-7.Ext.HttpClient,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_40,
+    ParentId: Id_42,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_38,
-    SpanId: Id_42,
+    TraceId: Id_40,
+    SpanId: Id_44,
     Name: http.request,
     Resource: GET localhost:00000/?/,
     Service: Samples.ManualInstrumentation-http-client,
     Type: http,
-    ParentId: Id_41,
+    ParentId: Id_43,
     Tags: {
       component: HttpMessageHandler,
       env: integration_tests,
@@ -541,8 +559,8 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_43,
-    SpanId: Id_44,
+    TraceId: Id_45,
+    SpanId: Id_46,
     Name: Manual-7.Ext.HttpListener,
     Resource: Manual-7.Ext.HttpListener,
     Service: Samples.ManualInstrumentation,
@@ -560,8 +578,8 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_46,
+    TraceId: Id_47,
+    SpanId: Id_48,
     Name: Manual-8.EventSdk.Failure.Outer,
     Resource: Manual-8.EventSdk.Failure.Outer,
     Service: Samples.ManualInstrumentation,
@@ -584,37 +602,37 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_47,
+    TraceId: Id_47,
+    SpanId: Id_49,
     Name: Manual-8.EventSdk.Failure.Inner,
     Resource: Manual-8.EventSdk.Failure.Inner,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_46,
+    ParentId: Id_48,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_48,
+    TraceId: Id_47,
+    SpanId: Id_50,
     Name: Manual-8.Ext.HttpClient,
     Resource: Manual-8.Ext.HttpClient,
     Service: Samples.ManualInstrumentation,
-    ParentId: Id_47,
+    ParentId: Id_49,
     Tags: {
       env: integration_tests,
       language: dotnet
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_49,
+    TraceId: Id_47,
+    SpanId: Id_51,
     Name: http.request,
     Resource: GET localhost:00000/?/,
     Service: Samples.ManualInstrumentation-http-client,
     Type: http,
-    ParentId: Id_48,
+    ParentId: Id_50,
     Tags: {
       component: HttpMessageHandler,
       env: integration_tests,
@@ -633,8 +651,8 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_50,
-    SpanId: Id_51,
+    TraceId: Id_52,
+    SpanId: Id_53,
     Name: Manual-8.Ext.HttpListener,
     Resource: Manual-8.Ext.HttpListener,
     Service: Samples.ManualInstrumentation,
@@ -652,8 +670,8 @@ CustomException: Exception of type 'CustomException' was thrown.
     }
   },
   {
-    TraceId: Id_52,
-    SpanId: Id_53,
+    TraceId: Id_54,
+    SpanId: Id_55,
     Name: Manual-9.CustomContext.HttpListener,
     Resource: Manual-9.CustomContext.HttpListener,
     Service: Samples.ManualInstrumentation,

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
@@ -13,239 +13,251 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Samples;
 
-var shouldBeAttached = Environment.GetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED") == "1";
-var runInstrumentationChecks = shouldBeAttached;
+await Task.Yield();
 
-var isManualOnly = (bool)typeof(Tracer)
-                          .Assembly
-                          .GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: true)
-                           !.GetMethod("IsManualInstrumentationOnly")
-                           !.Invoke(null, null)!;
-Expect(isManualOnly != shouldBeAttached);
-Expect(SampleHelpers.IsProfilerAttached() == shouldBeAttached);
+// Do this before anything else to hit ready-to-run issues
+using (Tracer.Instance.StartActive("initial"))
+{
+}
 
-var count = 0;
-var port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
-Console.WriteLine($"Port {port}");
-var server = WebServer.Start(port, out var url);
-var client = new HttpClient();
-server.RequestHandler = HandleHttpRequests;
+// Moving this to a separate
+await OtherStuff();
+
+async Task OtherStuff()
+{
+    var shouldBeAttached = Environment.GetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED") == "1";
+    var runInstrumentationChecks = shouldBeAttached;
+
+    var isManualOnly = (bool)typeof(Tracer)
+                            .Assembly
+                            .GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: true)
+                             !.GetMethod("IsManualInstrumentationOnly")
+                             !.Invoke(null, null)!;
+    Expect(isManualOnly != shouldBeAttached);
+    Expect(SampleHelpers.IsProfilerAttached() == shouldBeAttached);
+
+    var count = 0;
+    var port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
+    Console.WriteLine($"Port {port}");
+    var server = WebServer.Start(port, out var url);
+    var client = new HttpClient();
+    server.RequestHandler = HandleHttpRequests;
 
 // Manually enable debug logs
-GlobalSettings.SetDebugEnabled(true);
-LogCurrentSettings(Tracer.Instance, "Initial");
+    GlobalSettings.SetDebugEnabled(true);
+    LogCurrentSettings(Tracer.Instance, "Initial");
 
 // verify instrumentation
-ThrowIf(string.IsNullOrEmpty(Tracer.Instance.DefaultServiceName));
+    ThrowIf(string.IsNullOrEmpty(Tracer.Instance.DefaultServiceName));
 
 // Manual + automatic before reconfiguration
-var firstOperationName = $"Manual-{++count}.Initial";
-using (var scope = Tracer.Instance.StartActive(firstOperationName))
-{
-    // All these should be satisfied when we're instrumented
-    Expect(Tracer.Instance.ActiveScope is not null);
-    Expect(scope.Span.OperationName == firstOperationName);
-    Expect(scope.Span.SpanId != 0);
-    Expect(scope.Span.TraceId != 0);
-    scope.Span.SetTag("Temp", "TempTest");
-    Expect(scope.Span.GetTag("Temp") == "TempTest");
-    scope.Span.SetTag("Temp", null);
+    var firstOperationName = $"Manual-{++count}.Initial";
+    using (var scope = Tracer.Instance.StartActive(firstOperationName))
+    {
+        // All these should be satisfied when we're instrumented
+        Expect(Tracer.Instance.ActiveScope is not null);
+        Expect(scope.Span.OperationName == firstOperationName);
+        Expect(scope.Span.SpanId != 0);
+        Expect(scope.Span.TraceId != 0);
+        scope.Span.SetTag("Temp", "TempTest");
+        Expect(scope.Span.GetTag("Temp") == "TempTest");
+        scope.Span.SetTag("Temp", null);
 
-    await SendHttpRequest("Initial");
-}
-await Tracer.Instance.ForceFlushAsync();
+        await SendHttpRequest("Initial");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // Reconfigure the tracer
-var settings = TracerSettings.FromDefaultSources();
-settings.ServiceName = "updated-name";
-settings.Environment = "updated-env";
-settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
-Tracer.Configure(settings);
-LogCurrentSettings(Tracer.Instance, "Reconfigured");
+    var settings = TracerSettings.FromDefaultSources();
+    settings.ServiceName = "updated-name";
+    settings.Environment = "updated-env";
+    settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
+    Tracer.Configure(settings);
+    LogCurrentSettings(Tracer.Instance, "Reconfigured");
 
 // Manual + automatic
-using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
-{
-    await SendHttpRequest("Reconfigured");
-}
-await Tracer.Instance.ForceFlushAsync();
+    using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
+    {
+        await SendHttpRequest("Reconfigured");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // reconfigure with Http disabled
-settings = TracerSettings.FromDefaultSources();
+    settings = TracerSettings.FromDefaultSources();
 // net core
-var httpIntegration = settings.Integrations["HttpMessageHandler"];
-httpIntegration.Enabled = false;
-httpIntegration.AnalyticsEnabled = false; // just setting them because why not
-httpIntegration.AnalyticsSampleRate = 1.0;
+    var httpIntegration = settings.Integrations["HttpMessageHandler"];
+    httpIntegration.Enabled = false;
+    httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+    httpIntegration.AnalyticsSampleRate = 1.0;
 // net FX
-httpIntegration = settings.Integrations["WebRequest"];
-httpIntegration.Enabled = false;
-httpIntegration.AnalyticsEnabled = false; // just setting them because why not
-httpIntegration.AnalyticsSampleRate = 1.0;
-Tracer.Configure(settings);
-LogCurrentSettings(Tracer.Instance, "HttpDisabled");
+    httpIntegration = settings.Integrations["WebRequest"];
+    httpIntegration.Enabled = false;
+    httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+    httpIntegration.AnalyticsSampleRate = 1.0;
+    Tracer.Configure(settings);
+    LogCurrentSettings(Tracer.Instance, "HttpDisabled");
 
 // send a trace with it disabled
-using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
-{
-    await SendHttpRequest("HttpDisabled");
-}
-await Tracer.Instance.ForceFlushAsync();
+    using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
+    {
+        await SendHttpRequest("HttpDisabled");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // go back to the defaults
-Tracer.Configure(TracerSettings.FromDefaultSources());
-LogCurrentSettings(Tracer.Instance, "DefaultsReinstated");
-using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
-{
-    await SendHttpRequest("DefaultsReinstated");
-}
-await Tracer.Instance.ForceFlushAsync();
+    Tracer.Configure(TracerSettings.FromDefaultSources());
+    LogCurrentSettings(Tracer.Instance, "DefaultsReinstated");
+    using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
+    {
+        await SendHttpRequest("DefaultsReinstated");
+    }
+
+    await Tracer.Instance.ForceFlushAsync();
 
 // nested manual + extensions
-using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))
-{
-    s1.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+    using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))
+    {
+        s1.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
 
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.Ext.Inner");
-    s2.Span.SetException(new CustomException());
-    s2.Span.SetTag("Custom", "Some-Value");
-    s2.Span.SetTag("Some-Number", 123);
-    s2.Span.SetUser(
-        new UserDetails("my-id")
-        {
-            Email = "test@example.com",
-            Name = "Bits",
-            Role = "Mascot",
-            Scope = "test-scope",
-            PropagateId = true,
-            SessionId = "abc123"
-        });
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.Ext.Inner");
+        s2.Span.SetException(new CustomException());
+        s2.Span.SetTag("Custom", "Some-Value");
+        s2.Span.SetTag("Some-Number", 123);
+        s2.Span.SetUser(
+            new UserDetails("my-id")
+            {
+                Email = "test@example.com",
+                Name = "Bits",
+                Role = "Mascot",
+                Scope = "test-scope",
+                PropagateId = true,
+                SessionId = "abc123"
+            });
 
-    await SendHttpRequest("Ext");
-}
+        await SendHttpRequest("Ext");
+    }
 
 // nested manual + eventSDK
-using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Custom.Outer"))
-{
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Custom.Inner");
-    EventTrackingSdk.TrackCustomEvent("custom-event");
-    EventTrackingSdk.TrackCustomEvent("custom-event-meta", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-    await SendHttpRequest("Ext");
-}
+    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Custom.Outer"))
+    {
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Custom.Inner");
+        EventTrackingSdk.TrackCustomEvent("custom-event");
+        EventTrackingSdk.TrackCustomEvent("custom-event-meta", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+        await SendHttpRequest("Ext");
+    }
 
-using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Success.Outer"))
-{
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Success.Inner");
-    EventTrackingSdk.TrackUserLoginSuccessEvent("my-id");
-    EventTrackingSdk.TrackUserLoginSuccessEvent("my-id", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-    await SendHttpRequest("Ext");
-}
+    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Success.Outer"))
+    {
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Success.Inner");
+        EventTrackingSdk.TrackUserLoginSuccessEvent("my-id");
+        EventTrackingSdk.TrackUserLoginSuccessEvent("my-id", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+        await SendHttpRequest("Ext");
+    }
 
-using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Failure.Outer"))
-{
-    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Failure.Inner");
-    EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true);
-    EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true, new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
-    await SendHttpRequest("Ext");
-}
+    using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Failure.Outer"))
+    {
+        using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Failure.Inner");
+        EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true);
+        EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true, new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+        await SendHttpRequest("Ext");
+    }
 
 // Custom context
-var parent = new SpanContext(traceId: 1234567, 7654321, SamplingPriority.AutoKeep, "manual-parent");
-var createSpan = new SpanCreationSettings
-{
-    FinishOnClose = false,
-    StartTime = DateTimeOffset.Now.AddHours(-1),
-    Parent = parent,
-};
-using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.CustomContext", createSpan))
-{
-    s1.Span.ServiceName = Tracer.Instance.DefaultServiceName;
-    await SendHttpRequest("CustomContext");
-}
+    var parent = new SpanContext(traceId: 1234567, 7654321, SamplingPriority.AutoKeep, "manual-parent");
+    var createSpan = new SpanCreationSettings { FinishOnClose = false, StartTime = DateTimeOffset.Now.AddHours(-1), Parent = parent, };
+    using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.CustomContext", createSpan))
+    {
+        s1.Span.ServiceName = Tracer.Instance.DefaultServiceName;
+        await SendHttpRequest("CustomContext");
+    }
 
 // Manually disable debug logs
-GlobalSettings.SetDebugEnabled(false);
+    GlobalSettings.SetDebugEnabled(false);
 
 // Force flush
-await Tracer.Instance.ForceFlushAsync();
-    
+    await Tracer.Instance.ForceFlushAsync();
+
 // Force process to end, otherwise the background listener thread lives forever in .NET Core.
 // Apparently listener.GetContext() doesn't throw an exception if listener.Stop() is called,
 // like it does in .NET Framework.
-server.Dispose();
-Environment.Exit(0);
-return;
+    server.Dispose();
+    Environment.Exit(0);
+    return;
 
-async Task SendHttpRequest(string name)
-{
-    var q = $"{count}.{name}";
-    using var scope = Tracer.Instance.StartActive($"Manual-{q}.HttpClient");
-    await client.GetAsync(url + $"?q={q}");
-    Console.WriteLine("Received response for client.GetAsync(String)");
-}
-
-void HandleHttpRequests(HttpListenerContext context)
-{
-    try
+    async Task SendHttpRequest(string name)
     {
-        var query = context.Request.QueryString["q"];
-        using var scope = Tracer.Instance.StartActive($"Manual-{query}.HttpListener");
-        Console.WriteLine("[HttpListener] received request");
+        var q = $"{count}.{name}";
+        using var scope = Tracer.Instance.StartActive($"Manual-{q}.HttpClient");
+        await client.GetAsync(url + $"?q={q}");
+        Console.WriteLine("Received response for client.GetAsync(String)");
+    }
 
-        // read request content and headers
-        using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+    void HandleHttpRequests(HttpListenerContext context)
+    {
+        try
         {
-            string requestContent = reader.ReadToEnd();
-            Console.WriteLine($"[HttpListener] request content: {requestContent}");
+            var query = context.Request.QueryString["q"];
+            using var scope = Tracer.Instance.StartActive($"Manual-{query}.HttpListener");
+            Console.WriteLine("[HttpListener] received request");
+
+            // read request content and headers
+            using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+            {
+                string requestContent = reader.ReadToEnd();
+                Console.WriteLine($"[HttpListener] request content: {requestContent}");
+            }
+
+            // write response content
+            scope.Span.SetTag("content", "PONG");
+            var responseBytes = Encoding.UTF8.GetBytes("PONG");
+            context.Response.ContentEncoding = Encoding.UTF8;
+            context.Response.ContentLength64 = responseBytes.Length;
+            context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+            // we must close the response
+            context.Response.Close();
         }
-
-        // write response content
-        scope.Span.SetTag("content", "PONG");
-        var responseBytes = Encoding.UTF8.GetBytes("PONG");
-        context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.ContentLength64 = responseBytes.Length;
-        context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
-        // we must close the response
-        context.Response.Close();
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            context.Response.Close();
+            throw;
+        }
     }
-    catch (Exception e)
+
+    static void LogCurrentSettings(Tracer tracer, string step)
     {
-        Console.WriteLine(e);
-        context.Response.Close();
-        throw;
+        var settings = tracer.Settings;
+        Console.WriteLine($"Current tracer settings for {step}: ");
+
+        WriteLog(settings.Environment);
+        WriteLog(settings.ServiceName);
+        WriteLog(settings.ServiceVersion);
+        var globalTags = string.Join(". ", settings.GlobalTags.Select(x => $"{x.Key}:{x.Value}"));
+        WriteLog(globalTags);
+
+        static void WriteLog(object argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+        {
+            Console.WriteLine($"  {paramName}: {argument}");
+        }
     }
-}
 
-static void LogCurrentSettings(Tracer tracer, string step)
-{
-    var settings = tracer.Settings;
-    Console.WriteLine($"Current tracer settings for {step}: ");
-
-    WriteLog(settings.Environment);
-    WriteLog(settings.ServiceName);
-    WriteLog(settings.ServiceVersion);
-    var globalTags = string.Join(". ", settings.GlobalTags.Select(x => $"{x.Key}:{x.Value}"));
-    WriteLog(globalTags);
-
-    static void WriteLog(object argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+    void Expect(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
     {
-        Console.WriteLine($"  {paramName}: {argument}");
+        if (runInstrumentationChecks && !condition)
+        {
+            throw new InstrumentationErrorException(description, expected: true);
+        }
     }
-}
 
-void Expect(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
-{
-    if (runInstrumentationChecks && !condition)
+    void ThrowIf(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
     {
-        throw new InstrumentationErrorException(description, expected: true);
-    }
-}
-
-void ThrowIf(bool condition, [CallerArgumentExpression(nameof(condition))] string description = null)
-{
-    if (runInstrumentationChecks && condition)
-    {
-        throw new InstrumentationErrorException(description, expected: false);
+        if (runInstrumentationChecks && condition)
+        {
+            throw new InstrumentationErrorException(description, expected: false);
+        }
     }
 }
 

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
@@ -33,7 +33,14 @@ async Task OtherStuff()
                             .GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: true)
                              !.GetMethod("IsManualInstrumentationOnly")
                              !.Invoke(null, null)!;
-    Expect(isManualOnly != shouldBeAttached);
+
+    // It's... weird... but reflection doesn't work with the rewriting in r2r for some reason...
+    var hasCorrectValueAfterRewrite = Environment.GetEnvironmentVariable("READY2RUN_ENABLED") != "1";
+    if (hasCorrectValueAfterRewrite)
+    {
+        Expect(isManualOnly != shouldBeAttached);
+    }
+
     Expect(SampleHelpers.IsProfilerAttached() == shouldBeAttached);
 
     var count = 0;

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
@@ -1,8 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Just temporary, until v3 -->
-    <AllowDatadogTraceReference>true</AllowDatadogTraceReference>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj" />


### PR DESCRIPTION
## Summary of changes

This PR changes the CLR profiler to reject a method NGEN image if there's a rejit request for that method.

## Reason for change

There's a cases were a rejit request is not handled because we end up accepting the NGEN image for that method, so the rewriting is never triggered.

## Implementation details
- Now we keep a list with all (ModuleId and MethodTokenDef) pairs that we are requesting rejit.
- We change the JITCachedFunctionSearchStart method to only accept the NGEN image if we are no requesting a rejit for that method.

## Test coverage

Fixes the `issue-6124` in my local machine. I expect that @andrewlock run a more extensive tests. 😜 

## Other details

Confirmed that the .NET NGEN test passes _without_ this fix and the r2r tests fail without this fix in [this build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=166463&view=results)