### PR TITLE
Fix typo in create_draft_release.yml

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -110,7 +110,7 @@ jobs:
         shell: bash
         run: |
           mkdir debug_symbols
-          tar zxcf linux-native-symbols.tar.gz -C debug_symbols
+          tar -zxcf linux-native-symbols.tar.gz -C debug_symbols
 
       - name: 'Push debug symbols to datadog'
         uses: ./.github/actions/publish-debug-symbols


### PR DESCRIPTION
## Summary of changes

Fixes a bug in the release process

## Reason for change

The release process is broken due to a typo in the tar command

## Implementation details

Fix the typo

## Test coverage

Can't really test it without running the release again

## Other details

Will do a manual upload of them using the other action