### PR TITLE
move all RC int values to long, to mirror RC backend

### DIFF
--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/ApplyDetails.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/ApplyDetails.cs
@@ -18,7 +18,7 @@ internal struct ApplyDetails
 
     public string Filename { get; }
 
-    public uint ApplyState { get; set; }
+    public ulong ApplyState { get; set; }
 
     public string? Error { get; set; }
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmCachedTargetFile.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmCachedTargetFile.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 {
     internal class RcmCachedTargetFile
     {
-        public RcmCachedTargetFile(string path, int length, List<RcmCachedTargetFileHash> hashes)
+        public RcmCachedTargetFile(string path, long length, List<RcmCachedTargetFileHash> hashes)
         {
             Path = path;
             Length = length;
@@ -21,7 +21,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
         public string Path { get; }
 
         [JsonProperty("length")]
-        public int Length { get; }
+        public long Length { get; }
 
         [JsonProperty("hashes")]
         public List<RcmCachedTargetFileHash> Hashes { get; }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientState.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientState.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 {
     internal class RcmClientState
     {
-        public RcmClientState(int rootVersion, int targetsVersion, List<RcmConfigState> configStates, bool hasError, string error, string backendClientState)
+        public RcmClientState(long rootVersion, long targetsVersion, List<RcmConfigState> configStates, bool hasError, string error, string backendClientState)
         {
             RootVersion = rootVersion;
             TargetsVersion = targetsVersion;
@@ -21,7 +21,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
         }
 
         [JsonProperty("root_version")]
-        public int RootVersion { get; }
+        public long RootVersion { get; }
 
         [JsonProperty("targets_version")]
         public long TargetsVersion { get; }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmConfigState.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmConfigState.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 {
     internal class RcmConfigState
     {
-        public RcmConfigState(string id, long version, string product, uint applyState, string applyError = null)
+        public RcmConfigState(string id, long version, string product, ulong applyState, string applyError = null)
         {
             Id = id;
             Version = version;
@@ -28,7 +28,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
         public string Product { get; }
 
         [JsonProperty("apply_state")]
-        public uint ApplyState { get; }
+        public ulong ApplyState { get; }
 
         [JsonProperty("apply_error")]
         public string ApplyError { get; }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmConfigState.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmConfigState.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 {
     internal class RcmConfigState
     {
-        public RcmConfigState(string id, int version, string product, uint applyState, string applyError = null)
+        public RcmConfigState(string id, long version, string product, uint applyState, string applyError = null)
         {
             Id = id;
             Version = version;
@@ -22,7 +22,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
         public string Id { get; }
 
         [JsonProperty("version")]
-        public int Version { get; }
+        public long Version { get; }
 
         [JsonProperty("product")]
         public string Product { get; }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Signed.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Signed.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol.Tuf
         public Dictionary<string, Target> Targets { get; set; } = new();
 
         [JsonProperty("version")]
-        public int Version { get; set; }
+        public long Version { get; set; }
 
         [JsonProperty("custom")]
         public TargetsCustom Custom { get; set; }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Target.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Target.cs
@@ -17,6 +17,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol.Tuf
         public Dictionary<string, string> Hashes { get; set; } = new();
 
         [JsonProperty("length")]
-        public int Length { get; set; }
+        public long Length { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/TargetCustom.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/TargetCustom.cs
@@ -11,6 +11,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol.Tuf
     internal class TargetCustom
     {
         [JsonProperty("v")]
-        public int V { get; set; }
+        public long V { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -39,7 +39,7 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
     private IReadOnlyList<ISubscription> _subscriptions = [];
 
     private string? _backendClientState;
-    private int _targetsVersion;
+    private long _targetsVersion;
     private BigInteger _capabilities;
     private string? _lastPollError;
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfiguration.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfiguration.cs
@@ -14,9 +14,9 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         public RemoteConfiguration(
             RemoteConfigurationPath path,
             byte[] contents,
-            int length,
+            long length,
             Dictionary<string, string> hashes,
-            int version)
+            long version)
         {
             Path = path;
             Contents = contents;
@@ -29,11 +29,11 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public byte[] Contents { get; }
 
-        public int Length { get; }
+        public long Length { get; }
 
         public Dictionary<string, string> Hashes { get; }
 
-        public int Version { get; }
+        public long Version { get; }
 
         public override bool Equals(object o)
         {

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationCache.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationCache.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public long Version { get; }
 
-        public uint ApplyState { get; private set; } = ApplyStates.UNACKNOWLEDGED;
+        public ulong ApplyState { get; private set; } = ApplyStates.UNACKNOWLEDGED;
 
         public string Error { get; private set; }
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationCache.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationCache.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 {
     internal class RemoteConfigurationCache
     {
-        public RemoteConfigurationCache(RemoteConfigurationPath path, int length, Dictionary<string, string> hashes, int version)
+        public RemoteConfigurationCache(RemoteConfigurationPath path, long length, Dictionary<string, string> hashes, long version)
         {
             Path = path;
             Length = length;
@@ -20,11 +20,11 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public RemoteConfigurationPath Path { get; }
 
-        public int Length { get; }
+        public long Length { get; }
 
         public Dictionary<string, string> Hashes { get; }
 
-        public int Version { get; }
+        public long Version { get; }
 
         public uint ApplyState { get; private set; } = ApplyStates.UNACKNOWLEDGED;
 


### PR DESCRIPTION
## Summary of changes

RC backend use long for there integer fields.

