### PR TITLE
[Profiler] CPU profiler: Check if the stackwalk lock was not already taken

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -22,7 +22,7 @@
 #include "SpinningMutex.hpp"
 using dd_mutex_t = SpinningMutex;
 #else
-using dd_mutex_t = std::mutex
+using dd_mutex_t = std::mutex;
 #endif
 
 static constexpr int32_t MinFieldAlignRequirement = 8;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SpinningMutex.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SpinningMutex.hpp
@@ -10,7 +10,10 @@
 #include <time.h>
 #include <unistd.h>
 
-// This class is temporary.
+// /!\ For now, this class is simple enough to replace the std::mutex used for the
+// /!\ stack walk lock. If in the future we need it to be on critical paths,
+// /!\ it should be reviewed/improved.
+
 // Its goal is just to make sure we do not use signal-unsafe mechanism with the
 // timer_create-based CPU profiler.
 // Once the CPU profiler (timer_create) is ready and fully working, we will

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SpinningMutex.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SpinningMutex.hpp
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <sched.h>
+#include <signal.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+// This class is temporary.
+// Its goal is just to make sure we do not use signal-unsafe mechanism with the
+// timer_create-based CPU profiler.
+// Once the CPU profiler (timer_create) is ready and fully working, we will
+// rethink a part of the collection pipeline and the stack walk lock (in ManagedThreadInfo)
+// won't be needed (as a lock mechanism)
+// So that's why we keep this class simple
+
+class SpinningMutex
+{
+public:
+    SpinningMutex() :
+        _isLockTaken{0}, _ownerTid{0} {};
+    ~SpinningMutex() = default;
+
+    SpinningMutex(SpinningMutex const&) = delete;
+    SpinningMutex& operator=(SpinningMutex const&) = delete;
+
+    SpinningMutex(SpinningMutex&&) = delete;
+    SpinningMutex& operator=(SpinningMutex&&) = delete;
+
+    // make it usable with std::unique_lock
+    // so naming will be different from the rest of the code
+    void lock()
+    {
+        for (int spin_count = 0; !try_lock(); ++spin_count)
+        {
+#ifdef __x86_64__
+            // 16 taken from https://probablydance.com/2019/12/30/measuring-mutexes-spinlocks-and-how-bad-the-linux-scheduler-really-is/
+            if (spin_count < 16)
+            {
+                asm volatile("pause");
+            }
+            else
+            {
+                sched_yield();
+                spin_count = 0;
+            }
+#else
+            asm volatile("yield");
+#endif
+        }
+    }
+
+    void unlock()
+    {
+        _ownerTid = 0;
+        __sync_lock_release(&_isLockTaken);
+    }
+
+    bool try_lock()
+    {
+        auto acquired = __sync_lock_test_and_set(&_isLockTaken, 1) == 0;
+        if (acquired)
+        {
+            _ownerTid = syscall(SYS_gettid);
+        }
+        return acquired;
+    }
+
+private:
+    volatile sig_atomic_t _isLockTaken;
+    // mainly for debug reason
+    pid_t _ownerTid;
+};

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -101,6 +101,80 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
             total.Should().Be(expectedExceptionCount);
         }
 
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.ExceptionGenerator")]
+        public void ThrowExceptionsInParallelWithNewCpuProfiler(string appName, string framework, string appAssembly)
+        {
+            StackTrace expectedStack;
+
+            if (framework == "net462")
+            {
+                expectedStack = new StackTrace(
+                    new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |cg: |fn:ThrowExceptions |fg: |sg:(object state)"),
+                    new StackFrame("|lm:mscorlib |ns:System.Threading |ct:ThreadHelper |cg: |fn:ThreadStart |fg: |sg:(object obj)"));
+            }
+            else if (framework == "net6.0")
+            {
+                expectedStack = new StackTrace(
+                    new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |cg: |fn:ThrowExceptions |fg: |sg:(object state)"),
+                    new StackFrame("|lm:System.Private.CoreLib |ns:System.Threading |ct:Thread |cg: |fn:StartCallback |fg: |sg:()"));
+            }
+            else if (framework == "net7.0" || framework == "net8.0")
+            {
+                expectedStack = new StackTrace(
+                    new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |cg: |fn:ThrowExceptions |fg: |sg:(object state)"));
+            }
+            else
+            {
+                expectedStack = new StackTrace(
+                    new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |cg: |fn:ThrowExceptions |fg: |sg:(object state)"),
+                    new StackFrame("|lm:System.Private.CoreLib |ns:System.Threading |ct:ThreadHelper |cg: |fn:ThreadStart |fg: |sg:(object obj)"));
+            }
+
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: Scenario2);
+            EnvironmentHelper.DisableDefaultProfilers(runner);
+            runner.Environment.SetVariable(EnvironmentVariables.ExceptionProfilerEnabled, "1");
+            runner.Environment.SetVariable(EnvironmentVariables.ExceptionSampleLimit, "10000");
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(_output);
+
+            runner.Run(agent);
+
+            Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
+
+            var exceptionSamples = SamplesHelper.GetSamples(runner.Environment.PprofDir, "exception").ToArray();
+
+            long total = exceptionSamples.Length;
+
+            foreach (var (stackTrace, labels, _) in exceptionSamples)
+            {
+                labels.Should().ContainSingle(x => x.Name == "exception type" && x.Value == "System.Exception");
+                labels.Should().ContainSingle(x => x.Name == "exception message" && string.IsNullOrWhiteSpace(x.Value));
+                Assert.True(stackTrace.EndWith(expectedStack));
+            }
+
+            foreach (var file in Directory.GetFiles(runner.Environment.LogDir))
+            {
+                _output.WriteLine($"Log file: {file}");
+            }
+
+            var logFile = Directory.GetFiles(runner.Environment.LogDir)
+                .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
+
+            // Stackwalk will fail if the walltime profiler tries to inspect the thread at the same time as the exception profiler
+            // This is expected so we remove those from the expected count
+            var missedExceptions = File.ReadLines(logFile)
+                .Count(l => l.Contains("Failed to walk stack for thrown exception: CORPROF_E_STACKSNAPSHOT_UNSAFE (80131360)"));
+
+            int expectedExceptionCount = (4 * 1000) - missedExceptions;
+
+            expectedExceptionCount.Should().BeGreaterThan(0, "only a few exceptions should be missed");
+
+            total.Should().Be(expectedExceptionCount);
+        }
+
         [TestAppFact("Samples.ExceptionGenerator")]
         public void Sampling(string appName, string framework, string appAssembly)
         {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
@@ -33,5 +33,15 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.BuggyBits")]
+        public void CheckSmokeForNewCpuProfiler(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.RunAndCheck();
+        }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
@@ -89,5 +89,45 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckAppDomainForNewCpuProfiler(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckGenericsForNewCpuProfiler(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", output: _output);
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckPiForNewCpuProfiler(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", output: _output);
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckFibonacciForNewCpuProfiler(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", output: _output);
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.RunAndCheck();
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

Check if the stack walk lock was not taken before unwinding in the `timer_create`-based CPU profiler.

## Reason for change

We got situation where a signal-based profiler (Walltime/CPU) interrupted a non-signal-based profiler (ex: Exception, Allocation, Contention...) while unwinding the callstack. This situation leads to a crash.

## Implementation details

* Implement a SpinningMutex: This class is simple based on its current usage. If it needs to be used elsewhere we need to review/improve it.
* Check if the stack walk lock is not already taken. If it the cases, bail out (for now)

## Test coverage

Added new tests.

## Other details
Another PR is in progress to have metrics around discarded samples due to those checks.
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
