### PR TITLE
Fix some build warnings in sample apps

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.HotChocolate/Samples.HotChocolate.csproj
+++ b/tracer/test/test-applications/integrations/Samples.HotChocolate/Samples.HotChocolate.csproj
@@ -12,6 +12,9 @@
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <!--  Workaround known issue with RouteHandlerAnalyer: https://github.com/dotnet/aspnetcore/issues/50836  -->
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SSRF/UrlEscapeTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SSRF/UrlEscapeTests.cs
@@ -9,11 +9,6 @@ public class UrlEscapeTests : InstrumentationTestsBase
 {
     private string _taintedValue = "tainted";
     private string _taintedValue2 = "/tainted?p1=t1&p2=t2";
-    private string _taintedFormat2Args = "format{0}{1}";
-    private string _taintedFormat3Args = "format{0}{1}{2}";
-    private string _taintedFormat1Arg = "format{0}";
-    private string _untaintedString = "UntaintedString";
-    private string _otherUntaintedString = "OtherUntaintedString";
 
     public UrlEscapeTests()
     {

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Xss/SqlDbReaderTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Xss/SqlDbReaderTests.cs
@@ -26,7 +26,7 @@ public class SqlDbReaderTests : InstrumentationTestsBase, IDisposable
         {
             databaseConnection.Close();
             databaseConnection.Dispose();
-            databaseConnection = null;
+            databaseConnection = null!;
         }
         base.Dispose();
     }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -1032,7 +1032,7 @@ namespace Samples.Security.AspNetCore5.Controllers
                 var rname = new SQLiteCommand(taintedQuery, DbConnection).ExecuteScalar();
                 return Content($"Result: " + rname);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return StatusCode(500);
             }


### PR DESCRIPTION
## Summary of changes

Fixes several warnings for things flagged in sample apps

## Reason for change

The warnings have been bugging me in CI recently

## Implementation details

Fixed the following:

- `[WRN] CompileSamplesWindow: D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\Xss\SqlDbReaderTests.cs(29,34): warning CS8625: Cannot convert null literal to non-nullable reference type.`
- `[WRN] CompileSamplesWindow: D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SSRF\UrlEscapeTests.cs(14,20): warning CS0414: The field 'UrlEscapeTests._taintedFormat1Arg' is assigned but its value is never used`
- `[WRN] CompileSamplesWindow: D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SSRF\UrlEscapeTests.cs(15,20): warning CS0414: The field 'UrlEscapeTests._untaintedString' is assigned but its value is never used`
- `[WRN] CompileSamplesWindow: D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SSRF\UrlEscapeTests.cs(12,20): warning CS0414: The field 'UrlEscapeTests._taintedFormat2Args' is assigned but its value is never used`
- `[WRN] CompileSamplesWindow: D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SSRF\UrlEscapeTests.cs(16,20): warning CS0414: The field 'UrlEscapeTests._otherUntaintedString' is assigned but its value is never used`
- `[WRN] CompileSamplesWindow: CSC : warning AD0001: Analyzer 'Microsoft.AspNetCore.Analyzers.RouteHandlers.RouteHandlerAnalyzer' threw an exception of type 'System.InvalidOperationException' with message 'Failed to resolve well-known type 'Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions'`
- `[WRN] CompileSamplesWindow: D:\a\1\s\tracer\test\test-applications\security\Samples.Security.AspNetCore5\Controllers\IastController.cs(1035,30): warning CS0168: The variable 'ex' is declared but never used`

## Test coverage

This is the test
