### PR TITLE
Revert "[Crashtracking] Disable crashtracking on Windows by default"

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
@@ -80,7 +80,7 @@ EXTERN_C BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_cal
         bool telemetry_enabled = true;
         shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(L"DD_INSTRUMENTATION_TELEMETRY_ENABLED"), telemetry_enabled);
 
-        bool crashtracking_enabled = false;
+        bool crashtracking_enabled = true;
         shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(L"DD_CRASHTRACKING_ENABLED"), crashtracking_enabled);
 
         if (telemetry_enabled && crashtracking_enabled)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -36,11 +36,6 @@ public class CreatedumpTests : ConsoleTestHelper
         SetEnvironmentVariable("COMPlus_DbgMiniDumpType", string.Empty);
         SetEnvironmentVariable("COMPlus_DbgEnableMiniDump", string.Empty);
         SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", string.Empty);
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            SetEnvironmentVariable("DD_CRASHTRACKING_ENABLED", "1");
-        }
     }
 
     private static (string Key, string Value) LdPreloadConfig


### PR DESCRIPTION
Reverts DataDog/dd-trace-dotnet#6152

Now that PDB support is implemented, we can reactivate crashtracking by default on Windows.