### PR TITLE
Pin Azure Functions version used in CI to get the integration tests running

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1821,7 +1821,8 @@ stages:
         
     - template: steps/install-msi.yml
       parameters:
-        # Pin to a specific version of Azure Functions, as beyond this requires Azurite 
+        # Pin to a specific version of Azure Functions, as beyond this requires Azurite
+        # TODO: Make this floating and use azurite if necessary down the line
         url: "https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/func-cli-4.0.6280-x64.msi"
         filename: "func-cli-4.0.6280-x64.msi"
         addToPath: "C:\\Program Files\\Microsoft\\Azure Functions Core Tools"

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1808,8 +1808,8 @@ stages:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
       # We're not using our _usual_ VMSS scale set because
-      # couldn't work out how to get Azure Functions working with Azurite...
-      vmImage: windows-2022
+      # couldn't work out how to get Azure 
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1819,14 +1819,20 @@ stages:
     - template: steps/install-dotnet-sdks.yml
     - template: steps/restore-working-directory.yml
         
+    - template: steps/install-msi.yml
+      parameters:
+        # Pin to a specific version of Azure Functions, as beyond this requires Azurite 
+        url: "https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/func-cli-4.0.6280-x64.msi"
+        filename: "func-cli-4.0.6280-x64.msi"
+        addToPath: "C:\\Program Files\\Microsoft\\Azure Functions Core Tools"
+
     - script: func
       displayName: 'Display Azure Functions core tools'
       workingDirectory: $(Pipeline.Workspace)
 
     - script: |
-        npx --yes --loglevel info azurite --version
-        npx --yes azurite --silent --inMemoryPersistence &
-      displayName: 'Install and start Azurite Emulator'
+        "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
+      displayName: 'Start Azure Storage Emulator'
       workingDirectory: $(Pipeline.Workspace)
       retryCountOnTaskFailure: 5
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1828,14 +1828,14 @@ stages:
       displayName: 'Display Azure Functions core tools'
       workingDirectory: $(Pipeline.Workspace)
 
+    # For some ridiculous reason, Azure won't let you run it in the background,
+    # so we have to run it in the same step and kill it with fire
+    # https://github.com/Azure/Azurite/issues/589
     - script: |
-        "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
-      displayName: 'Start Azure Storage Emulator'
-      workingDirectory: $(Pipeline.Workspace)
-      retryCountOnTaskFailure: 5
-
-    - script: tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
-      displayName: Run Azure Functions tests
+        start /B "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"
+        tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+        taskkill /f /im azurite.exe
+      displayName: Start Azurite and Run Azure Functions tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         Filter: $(IntegrationTestFilter)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1832,8 +1832,13 @@ stages:
     # so we have to run it in the same step and kill it with fire
     # https://github.com/Azure/Azurite/issues/589
     - script: |
-        start /B "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"
+        echo "Start Azurite"
+        "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"
+
+        echo "Run tests"
         tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+
+        echo "Kill Azurite"
         taskkill /f /im azurite.exe
       displayName: Start Azurite and Run Azure Functions tests
       env:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1809,7 +1809,7 @@ stages:
     pool:
       # We're not using our _usual_ VMSS scale set because
       # couldn't work out how to get Azure Functions working with Azurite...
-      name: windows-latest
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1807,7 +1807,9 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
-      name: azure-windows-scale-set-2
+      # We're not using our _usual_ VMSS scale set because
+      # couldn't work out how to get Azure Functions working with Azurite...
+      name: windows-latest
 
     steps:
     - template: steps/clone-repo.yml
@@ -1817,30 +1819,19 @@ stages:
     - template: steps/install-dotnet-sdks.yml
     - template: steps/restore-working-directory.yml
         
