### PR TITLE
[Profiler] Make sure we log only once for DebugInfoStore errors

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
@@ -128,7 +128,7 @@ void DebugInfoStore::ParseModuleDebugInfo(ModuleID moduleId)
     catch (PPDB::Exception const& ec)
     {
         Log::Warn("Failed to parse debug info from ", pdbFile,
-                  ".(Module: ", modulfilePathId, "Error name: ", ec.Name, ", code: ", std::hex, static_cast<std::uint32_t>(ec.Error), ", metadata table: ", static_cast<std::uint32_t>(ec.Table), ")");
+                  ".(Module: ", filePath, "Error name: ", ec.Name, ", code: ", std::hex, static_cast<std::uint32_t>(ec.Error), ", metadata table: ", static_cast<std::uint32_t>(ec.Table), ")");
     }
     catch (...)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
@@ -52,6 +52,8 @@ void DebugInfoStore::ParseModuleDebugInfo(ModuleID moduleId)
     auto& moduleInfo = _modulesInfo[moduleId];
 
     fs::path filePath = GetModuleFilePath(moduleId);
+    moduleInfo.ModulePath = filePath.string();
+
     if (!filePath.has_extension() || (filePath.extension() != ".dll" && filePath.extension() != ".exe"))
     {
         // An invalid entry has been created for this file
@@ -65,11 +67,11 @@ void DebugInfoStore::ParseModuleDebugInfo(ModuleID moduleId)
     if (!fs::exists(pdbFile, ec))
     {
         // TODO: we may supply other path to search for the pdb file
-        Log::Info("No PDB file (associated to module id ", moduleId, ")`", pdbFile.filename(), "` was found in ", filePath.parent_path());
+        Log::Info("No PDB file (associated to module ", filePath, ")`", pdbFile.filename(), "` was found in ", filePath.parent_path());
         return;
     }
 
-    Log::Debug("Parsing ", pdbFile, " pdb file. (module id ", moduleId,")");
+    Log::Debug("Parsing ", pdbFile, " pdb file. (for module ", filePath,")");
 
     try
     {
@@ -121,16 +123,16 @@ void DebugInfoStore::ParseModuleDebugInfo(ModuleID moduleId)
             moduleInfo.SymbolsDebugInfo.emplace_back() = {moduleInfo.Files[row.InitialDocument], startLine};
         }
         moduleInfo.IsValid = true;
-        Log::Debug("PDB file ", pdbFile, " parsed successfully (module id", moduleId,")");
+        Log::Debug("PDB file ", pdbFile, " parsed successfully (for module ", filePath,")");
     }
     catch (PPDB::Exception const& ec)
     {
         Log::Warn("Failed to parse debug info from ", pdbFile,
-                  ".(Module id: ", moduleId, "Error name: ", ec.Name, ", code: ", std::hex, static_cast<std::uint32_t>(ec.Error), ", metadata table: ", static_cast<std::uint32_t>(ec.Table), ")");
+                  ".(Module: ", modulfilePathId, "Error name: ", ec.Name, ", code: ", std::hex, static_cast<std::uint32_t>(ec.Error), ", metadata table: ", static_cast<std::uint32_t>(ec.Table), ")");
     }
     catch (...)
     {
-        Log::Warn("Unexpected error happened while parsing the pdb file (Module id: ", moduleId, "): ", pdbFile);
+        Log::Warn("Unexpected error happened while parsing the pdb file (Module: ", filePath, "): ", pdbFile);
     }
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
@@ -60,15 +60,16 @@ void DebugInfoStore::ParseModuleDebugInfo(ModuleID moduleId)
     }
 
     auto pdbFile = filePath.parent_path() / filePath.filename().replace_extension(".pdb");
-    Log::Debug("Parsing ", pdbFile, " pdb file.");
 
     std::error_code ec;
     if (!fs::exists(pdbFile, ec))
     {
         // TODO: we may supply other path to search for the pdb file
-        Log::Info("No PDB file `", pdbFile.filename(), "` was found in ", filePath.parent_path());
+        Log::Info("No PDB file (associated to module id ", moduleId, ")`", pdbFile.filename(), "` was found in ", filePath.parent_path());
         return;
     }
+
+    Log::Debug("Parsing ", pdbFile, " pdb file. (module id ", moduleId,")");
 
     try
     {
@@ -120,16 +121,16 @@ void DebugInfoStore::ParseModuleDebugInfo(ModuleID moduleId)
             moduleInfo.SymbolsDebugInfo.emplace_back() = {moduleInfo.Files[row.InitialDocument], startLine};
         }
         moduleInfo.IsValid = true;
