### PR TITLE
Fix using the wrong pool for smoke tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6212,7 +6212,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/install-docker-compose-v1.yml


### PR DESCRIPTION
## Summary of changes

Use `azure-windows-scale-set-2` instead of `azure-windows-scale-set`

## Reason for change

This was an oversight way back when we updated. It shouldn't matter, it's just sub-optimal.

## Implementation details

Fix the pool we use
