### PR TITLE
[DBM][fix] Do not prepend DBM injected comment when a pg plan hint is present

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -79,7 +79,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                 if (tracer.Settings.DbmPropagationMode != DbmPropagationLevel.Disabled
                     && command.CommandType != CommandType.StoredProcedure)
                 {
-                    var alreadyInjected = commandText.StartsWith(DatabaseMonitoringPropagator.DbmPrefix);
+                    var alreadyInjected = commandText.StartsWith(DatabaseMonitoringPropagator.DbmPrefix) ||
+                                          // if we appended the comment, we need to look for a potential DBM comment in the whole string.
+                                          (DatabaseMonitoringPropagator.ShouldAppend(integrationId, commandText) && commandText.Contains(DatabaseMonitoringPropagator.DbmPrefix));
                     if (alreadyInjected)
                     {
                         // The command text is already injected, so they're probably caching the SqlCommand
@@ -100,11 +102,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     }
                     else
                     {
-                        var propagationComment = DatabaseMonitoringPropagator.PropagateDataViaComment(tracer.Settings.DbmPropagationMode, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span, integrationId, out var traceParentInjectedInComment);
-                        if (!string.IsNullOrEmpty(propagationComment))
-                        {
-                            command.CommandText = $"{propagationComment} {commandText}";
-                        }
+                        var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(tracer.Settings.DbmPropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span);
 
                         // try context injection only after comment injection, so that if it fails, we still have service level propagation
                         var traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(tracer.Settings.DbmPropagationMode, integrationId, command.Connection, scope.Span);

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -35,76 +35,129 @@ namespace Datadog.Trace.DatabaseMonitoring
 
         private static int _remainingErrorLogs = 100; // to prevent too many similar errors in the logs. We assume that after 100 logs, the incremental value of more logs is negligible.
 
-        internal static string PropagateDataViaComment(DbmPropagationLevel propagationStyle, string configuredServiceName, string? dbName, string? outhost, Span span, IntegrationId integrationId, out bool traceParentInjected)
+        internal static bool PropagateDataViaComment(DbmPropagationLevel propagationLevel, IntegrationId integrationId, IDbCommand command, string configuredServiceName, string? dbName, string? outhost, Span span)
         {
-            traceParentInjected = false;
-
-            if (integrationId is IntegrationId.MySql or IntegrationId.Npgsql or IntegrationId.SqlClient or IntegrationId.Oracle &&
-                (propagationStyle is DbmPropagationLevel.Service or DbmPropagationLevel.Full))
+            if (integrationId is not (IntegrationId.MySql or IntegrationId.Npgsql or IntegrationId.SqlClient or IntegrationId.Oracle) ||
+                propagationLevel is not (DbmPropagationLevel.Service or DbmPropagationLevel.Full))
             {
-                var propagatorStringBuilder = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-                var dddbs = span.Context.ServiceNameInternal;
-                propagatorStringBuilder.Append(DbmPrefix).Append(Uri.EscapeDataString(dddbs)).Append('\'');
-
-                string? ddprs = null;
-                if (span.Tags is SqlV1Tags sqlTags)
-                {
-                    if (sqlTags.PeerServiceSource == "peer.service")
-                    {
-                        ddprs = sqlTags.PeerService;
-                    }
-                }
-                else
-                {
-                    if (span.Tags.GetTag(Tags.PeerServiceRemappedFrom) != null)
-                    {
-                        ddprs = span.Tags.GetTag(Tags.PeerService);
-                    }
-                }
-
-                if (ddprs != null)
-                {
-                    propagatorStringBuilder.Append(',').Append(SqlCommentPeerService).Append("='").Append(Uri.EscapeDataString(ddprs)).Append('\'');
-                }
-
-                if (span.Context.TraceContext?.Environment is { } envTag)
-                {
-                    propagatorStringBuilder.Append(',').Append(SqlCommentEnv).Append("='").Append(Uri.EscapeDataString(envTag)).Append('\'');
-                }
-
-                propagatorStringBuilder.Append(',').Append(SqlCommentRootService).Append("='").Append(Uri.EscapeDataString(configuredServiceName)).Append('\'');
-
-                if (!string.IsNullOrEmpty(dbName))
-                {
-                    propagatorStringBuilder.Append(value: ',').Append(SqlCommentDbName).Append("='").Append(Uri.EscapeDataString(dbName)).Append(value: '\'');
-                }
-
-                if (!string.IsNullOrEmpty(outhost))
-                {
-                    propagatorStringBuilder.Append(value: ',').Append(SqlCommentOuthost).Append("='").Append(Uri.EscapeDataString(outhost)).Append(value: '\'');
-                }
-
-                if (span.Context.TraceContext?.ServiceVersion is { } versionTag)
-                {
-                    propagatorStringBuilder.Append(',').Append(SqlCommentVersion).Append("='").Append(Uri.EscapeDataString(versionTag)).Append('\'');
-                }
-
-                // For SqlServer & Oracle we don't inject the traceparent to avoid affecting performance, since those DBs generate a new plan for any query changes
-                if (propagationStyle == DbmPropagationLevel.Full
-                 && integrationId is not (IntegrationId.SqlClient or IntegrationId.Oracle))
-                {
-                    traceParentInjected = true;
-                    propagatorStringBuilder.Append(',').Append(W3CTraceContextPropagator.TraceParentHeaderName).Append("='").Append(W3CTraceContextPropagator.CreateTraceParentHeader(span.Context)).Append("'*/");
-                }
-                else
-                {
-                    propagatorStringBuilder.Append("*/");
-                }
-
-                return StringBuilderCache.GetStringAndRelease(propagatorStringBuilder);
+                return false;
             }
 
-            return string.Empty;
+            var propagatorStringBuilder = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+            var dddbs = span.Context.ServiceNameInternal;
+            propagatorStringBuilder.Append(DbmPrefix).Append(Uri.EscapeDataString(dddbs)).Append('\'');
+
+            string? ddprs = null;
+            if (span.Tags is SqlV1Tags sqlTags)
+            {
+                if (sqlTags.PeerServiceSource == "peer.service")
+                {
+                    ddprs = sqlTags.PeerService;
+                }
+            }
+            else
+            {
+                if (span.Tags.GetTag(Tags.PeerServiceRemappedFrom) != null)
+                {
+                    ddprs = span.Tags.GetTag(Tags.PeerService);
+                }
+            }
+
+            if (ddprs != null)
+            {
+                propagatorStringBuilder.Append(',').Append(SqlCommentPeerService).Append("='").Append(Uri.EscapeDataString(ddprs)).Append('\'');
+            }
+
+            if (span.Context.TraceContext?.Environment is { } envTag)
+            {
+                propagatorStringBuilder.Append(',').Append(SqlCommentEnv).Append("='").Append(Uri.EscapeDataString(envTag)).Append('\'');
+            }
+
+            propagatorStringBuilder.Append(',').Append(SqlCommentRootService).Append("='").Append(Uri.EscapeDataString(configuredServiceName)).Append('\'');
+
+            if (!string.IsNullOrEmpty(dbName))
+            {
+                propagatorStringBuilder.Append(value: ',').Append(SqlCommentDbName).Append("='").Append(Uri.EscapeDataString(dbName)).Append(value: '\'');
+            }
+
+            if (!string.IsNullOrEmpty(outhost))
+            {
+                propagatorStringBuilder.Append(value: ',').Append(SqlCommentOuthost).Append("='").Append(Uri.EscapeDataString(outhost)).Append(value: '\'');
+            }
+
+            if (span.Context.TraceContext?.ServiceVersion is { } versionTag)
+            {
+                propagatorStringBuilder.Append(',').Append(SqlCommentVersion).Append("='").Append(Uri.EscapeDataString(versionTag)).Append('\'');
+            }
+
+            var traceParentInjected = false;
+            // For SqlServer & Oracle we don't inject the traceparent to avoid affecting performance, since those DBs generate a new plan for any query changes
+            if (propagationLevel == DbmPropagationLevel.Full
+             && integrationId is not (IntegrationId.SqlClient or IntegrationId.Oracle))
+            {
+                traceParentInjected = true;
+                propagatorStringBuilder.Append(',').Append(W3CTraceContextPropagator.TraceParentHeaderName).Append("='").Append(W3CTraceContextPropagator.CreateTraceParentHeader(span.Context)).Append('\'');
+            }
+
+            propagatorStringBuilder.Append("*/");
+
+            // modify the command to add the comment
+            var commandText = command.CommandText ?? string.Empty;
+            var propagationComment = StringBuilderCache.GetStringAndRelease(propagatorStringBuilder);
+            if (ShouldAppend(integrationId, commandText))
+            {
+                command.CommandText = $"{commandText} {propagationComment}";
+            }
+            else
+            {
+                // prepending the propagation comment is the preferred way,
+                // as this protects it from being truncated by the character limit if the command is very long.
+                command.CommandText = $"{propagationComment} {commandText}";
+            }
+
+            return traceParentInjected;
+        }
+
+        internal static bool ShouldAppend(IntegrationId integrationId, string commandText)
+        {
+            // pg_hint_plan allows setting hints for the execution plan as the *first* comment. If such a hint is present,
+            // we need to append our comment rather than prepend, to avoid invalidating the hint
+            // see https://pg-hint-plan.readthedocs.io/en/latest/hint_details.html#syntax-and-placement
+            return integrationId == IntegrationId.Npgsql && StartsWithHint(commandText);
+        }
+
+        /// <summary>
+        /// Detect if a command contains a pg_hint_plan.
+        /// Basically equivalent to `commandText.TrimStart().StartsWith("/*+")` except it avoids the new string allocation that Trim does.
+        /// </summary>
+        private static bool StartsWithHint(string commandText)
+        {
+            var commandIndex = 0;
+            // skip leading whitespace
+            while (commandIndex < commandText.Length && char.IsWhiteSpace(commandText[commandIndex]))
+            {
+                commandIndex++;
+            }
+
+            // the pattern we are looking for
+            var pattern = "/*+";
+            for (var patternIndex = 0; patternIndex < pattern.Length; patternIndex++, commandIndex++)
+            {
+                if (commandIndex >= commandText.Length)
+                {
+                    // we reached the end of the command before reaching the end of the pattern
+                    return false;
+                }
+
+                if (commandText[commandIndex] != pattern[patternIndex])
+                {
+                    // pattern does not match
+                    return false;
+                }
+            }
+
+            // if we reach here, it means we were able to validate all chars of the pattern
+            return true;
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
@@ -5,10 +5,8 @@
 
 using System;
 using System.Data;
-using System.Numerics;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.DatabaseMonitoring;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Sampling;
@@ -59,10 +57,14 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             var span = _v0Tracer.StartSpan(operationName: "db.query", parent: SpanContext.None, serviceName: dbServiceName, traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
             span.SetTraceSamplingPriority((SamplingPriority)samplingPriority.Value);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, "Test.Service", "MyDatabase", "MyHost", span, integrationId, out var traceParentInjectedValue);
+            var initialCommandText = "select * from table";
+            var command = CreateCommand(initialCommandText);
+
+            var traceParentInjectedValue = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, integrationId, command, "Test.Service", "MyDatabase", "MyHost", span);
 
             traceParentInjectedValue.Should().Be(traceParentInjected);
-            returnedComment.Should().Be(expectedComment);
+            command.CommandText.Should().StartWith(expectedComment);
+            command.CommandText.Should().EndWith(initialCommandText);
         }
 
         [Theory]
@@ -77,11 +79,15 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             span.Context.TraceContext.ServiceVersion = version;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateDataViaComment(DbmPropagationLevel.Service, "Test.Service", "MyDatabase", "MyHost", span, IntegrationId.MySql, out var traceParentInjected);
+            var initialCommandText = "select * from table";
+            var command = CreateCommand(initialCommandText);
+
+            var traceParentInjected = DatabaseMonitoringPropagator.PropagateDataViaComment(DbmPropagationLevel.Service, IntegrationId.MySql, command, "Test.Service", "MyDatabase", "MyHost", span);
 
             // Always false since this test never runs for full mode
             traceParentInjected.Should().Be(false);
-            returnedComment.Should().Be(expectedComment);
+            command.CommandText.Should().StartWith(expectedComment);
+            command.CommandText.Should().EndWith(initialCommandText);
         }
 
         [Theory]