-        Log::Debug("PDB file ", pdbFile, " parsed successfully");
+        Log::Debug("PDB file ", pdbFile, " parsed successfully (module id", moduleId,")");
     }
     catch (PPDB::Exception const& ec)
     {
         Log::Warn("Failed to parse debug info from ", pdbFile,
-                  ".(Error name: ", ec.Name, ", code: ", std::hex, static_cast<std::uint32_t>(ec.Error), ", metadata table: ", static_cast<std::uint32_t>(ec.Table), ")");
+                  ".(Module id: ", moduleId, "Error name: ", ec.Name, ", code: ", std::hex, static_cast<std::uint32_t>(ec.Error), ", metadata table: ", static_cast<std::uint32_t>(ec.Table), ")");
     }
     catch (...)
     {
-        Log::Warn("Unexpected error happened while parsing the pdb file: ", pdbFile);
+        Log::Warn("Unexpected error happened while parsing the pdb file (Module id: ", moduleId, "): ", pdbFile);
     }
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.h
@@ -34,6 +34,7 @@ private:
         std::vector<std::string> Files;
         std::vector<SymbolDebugInfo> SymbolsDebugInfo;
         bool IsValid = false;
+        bool ErrorLogged = false;
     };
 
     void ParseModuleDebugInfo(ModuleID moduleID);
@@ -42,10 +43,16 @@ private:
     template <typename TInfo>
     SymbolDebugInfo Get(TInfo& info, ModuleID moduleId, RID rid)
     {
-        if (!info.IsValid || rid >= info.SymbolsDebugInfo.size())
+        auto invalidInfo = !info.IsValid || rid >= info.SymbolsDebugInfo.size();
+
+        if (invalidInfo)
         {
-            Log::Info("The debug info for the module `", moduleId, "` seems to be invalid (is valid? '", info.IsValid, "') or the RID is out of the symbols array bounds (RID: ",
+            auto alreadyLogged = std::exchange(info.ErrorLogged, true);
+            if (!alreadyLogged)
+            {
+                Log::Info("The debug info for the module `", moduleId, "` seems to be invalid (is valid? '", info.IsValid, "') or the RID is out of the symbols array bounds (RID: ",
                       rid, "). Number of debug info: ", info.SymbolsDebugInfo.size());
+            }
             return SymbolDebugInfo{NoFileFound, NoStartLine};
         }
         return info.SymbolsDebugInfo[rid];

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.h
@@ -31,6 +31,7 @@ private:
     struct ModuleDebugInfo
     {
     public:
+        std::string ModulePath;
         std::vector<std::string> Files;
         std::vector<SymbolDebugInfo> SymbolsDebugInfo;
         bool IsValid = false;
@@ -50,8 +51,15 @@ private:
             auto alreadyLogged = std::exchange(info.ErrorLogged, true);
             if (!alreadyLogged)
             {
-                Log::Info("The debug info for the module `", moduleId, "` seems to be invalid (is valid? '", info.IsValid, "') or the RID is out of the symbols array bounds (RID: ",
-                      rid, "). Number of debug info: ", info.SymbolsDebugInfo.size());
+                if (!info.IsValid)
+                {
+                    Log::Info("The debug info for the module `", info.ModulePath, "` seems to be invalid");
+                }
+                if (rid >= info.SymbolsDebugInfo.size())
+                {
+                    Log::Info("The RID is out of the symbols array bounds (RID: ", rid, "). Number of debug info: ", info.SymbolsDebugInfo.size(),
+                              ", module path: ", info.ModulePath);
+                }
             }
             return SymbolDebugInfo{NoFileFound, NoStartLine};
         }


### PR DESCRIPTION
## Summary of changes

Make sure that in case of errors, the DebugInfoStore (line number feature) logs only once the error per module.
## Reason for change
When enabling the "line number" feature, if a module is invalid (does not exist, discrepancies between the pdb and the image...), we log an error each time we ask for debug info.
```
[2024-10-23 12:46:18.933 | info | PId: 21 | TId: 21] The debug info for the module `140011354144768` seems to be invalid (is valid? '0') or the RID is out of the symbols array bounds (RID: 23527). Number of debug info: 0
```
This clutters the log file and does not help.

## Implementation details

Add a field per module datatstructure that says if the error was already logged for that module.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
