### PR TITLE
[Profiler] Fix bugs in the `timer_create`-based CPU profiler

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -41,6 +41,7 @@ public:
 
 private:
     static bool CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext);
+    static bool CanCollect(void* context);
     static TimerCreateCpuProfiler* Instance;
 
     bool Collect(void* ucontext);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -45,6 +45,7 @@ private:
 
     bool Collect(void* ucontext);
     void RegisterThreadImpl(ManagedThreadInfo* thread);
+    void UnregisterThreadImpl(ManagedThreadInfo* threadInfo);
 
     bool StartImpl() override;
     bool StopImpl() override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1629,8 +1629,12 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
     // is the same native thread assigned to the managed thread.
     ManagedThreadInfo::CurrentThreadInfo = threadInfo;
 
-#ifdef LINUX
+    _pManagedThreadList->SetThreadOsInfo(managedThreadId, osThreadId, dupOsThreadHandle);
 
+#ifdef LINUX
+    // This call must be made *after* we assigne the SetThreadOsInfo function call.
+    // Otherwise the threadInfo won't have it's OsThread field set and timer_create
+    // will have random behavior.
     if (_pCpuProfiler != nullptr)
     {
         _pCpuProfiler->RegisterThread(threadInfo);
@@ -1666,7 +1670,6 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
         return S_OK;
     }
 #endif
-    _pManagedThreadList->SetThreadOsInfo(managedThreadId, osThreadId, dupOsThreadHandle);
 
     return S_OK;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
@@ -45,6 +45,7 @@ ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, ICorProfilerInfo4* pC
     _traceContext{},
 #ifdef LINUX
     _sharedMemoryArea{nullptr},
+    _timerId{-1},
 #endif
     _info{pCorProfilerInfo},
     _blockingThreadId{0}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
+using System.IO;
+using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
 using FluentAssertions;
 using Xunit;
@@ -23,6 +25,32 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         }
 
         [TestAppFact("Samples.Computer01")]
+        public void CheckLogForError(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
+            // disable default profilers except CPU
+            EnvironmentHelper.DisableDefaultProfilers(runner);
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(_output);
+
+            runner.Run(agent);
+
+            var logFile = Directory.GetFiles(runner.Environment.LogDir)
+               .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
+
+            var logLines = File.ReadLines(logFile);
+
+            logLines.Should().ContainMatch("*timer_create Cpu profiler is enabled*");
+
+            logLines.Should().NotContainMatch("*Call to timer_create failed for thread 0*");
+            logLines.Should().NotContainMatch("*Timer was already created for thread 0*");
+            logLines.Should().NotContainMatch("*Call to timer_create failed for thread 0*");
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotBeEmpty("No samples were found");
+        }
+
+        [TestAppFact("Samples.Computer01")]
         public void CheckCpuSamples(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
@@ -38,7 +66,9 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             runner.Run(agent);
 
             // only cpu  profiler enabled so should see 1 value per sample and
-            foreach (var (_, _, values) in SamplesHelper.GetSamples(runner.Environment.PprofDir))
+            var samples = SamplesHelper.GetSamples(runner.Environment.PprofDir);
+            samples.Should().NotBeEmpty();
+            foreach (var (_, _, values) in samples)
             {
                 values.Length.Should().Be(1);
                 values.Should().OnlyContain(x => x == long.Parse(samplingInterval) * 1_000_000);
@@ -61,7 +91,34 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             var expectedInterval = long.Parse(samplingInterval) * 1_000_000;
             // only cpu  profiler enabled so should see 1 value per sample and
-            foreach (var (_, _, values) in SamplesHelper.GetSamples(runner.Environment.PprofDir))
+            var samples = SamplesHelper.GetSamples(runner.Environment.PprofDir);
+            samples.Should().NotBeEmpty();
+            foreach (var (_, _, values) in samples)
+            {
+                values.Length.Should().Be(1);
+                values.Should().OnlyContain(x => x == expectedInterval);
+            }
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void CheckDefaultCpuSamplingInterval(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
+            var samplingInterval = "9"; // ms (default)
+            // disable default profilers except CPU
+            EnvironmentHelper.DisableDefaultProfilers(runner);
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(_output);
+
+            runner.Run(agent);
+
+            var expectedInterval = long.Parse(samplingInterval) * 1_000_000;
+            // only cpu  profiler enabled so should see 1 value per sample and
+            var samples = SamplesHelper.GetSamples(runner.Environment.PprofDir);
+            samples.Should().NotBeEmpty();
+            foreach (var (_, _, values) in samples)
             {
                 values.Length.Should().Be(1);
                 values.Should().OnlyContain(x => x == expectedInterval);


### PR DESCRIPTION
## Summary of changes

Fix bugs in the future default CPU profiler (based on `timer_create`)

## Reason for change

The implementation was not correct when introduced the first time.
* The timer id was not correctly initialized and save
* The thread registering was done too early in the process
* Missing checks (not safe to unwind)
* Save and Restore `errno`: libunwind can change `errno` value and this can impact the application behavior

## Implementation details

* Add the missing check
* Add class to handle errno save and restore
* Fix the thread registration and the timer id initialization and saving.

## Test coverage

Add a new test to check the default value

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
