### PR TITLE
[ASM] Fix possible null reference exception in extracting headers

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -413,7 +413,7 @@ internal readonly partial struct SecurityCoordinator
                     {
                         if (!queryDic.ContainsKey(v))
                         {
-                            queryDic.Add(v, Array.Empty<string>());
+                            queryDic.Add(v, []);
                         }
                     }
                 }
@@ -485,7 +485,7 @@ internal readonly partial struct SecurityCoordinator
         foreach (string originalKey in headerKeys)
         {
             var keyForDictionary = originalKey ?? string.Empty;
-            if (!keyForDictionary.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
+            if (!keyForDictionary.Equals("cookie", StringComparison.OrdinalIgnoreCase))
             {
                 keyForDictionary = keyForDictionary.ToLowerInvariant();
                 if (!headersDic.ContainsKey(keyForDictionary))

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -468,7 +468,7 @@ internal readonly partial struct SecurityCoordinator
 
     private static object GetHeaderAsArray(string[] value) => value.Length == 1 ? value[0] : value;
 
-    private static object GetHeaderValueForWaf(NameValueCollection headers, string currentKey) => GetHeaderAsArray(headers.GetValues(currentKey));
+    private static object GetHeaderValueForWaf(NameValueCollection headers, string currentKey) => GetHeaderAsArray(headers.GetValues(currentKey) ?? [string.Empty]);
 
     private static void GetCookieKeyValueFromIndex(HttpCookieCollection cookies, int i, out string key, out string value)
     {

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -171,10 +171,11 @@ internal readonly partial struct SecurityCoordinator
     {
         var cookies = RequestDataHelper.GetCookies(request);
 
-        if (cookies is not null)
+        if (cookies is not null && cookies.Count is > 0)
         {
-            var cookiesDic = new Dictionary<string, object>();
-            for (var i = 0; i < cookies.Count; i++)
+            var cookiesCount = cookies.Count;
+            var cookiesDic = new Dictionary<string, object>(cookiesCount);
+            for (var i = 0; i < cookiesCount; i++)
             {
                 GetCookieKeyValueFromIndex(cookies, i, out var keyForDictionary, out var cookieValue);
 


### PR DESCRIPTION
## Summary of changes

`headers.GetValues(currentKey)` can return null and we do stuff with it later on 

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
