### PR TITLE
Add additional exclusions to for obsolete libraries

### DIFF
--- a/tracer/test/test-applications/integrations/dependency-libs/Directory.Build.props
+++ b/tracer/test/test-applications/integrations/dependency-libs/Directory.Build.props
@@ -11,7 +11,7 @@
     <NuGetAudit>false</NuGetAudit>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <!-- Ignore complaints from NuGet about out of support packages-->
-    <NoWarn>NU1901;NU1902;NU1903;NU1904</NoWarn>
+    <NoWarn>NETSDK1215;NU1901;NU1902;NU1903;NU1904</NoWarn>
 
     <ArtifactsPath>$(MSBuildThisFileDirectory)../../../../../artifacts</ArtifactsPath>
     <UseArtifactsOutput>true</UseArtifactsOutput>

--- a/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Directory.Build.props
+++ b/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Directory.Build.props
@@ -3,4 +3,9 @@
   This file intentionally left blank...
   to stop msbuild from looking up the folder hierarchy
   -->
+
+  <PropertyGroup>
+    <!-- Stop complaining about obsolete/vulnerable packages, we know they are -->
+    <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Directory.Build.props
+++ b/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Directory.Build.props
@@ -3,4 +3,9 @@
   This file intentionally left blank...
   to stop msbuild from looking up the folder hierarchy
   -->
+
+  <PropertyGroup>
+    <!-- Stop complaining about obsolete/vulnerable packages, we know they are -->
+    <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes

Silence some more warnings we don't care about

## Reason for change

These are test apps, testing old libraries etc. We don't care about them being obsolete

## Implementation details

- The `NETSDK1215` silences a warning about using `netstandard1.0` because it's not recommended (we don't care)
- The Redis additions are because the (obsolete) libs bring in libraries with vulns, but again, we don't care, this is a test project, we're not shipping it.

## Test coverage

No change

## Other details

These are flagged by the .NET 9 SDK, but there's no harm in adding the exclusions now