### PR TITLE
[ASM] Fix issue with waf disposing while it might concurrently be updating 

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -268,6 +268,7 @@ src/Datadog.Trace/Agent/Transports/HttpStreamRequestFactory.cs
 src/Datadog.Trace/Agent/Transports/MimeTypes.cs
 src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
 src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs
+src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.cs
 src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Framework.cs
 src/Datadog.Trace/AppSec/Waf/WafConstants.cs
 src/Datadog.Trace/AppSec/Waf/WafReturnCode.cs

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -267,9 +267,6 @@ src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
 src/Datadog.Trace/Agent/Transports/HttpStreamRequestFactory.cs
 src/Datadog.Trace/Agent/Transports/MimeTypes.cs
 src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
-src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs
-src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.cs
-src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Framework.cs
 src/Datadog.Trace/AppSec/Waf/WafConstants.cs
 src/Datadog.Trace/AppSec/Waf/WafReturnCode.cs
 src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs

--- a/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 #if !NETFRAMEWORK
 using System;

--- a/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs
@@ -25,11 +25,11 @@ internal partial class ReaderWriterLock : IDisposable
         return true;
     }
 
-    internal bool EnterWriteLock()
+    internal bool EnterWriteLock(int timeout = TimeoutInMs)
     {
-        if (!_readerWriterLock.TryEnterWriteLock(TimeoutInMs))
+        if (!_readerWriterLock.TryEnterWriteLock(timeout))
         {
-            Log.Error<int>("Couldn't acquire writer lock in {Timeout} ms", TimeoutInMs);
+            Log.Error<int>("Couldn't acquire writer lock in {Timeout} ms", timeout);
             return false;
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Framework.cs
@@ -2,6 +2,8 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+
+#nullable enable
 #if NETFRAMEWORK
 
 using System;

--- a/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Framework.cs
@@ -2,18 +2,15 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#if NETFRAMEWORK
 
 using System;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Vendors.Serilog;
 
 namespace Datadog.Trace.AppSec.Concurrency;
 
 internal partial class ReaderWriterLock : IDisposable
 {
-    private const int TimeoutInMs = 4000;
-    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ReaderWriterLock>();
-#if NETFRAMEWORK
     private readonly System.Threading.ReaderWriterLock _readerWriterLock = new();
 
     internal bool IsReadLockHeld => _readerWriterLock.IsReaderLockHeld;
@@ -32,16 +29,16 @@ internal partial class ReaderWriterLock : IDisposable
         }
     }
 
-    internal bool EnterWriteLock()
+    internal bool EnterWriteLock(int timeout = TimeoutInMs)
     {
         try
         {
-            _readerWriterLock.AcquireWriterLock(TimeoutInMs);
+            _readerWriterLock.AcquireWriterLock(timeout);
             return true;
         }
         catch (ApplicationException)
         {
-            Log.Error<int>("Couldn't acquire writer lock in {Timeout} ms", TimeoutInMs);
+            Log.Error<int>("Couldn't acquire writer lock in {Timeout} ms", timeout);
             return false;
         }
     }
@@ -74,5 +71,6 @@ internal partial class ReaderWriterLock : IDisposable
     public void Dispose()
     {
     }
-#endif
 }
+
+#endif

--- a/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.cs
@@ -1,0 +1,15 @@
+// <copyright file="ReaderWriterLock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.AppSec.Concurrency;
+
+internal partial class ReaderWriterLock : IDisposable
+{
+    private const int TimeoutInMs = 4000;
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ReaderWriterLock>();
+}

--- a/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.cs
@@ -2,7 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
-
+#nullable enable
 using System;
 using Datadog.Trace.Logging;
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.AppSec.Waf
 
         internal unsafe WafReturnCode Run(IntPtr contextHandle, DdwafObjectStruct* rawPersistentData, DdwafObjectStruct* rawEphemeralData, ref DdwafResultStruct retNative, ulong timeoutMicroSeconds);
 
-        UpdateResult Update(ConfigurationState configurationStatus, string? staticRulesFilePath = null);
+        UpdateResult Update(ConfigurationState configurationStatus);
 
         public string[] GetKnownAddresses();
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/UpdateResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/UpdateResult.cs
@@ -36,6 +36,11 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
             NothingToUpdate = nothingToUpdate;
         }
 
+        private UpdateResult(string errorMessage)
+        {
+            ErrorMessage = errorMessage;
+        }
+
         internal bool Success { get; }
 
         internal bool UnusableRules { get; }
@@ -66,5 +71,9 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
         public static UpdateResult FromFailed(DdwafObjectStruct diagObj) => new(diagObj, false);
 
         public static UpdateResult FromSuccess(DdwafObjectStruct diagObj) => new(diagObj, true);
+
+        internal static UpdateResult FromException(Exception e) => new(e.Message);
+
+        internal static UpdateResult FromFailed(string message) => new(message);
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -11,17 +11,14 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Xml.Linq;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
-using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Datadog.Trace.Vendors.Serilog.Events;
-using Datadog.Trace.Vendors.StatsdClient.Utils;
 
 namespace Datadog.Trace.AppSec.WafEncoding
 {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Datadog.Trace.Security.Unit.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Datadog.Trace.Security.Unit.Tests.csproj
@@ -43,6 +43,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="ruleset-withblockips.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="wrong-tags-rule-set.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary of changes

When disposing the waf, sometimes an update might be taking place at the same time, in a concurrent thread. 
We shouldn't dispose while an update is taking place, so use the ReaderWriterLock to dispose and block any access. 

## Reason for change
Fix for this [ticket](https://datadoghq.atlassian.net/jira/software/c/projects/APPSEC/boards/2876?selectedIssue=APPSEC-55734&atlOrigin=eyJpIjoiMmE0ZDM2ZjhhOTdjNGUyZGI5MDIwNmVkNjQ3MDlkNDkiLCJwIjoiaiJ9)
## Implementation details

## Test coverage
Added a unit test testing that update is either a success ,e ither fails because dispose happened before. 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
