### PR TITLE
Add profiling scenario to onboarding tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ onboarding_tests_installer:
   parallel:
     matrix:
       - ONBOARDING_FILTER_WEBLOG: [test-app-dotnet, test-app-dotnet-container]
-      - SCENARIO: [ SIMPLE_INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING ]
+        SCENARIO: [ SIMPLE_INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING ]
 
 onboarding_tests_k8s_injection:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,7 @@ onboarding_tests_installer:
   parallel:
     matrix:
       - ONBOARDING_FILTER_WEBLOG: [test-app-dotnet, test-app-dotnet-container]
+      - SCENARIO: [ SIMPLE_INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING ]
 
 onboarding_tests_k8s_injection:
   variables:


### PR DESCRIPTION
## Summary of changes

The one APM pipeline by default runs the `SIMPLE_INSTALLER_AUTO_INJECTION` scenario. This adds `SIMPLE_AUTO_INJECTION_PROFILING`.

## Reason for change

Profiling scenarios for .NET now work correctly in nightly onboarding system tests runs. Adding one of them here helps catch breakage of SSI profiling functionality early.

## Implementation details

## Test coverage

The sole reason of this change is expanding test coverage.

## Other details
JIRA [PROF-10811]

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->


[PROF-10811]: https://datadoghq.atlassian.net/browse/PROF-10811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