-    # Not using chocolatey as we're getting 429 Too Many Requests
-    - template: steps/install-msi.yml
-      parameters:
-        url: "https://functionscdn.azureedge.net/public/artifacts/v4/latest/func-cli-x64.msi"
-        filename: "func-cli-x64.msi"
-        addToPath: "C:\\Program Files\\Microsoft\\Azure Functions Core Tools"
-
     - script: func
       displayName: 'Display Azure Functions core tools'
       workingDirectory: $(Pipeline.Workspace)
 
-    # For some ridiculous reason, Azure won't let you run it in the background,
-    # so we have to run it in the same step and kill it with fire
-    # https://github.com/Azure/Azurite/issues/589
     - script: |
-        echo "Start Azurite in the background"
-        start /b "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"
+        npx --yes --loglevel info azurite --version
+        npx --yes azurite --silent --inMemoryPersistence &
+      displayName: 'Install and start Azurite Emulator'
+      workingDirectory: $(Pipeline.Workspace)
+      retryCountOnTaskFailure: 5
 
-        echo "Run tests"
-        tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
-
-        echo "Kill Azurite"
-        taskkill /f /im azurite.exe
-      displayName: Start Azurite and Run Azure Functions tests
+    - script: tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+      displayName: Run Azure Functions tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         Filter: $(IntegrationTestFilter)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1832,8 +1832,8 @@ stages:
     # so we have to run it in the same step and kill it with fire
     # https://github.com/Azure/Azurite/issues/589
     - script: |
-        echo "Start Azurite"
-        "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"
+        echo "Start Azurite in the background"
+        start /b "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"
 
         echo "Run tests"
         tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1807,8 +1807,6 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
-      # We're not using our _usual_ VMSS scale set because
-      # couldn't work out how to get Azure 
       name: azure-windows-scale-set-2
 
     steps:


### PR DESCRIPTION
## Summary of changes

Pins Azure functions to `4.0.6280` to fix CI

## Reason for change

The "latest" Azure Functions installer installs version `4.0.6543`. [This causes the Azure Functions integration tests to fail](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=166249&view=logs&j=b915f7fe-737b-590c-2437-5d9fd23477ed&t=b6a81d99-5699-541f-919b-ca36a45374e0) with:

```
Status: 400 (The REST version of this request is not supported by this release of the Storage Emulator. Please upgrade the storage emulator to the latest version. Refer to the following URL for more information: http://go.microsoft.com/fwlink/?LinkId=392237)
```

However, there isn't_ a later version AFAICT... 

My assumption is we need to use the azurite tool, because the storage emulator is no longer supported. However, my efforst to get that working have been... frustrating... as you can see from the commit list...

Essentially, azurite is installed in the VMs, and you can start it by hitting `"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"`, and it will start listening on the expected ports:

```
Azurite Blob service is starting at http://127.0.0.1:10000/
Azurite Blob service is successfully listening at http://127.0.0.1:10000/
Azurite Queue service is starting at http://127.0.0.1:10001/
Azurite Queue service is successfully listening at http://127.0.0.1:10001/
Azurite Table service is starting at http://127.0.0.1:10002/
Azurite Table service is successfully listening at http://127.0.0.1:10002/
```

But [there's no way to "properly" run it in the background on Windows](https://github.com/Azure/Azurite/issues/589) other than using `start /b` which fundamentally doesn't seem to work (azure functions fails to connect to it):

```
13:28:31 [DBG]  [2024-10-25T13:19:09.878Z] The listener for function 'TriggerAllTimer' was unable to start. Azure.Core: Retry failed after 6 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)). Azure.Core: No connection could be made because the target machine actively refused it. (127.0.0.1:10000). System.Net.Http: No connection could be made because the target machine actively refused it. (127.0.0.1:10000). System.Net.Sockets: No connection could be made because the target machine actively refused it.
```

## Implementation details

I gave up and just pinned the version of Azure functions we install. We should update this to the latest when we can.

FWIW, https://github.com/Azure/azure-functions-core-tools/releases doesn't even list the new, breaking, version yet

## Test coverage

The bit downside is we are no longer testing with the latest version of Azure Functions tools 🙁 