@@ -96,11 +102,15 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             span.Context.TraceContext.ServiceVersion = version;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateDataViaComment(DbmPropagationLevel.Service, service, dbName, host, span, IntegrationId.MySql, out var traceParentInjected);
+            var initialCommandText = "select * from table";
+            var command = CreateCommand(initialCommandText);
+
+            var traceParentInjected = DatabaseMonitoringPropagator.PropagateDataViaComment(DbmPropagationLevel.Service, IntegrationId.MySql, command, service, dbName, host, span);
 
             // Always false since this test never runs for full mode
             traceParentInjected.Should().Be(false);
-            returnedComment.Should().Be(expectedComment);
+            command.CommandText.Should().StartWith(expectedComment);
+            command.CommandText.Should().EndWith(initialCommandText);
         }
 
         [Fact]
@@ -113,14 +123,65 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             var expectedComment = $"/*dddbs='{dbServiceName}',ddps='Test.Service',dddb='MyDatabase',ddh='MyHost'*/";
             var traceParentInjected = false;
             var dbName = "dbname";
+            var initialCommandText = "select * from table";
+            var command = CreateCommand(initialCommandText);
 
             var span = _v1Tracer.StartSpan(tags: new SqlV1Tags() { DbName = dbName }, operationName: "db.query", parent: SpanContext.None, serviceName: dbServiceName, traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
             span.SetTraceSamplingPriority(samplingPriority);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, "Test.Service", "MyDatabase", "MyHost", span, integrationId, out var traceParentInjectedValue);
