### PR TITLE
Pin Azure Functions version used in CI to get the integration tests running (#6203 => v2)

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1626,11 +1626,12 @@ stages:
     - template: steps/install-dotnet-sdks.yml
     - template: steps/restore-working-directory.yml
         
-    # Not using chocolatey as we're getting 429 Too Many Requests
     - template: steps/install-msi.yml
       parameters:
-        url: "https://functionscdn.azureedge.net/public/artifacts/v4/latest/func-cli-x64.msi"
-        filename: "func-cli-x64.msi"
+        # Pin to a specific version of Azure Functions, as beyond this requires Azurite
+        # TODO: Make this floating and use azurite if necessary down the line
+        url: "https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/func-cli-4.0.6280-x64.msi"
+        filename: "func-cli-4.0.6280-x64.msi"
         addToPath: "C:\\Program Files\\Microsoft\\Azure Functions Core Tools"
 
     - script: func


### PR DESCRIPTION
## Summary of changes

Pins Azure functions to `4.0.6280` to fix CI

## Reason for change

The "latest" Azure Functions installer installs version `4.0.6543`. [This causes the Azure Functions integration tests to fail](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=166249&view=logs&j=b915f7fe-737b-590c-2437-5d9fd23477ed&t=b6a81d99-5699-541f-919b-ca36a45374e0) with:

```
Status: 400 (The REST version of this request is not supported by this release of the Storage Emulator. Please upgrade the storage emulator to the latest version. Refer to the following URL for more information: http://go.microsoft.com/fwlink/?LinkId=392237)
```

However, there isn't_ a later version AFAICT... 

My assumption is we need to use the azurite tool, because the storage emulator is no longer supported. However, my efforst to get that working have been... frustrating... as you can see from the commit list...

Essentially, azurite is installed in the VMs, and you can start it by hitting `"%ProgramFiles%\Microsoft Visual
Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Azure Storage Emulator\azurite.exe"`, and it will start listening on the expected ports:

```
Azurite Blob service is starting at http://127.0.0.1:10000/
Azurite Blob service is successfully listening at http://127.0.0.1:10000/
Azurite Queue service is starting at http://127.0.0.1:10001/
Azurite Queue service is successfully listening at http://127.0.0.1:10001/
Azurite Table service is starting at http://127.0.0.1:10002/
Azurite Table service is successfully listening at http://127.0.0.1:10002/
```

But [there's no way to "properly" run it in the background on Windows](https://github.com/Azure/Azurite/issues/589) other than using `start /b` which fundamentally doesn't seem to work (azure functions fails to connect to it):

```
13:28:31 [DBG]  [2024-10-25T13:19:09.878Z] The listener for function 'TriggerAllTimer' was unable to start. Azure.Core: Retry failed after 6 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)) (No connection could be made because the target machine actively refused it. (127.0.0.1:10000)). Azure.Core: No connection could be made because the target machine actively refused it. (127.0.0.1:10000). System.Net.Http: No connection could be made because the target machine actively refused it. (127.0.0.1:10000). System.Net.Sockets: No connection could be made because the target machine actively refused it.
```

## Implementation details

I gave up and just pinned the version of Azure functions we install. We should update this to the latest when we can.

FWIW, https://github.com/Azure/azure-functions-core-tools/releases doesn't even list the new, breaking, version yet

## Test coverage

The bit downside is we are no longer testing with the latest version of Azure Functions tools 🙁

## Other details

Backport of 
- #6203 