### PR TITLE
[IAST] Macos compilation warning fix

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -415,10 +415,8 @@ namespace iast
             verificationFail = analysis.GetError();
             if (!correct || dump)
             {
-                std::string message = correct ? " [ Written Correctly ] " 
-                                              : " [ IL Verification FAILED. Discarded ] " + 
-                                      isRejit ? "ReJit " : "  Jit ";
-                analysis.Dump(correct, message);
+                std::string message = (correct ? " [ Written Correctly ] " : " [ IL Verification FAILED. Discarded ] ");
+                analysis.Dump(correct, message + (isRejit ? "ReJit " : "  Jit "));
             }
         }
 


### PR DESCRIPTION
## Summary of changes
Fix expression so MacOs c++ compiler does not throw a warning

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
