### PR TITLE
Fix flake in Ngen `ManualInstrumentationTests`

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -15,6 +15,11 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 
+#if NETFRAMEWORK
+// The .NET Framework tests use NGEN which is a global thing, so make sure we don't parallelize
+[CollectionDefinition(nameof(ManualInstrumentationTests), DisableParallelization = true)]
+[Collection(nameof(ManualInstrumentationTests))]
+#endif
 [UsesVerify]
 public class ManualInstrumentationTests : TestHelper
 {

--- a/tracer/test/Datadog.Trace.TestHelpers/NgenHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/NgenHelper.cs
@@ -21,9 +21,6 @@ public static class NgenHelper
 
         var install = $"install \"{appFilename}\"";
         RunNgen(output, workingDirectory, install);
-
-        // display NGEN'd assemblies
-        RunNgen(output, workingDirectory, "display");
     }
 
     public static void UninstallFromNativeImageCache(ITestOutputHelper output, string applicationPath)
@@ -33,9 +30,6 @@ public static class NgenHelper
 
         var install = $"uninstall \"{appFilename}\"";
         RunNgen(output, workingDirectory, install);
-
-        // display NGEN'd assemblies
-        RunNgen(output, workingDirectory, "display");
     }
 
     private static void RunNgen(ITestOutputHelper output, string workingDirectory, string arguments)
@@ -56,7 +50,7 @@ public static class NgenHelper
         var process = Process.Start(startInfo);
 
         using var helper = new ProcessHelper(process);
-        var timeoutMs = 30_000;
+        var timeoutMs = 60_000;
 
         var ranToCompletion = process.WaitForExit(timeoutMs) && helper.Drain(timeoutMs / 2);
         var standardOutput = helper.StandardOutput;


### PR DESCRIPTION
## Summary of changes

Try to make sure the new Ngen tests don't flake

## Reason for change

#6184 added some new tests which use NGEN. Those tests seem to be flaky (on x86 particularly). AFAICT it's a timeout issue with the `ngen.exe` execution, not an issue with the underlying implementation.

## Implementation details

- Increase the ngen.exe timeout
- Remove the call to `ngen display` - it was only added for debugging, and seems to take a _long_ time
- Add the tests to a collection (in .NET FX) so that they don't run in parallel with other tests

## Test coverage

This is the test