### PR TITLE
Add more info when GenerateDumpIfDbgRequested fails (take 2)

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -111,7 +111,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
                 _output.WriteLine("************************");
 
                 // Enumerating status for each thread
-                var threads = Directory.GetFiles($"/proc/{pid}/task");
+                var threads = Directory.GetDirectories($"/proc/{pid}/task");
 
                 foreach (var thread in threads)
                 {


### PR DESCRIPTION
## Summary of changes

List the status of the threads when GenerateDumpIfDbgRequested fails.

This is a continuation of https://github.com/DataDog/dd-trace-dotnet/pull/6113. I enumerated the files, but the threads are directories 🤦 

## Reason for change

Flaky test