+            var traceParentInjectedValue = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, integrationId, command, "Test.Service", "MyDatabase", "MyHost", span);
 
             traceParentInjectedValue.Should().Be(traceParentInjected);
-            returnedComment.Should().Be(expectedComment);
+            command.CommandText.Should().StartWith(expectedComment);
+            command.CommandText.Should().EndWith(initialCommandText);
+        }
+
+        [Fact]
+        public void ExpectedCommentAppendedV1()
+        {
+            var dbmPropagationLevel = DbmPropagationLevel.Service;
+            var integrationId = IntegrationId.Npgsql;
+            var samplingPriority = SamplingPriority.AutoReject;
+            var dbServiceName = "Test.Service-postgres";
+            var expectedComment = $"/*dddbs='{dbServiceName}',ddps='Test.Service',dddb='MyDatabase',ddh='MyHost'*/";
+            var traceParentInjected = false;
+            var dbName = "dbname";
+            var initialCommandText = "/*+ this is a hint */ select * from table";
+            var command = CreateCommand(initialCommandText);
+
+            var span = _v1Tracer.StartSpan(tags: new SqlV1Tags() { DbName = dbName }, operationName: "db.query", parent: SpanContext.None, serviceName: dbServiceName, traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
+            span.SetTraceSamplingPriority(samplingPriority);
+
+            var traceParentInjectedValue = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, integrationId, command, "Test.Service", "MyDatabase", "MyHost", span);
+
+            traceParentInjectedValue.Should().Be(traceParentInjected);
+            command.CommandText.Should().EndWith(expectedComment);
+            command.CommandText.Should().StartWith(initialCommandText);
+        }
+
+        [Theory]
+        [InlineData(SchemaVersion.V0)]
+        [InlineData(SchemaVersion.V1)]
+        internal void PeerServiceInjected(SchemaVersion version)
+        {
+            var dbmPropagationLevel = DbmPropagationLevel.Service;
+            var traceParentInjected = false;
+            var peerService = "myPeerService";
+            var initialCommandText = "select * from table";
+            var command = CreateCommand(initialCommandText);
+
+            var sqlTags = version == SchemaVersion.V1 ? new SqlV1Tags() : new SqlTags();
+            sqlTags.SetTag(Tags.PeerServiceRemappedFrom, "old_value");
+            sqlTags.SetTag(Tags.PeerService, peerService);
+
+            var tracer = version == SchemaVersion.V1 ? _v1Tracer : _v0Tracer;
+            var span = tracer.StartSpan("db.query", sqlTags, serviceName: "myServiceName");
+
+            var traceParentInjectedValue = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, IntegrationId.Npgsql, command, "Test.Service", "MyDatabase", "MyHost", span);
+
+            traceParentInjectedValue.Should().Be(traceParentInjected);
+            command.CommandText.Should().StartWith("/*dddbs='myServiceName',ddprs='myPeerService',ddps='Test.Service',dddb='MyDatabase',ddh='MyHost'*/");
+            command.CommandText.Should().EndWith(initialCommandText);
         }
 
         [Theory]
