### PR TITLE
add baggage propagator to the default list of propagators

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -389,8 +389,8 @@ namespace Datadog.Trace.Configuration
                         .ToArray();
 
             var getDefaultPropagationHeaders = () => new DefaultResult<string[]>(
-                [ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext],
-                $"{ContextPropagationHeaderStyle.Datadog},{ContextPropagationHeaderStyle.W3CTraceContext}");
+                [ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.W3CBaggage],
+                $"{ContextPropagationHeaderStyle.Datadog},{ContextPropagationHeaderStyle.W3CTraceContext},{ContextPropagationHeaderStyle.W3CBaggage}");
 
             // Same otel config is used for both injection and extraction
             var otelPropagation = config

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -68,8 +68,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             telemetry.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
-            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext");
-            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext");
+            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext,baggage");
+            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext,baggage");
 
             AssertService(telemetry, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(telemetry, enableDependencies);
@@ -100,8 +100,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
-            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext");
-            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext");
+            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext,baggage");
+            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext,baggage");
 
             AssertService(agent, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(agent, enableDependencies);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return (s => s.Exporter.AgentUri, new Uri("http://127.0.0.1:8126/"));
             yield return (s => s.Environment, null);
             yield return (s => s.ServiceName, null);
-            yield return (s => s.DisabledIntegrationNames.Count, 1); // The OpenTelemetry integration is disabled by defa)t
+            yield return (s => s.DisabledIntegrationNames.Count, 1); // The OpenTelemetry integration is disabled by default
             yield return (s => s.LogsInjectionEnabled, false);
             yield return (s => s.GlobalTags.Count, 0);
 #pragma warning disable 618 // App analytics is deprecated but supported
@@ -81,8 +81,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return (s => s.MaxTracesSubmittedPerSecond, 100);
             yield return (s => s.TracerMetricsEnabled, false);
             yield return (s => s.Exporter.DogStatsdPort, 8125);
-            yield return (s => s.PropagationStyleInject, new[] { "Datadog", "tracecontext" });
-            yield return (s => s.PropagationStyleExtract, new[] { "Datadog", "tracecontext" });
+            yield return (s => s.PropagationStyleInject, new[] { "Datadog", "tracecontext", "baggage" });
+            yield return (s => s.PropagationStyleExtract, new[] { "Datadog", "tracecontext", "baggage" });
             yield return (s => s.ServiceNameMappings, null);
 
             yield return (s => s.TraceId128BitGenerationEnabled, true);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -880,14 +880,14 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", null, new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", null, new[] { "Datadog", "tracecontext" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", null, new[] { "Datadog", "tracecontext", "baggage" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", null, new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", null, new[] { "test5", "test6" })]
         [InlineData(null, null, null, "tracecontext,datadog", new[] { "tracecontext", "datadog" })]
         [InlineData(null, null, null, "tracecontext", new[] { "tracecontext" })]
         [InlineData(null, null, null, "tracecontext,b3,b3multi", new[] { "tracecontext", "b3 single header", "b3multi" })]
-        [InlineData(null, null, null, null, new[] { "Datadog", "tracecontext" })]
-        [InlineData(null, null, null, ",", new[] { "Datadog", "tracecontext" })]
+        [InlineData(null, null, null, null, new[] { "Datadog", "tracecontext", "baggage" })]
+        [InlineData(null, null, null, ",", new[] { "Datadog", "tracecontext", "baggage" })]
         public void PropagationStyleInject(string value, string legacyValue, string fallbackValue, string otelValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_INJECT";
@@ -920,14 +920,14 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", null, new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", null, new[] { "Datadog", "tracecontext" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", null, new[] { "Datadog", "tracecontext", "baggage" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", null, new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", null, new[] { "test5", "test6" })]
         [InlineData(null, null, null, "tracecontext,datadog", new[] { "tracecontext", "datadog" })]
         [InlineData(null, null, null, "tracecontext", new[] { "tracecontext" })]
         [InlineData(null, null, null, "tracecontext,b3,b3multi", new[] { "tracecontext", "b3 single header", "b3multi" })]
-        [InlineData(null, null, null, null, new[] { "Datadog", "tracecontext" })]
-        [InlineData(null, null, null, ",", new[] { "Datadog", "tracecontext" })]
+        [InlineData(null, null, null, null, new[] { "Datadog", "tracecontext", "baggage" })]
+        [InlineData(null, null, null, ",", new[] { "Datadog", "tracecontext", "baggage" })]
         public void PropagationStyleExtract(string value, string legacyValue, string fallbackValue, string otelValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_EXTRACT";

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using FluentAssertions;
@@ -263,6 +264,21 @@ public class W3CBaggagePropagatorTests
 
         headers.Setup(h => h.GetValues("baggage"))
                .Returns([header]);
+
+        var context = BaggagePropagator.Extract(headers.Object);
+
+        headers.Verify(h => h.GetValues("baggage"), Times.Once());
+        context.Baggage.Should().BeNull();
+        context.SpanContext.Should().BeNull();
+    }
+
+    [Fact]
+    public void Extract_NoHeader()
+    {
+        var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
+        headers.Setup(h => h.GetValues("baggage"))
+               .Returns([]);
 
         var context = BaggagePropagator.Extract(headers.Object);
 

--- a/tracer/test/Datadog.Trace.Tests/SpanContextInjectorExtractorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextInjectorExtractorTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -197,15 +198,13 @@ public class SpanContextInjectorExtractorTests
             { "x-datadog-trace-id", "1" },
             { "x-datadog-parent-id", "2" },
             { "x-datadog-sampling-priority", "1" },
-            { "x-datadog-origin", "nowhere" },
-            { "x-datadog-tags", string.Empty },
             { "traceparent", "00-00000000000000000000000000000001-0000000000000002-01" },
             { "tracestate", string.Empty },
             { DataStreamsPropagationHeaders.TemporaryBase64PathwayContext, "VGhlIHF1aWMWIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=" } // it's a semi-random base64 string that's good enough to pass the parsing checks
         };
         var extractor = new SpanContextExtractor();
 
-        var newContext = extractor.Extract(headers, (h, k) => [h[k]]);
+        var newContext = extractor.Extract(headers, (h, k) => [h.GetValueOrDefault(k)]);
 
         newContext.Should().NotBeNull();
         ((SpanContext)newContext).PathwayContext.Should().NotBeNull();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -205,14 +205,14 @@ public class ConfigurationTelemetryCollectorTests
         {
             (not null, _) => (ConfigurationKeys.PropagationStyleExtract, propagationStyleExtract),
             (null, not null) => (ConfigurationKeys.PropagationStyle, propagationStyle),
-            (null, null) => (ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext"),
+            (null, null) => (ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext,baggage"),
         };
 
         var (injectKey, injectValue) = (propagationStyleInject, propagationStyle) switch
         {
             (not null, _) => (ConfigurationKeys.PropagationStyleInject, propagationStyleInject),
             (null, not null) => (ConfigurationKeys.PropagationStyle, propagationStyle),
-            (null, null) => (ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext"),
+            (null, null) => (ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext,baggage"),
         };
 
         GetLatestValueFromConfig(data, extractKey).Should().Be(extractValue);


### PR DESCRIPTION
## Summary of changes

Missed from #6158 😅 
- Add baggage to the default list of propagators.

## Reason for change

Adding support for OpenTelemetry baggage.

## Implementation details

Add `"baggage"` to the default list of propagators in `DD_TRACE_PROPAGATION_STYLE`.

## Test coverage

Fixed all failing tests after the change, including
- tests for default config values
- telemetry tests

bonus:
- added a propagator test where baggage header is no present
- fixed an unrelated test that threw an exception on missing headers

## Other details
Follow-up from #6158.
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
