### PR TITLE
Avoid `Npgsql` `NotSupportedException` for DBM

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -105,17 +105,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     {
                         var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(tracer.Settings.DbmPropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span);
 
-                        // try context injection only after comment injection, so that if it fails, we still have service level propagation
-                        // This only works for Microsoft SQL Server
-                        // FIXME: For Npgsql command.Connection throws NotSupportedException for NpgsqlDataSourceCommand (v7.0+)
-                        //        Since the feature isn't available for Npgsql, just skipping over it for now.
+                        var traceParentInjectedInContext = false;
                         if (propagationMode == DbmPropagationLevel.Full && integrationId == IntegrationId.SqlClient)
                         {
-                            var traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(propagationMode, integrationId, command.Connection, scope.Span);
-                            if (traceParentInjectedInComment || traceParentInjectedInContext)
-                            {
-                                tags.DbmTraceInjected = "true";
-                            }
+                            // FIXME: For Npgsql command.Connection throws NotSupportedException for NpgsqlDataSourceCommand (v7.0+)
+                            //        Since the feature isn't available for Npgsql, just skipping over it for now.
+                            // try context injection only after comment injection, so that if it fails, we still have service level propagation
+                            // This only works for Microsoft SQL Server
+                            traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(propagationMode, integrationId, command.Connection, scope.Span);
+                        }
+
+                        if (traceParentInjectedInComment || traceParentInjectedInContext)
+                        {
+                            tags.DbmTraceInjected = "true";
                         }
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -103,17 +103,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     }
                     else
                     {
-                        var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(tracer.Settings.DbmPropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span);
+                        var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(propagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span);
 
                         var traceParentInjectedInContext = false;
-                        if (propagationMode == DbmPropagationLevel.Full && integrationId == IntegrationId.SqlClient)
-                        {
-                            // FIXME: For Npgsql command.Connection throws NotSupportedException for NpgsqlDataSourceCommand (v7.0+)
-                            //        Since the feature isn't available for Npgsql, just skipping over it for now.
-                            // try context injection only after comment injection, so that if it fails, we still have service level propagation
-                            // This only works for Microsoft SQL Server
-                            traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(propagationMode, integrationId, command.Connection, scope.Span);
-                        }
+                        // try context injection only after comment injection, so that if it fails, we still have service level propagation
+                        // This only works for Microsoft SQL Server
+                        traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(propagationMode, integrationId, command, scope.Span);
 
                         if (traceParentInjectedInComment || traceParentInjectedInContext)
                         {


### PR DESCRIPTION
## Summary of changes

Avoids `Npgsql` `NotSupportedException` for DBM.

## Reason for change

When using `Npgsql` `DbDataSource` (standard in v7.0)
the `.Connection` property throws a `NotSupportedException` as the `DbDataSource` type doesn't have "Connections" as you'd normally expect.

The exact type that is getting hit here is `NpgsqlDataSourceCommand`

https://github.com/npgsql/npgsql/blob/e6c166ba51bc1632498c944981e648fa987b9c12/src/Npgsql/NpgsqlDataSourceCommand.cs#L62

https://www.npgsql.org/doc/basic-usage.html

## Implementation details

Moved the check for DBM propagation mode up

## Test coverage

- I need to write a new sample for `Npgsql` to use `DbDataSource` for v7+
- I have started this locally and tested that this no longer throws an exception
- No tests at the moment :(

## Other details
<!-- Fixes #{issue} -->

We need to properly support the `DbDataSource`, currently it gets wrapped up in the `ADO.NET` integration, but seeing that this is the recommended/standard approach we should look into supporting it better.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