@@ -132,7 +193,7 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
         [InlineData("full", "sqlite", SamplingPriorityValues.UserKeep, false, null)]
         [InlineData("full", "oracle", SamplingPriorityValues.UserKeep, false, null)]
         [InlineData("full", "mysql", SamplingPriorityValues.UserKeep, false, null)]
-        public void ExpectedContextSet(string propagationMode, string integration, int samplingPriority, bool shouldInject, string expectedContext)
+        internal void ExpectedContextSet(string propagationMode, string integration, int samplingPriority, bool shouldInject, string expectedContext)
         {
             Enum.TryParse(propagationMode, ignoreCase: true, out DbmPropagationLevel dbmPropagationLevel);
             Enum.TryParse(integration, ignoreCase: true, out IntegrationId integrationId);
@@ -172,25 +233,29 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
         }
 
         [Theory]
-        [InlineData(SchemaVersion.V0)]
-        [InlineData(SchemaVersion.V1)]
-        internal void PeerServiceInjected(SchemaVersion version)
+        [InlineData(true, IntegrationId.Npgsql, "/*+ HashJoin(t1 t1) */ EXPLAIN SELECT * FROM s1.t1 JOIN public.t1 ON (s1.t1.id=public.t1.id);")]
+        // only for PG, not the others
+        [InlineData(false, IntegrationId.MySql, "/*+ HashJoin(t1 t1) */ EXPLAIN SELECT * FROM s1.t1 JOIN public.t1 ON (s1.t1.id=public.t1.id);")]
+        [InlineData(false, IntegrationId.Oracle, "/*+ HashJoin(t1 t1) */ EXPLAIN SELECT * FROM s1.t1 JOIN public.t1 ON (s1.t1.id=public.t1.id);")]
+        [InlineData(false, IntegrationId.SqlClient, "/*+ HashJoin(t1 t1) */ EXPLAIN SELECT * FROM s1.t1 JOIN public.t1 ON (s1.t1.id=public.t1.id);")]
+        // leading whitespace is ignored
+        [InlineData(true, IntegrationId.Npgsql, " \n\t \u00A0\r /*+ HashJoin(t1 t1) */ EXPLAIN SELECT * FROM s1.t1 JOIN public.t1 ON (s1.t1.id=public.t1.id);")]
+        // some other cases
+        [InlineData(false, IntegrationId.Npgsql, "/* HashJoin(t1 t1) */ EXPLAIN SELECT * FROM s1.t1 JOIN public.t1 ON (s1.t1.id=public.t1.id);")]
+        [InlineData(false, IntegrationId.Npgsql, "/*")]
+        [InlineData(false, IntegrationId.Npgsql, "")]
+        internal void ShouldAppendComment(bool expected, IntegrationId integrationId, string commandText)
         {
-            var dbmPropagationLevel = DbmPropagationLevel.Service;
-            var traceParentInjected = false;
-            var peerService = "myPeerService";
+            DatabaseMonitoringPropagator.ShouldAppend(integrationId, commandText).Should().Be(expected);
+        }
 
-            var sqlTags = version == SchemaVersion.V1 ? new SqlV1Tags() : new SqlTags();
-            sqlTags.SetTag(Tags.PeerServiceRemappedFrom, "old_value");
-            sqlTags.SetTag(Tags.PeerService, peerService);
-
-            var tracer = version == SchemaVersion.V1 ? _v1Tracer : _v0Tracer;
-            var span = tracer.StartSpan("db.query", sqlTags, serviceName: "myServiceName");
-
-            var returnedComment = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, "Test.Service", "MyDatabase", "MyHost", span, IntegrationId.Npgsql, out var traceParentInjectedValue);
-
-            traceParentInjectedValue.Should().Be(traceParentInjected);
-            returnedComment.Should().Be("/*dddbs='myServiceName',ddprs='myPeerService',ddps='Test.Service',dddb='MyDatabase',ddh='MyHost'*/");
+        private IDbCommand CreateCommand(string commandText)
+        {
+            var commandMock = new Mock<IDbCommand>();
+            // allow properties to be used "normally" (value set is returned on get)
+            commandMock.SetupAllProperties();
+            commandMock.Object.CommandText = commandText;
+            return commandMock.Object;
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Postgres supports hints for execution plans, provided they are in the *first comment*, and start with `/*+`.
If we prepend the DBM injected comment in those cases, the hint is not the first comment anymore, and is not taken into account.
This PR fixes that problem by detecting the hints when using Npgsql, and when we do, we append the comment instead of prepending it.

## Implementation details

Took the opportunity to integrate modifying the comment into `DatabaseMonitoringPropagator`, so that it's all self-contained. This requires passing the `IDbCommand` as a parameter so that we can set the property.
I made sure to also edit the check on reused commands to also detect appended comments (with some extra conditions to avoid "paying the price" of a full string search every time).

I recommend reviewing with "ignore whitespace changes" active, as I flipped the `if` condition in `PropagateDataViaComment` to avoid having the whole body of the method indented by an extra level.

## Test coverage

yes.