### PR TITLE
Update version conflict test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -60,18 +60,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 // When version 2.1 of the tracer ships, we can go back to the test and add a case using nuget 2.0,
                 // which will actually test the version conflict behavior.
 
-#if NETCOREAPP
-                httpSpans.Should()
-                    .HaveCount(2)
-                    .And.OnlyContain(s => s.ParentId == rootSpan.SpanId && s.TraceId == rootSpan.TraceId)
-                    .And.OnlyContain(s => !s.Metrics.ContainsKey(Metrics.SamplingPriority));
-#else
                 httpSpans.Should()
                     .HaveCount(2)
                     .And.OnlyContain(s => s.ParentId == rootSpan.SpanId && s.TraceId == rootSpan.TraceId)
                     .And.ContainSingle(s => s.Metrics[Metrics.SamplingPriority] == SamplingPriorityValues.UserKeep)
                     .And.ContainSingle(s => s.Metrics[Metrics.SamplingPriority] == SamplingPriorityValues.UserReject);
-#endif
 
                 // Check the headers of the outbound http requests
                 var outputLines = processResult.StandardOutput.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
@@ -2,7 +2,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="255.1.6-prerelease" />
+    <PackageReference Include="Datadog.Trace" Version="2.60.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of changes

Change the version conflict test to something sane

## Reason for change

Since 3.x, this test doesn't really make sense - it's meant to test the behaviour of the app when the _manual_ version is _higher_ than the automatic version. Since 3.x, we don't ship Datadog.Trace.dll in the NuGet package, so this scenario, where the manual version is _higher_ than the automatic, can't happen in practice.

What we _can_ still have is a manual version 2.x with automatic 3.x, so changed the test to check that scenario instead.

## Implementation details

- Stop using the magic "future" NuGet and use the existing latest 2.x line.
- The behaviour should be the same for both .NET FX and .NET Core now

## Test coverage

Kinda the same, kinda different. We're testing auto > manual instead of manual > auto now.

## Other details

This is particularly necessarily for supporting .NET 9, seeing as the existing 255.x.x package won't support it, so we would need to create a new one, which isn't worth the hassle seeing as it can't happen.