### PR TITLE
[CI Visibility] Add more checks for the object pack files

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -592,7 +592,7 @@ internal class IntelligentTestRunnerClient
         long totalUploadSize = 0;
         foreach (var packFile in packFilesObject.Files)
         {
-            if (!File.Exists(packFile))
+            if (!Directory.Exists(Path.GetDirectoryName(packFile)) || !File.Exists(packFile))
             {
                 // Pack files must be sent in order, if a pack file is missing, we stop the upload of the rest of the pack files
                 // Previous pack files will enrich the backend with some of the data.
@@ -1083,7 +1083,10 @@ internal class IntelligentTestRunnerClient
             {
                 var sourceException = exceptionDispatchInfo.SourceException;
 
-                if (isFinalTry || sourceException is RateLimitException { DelayTimeInSeconds: null })
+                if (isFinalTry ||
+                    sourceException is RateLimitException { DelayTimeInSeconds: null } ||
+                    sourceException is DirectoryNotFoundException ||
+                    sourceException is FileNotFoundException)
                 {
                     // stop retrying
                     Log.Error<int>(sourceException, "ITR: An error occurred while sending intelligent test runner data after {Retries} retries.", retryCount);


### PR DESCRIPTION
## Summary of changes

This PR adds more checks to the object pack files uploader.

## Reason for change

Still receiving this kind of errors: 
```
2024-11-07 16:15:11.381 +00:00 [WRN] ITR: 'git pack-objects...' returned a cross-device error, retrying using a local temporal folder.  { MachineName: ".", Process: "[4026 dotnet]", AppDomain: "[1 datacollector]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "3.6.0.0" }
2024-11-07 16:15:11.524 +00:00 [INF] ITR: Sending /project/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/Release/net6.0/.git_tmp/tmplEpfnp.tmp-215f1b02d59b2b9ac7f5468767913cdcbaade353.pack  { MachineName: ".", Process: "[4026 dotnet]", AppDomain: "[1 datacollector]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "3.6.0.0" }
2024-11-07 16:15:13.144 +00:00 [ERR] ITR: An error occurred while sending intelligent test runner data after 5 retries. System.IO.DirectoryNotFoundException: Could not find a part of the path '/project/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/Release/net6.0/.git_tmp/tmplEpfnp.tmp-215f1b02d59b2b9ac7f5468767913cdcbaade353.pack'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.Open(String path, FileMode mode, FileAccess access, FileShare share)
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.<>c__DisplayClass32_0.<<SendObjectsPackFileAsync>g__InternalSendObjectsPackFileAsync|0>d.MoveNext() in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 646
--- End of stack trace from previous location ---
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.WithRetries[T,TState](Func`3 sendDelegate, TState state, Int32 numOfRetries) in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 1074
 { MachineName: ".", Process: "[4026 dotnet]", AppDomain: "[1 datacollector]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "3.6.0.0" }
2024-11-07 16:15:13.152 +00:00 [ERR] Error detecting and reconfiguring git repository for shallow clone. System.IO.DirectoryNotFoundException: Could not find a part of the path '/project/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/Release/net6.0/.git_tmp/tmplEpfnp.tmp-215f1b02d59b2b9ac7f5468767913cdcbaade353.pack'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.Open(String path, FileMode mode, FileAccess access, FileShare share)
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.<>c__DisplayClass32_0.<<SendObjectsPackFileAsync>g__InternalSendObjectsPackFileAsync|0>d.MoveNext() in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 646
--- End of stack trace from previous location ---
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.WithRetries[T,TState](Func`3 sendDelegate, TState state, Int32 numOfRetries) in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 1074
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.WithRetries[T,TState](Func`3 sendDelegate, TState state, Int32 numOfRetries) in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 1090
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.SendObjectsPackFileAsync(String commitSha, String[] commitsToInclude, String[] commitsToExclude) in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 605
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.UploadRepositoryChangesAsync() in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 236
 { MachineName: ".", Process: "[4026 dotnet]", AppDomain: "[1 datacollector]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "3.6.0.0" }
```
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
