### PR TITLE
[Profiler] Prevent `StackSamplerLoop` from crashing at shutdown

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -122,11 +122,13 @@ bool StackSamplerLoop::StartImpl()
 bool StackSamplerLoop::StopImpl()
 {
     _shutdownRequested = true;
+
     if (_pLoopThread != nullptr)
     {
         try
         {
             _pLoopThread->join();
+            _pLoopThread.reset();
         }
         catch (const std::exception&)
         {


### PR DESCRIPTION
## Summary of changes

Make sure the `StackSamplerLoop` does not crash at shutdown.

## Reason for change

`StackSamplerLoopManager` instance calls `Stop` on the `StackSamplerLoop` instance. Which allows to finish and stop the thread.
Then the `StackSamplerLoop` dtor is call (because the instance is destroyed), and `Stop` is called a second times. The thread object is not cleanup so not nullptr... so we call `join` on a non-running thread (`join` was called on the first call to `Stop`).

This lead to a crash
```
 # ChildEBP RetAddr      
00 001ef318 705afdca     KERNELBASE!RaiseException+0x62
01 001ef34c 705ab8e7     Datadog_Profiler_Native!_CxxThrowException+0x66 [D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\throw.cpp @ 77] 
02 001ef374 7052a0ae     Datadog_Profiler_Native!std::_Throw_Cpp_error+0x34 [D:\a\_work\1\s\src\vctools\crt\github\stl\src\thread0.cpp @ 35] 
03 001ef38c 7059ff90     Datadog_Profiler_Native!std::thread::join+0x3e [c:\devtools\vstudio\VC\Tools\MSVC\14.37.32822\include\thread @ 125] 
04 001ef3b4 7059fda9     Datadog_Profiler_Native!StackSamplerLoop::StopImpl+0x40 [c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\StackSamplerLoop.cpp @ 136] 
05 (Inline) --------     Datadog_Profiler_Native!StackSamplerLoop::{dtor}+0x12 [c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\StackSamplerLoop.cpp @ 96] 
```
## Implementation details

- Move thread ownership from `_pThreadLoop` to another local variable (will set _pThreadLoop instance to nullptr)
- Check for nullity and if the thread is joinable

## Test coverage

Since we inject the ICorprofilerInfo, it's difficult to make this a unit test. And the integration should catch it but.... never did...

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
