### PR TITLE
[CI Visibility] GitInfoProvider refactor

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -70,7 +70,6 @@ src/Datadog.Trace/AspNet/TracingHttpModule.cs
 src/Datadog.Trace/Ci/CITracerManager.cs
 src/Datadog.Trace/Ci/CITracerManagerFactory.cs
 src/Datadog.Trace/Ci/CodeOwners.cs
-src/Datadog.Trace/Ci/GitInfo.cs
 src/Datadog.Trace/Ci/IEvent.cs
 src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
 src/Datadog.Trace/ClrProfiler/CallTargetKind.cs

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/AWSCodePipelineEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/AWSCodePipelineEnvironmentValues.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class AWSCodePipelineEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: AWS CodePipeline detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/AppveyorEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/AppveyorEnvironmentValues.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class AppveyorEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Appveyor detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/AzurePipelinesEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/AzurePipelinesEnvironmentValues.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class AzurePipelinesEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Azure Pipelines detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitbucketEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitbucketEnvironmentValues.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class BitbucketEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Bitbucket detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitriseEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitriseEnvironmentValues.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class BitriseEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Bitrise detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuddyEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuddyEnvironmentValues.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class BuddyEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Buddy detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuildkiteEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuildkiteEnvironmentValues.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class BuildkiteEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Buildkite detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
@@ -288,7 +288,7 @@ internal abstract class CIEnvironmentValues
         }
     }
 
-    protected abstract void Setup(GitInfo gitInfo);
+    protected abstract void Setup(IGitInfo gitInfo);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void CleanBranchAndTag()

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
@@ -238,7 +238,7 @@ internal abstract class CIEnvironmentValues
         Message = null;
         SourceRoot = null;
 
-        Setup(string.IsNullOrEmpty(_gitSearchFolder) ? GitInfo.GetCurrent() : GitInfo.GetFrom(_gitSearchFolder));
+        Setup(string.IsNullOrEmpty(_gitSearchFolder) ? GitInfo.GetCurrent() : GitInfo.GetFrom(_gitSearchFolder!));
 
         // **********
         // Remove sensitive info from repository url

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
@@ -146,7 +146,7 @@ internal abstract class CIEnvironmentValues<TValueProvider>(TValueProvider value
                 // If we have the original commit message we use that.
                 if (string.IsNullOrWhiteSpace(Message) ||
                     (Message!.StartsWith("Merge", StringComparison.Ordinal) &&
-                     !gitInfo.Message.StartsWith("Merge", StringComparison.Ordinal)))
+                     !gitInfo.Message!.StartsWith("Merge", StringComparison.Ordinal)))
                 {
                     Message = gitInfo.Message;
                 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
@@ -100,7 +100,7 @@ internal abstract class CIEnvironmentValues<TValueProvider>(TValueProvider value
         return new UnsupportedCIEnvironmentValues<TValueProvider>(valueProvider);
     }
 
-    protected override void Setup(GitInfo gitInfo)
+    protected override void Setup(IGitInfo gitInfo)
     {
         OnInitialize(gitInfo);
 
@@ -344,7 +344,7 @@ internal abstract class CIEnvironmentValues<TValueProvider>(TValueProvider value
         return path;
     }
 
-    protected abstract void OnInitialize(GitInfo gitInfo);
+    protected abstract void OnInitialize(IGitInfo gitInfo);
 }
 
 #pragma warning restore SA1649

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CircleCiEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CircleCiEnvironmentValues.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class CircleCiEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: CircleCI detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CodefreshEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CodefreshEnvironmentValues.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class CodefreshEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Codefresh detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
@@ -20,12 +20,6 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
 
     public static IGitInfoProvider Instance { get; } = new GitCommandGitInfoProvider();
 
-    private static DateTimeOffset UnixTimeStampToDateTime(long unixTimeStamp)
-    {
-        const long unixEpochTicks = TimeSpan.TicksPerDay * 719162; // 621,355,968,000,000,000
-        return new DateTimeOffset((unixTimeStamp * TimeSpan.TicksPerSecond) + unixEpochTicks, TimeSpan.Zero);
-    }
-
     protected override bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo)
     {
         var localGitInfo = new GitInfo
@@ -116,10 +110,10 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
 
             // Populate the localGitData struct with the parsed information
             localGitInfo.Commit = gitLogDataArray[0];
-            localGitInfo.AuthorDate = UnixTimeStampToDateTime(authorUnixDate);
+            localGitInfo.AuthorDate = DateTimeOffset.FromUnixTimeSeconds(authorUnixDate);
             localGitInfo.AuthorName = gitLogDataArray[2];
             localGitInfo.AuthorEmail = gitLogDataArray[3];
-            localGitInfo.CommitterDate = UnixTimeStampToDateTime(committerUnixDate);
+            localGitInfo.CommitterDate = DateTimeOffset.FromUnixTimeSeconds(committerUnixDate);
             localGitInfo.CommitterName = gitLogDataArray[5];
             localGitInfo.CommitterEmail = gitLogDataArray[6];
             localGitInfo.Message = string.Join("|,|", gitLogDataArray.Skip(7)).Trim();

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Datadog.Trace.Logging;
@@ -20,7 +21,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
 
     public static IGitInfoProvider Instance { get; } = new GitCommandGitInfoProvider();
 
-    protected override bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo)
+    protected override bool TryGetFrom(DirectoryInfo gitDirectory, [NotNullWhen(true)] out IGitInfo? gitInfo)
     {
         var localGitInfo = new GitInfo
         {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
@@ -2,24 +2,27 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class GitCommandGitInfoProvider : IGitInfoProvider
 {
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(GitCommandGitInfoProvider));
+
     private GitCommandGitInfoProvider()
     {
     }
 
     public static IGitInfoProvider Instance { get; } = new GitCommandGitInfoProvider();
 
-    public bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo gitInfo)
+    public bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo)
     {
         var localGitInfo = new GitInfo
         {
@@ -28,79 +31,95 @@ internal sealed class GitCommandGitInfoProvider : IGitInfoProvider
 
         gitInfo = localGitInfo;
 
-        // Get the repository URL
-        var repositoryOutput = ProcessHelpers.RunCommand(new ProcessHelpers.Command(
-                                                             cmd: "git",
-                                                             arguments: "ls-remote --get-url",
-                                                             workingDirectory: gitDirectory.FullName));
-        if (repositoryOutput?.ExitCode == 0)
+        try
         {
-            localGitInfo.Repository = repositoryOutput.Output.Trim();
-        }
+            // Get the repository URL
+            var repositoryOutput = ProcessHelpers.RunCommand(
+                new ProcessHelpers.Command(
+                    cmd: "git",
+                    arguments: "ls-remote --get-url",
+                    workingDirectory: gitDirectory.FullName,
+                    useWhereIsIfFileNotFound: true));
+            if (repositoryOutput?.ExitCode == 0)
+            {
+                localGitInfo.Repository = repositoryOutput.Output.Trim();
+            }
 
-        // Get the branch name
-        var branchOutput = ProcessHelpers.RunCommand(new ProcessHelpers.Command(
-                                                             cmd: "git",
-                                                             arguments: "rev-parse --abbrev-ref HEAD",
-                                                             workingDirectory: gitDirectory.FullName));
-        if (branchOutput?.ExitCode == 0 && branchOutput.Output.Trim() is { Length: > 0 } branchName && branchName != "HEAD")
-        {
-            localGitInfo.Branch = branchName;
-        }
+            // Get the branch name
+            var branchOutput = ProcessHelpers.RunCommand(
+                new ProcessHelpers.Command(
+                    cmd: "git",
+                    arguments: "rev-parse --abbrev-ref HEAD",
+                    workingDirectory: gitDirectory.FullName,
+                    useWhereIsIfFileNotFound: true));
+            if (branchOutput?.ExitCode == 0 && branchOutput.Output.Trim() is { Length: > 0 } branchName && branchName != "HEAD")
+            {
+                localGitInfo.Branch = branchName;
+            }
 
-        // Get the remaining data from the log -1
-        var gitLogOutput = ProcessHelpers.RunCommand(new ProcessHelpers.Command(
-                                                   cmd: "git",
-                                                   arguments: """log -1 --pretty='%H|,|%at|,|%an|,|%ae|,|%ct|,|%cn|,|%ce|,|%B'""",
-                                                   workingDirectory: gitDirectory.FullName));
-        if (gitLogOutput?.ExitCode != 0)
+            // Get the remaining data from the log -1
+            var gitLogOutput = ProcessHelpers.RunCommand(
+                new ProcessHelpers.Command(
+                    cmd: "git",
+                    arguments: """log -1 --pretty='%H|,|%at|,|%an|,|%ae|,|%ct|,|%cn|,|%ce|,|%B'""",
+                    workingDirectory: gitDirectory.FullName,
+                    useWhereIsIfFileNotFound: true));
+            if (gitLogOutput?.ExitCode != 0)
+            {
+                return false;
+            }
+
+            var gitLogDataArray = gitLogOutput.Output.Split(["|,|"], StringSplitOptions.None);
+            if (gitLogDataArray.Length < 8)
+            {
+                ThrowHelper.ThrowException("Git log output does not contain the expected number of fields");
+                return false;
+            }
+
+            // Parse author and committer dates from Unix timestamp
+            if (!long.TryParse(gitLogDataArray[1], out var authorUnixDate))
+            {
+                ThrowHelper.ThrowException("Error parsing author date from git log output");
+                return false;
+            }
+
+            if (!long.TryParse(gitLogDataArray[4], out var committerUnixDate))
+            {
+                ThrowHelper.ThrowException("Error parsing committer date from git log output");
+                return false;
+            }
+
+            // Populate the localGitData struct with the parsed information
+            localGitInfo.Commit = gitLogDataArray[0];
+            localGitInfo.AuthorDate = UnixTimeStampToDateTime(authorUnixDate);
+            localGitInfo.AuthorName = gitLogDataArray[2];
+            localGitInfo.AuthorEmail = gitLogDataArray[3];
+            localGitInfo.CommitterDate = UnixTimeStampToDateTime(committerUnixDate);
+            localGitInfo.CommitterName = gitLogDataArray[5];
+            localGitInfo.CommitterEmail = gitLogDataArray[6];
+            localGitInfo.Message = string.Join("|,|", gitLogDataArray.Skip(7)).Trim();
+            if (localGitInfo.Commit.StartsWith("'"))
+            {
+                localGitInfo.Commit = localGitInfo.Commit.Substring(1);
+            }
+
+            if (localGitInfo.Message.EndsWith("'"))
+            {
+                localGitInfo.Message = localGitInfo.Message.Substring(0, localGitInfo.Message.Length - 1);
+            }
+        }
+        catch (Exception ex)
         {
+            Log.Error(ex, "Error while trying to get git information from the repository");
             return false;
-        }
-
-        var gitLogDataArray = gitLogOutput.Output.Split(["|,|"], StringSplitOptions.None);
-        if (gitLogDataArray.Length < 8)
-        {
-            return false;
-        }
-
-        // Parse author and committer dates from Unix timestamp
-        if (!double.TryParse(gitLogDataArray[1], out var authorUnixDate))
-        {
-            return false;
-        }
-
-        if (!double.TryParse(gitLogDataArray[4], out var committerUnixDate))
-        {
-            return false;
-        }
-
-        // Populate the localGitData struct with the parsed information
-        localGitInfo.Commit = gitLogDataArray[0];
-        localGitInfo.AuthorDate = UnixTimeStampToDateTime(authorUnixDate);
-        localGitInfo.AuthorName = gitLogDataArray[2];
-        localGitInfo.AuthorEmail = gitLogDataArray[3];
-        localGitInfo.CommitterDate = UnixTimeStampToDateTime(committerUnixDate);
-        localGitInfo.CommitterName = gitLogDataArray[5];
-        localGitInfo.CommitterEmail = gitLogDataArray[6];
-        localGitInfo.Message = string.Join("|,|", gitLogDataArray.Skip(7)).Trim();
-        if (localGitInfo.Commit.StartsWith("'"))
-        {
-            localGitInfo.Commit = localGitInfo.Commit.Substring(1);
-        }
-
-        if (localGitInfo.Message.EndsWith("'"))
-        {
-            localGitInfo.Message = localGitInfo.Message.Substring(0, localGitInfo.Message.Length - 1);
         }
 
         return true;
     }
 
-    private static DateTime UnixTimeStampToDateTime(double unixTimeStamp)
+    private static DateTimeOffset UnixTimeStampToDateTime(long unixTimeStamp)
     {
-        var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-        dateTime = dateTime.AddSeconds(unixTimeStamp);
-        return dateTime;
+        const long unixEpochTicks = TimeSpan.TicksPerDay * 719162; // 621,355,968,000,000,000
+        return new DateTimeOffset((unixTimeStamp * TimeSpan.TicksPerSecond) + unixEpochTicks, TimeSpan.Zero);
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
@@ -84,7 +84,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
                 return false;
             }
 
-            var gitLogDataArray = gitLogOutput.Output.Split(["|,|"], StringSplitOptions.None);
+            var gitLogDataArray = gitLogOutput.Output.Trim().Split(["|,|"], StringSplitOptions.None);
             if (gitLogDataArray.Length < 8)
             {
                 localGitInfo.Errors.Add($"Git log output does not contain the expected number of fields: {gitLogOutput.Output}");
@@ -120,7 +120,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
 
             if (localGitInfo.Message.EndsWith("'"))
             {
-                localGitInfo.Message = localGitInfo.Message.Substring(0, localGitInfo.Message.Length - 1);
+                localGitInfo.Message = localGitInfo.Message.Substring(0, localGitInfo.Message.Length - 1).Trim();
             }
         }
         catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
@@ -1,0 +1,106 @@
+// <copyright file="GitCommandGitInfoProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Ci.CiEnvironment;
+
+internal sealed class GitCommandGitInfoProvider : IGitInfoProvider
+{
+    private GitCommandGitInfoProvider()
+    {
+    }
+
+    public static IGitInfoProvider Instance { get; } = new GitCommandGitInfoProvider();
+
+    public bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo gitInfo)
+    {
+        var localGitInfo = new GitInfo
+        {
+            SourceRoot = gitDirectory.Parent?.FullName
+        };
+
+        gitInfo = localGitInfo;
+
+        // Get the repository URL
+        var repositoryOutput = ProcessHelpers.RunCommand(new ProcessHelpers.Command(
+                                                             cmd: "git",
+                                                             arguments: "ls-remote --get-url",
+                                                             workingDirectory: gitDirectory.FullName));
+        if (repositoryOutput?.ExitCode == 0)
+        {
+            localGitInfo.Repository = repositoryOutput.Output.Trim();
+        }
+
+        // Get the branch name
+        var branchOutput = ProcessHelpers.RunCommand(new ProcessHelpers.Command(
+                                                             cmd: "git",
+                                                             arguments: "rev-parse --abbrev-ref HEAD",
+                                                             workingDirectory: gitDirectory.FullName));
+        if (branchOutput?.ExitCode == 0 && branchOutput.Output.Trim() is { Length: > 0 } branchName && branchName != "HEAD")
+        {
+            localGitInfo.Branch = branchName;
+        }
+
+        // Get the remaining data from the log -1
+        var gitLogOutput = ProcessHelpers.RunCommand(new ProcessHelpers.Command(
+                                                   cmd: "git",
+                                                   arguments: """log -1 --pretty='%H|,|%at|,|%an|,|%ae|,|%ct|,|%cn|,|%ce|,|%B'""",
+                                                   workingDirectory: gitDirectory.FullName));
+        if (gitLogOutput?.ExitCode != 0)
+        {
+            return false;
+        }
+
+        var gitLogDataArray = gitLogOutput.Output.Split(["|,|"], StringSplitOptions.None);
+        if (gitLogDataArray.Length < 8)
+        {
+            return false;
+        }
+
+        // Parse author and committer dates from Unix timestamp
+        if (!double.TryParse(gitLogDataArray[1], out var authorUnixDate))
+        {
+            return false;
+        }
+
+        if (!double.TryParse(gitLogDataArray[4], out var committerUnixDate))
+        {
+            return false;
+        }
+
+        // Populate the localGitData struct with the parsed information
+        localGitInfo.Commit = gitLogDataArray[0];
+        localGitInfo.AuthorDate = UnixTimeStampToDateTime(authorUnixDate);
+        localGitInfo.AuthorName = gitLogDataArray[2];
+        localGitInfo.AuthorEmail = gitLogDataArray[3];
+        localGitInfo.CommitterDate = UnixTimeStampToDateTime(committerUnixDate);
+        localGitInfo.CommitterName = gitLogDataArray[5];
+        localGitInfo.CommitterEmail = gitLogDataArray[6];
+        localGitInfo.Message = string.Join("|,|", gitLogDataArray.Skip(7)).Trim();
+        if (localGitInfo.Commit.StartsWith("'"))
+        {
+            localGitInfo.Commit = localGitInfo.Commit.Substring(1);
+        }
+
+        if (localGitInfo.Message.EndsWith("'"))
+        {
+            localGitInfo.Message = localGitInfo.Message.Substring(0, localGitInfo.Message.Length - 1);
+        }
+
+        return true;
+    }
+
+    private static DateTime UnixTimeStampToDateTime(double unixTimeStamp)
+    {
+        var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        dateTime = dateTime.AddSeconds(unixTimeStamp);
+        return dateTime;
+    }
+}

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
@@ -159,7 +159,22 @@ internal class GitInfo : IGitInfo
         var dirInfo = new DirectoryInfo(innerFolder);
         while (dirInfo != null)
         {
-            var gitDirectories = dirInfo.GetDirectories(".git");
+            DirectoryInfo[] gitDirectories;
+            try
+            {
+                gitDirectories = dirInfo.GetDirectories(".git");
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                Log.Error(ex, "Get directories failed with DirectoryNotFoundException");
+                return null;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Log.Error(ex, "Get directories failed with UnauthorizedAccessException");
+                return null;
+            }
+
             if (gitDirectories.Length > 0)
             {
                 foreach (var gitDir in gitDirectories)
@@ -175,10 +190,5 @@ internal class GitInfo : IGitInfo
         }
 
         return null;
-    }
-
-    internal static void SetGitInfoProviders(params IGitInfoProvider[] providers)
-    {
-        _gitInfoProviders = providers;
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 using System;
 using System.IO;
@@ -18,32 +19,32 @@ internal class GitInfo : IGitInfo
     /// <summary>
     /// Gets or sets Source root
     /// </summary>
-    public string SourceRoot { get; internal set; }
+    public string? SourceRoot { get; internal set; }
 
     /// <summary>
     /// Gets or sets Repository
     /// </summary>
-    public string Repository { get; internal set; }
+    public string? Repository { get; internal set; }
 
     /// <summary>
     /// Gets or sets Branch
     /// </summary>
-    public string Branch { get; internal set; }
+    public string? Branch { get; internal set; }
 
     /// <summary>
     /// Gets or sets Commit
     /// </summary>
-    public string Commit { get; internal set; }
+    public string? Commit { get; internal set; }
 
     /// <summary>
     /// Gets or sets Author Name
     /// </summary>
-    public string AuthorName { get; internal set; }
+    public string? AuthorName { get; internal set; }
 
     /// <summary>
     /// Gets or sets Author Email
     /// </summary>
-    public string AuthorEmail { get; internal set; }
+    public string? AuthorEmail { get; internal set; }
 
     /// <summary>
     /// Gets or sets Author Date
@@ -53,12 +54,12 @@ internal class GitInfo : IGitInfo
     /// <summary>
     /// Gets or sets Committer Name
     /// </summary>
-    public string CommitterName { get; internal set; }
+    public string? CommitterName { get; internal set; }
 
     /// <summary>
     /// Gets or sets Committer Email
     /// </summary>
-    public string CommitterEmail { get; internal set; }
+    public string? CommitterEmail { get; internal set; }
 
     /// <summary>
     /// Gets or sets Committer Date
@@ -68,7 +69,7 @@ internal class GitInfo : IGitInfo
     /// <summary>
     /// Gets or sets Commit Message
     /// </summary>
-    public string Message { get; internal set; }
+    public string? Message { get; internal set; }
 
     /// <summary>
     /// Gets a GitInfo from a folder
@@ -81,14 +82,14 @@ internal class GitInfo : IGitInfo
         foreach (var provider in _gitInfoProviders)
         {
             // Try to load git metadata from the folder
-            if (provider.TryGetFrom(dirInfo, out var gitInfo))
+            if (provider.TryGetFrom(dirInfo, out var gitInfo) && gitInfo != null)
             {
                 return gitInfo;
             }
 
             // If not let's try to find the .git folder in a parent folder
             var parentGitFolder = GetParentGitFolder(folder);
-            if (parentGitFolder != null && provider.TryGetFrom(parentGitFolder, out var pFolderGitInfo))
+            if (parentGitFolder != null && provider.TryGetFrom(parentGitFolder, out var pFolderGitInfo) && pFolderGitInfo != null)
             {
                 return pFolderGitInfo;
             }
@@ -110,7 +111,7 @@ internal class GitInfo : IGitInfo
         {
             foreach (var provider in _gitInfoProviders)
             {
-                if (provider.TryGetFrom(gitDirectory, out var gitInfo))
+                if (provider.TryGetFrom(gitDirectory, out var gitInfo) && gitInfo != null)
                 {
                     return gitInfo;
                 }
@@ -120,7 +121,7 @@ internal class GitInfo : IGitInfo
         return new GitInfo { SourceRoot = gitDirectory?.Parent?.FullName };
     }
 
-    private static DirectoryInfo GetParentGitFolder(string innerFolder)
+    private static DirectoryInfo? GetParentGitFolder(string? innerFolder)
     {
         if (string.IsNullOrEmpty(innerFolder))
         {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
@@ -1,0 +1,155 @@
+// <copyright file="GitInfo.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+
+namespace Datadog.Trace.Ci.CiEnvironment;
+
+internal class GitInfo : IGitInfo
+{
+    private static IGitInfoProvider[] _gitInfoProviders = [
+        GitCommandGitInfoProvider.Instance,
+        ManualParserGitInfoProvider.Instance,
+    ];
+
+    /// <summary>
+    /// Gets or sets Source root
+    /// </summary>
+    public string SourceRoot { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Repository
+    /// </summary>
+    public string Repository { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Branch
+    /// </summary>
+    public string Branch { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Commit
+    /// </summary>
+    public string Commit { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Author Name
+    /// </summary>
+    public string AuthorName { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Author Email
+    /// </summary>
+    public string AuthorEmail { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Author Date
+    /// </summary>
+    public DateTimeOffset? AuthorDate { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Committer Name
+    /// </summary>
+    public string CommitterName { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Committer Email
+    /// </summary>
+    public string CommitterEmail { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Committer Date
+    /// </summary>
+    public DateTimeOffset? CommitterDate { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets Commit Message
+    /// </summary>
+    public string Message { get; internal set; }
+
+    /// <summary>
+    /// Gets a GitInfo from a folder
+    /// </summary>
+    /// <param name="folder">Target folder to retrieve the git info</param>
+    /// <returns>Git info</returns>
+    public static IGitInfo GetFrom(string folder)
+    {
+        var dirInfo = new DirectoryInfo(folder);
+        foreach (var provider in _gitInfoProviders)
+        {
+            // Try to load git metadata from the folder
+            if (provider.TryGetFrom(dirInfo, out var gitInfo))
+            {
+                return gitInfo;
+            }
+
+            // If not let's try to find the .git folder in a parent folder
+            var parentGitFolder = GetParentGitFolder(folder);
+            if (parentGitFolder != null && provider.TryGetFrom(parentGitFolder, out var pFolderGitInfo))
+            {
+                return pFolderGitInfo;
+            }
+        }
+
+        // Return the partial gitInfo instance with the initial source root
+        return new GitInfo { SourceRoot = dirInfo.Parent?.FullName };
+    }
+
+    /// <summary>
+    /// Gets a GitInfo from the current folder or assembly attribute
+    /// </summary>
+    /// <returns>Git info</returns>
+    public static IGitInfo GetCurrent()
+    {
+        var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+        var gitDirectory = GetParentGitFolder(baseDirectory) ?? GetParentGitFolder(Environment.CurrentDirectory);
+        if (gitDirectory != null)
+        {
+            foreach (var provider in _gitInfoProviders)
+            {
+                if (provider.TryGetFrom(gitDirectory, out var gitInfo))
+                {
+                    return gitInfo;
+                }
+            }
+        }
+
+        return new GitInfo { SourceRoot = gitDirectory?.Parent?.FullName };
+    }
+
+    private static DirectoryInfo GetParentGitFolder(string innerFolder)
+    {
+        if (string.IsNullOrEmpty(innerFolder))
+        {
+            return null;
+        }
+
+        var dirInfo = new DirectoryInfo(innerFolder);
+        while (dirInfo != null)
+        {
+            var gitDirectories = dirInfo.GetDirectories(".git");
+            if (gitDirectories.Length > 0)
+            {
+                foreach (var gitDir in gitDirectories)
+                {
+                    if (gitDir.Name == ".git")
+                    {
+                        return gitDir;
+                    }
+                }
+            }
+
+            dirInfo = dirInfo.Parent;
+        }
+
+        return null;
+    }
+
+    internal static void SetGitInfoProviders(params IGitInfoProvider[] providers)
+    {
+        _gitInfoProviders = providers;
+    }
+}

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfoProvider.cs
@@ -11,34 +11,6 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal abstract class GitInfoProvider : IGitInfoProvider
 {
-    protected static DirectoryInfo? GetParentGitFolder(string? innerFolder)
-    {
-        if (string.IsNullOrEmpty(innerFolder))
-        {
-            return null;
-        }
-
-        var dirInfo = new DirectoryInfo(innerFolder);
-        while (dirInfo != null)
-        {
-            var gitDirectories = dirInfo.GetDirectories(".git");
-            if (gitDirectories.Length > 0)
-            {
-                foreach (var gitDir in gitDirectories)
-                {
-                    if (gitDir.Name == ".git")
-                    {
-                        return gitDir;
-                    }
-                }
-            }
-
-            dirInfo = dirInfo.Parent;
-        }
-
-        return null;
-    }
-
     public bool TryGetFrom(string folder, out IGitInfo? gitInfo)
     {
         // Try to load git metadata from the folder

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfoProvider.cs
@@ -1,0 +1,61 @@
+// <copyright file="GitInfoProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+using System.IO;
+
+namespace Datadog.Trace.Ci.CiEnvironment;
+
+internal abstract class GitInfoProvider : IGitInfoProvider
+{
+    protected static DirectoryInfo? GetParentGitFolder(string? innerFolder)
+    {
+        if (string.IsNullOrEmpty(innerFolder))
+        {
+            return null;
+        }
+
+        var dirInfo = new DirectoryInfo(innerFolder);
+        while (dirInfo != null)
+        {
+            var gitDirectories = dirInfo.GetDirectories(".git");
+            if (gitDirectories.Length > 0)
+            {
+                foreach (var gitDir in gitDirectories)
+                {
+                    if (gitDir.Name == ".git")
+                    {
+                        return gitDir;
+                    }
+                }
+            }
+
+            dirInfo = dirInfo.Parent;
+        }
+
+        return null;
+    }
+
+    public bool TryGetFrom(string folder, out IGitInfo? gitInfo)
+    {
+        // Try to load git metadata from the folder
+        if (TryGetFrom(new DirectoryInfo(folder), out gitInfo) && gitInfo != null)
+        {
+            return true;
+        }
+
+        // If not let's try to find the .git folder in a parent folder
+        var parentGitFolder = GitInfo.GetParentGitFolder(folder);
+        if (parentGitFolder != null && TryGetFrom(parentGitFolder, out var pFolderGitInfo) && pFolderGitInfo != null)
+        {
+            gitInfo = pFolderGitInfo;
+            return true;
+        }
+
+        gitInfo = null;
+        return false;
+    }
+
+    protected abstract bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo);
+}

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfoProvider.cs
@@ -4,6 +4,7 @@
 // </copyright>
 #nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -11,7 +12,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal abstract class GitInfoProvider : IGitInfoProvider
 {
-    public bool TryGetFrom(string folder, out IGitInfo? gitInfo)
+    public bool TryGetFrom(string folder, [NotNullWhen(true)] out IGitInfo? gitInfo)
     {
         // Try to load git metadata from the folder
         if (TryGetFrom(new DirectoryInfo(folder), out gitInfo))
@@ -44,5 +45,5 @@ internal abstract class GitInfoProvider : IGitInfoProvider
         return false;
     }
 
-    protected abstract bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo);
+    protected abstract bool TryGetFrom(DirectoryInfo gitDirectory, [NotNullWhen(true)] out IGitInfo? gitInfo);
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class GithubActionsEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: GitHub Actions detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitlabEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitlabEnvironmentValues.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class GitlabEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Gitlab CI detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfo.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 using System;
 
@@ -15,32 +16,32 @@ internal interface IGitInfo
     /// <summary>
     /// Gets Source root
     /// </summary>
-    string SourceRoot { get; }
+    string? SourceRoot { get; }
 
     /// <summary>
     /// Gets Repository
     /// </summary>
-    string Repository { get; }
+    string? Repository { get; }
 
     /// <summary>
     /// Gets Branch
     /// </summary>
-    string Branch { get; }
+    string? Branch { get; }
 
     /// <summary>
     /// Gets Commit
     /// </summary>
-    string Commit { get; }
+    string? Commit { get; }
 
     /// <summary>
     /// Gets Author Name
     /// </summary>
-    string AuthorName { get; }
+    string? AuthorName { get; }
 
     /// <summary>
     /// Gets Author Email
     /// </summary>
-    string AuthorEmail { get; }
+    string? AuthorEmail { get; }
 
     /// <summary>
     /// Gets Author Date
@@ -50,12 +51,12 @@ internal interface IGitInfo
     /// <summary>
     /// Gets Committer Name
     /// </summary>
-    string CommitterName { get; }
+    string? CommitterName { get; }
 
     /// <summary>
     /// Gets Committer Email
     /// </summary>
-    string CommitterEmail { get; }
+    string? CommitterEmail { get; }
 
     /// <summary>
     /// Gets Committer Date
@@ -65,5 +66,5 @@ internal interface IGitInfo
     /// <summary>
     /// Gets Commit Message
     /// </summary>
-    string Message { get; }
+    string? Message { get; }
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfo.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -67,4 +68,9 @@ internal interface IGitInfo
     /// Gets Commit Message
     /// </summary>
     string? Message { get; }
+
+    /// <summary>
+    /// Gets parsing errors
+    /// </summary>
+    public List<string> Errors { get; }
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfo.cs
@@ -1,0 +1,69 @@
+// <copyright file="IGitInfo.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.Ci.CiEnvironment;
+
+/// <summary>
+/// Git info interface
+/// </summary>
+internal interface IGitInfo
+{
+    /// <summary>
+    /// Gets Source root
+    /// </summary>
+    string SourceRoot { get; }
+
+    /// <summary>
+    /// Gets Repository
+    /// </summary>
+    string Repository { get; }
+
+    /// <summary>
+    /// Gets Branch
+    /// </summary>
+    string Branch { get; }
+
+    /// <summary>
+    /// Gets Commit
+    /// </summary>
+    string Commit { get; }
+
+    /// <summary>
+    /// Gets Author Name
+    /// </summary>
+    string AuthorName { get; }
+
+    /// <summary>
+    /// Gets Author Email
+    /// </summary>
+    string AuthorEmail { get; }
+
+    /// <summary>
+    /// Gets Author Date
+    /// </summary>
+    DateTimeOffset? AuthorDate { get; }
+
+    /// <summary>
+    /// Gets Committer Name
+    /// </summary>
+    string CommitterName { get; }
+
+    /// <summary>
+    /// Gets Committer Email
+    /// </summary>
+    string CommitterEmail { get; }
+
+    /// <summary>
+    /// Gets Committer Date
+    /// </summary>
+    DateTimeOffset? CommitterDate { get; }
+
+    /// <summary>
+    /// Gets Commit Message
+    /// </summary>
+    string Message { get; }
+}

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
@@ -13,5 +13,5 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 /// </summary>
 internal interface IGitInfoProvider
 {
-    bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo);
+    bool TryGetFrom(string folder, out IGitInfo? gitInfo);
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
@@ -4,7 +4,7 @@
 // </copyright>
 #nullable enable
 
-using System.IO;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -13,5 +13,5 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 /// </summary>
 internal interface IGitInfoProvider
 {
-    bool TryGetFrom(string folder, out IGitInfo? gitInfo);
+    bool TryGetFrom(string folder, [NotNullWhen(true)] out IGitInfo? gitInfo);
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
@@ -1,0 +1,16 @@
+// <copyright file="IGitInfoProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+
+namespace Datadog.Trace.Ci.CiEnvironment;
+
+/// <summary>
+/// Git info provider interface
+/// </summary>
+internal interface IGitInfoProvider
+{
+    bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo gitInfo);
+}

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/IGitInfoProvider.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 using System.IO;
 
@@ -12,5 +13,5 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 /// </summary>
 internal interface IGitInfoProvider
 {
-    bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo gitInfo);
+    bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo);
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/JenkinsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/JenkinsEnvironmentValues.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class JenkinsEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Jenkins detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/ManualParserGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/ManualParserGitInfoProvider.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -27,7 +28,7 @@ namespace Datadog.Trace.Ci.CiEnvironment
 
         public static IGitInfoProvider Instance { get; } = new ManualParserGitInfoProvider();
 
-        public bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo gitInfo)
+        public bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo)
         {
             if (gitDirectory == null)
             {
@@ -111,8 +112,8 @@ namespace Datadog.Trace.Ci.CiEnvironment
                 // Get author and committer data
                 if (!string.IsNullOrEmpty(tempGitInfo.Commit))
                 {
-                    var folder = tempGitInfo.Commit.Substring(0, 2);
-                    var file = tempGitInfo.Commit.Substring(2);
+                    var folder = tempGitInfo.Commit!.Substring(0, 2);
+                    var file = tempGitInfo.Commit!.Substring(2);
                     var objectFilePath = Path.Combine(gitDirectory.FullName, "objects", folder, file);
                     if (File.Exists(objectFilePath))
                     {
@@ -165,7 +166,7 @@ namespace Datadog.Trace.Ci.CiEnvironment
             return true;
         }
 
-        private static List<ConfigItem> GetConfigItems(string configFile)
+        private static List<ConfigItem>? GetConfigItems(string configFile)
         {
             if (!File.Exists(configFile))
             {
@@ -173,17 +174,17 @@ namespace Datadog.Trace.Ci.CiEnvironment
             }
 
             var lstConfig = new List<ConfigItem>();
-            ConfigItem currentItem = null;
+            ConfigItem? currentItem = null;
 
             var regex = new Regex("^\\[(.*) \\\"(.*)\\\"\\]");
-            string[] lines = File.ReadAllLines(configFile);
-            foreach (string line in lines)
+            var lines = File.ReadAllLines(configFile);
+            foreach (var line in lines)
             {
                 if (line[0] == '\t')
                 {
                     if (currentItem != null)
                     {
-                        string[] keyValue = line.Substring(1).Split(new string[] { " = " }, StringSplitOptions.RemoveEmptyEntries);
+                        var keyValue = line.Substring(1).Split([" = "], StringSplitOptions.RemoveEmptyEntries);
                         switch (keyValue[0])
                         {
                             case "url":
@@ -222,16 +223,16 @@ namespace Datadog.Trace.Ci.CiEnvironment
 
         internal readonly struct GitCommitObject
         {
-            public readonly string Tree;
-            public readonly string Parent;
-            public readonly string AuthorName;
-            public readonly string AuthorEmail;
+            public readonly string? Tree;
+            public readonly string? Parent;
+            public readonly string? AuthorName;
+            public readonly string? AuthorEmail;
             public readonly DateTimeOffset? AuthorDate;
-            public readonly string CommitterName;
-            public readonly string CommitterEmail;
+            public readonly string? CommitterName;
+            public readonly string? CommitterEmail;
             public readonly DateTimeOffset? CommitterDate;
-            public readonly string PgpSignature;
-            public readonly string Message;
+            public readonly string? PgpSignature;
+            public readonly string? Message;
 
             private const string TreePrefix = "tree ";
             private const string ParentPrefix = "parent ";
@@ -240,7 +241,7 @@ namespace Datadog.Trace.Ci.CiEnvironment
             private const string GpgSigPrefix = "gpgsig ";
             private const long UnixEpochTicks = TimeSpan.TicksPerDay * 719162; // 621,355,968,000,000,000
 
-            private static readonly byte[] _commitByteArray = Encoding.UTF8.GetBytes("commit");
+            private static readonly byte[] CommitByteArray = Encoding.UTF8.GetBytes("commit");
 
             private GitCommitObject(string content)
             {
@@ -255,11 +256,11 @@ namespace Datadog.Trace.Ci.CiEnvironment
                 PgpSignature = null;
                 Message = null;
 
-                string[] lines = content.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                List<string> msgLines = new List<string>();
+                var lines = content.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                var msgLines = new List<string>();
                 for (var i = 0; i < lines.Length; i++)
                 {
-                    string line = lines[i];
+                    var line = lines[i];
 
                     if (line.StartsWith(TreePrefix))
                     {
@@ -275,13 +276,13 @@ namespace Datadog.Trace.Ci.CiEnvironment
 
                     if (line.StartsWith(AuthorPrefix))
                     {
-                        string authorContent = line.Substring(AuthorPrefix.Length);
-                        string[] authorArray = authorContent.Split('<', '>');
+                        var authorContent = line.Substring(AuthorPrefix.Length);
+                        var authorArray = authorContent.Split('<', '>');
                         AuthorName = authorArray[0].Trim();
                         AuthorEmail = authorArray[1].Trim();
-                        string authorDate = authorArray[2].Trim();
-                        string[] authorDateArray = authorDate.Split(' ');
-                        if (long.TryParse(authorDateArray[0], out long unixSeconds))
+                        var authorDate = authorArray[2].Trim();
+                        var authorDateArray = authorDate.Split(' ');
+                        if (long.TryParse(authorDateArray[0], out var unixSeconds))
                         {
                             AuthorDate = new DateTimeOffset((unixSeconds * TimeSpan.TicksPerSecond) + UnixEpochTicks, TimeSpan.Zero);
                         }
@@ -291,13 +292,13 @@ namespace Datadog.Trace.Ci.CiEnvironment
 
                     if (line.StartsWith(CommitterPrefix))
                     {
-                        string committerContent = line.Substring(CommitterPrefix.Length);
-                        string[] committerArray = committerContent.Split('<', '>');
+                        var committerContent = line.Substring(CommitterPrefix.Length);
+                        var committerArray = committerContent.Split('<', '>');
                         CommitterName = committerArray[0].Trim();
                         CommitterEmail = committerArray[1].Trim();
-                        string committerDate = committerArray[2].Trim();
-                        string[] committerDateArray = committerDate.Split(' ');
-                        if (long.TryParse(committerDateArray[0], out long unixSeconds))
+                        var committerDate = committerArray[2].Trim();
+                        var committerDateArray = committerDate.Split(' ');
+                        if (long.TryParse(committerDateArray[0], out var unixSeconds))
                         {
                             CommitterDate = new DateTimeOffset((unixSeconds * TimeSpan.TicksPerSecond) + UnixEpochTicks, TimeSpan.Zero);
                         }
@@ -307,7 +308,7 @@ namespace Datadog.Trace.Ci.CiEnvironment
 
                     if (line.StartsWith(GpgSigPrefix))
                     {
-                        string pgpLine = line.Substring(GpgSigPrefix.Length) + Environment.NewLine;
+                        var pgpLine = line.Substring(GpgSigPrefix.Length) + Environment.NewLine;
                         PgpSignature = pgpLine;
                         while (!pgpLine.Contains("END PGP SIGNATURE") && !pgpLine.Contains("END SSH SIGNATURE") && i + 1 < lines.Length)
                         {
@@ -330,24 +331,21 @@ namespace Datadog.Trace.Ci.CiEnvironment
                 commitObject = default;
                 try
                 {
-                    using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                    {
-                        // We skip the 2 bytes zlib header magic number.
-                        fs.Seek(2, SeekOrigin.Begin);
-                        using (var defStream = new DeflateStream(fs, CompressionMode.Decompress))
-                        {
-                            byte[] buffer = new byte[8192];
-                            int readBytes = defStream.Read(buffer, 0, buffer.Length);
-                            defStream.Close();
+                    using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-                            if (_commitByteArray.SequenceEqual(buffer.Take(_commitByteArray.Length)))
-                            {
-                                string strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
-                                string dataContent = strContent.Substring(strContent.IndexOf('\0') + 1);
-                                commitObject = new GitCommitObject(dataContent);
-                                return true;
-                            }
-                        }
+                    // We skip the 2 bytes zlib header magic number.
+                    fs.Seek(2, SeekOrigin.Begin);
+                    using var defStream = new DeflateStream(fs, CompressionMode.Decompress);
+                    var buffer = new byte[8192];
+                    var readBytes = defStream.Read(buffer, 0, buffer.Length);
+                    defStream.Close();
+
+                    if (CommitByteArray.SequenceEqual(buffer.Take(CommitByteArray.Length)))
+                    {
+                        var strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
+                        var dataContent = strContent.Substring(strContent.IndexOf('\0') + 1);
+                        commitObject = new GitCommitObject(dataContent);
+                        return true;
                     }
                 }
                 catch (Exception ex)
@@ -363,65 +361,62 @@ namespace Datadog.Trace.Ci.CiEnvironment
                 commitObject = default;
                 try
                 {
-                    string packFile = Path.ChangeExtension(packageOffset.FilePath, ".pack");
+                    var packFile = Path.ChangeExtension(packageOffset.FilePath, ".pack");
                     if (File.Exists(packFile))
                     {
                         // packfile format explanation:
                         // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#:~:text=idx%20file%20contains%20the%20index,pack%20file.&text=Objects%20in%20a%20packfile%20can,of%20storing%20the%20whole%20object.
 
-                        using (var fs = new FileStream(packFile, FileMode.Open, FileAccess.Read, FileShare.Read))
-                        using (var br = new BigEndianBinaryReader(fs))
+                        using var fs = new FileStream(packFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+                        using var br = new BigEndianBinaryReader(fs);
+
+                        // Move to the offset of the object
+                        fs.Seek(packageOffset.Offset, SeekOrigin.Begin);
+                        var packData = br.ReadBytes(2);
+
+                        // Extract the object size (https://codewords.recurse.com/images/three/varint.svg)
+                        var objectSize = (int)(packData[0] & 0x0F);
+                        if (packData[0] >= 128)
                         {
-                            // Move to the offset of the object
-                            fs.Seek(packageOffset.Offset, SeekOrigin.Begin);
-                            byte[] packData = br.ReadBytes(2);
-
-                            // Extract the object size (https://codewords.recurse.com/images/three/varint.svg)
-                            int objectSize = (int)(packData[0] & 0x0F);
-                            if (packData[0] >= 128)
+                            int shift = 4;
+                            objectSize += (packData[1] & 0x7F) << shift;
+                            if (packData[1] >= 128)
                             {
-                                int shift = 4;
-                                objectSize += (packData[1] & 0x7F) << shift;
-                                if (packData[1] >= 128)
+                                byte pData;
+                                do
                                 {
-                                    byte pData;
-                                    do
-                                    {
-                                        shift += 7;
-                                        pData = br.ReadByte();
-                                        objectSize += (pData & 0x7F) << shift;
-                                    }
-                                    while (pData >= 128);
+                                    shift += 7;
+                                    pData = br.ReadByte();
+                                    objectSize += (pData & 0x7F) << shift;
                                 }
+                                while (pData >= 128);
                             }
+                        }
 
-                            // Check if the object size is in the aceptable range
-                            if (objectSize is > 0 and < ushort.MaxValue)
+                        // Check if the object size is in the aceptable range
+                        if (objectSize is > 0 and < ushort.MaxValue)
+                        {
+                            // Advance 2 bytes to skip the zlib magic number
+                            uint zlibMagicNumber = br.ReadUInt16();
+                            if ((byte)zlibMagicNumber == 0x78)
                             {
-                                // Advance 2 bytes to skip the zlib magic number
-                                uint zlibMagicNumber = br.ReadUInt16();
-                                if ((byte)zlibMagicNumber == 0x78)
-                                {
-                                    // Read the git commit object
-                                    using (var defStream = new DeflateStream(br.BaseStream, CompressionMode.Decompress))
-                                    {
-                                        byte[] buffer = new byte[objectSize];
-                                        int readBytes = defStream.Read(buffer, 0, buffer.Length);
-                                        defStream.Close();
-                                        string strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
-                                        commitObject = new GitCommitObject(strContent);
-                                        return true;
-                                    }
-                                }
-                                else
-                                {
-                                    Log.Warning("The commit data doesn't have a valid zlib header magic number. [Received: 0x{ZlibMagicNumber}, Expected: 0x78]", zlibMagicNumber.ToString("X2"));
-                                }
+                                // Read the git commit object
+                                using var defStream = new DeflateStream(br.BaseStream, CompressionMode.Decompress);
+                                var buffer = new byte[objectSize];
+                                var readBytes = defStream.Read(buffer, 0, buffer.Length);
+                                defStream.Close();
+                                var strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
+                                commitObject = new GitCommitObject(strContent);
+                                return true;
                             }
                             else
                             {
-                                Log.Warning<int>("The object size is outside of an acceptable range: {ObjectSize}", objectSize);
+                                Log.Warning("The commit data doesn't have a valid zlib header magic number. [Received: 0x{ZlibMagicNumber}, Expected: 0x78]", zlibMagicNumber.ToString("X2"));
                             }
+                        }
+                        else
+                        {
+                            Log.Warning<int>("The object size is outside of an acceptable range: {ObjectSize}", objectSize);
                         }
                     }
                 }
@@ -452,85 +447,84 @@ namespace Datadog.Trace.Ci.CiEnvironment
                 // packfile format explanation:
                 // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#:~:text=idx%20file%20contains%20the%20index,pack%20file.&text=Objects%20in%20a%20packfile%20can,of%20storing%20the%20whole%20object.
 
-                string index = commitSha.Substring(0, 2);
-                int folderIndex = int.Parse(index, System.Globalization.NumberStyles.HexNumber);
-                int previousIndex = folderIndex > 0 ? folderIndex - 1 : folderIndex;
+                var index = commitSha.Substring(0, 2);
+                var folderIndex = int.Parse(index, System.Globalization.NumberStyles.HexNumber);
+                var previousIndex = folderIndex > 0 ? folderIndex - 1 : folderIndex;
 
                 try
                 {
-                    using (var fs = new FileStream(idxFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                    using (var br = new BigEndianBinaryReader(fs))
+                    using var fs = new FileStream(idxFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    using var br = new BigEndianBinaryReader(fs);
+
+                    // Skip header and version
+                    fs.Seek(8, SeekOrigin.Begin);
+
+                    // First layer: 256 4-byte elements, with number of elements per folder
+                    uint numberOfObjectsInPreviousIndex = 0;
+                    if (previousIndex > -1)
                     {
-                        // Skip header and version
-                        fs.Seek(8, SeekOrigin.Begin);
+                        // Seek to previous index position and read the number of objects
+                        fs.Seek(previousIndex * 4, SeekOrigin.Current);
+                        numberOfObjectsInPreviousIndex = br.ReadUInt32();
+                    }
 
-                        // First layer: 256 4-byte elements, with number of elements per folder
-                        uint numberOfObjectsInPreviousIndex = 0;
-                        if (previousIndex > -1)
+                    // In the fanout table, every index has its objects + the previous ones.
+                    // We need to subtract the previous index objects to know the correct
+                    // actual number of objects for this specific index.
+                    var numberOfObjectsInIndex = br.ReadUInt32() - numberOfObjectsInPreviousIndex;
+
+                    // Seek to last position. The last position contains the number of all objects.
+                    fs.Seek((255 - (folderIndex + 1)) * 4, SeekOrigin.Current);
+                    var totalNumberOfObjects = br.ReadUInt32();
+
+                    // Second layer: 20-byte elements with the names in order
+                    // Search the sha index in the second layer: the SHA listing.
+                    uint? indexOfCommit = null;
+                    fs.Seek(20 * (int)numberOfObjectsInPreviousIndex, SeekOrigin.Current);
+                    for (uint i = 0; i < numberOfObjectsInIndex; i++)
+                    {
+                        var str = BitConverter.ToString(br.ReadBytes(20)).Replace("-", string.Empty);
+                        if (str.Equals(commitSha, StringComparison.OrdinalIgnoreCase))
                         {
-                            // Seek to previous index position and read the number of objects
-                            fs.Seek(previousIndex * 4, SeekOrigin.Current);
-                            numberOfObjectsInPreviousIndex = br.ReadUInt32();
+                            indexOfCommit = numberOfObjectsInPreviousIndex + i;
+
+                            // If we find the SHA, we skip all SHA listing table.
+                            fs.Seek(20 * (totalNumberOfObjects - (indexOfCommit.Value + 1)), SeekOrigin.Current);
+                            break;
+                        }
+                    }
+
+                    if (indexOfCommit.HasValue)
+                    {
+                        // Third layer: 4 byte CRC for each object. We skip it
+                        fs.Seek(4 * totalNumberOfObjects, SeekOrigin.Current);
+
+                        var indexOfCommitValue = indexOfCommit.Value;
+
+                        // Fourth layer: 4 byte per object of offset in pack file
+                        fs.Seek(4 * indexOfCommitValue, SeekOrigin.Current);
+                        var offset = br.ReadUInt32();
+
+                        ulong packOffset;
+                        if (((offset >> 31) & 1) == 0)
+                        {
+                            // offset is in the layer
+                            packOffset = (ulong)offset;
+                        }
+                        else
+                        {
+                            // offset is not in this layer, clear first bit and look at it at the 5th layer
+                            offset &= 0x7FFFFFFF;
+                            // Skip complete fourth layer.
+                            fs.Seek(4 * (totalNumberOfObjects - (indexOfCommitValue + 1)), SeekOrigin.Current);
+                            // Use the offset from fourth layer, to find the actual pack file offset in the fifth layer.
+                            // In this case, the offset is 8 bytes long.
+                            fs.Seek(8 * offset, SeekOrigin.Current);
+                            packOffset = br.ReadUInt64();
                         }
 
-                        // In the fanout table, every index has its objects + the previous ones.
-                        // We need to subtract the previous index objects to know the correct
-                        // actual number of objects for this specific index.
-                        uint numberOfObjectsInIndex = br.ReadUInt32() - numberOfObjectsInPreviousIndex;
-
-                        // Seek to last position. The last position contains the number of all objects.
-                        fs.Seek((255 - (folderIndex + 1)) * 4, SeekOrigin.Current);
-                        uint totalNumberOfObjects = br.ReadUInt32();
-
-                        // Second layer: 20-byte elements with the names in order
-                        // Search the sha index in the second layer: the SHA listing.
-                        uint? indexOfCommit = null;
-                        fs.Seek(20 * (int)numberOfObjectsInPreviousIndex, SeekOrigin.Current);
-                        for (uint i = 0; i < numberOfObjectsInIndex; i++)
-                        {
-                            string str = BitConverter.ToString(br.ReadBytes(20)).Replace("-", string.Empty);
-                            if (str.Equals(commitSha, StringComparison.OrdinalIgnoreCase))
-                            {
-                                indexOfCommit = numberOfObjectsInPreviousIndex + i;
-
-                                // If we find the SHA, we skip all SHA listing table.
-                                fs.Seek(20 * (totalNumberOfObjects - (indexOfCommit.Value + 1)), SeekOrigin.Current);
-                                break;
-                            }
-                        }
-
-                        if (indexOfCommit.HasValue)
-                        {
-                            // Third layer: 4 byte CRC for each object. We skip it
-                            fs.Seek(4 * totalNumberOfObjects, SeekOrigin.Current);
-
-                            uint indexOfCommitValue = indexOfCommit.Value;
-
-                            // Fourth layer: 4 byte per object of offset in pack file
-                            fs.Seek(4 * indexOfCommitValue, SeekOrigin.Current);
-                            uint offset = br.ReadUInt32();
-
-                            ulong packOffset;
-                            if (((offset >> 31) & 1) == 0)
-                            {
-                                // offset is in the layer
-                                packOffset = (ulong)offset;
-                            }
-                            else
-                            {
-                                // offset is not in this layer, clear first bit and look at it at the 5th layer
-                                offset &= 0x7FFFFFFF;
-                                // Skip complete fourth layer.
-                                fs.Seek(4 * (totalNumberOfObjects - (indexOfCommitValue + 1)), SeekOrigin.Current);
-                                // Use the offset from fourth layer, to find the actual pack file offset in the fifth layer.
-                                // In this case, the offset is 8 bytes long.
-                                fs.Seek(8 * offset, SeekOrigin.Current);
-                                packOffset = br.ReadUInt64();
-                            }
-
-                            packageOffset = new GitPackageOffset(idxFilePath, (long)packOffset);
-                            return true;
-                        }
+                        packageOffset = new GitPackageOffset(idxFilePath, (long)packOffset);
+                        return true;
                     }
                 }
                 catch (Exception ex)
@@ -544,24 +538,19 @@ namespace Datadog.Trace.Ci.CiEnvironment
 
         internal class ConfigItem
         {
-            public string Type { get; set; }
+            public string? Type { get; set; }
 
-            public string Name { get; set; }
+            public string? Name { get; set; }
 
-            public string Url { get; set; }
+            public string? Url { get; set; }
 
-            public string Remote { get; set; }
+            public string? Remote { get; set; }
 
-            public string Merge { get; set; }
+            public string? Merge { get; set; }
         }
 
-        internal class BigEndianBinaryReader : BinaryReader
+        internal class BigEndianBinaryReader(Stream stream) : BinaryReader(stream)
         {
-            public BigEndianBinaryReader(Stream stream)
-                : base(stream)
-            {
-            }
-
             public override int ReadInt32()
             {
                 var data = ReadBytes(4);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/ManualParserGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/ManualParserGitInfoProvider.cs
@@ -13,571 +13,572 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Datadog.Trace.Logging;
 
-namespace Datadog.Trace.Ci.CiEnvironment
-{
-    /// <summary>
-    /// Manual parser Git information class
-    /// </summary>
-    internal sealed class ManualParserGitInfoProvider : IGitInfoProvider
-    {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ManualParserGitInfoProvider));
+namespace Datadog.Trace.Ci.CiEnvironment;
 
-        private ManualParserGitInfoProvider()
+/// <summary>
+/// Manual parser Git information class
+/// </summary>
+internal sealed class ManualParserGitInfoProvider : GitInfoProvider
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ManualParserGitInfoProvider));
+
+    private ManualParserGitInfoProvider()
+    {
+    }
+
+    public static IGitInfoProvider Instance { get; } = new ManualParserGitInfoProvider();
+
+    protected override bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo)
+    {
+        if (gitDirectory == null)
         {
+            gitInfo = null;
+            return false;
         }
 
-        public static IGitInfoProvider Instance { get; } = new ManualParserGitInfoProvider();
+        var tempGitInfo = new GitInfo();
 
-        public bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo)
+        try
         {
-            if (gitDirectory == null)
+            tempGitInfo.SourceRoot = gitDirectory.Parent?.FullName;
+
+            // Get Git commit
+            var headPath = Path.Combine(gitDirectory.FullName, "HEAD");
+            if (File.Exists(headPath))
             {
-                gitInfo = null;
-                return false;
-            }
+                var head = File.ReadAllText(headPath).Trim();
 
-            var tempGitInfo = new GitInfo();
-
-            try
-            {
-                tempGitInfo.SourceRoot = gitDirectory.Parent?.FullName;
-
-                // Get Git commit
-                var headPath = Path.Combine(gitDirectory.FullName, "HEAD");
-                if (File.Exists(headPath))
+                // Symbolic Reference
+                if (head.StartsWith("ref:"))
                 {
-                    var head = File.ReadAllText(headPath).Trim();
+                    tempGitInfo.Branch = head.Substring(4).Trim();
 
-                    // Symbolic Reference
-                    if (head.StartsWith("ref:"))
+                    var refPath = Path.Combine(gitDirectory.FullName, tempGitInfo.Branch);
+                    var infoRefPath = Path.Combine(gitDirectory.FullName, "info", "refs");
+
+                    if (File.Exists(refPath))
                     {
-                        tempGitInfo.Branch = head.Substring(4).Trim();
-
-                        var refPath = Path.Combine(gitDirectory.FullName, tempGitInfo.Branch);
-                        var infoRefPath = Path.Combine(gitDirectory.FullName, "info", "refs");
-
-                        if (File.Exists(refPath))
+                        // Get the commit from the .git/{refPath} file.
+                        tempGitInfo.Commit = File.ReadAllText(refPath).Trim();
+                    }
+                    else if (File.Exists(infoRefPath))
+                    {
+                        // Get the commit from the .git/info/refs file.
+                        var lines = File.ReadAllLines(infoRefPath);
+                        foreach (var line in lines)
                         {
-                            // Get the commit from the .git/{refPath} file.
-                            tempGitInfo.Commit = File.ReadAllText(refPath).Trim();
-                        }
-                        else if (File.Exists(infoRefPath))
-                        {
-                            // Get the commit from the .git/info/refs file.
-                            var lines = File.ReadAllLines(infoRefPath);
-                            foreach (var line in lines)
+                            var hashRef = line.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                            if (hashRef[1] == tempGitInfo.Branch)
                             {
-                                var hashRef = line.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                                if (hashRef[1] == tempGitInfo.Branch)
-                                {
-                                    tempGitInfo.Commit = hashRef[0];
-                                }
+                                tempGitInfo.Commit = hashRef[0];
                             }
                         }
-                    }
-                    else
-                    {
-                        // Hash reference
-                        tempGitInfo.Commit = head;
                     }
                 }
                 else
                 {
-                    Log.Warning("GitInfo: HEAD file not found in the git directory: {GitDirectory}", headPath);
-                    gitInfo = null;
-                    return false;
+                    // Hash reference
+                    tempGitInfo.Commit = head;
+                }
+            }
+            else
+            {
+                tempGitInfo.Errors.Add($"HEAD file not found in the git directory: {headPath}");
+                Log.Warning("GitInfo: HEAD file not found in the git directory: {GitDirectory}", headPath);
+                gitInfo = null;
+                return false;
+            }
+
+            // Process Git Config
+            var configPath = Path.Combine(gitDirectory.FullName, "config");
+            var lstConfigs = GetConfigItems(configPath);
+            if (lstConfigs is { Count: > 0 })
+            {
+                var remote = "origin";
+
+                var branchItem = lstConfigs.Find(i => i.Type == "branch" && i.Merge == tempGitInfo.Branch);
+                if (branchItem != null)
+                {
+                    tempGitInfo.Branch = branchItem.Name;
+                    remote = branchItem.Remote;
                 }
 
-                // Process Git Config
-                var configPath = Path.Combine(gitDirectory.FullName, "config");
-                var lstConfigs = GetConfigItems(configPath);
-                if (lstConfigs != null && lstConfigs.Count > 0)
+                var remoteItem = lstConfigs.Find(i => i.Type == "remote" && i.Name == remote);
+                if (remoteItem != null)
                 {
-                    var remote = "origin";
+                    tempGitInfo.Repository = remoteItem.Url;
+                }
+            }
 
-                    var branchItem = lstConfigs.Find(i => i.Type == "branch" && i.Merge == tempGitInfo.Branch);
-                    if (branchItem != null)
+            // Get author and committer data
+            if (!string.IsNullOrEmpty(tempGitInfo.Commit))
+            {
+                var folder = tempGitInfo.Commit!.Substring(0, 2);
+                var file = tempGitInfo.Commit!.Substring(2);
+                var objectFilePath = Path.Combine(gitDirectory.FullName, "objects", folder, file);
+                if (File.Exists(objectFilePath))
+                {
+                    // Load and parse object file
+                    if (GitCommitObject.TryGetFromObjectFile(objectFilePath, out var commitObject))
                     {
-                        tempGitInfo.Branch = branchItem.Name;
-                        remote = branchItem.Remote;
-                    }
-
-                    var remoteItem = lstConfigs.Find(i => i.Type == "remote" && i.Name == remote);
-                    if (remoteItem != null)
-                    {
-                        tempGitInfo.Repository = remoteItem.Url;
+                        tempGitInfo.AuthorDate = commitObject.AuthorDate;
+                        tempGitInfo.AuthorEmail = commitObject.AuthorEmail;
+                        tempGitInfo.AuthorName = commitObject.AuthorName;
+                        tempGitInfo.CommitterDate = commitObject.CommitterDate;
+                        tempGitInfo.CommitterEmail = commitObject.CommitterEmail;
+                        tempGitInfo.CommitterName = commitObject.CommitterName;
+                        tempGitInfo.Message = commitObject.Message;
                     }
                 }
-
-                // Get author and committer data
-                if (!string.IsNullOrEmpty(tempGitInfo.Commit))
+                else
                 {
-                    var folder = tempGitInfo.Commit!.Substring(0, 2);
-                    var file = tempGitInfo.Commit!.Substring(2);
-                    var objectFilePath = Path.Combine(gitDirectory.FullName, "objects", folder, file);
-                    if (File.Exists(objectFilePath))
+                    // Search git object file from the pack files
+                    var packFolder = Path.Combine(gitDirectory.FullName, "objects", "pack");
+                    var files = Directory.GetFiles(packFolder, "*.idx", SearchOption.TopDirectoryOnly);
+                    foreach (var idxFile in files)
                     {
-                        // Load and parse object file
-                        if (GitCommitObject.TryGetFromObjectFile(objectFilePath, out var commitObject))
+                        if (GitPackageOffset.TryGetPackageOffset(idxFile, tempGitInfo.Commit, out var packageOffset))
                         {
-                            tempGitInfo.AuthorDate = commitObject.AuthorDate;
-                            tempGitInfo.AuthorEmail = commitObject.AuthorEmail;
-                            tempGitInfo.AuthorName = commitObject.AuthorName;
-                            tempGitInfo.CommitterDate = commitObject.CommitterDate;
-                            tempGitInfo.CommitterEmail = commitObject.CommitterEmail;
-                            tempGitInfo.CommitterName = commitObject.CommitterName;
-                            tempGitInfo.Message = commitObject.Message;
-                        }
-                    }
-                    else
-                    {
-                        // Search git object file from the pack files
-                        var packFolder = Path.Combine(gitDirectory.FullName, "objects", "pack");
-                        var files = Directory.GetFiles(packFolder, "*.idx", SearchOption.TopDirectoryOnly);
-                        foreach (var idxFile in files)
-                        {
-                            if (GitPackageOffset.TryGetPackageOffset(idxFile, tempGitInfo.Commit, out var packageOffset))
+                            if (GitCommitObject.TryGetFromPackageOffset(packageOffset, out var commitObject))
                             {
-                                if (GitCommitObject.TryGetFromPackageOffset(packageOffset, out var commitObject))
-                                {
-                                    tempGitInfo.AuthorDate = commitObject.AuthorDate;
-                                    tempGitInfo.AuthorEmail = commitObject.AuthorEmail;
-                                    tempGitInfo.AuthorName = commitObject.AuthorName;
-                                    tempGitInfo.CommitterDate = commitObject.CommitterDate;
-                                    tempGitInfo.CommitterEmail = commitObject.CommitterEmail;
-                                    tempGitInfo.CommitterName = commitObject.CommitterName;
-                                    tempGitInfo.Message = commitObject.Message;
-                                    break;
-                                }
+                                tempGitInfo.AuthorDate = commitObject.AuthorDate;
+                                tempGitInfo.AuthorEmail = commitObject.AuthorEmail;
+                                tempGitInfo.AuthorName = commitObject.AuthorName;
+                                tempGitInfo.CommitterDate = commitObject.CommitterDate;
+                                tempGitInfo.CommitterEmail = commitObject.CommitterEmail;
+                                tempGitInfo.CommitterName = commitObject.CommitterName;
+                                tempGitInfo.Message = commitObject.Message;
+                                break;
                             }
                         }
                     }
                 }
             }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "GitInfo: Error loading git information from directory");
-                gitInfo = null;
-                return false;
-            }
-
-            tempGitInfo.Branch = tempGitInfo.Branch?.Replace("refs/heads/", string.Empty);
-            gitInfo = tempGitInfo;
-            return true;
+        }
+        catch (Exception ex)
+        {
+            tempGitInfo.Errors.Add($"GitInfo: Error loading git information from directory: {ex}");
+            Log.Error(ex, "GitInfo: Error loading git information from directory");
+            gitInfo = null;
+            return false;
         }
 
-        private static List<ConfigItem>? GetConfigItems(string configFile)
+        tempGitInfo.Branch = tempGitInfo.Branch?.Replace("refs/heads/", string.Empty);
+        gitInfo = tempGitInfo;
+        return true;
+    }
+
+    private static List<ConfigItem>? GetConfigItems(string configFile)
+    {
+        if (!File.Exists(configFile))
         {
-            if (!File.Exists(configFile))
+            return null;
+        }
+
+        var lstConfig = new List<ConfigItem>();
+        ConfigItem? currentItem = null;
+
+        var regex = new Regex("^\\[(.*) \\\"(.*)\\\"\\]");
+        var lines = File.ReadAllLines(configFile);
+        foreach (var line in lines)
+        {
+            if (line[0] == '\t')
             {
-                return null;
+                if (currentItem != null)
+                {
+                    var keyValue = line.Substring(1).Split([" = "], StringSplitOptions.RemoveEmptyEntries);
+                    switch (keyValue[0])
+                    {
+                        case "url":
+                            currentItem.Url = keyValue[1];
+                            break;
+                        case "remote":
+                            currentItem.Remote = keyValue[1];
+                            break;
+                        case "merge":
+                            currentItem.Merge = keyValue[1];
+                            break;
+                    }
+                }
+
+                continue;
             }
 
-            var lstConfig = new List<ConfigItem>();
-            ConfigItem? currentItem = null;
-
-            var regex = new Regex("^\\[(.*) \\\"(.*)\\\"\\]");
-            var lines = File.ReadAllLines(configFile);
-            foreach (var line in lines)
+            var match = regex.Match(line);
+            if (match.Success)
             {
-                if (line[0] == '\t')
+                if (currentItem != null)
                 {
-                    if (currentItem != null)
+                    lstConfig.Add(currentItem);
+                }
+
+                currentItem = new ConfigItem
+                {
+                    Type = match.Groups[1].Value,
+                    Name = match.Groups[2].Value
+                };
+            }
+        }
+
+        return lstConfig;
+    }
+
+    internal readonly struct GitCommitObject
+    {
+        public readonly string? Tree;
+        public readonly string? Parent;
+        public readonly string? AuthorName;
+        public readonly string? AuthorEmail;
+        public readonly DateTimeOffset? AuthorDate;
+        public readonly string? CommitterName;
+        public readonly string? CommitterEmail;
+        public readonly DateTimeOffset? CommitterDate;
+        public readonly string? PgpSignature;
+        public readonly string? Message;
+
+        private const string TreePrefix = "tree ";
+        private const string ParentPrefix = "parent ";
+        private const string AuthorPrefix = "author ";
+        private const string CommitterPrefix = "committer ";
+        private const string GpgSigPrefix = "gpgsig ";
+        private const long UnixEpochTicks = TimeSpan.TicksPerDay * 719162; // 621,355,968,000,000,000
+
+        private static readonly byte[] CommitByteArray = Encoding.UTF8.GetBytes("commit");
+
+        private GitCommitObject(string content)
+        {
+            Tree = null;
+            Parent = null;
+            AuthorName = null;
+            AuthorEmail = null;
+            AuthorDate = null;
+            CommitterName = null;
+            CommitterEmail = null;
+            CommitterDate = null;
+            PgpSignature = null;
+            Message = null;
+
+            var lines = content.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            var msgLines = new List<string>();
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+
+                if (line.StartsWith(TreePrefix))
+                {
+                    Tree = line.Substring(TreePrefix.Length);
+                    continue;
+                }
+
+                if (line.StartsWith(ParentPrefix))
+                {
+                    Parent = line.Substring(ParentPrefix.Length);
+                    continue;
+                }
+
+                if (line.StartsWith(AuthorPrefix))
+                {
+                    var authorContent = line.Substring(AuthorPrefix.Length);
+                    var authorArray = authorContent.Split('<', '>');
+                    AuthorName = authorArray[0].Trim();
+                    AuthorEmail = authorArray[1].Trim();
+                    var authorDate = authorArray[2].Trim();
+                    var authorDateArray = authorDate.Split(' ');
+                    if (long.TryParse(authorDateArray[0], out var unixSeconds))
                     {
-                        var keyValue = line.Substring(1).Split([" = "], StringSplitOptions.RemoveEmptyEntries);
-                        switch (keyValue[0])
-                        {
-                            case "url":
-                                currentItem.Url = keyValue[1];
-                                break;
-                            case "remote":
-                                currentItem.Remote = keyValue[1];
-                                break;
-                            case "merge":
-                                currentItem.Merge = keyValue[1];
-                                break;
-                        }
+                        AuthorDate = new DateTimeOffset((unixSeconds * TimeSpan.TicksPerSecond) + UnixEpochTicks, TimeSpan.Zero);
                     }
 
                     continue;
                 }
 
-                var match = regex.Match(line);
-                if (match.Success)
+                if (line.StartsWith(CommitterPrefix))
                 {
-                    if (currentItem != null)
+                    var committerContent = line.Substring(CommitterPrefix.Length);
+                    var committerArray = committerContent.Split('<', '>');
+                    CommitterName = committerArray[0].Trim();
+                    CommitterEmail = committerArray[1].Trim();
+                    var committerDate = committerArray[2].Trim();
+                    var committerDateArray = committerDate.Split(' ');
+                    if (long.TryParse(committerDateArray[0], out var unixSeconds))
                     {
-                        lstConfig.Add(currentItem);
+                        CommitterDate = new DateTimeOffset((unixSeconds * TimeSpan.TicksPerSecond) + UnixEpochTicks, TimeSpan.Zero);
                     }
 
-                    currentItem = new ConfigItem
-                    {
-                        Type = match.Groups[1].Value,
-                        Name = match.Groups[2].Value
-                    };
+                    continue;
                 }
+
+                if (line.StartsWith(GpgSigPrefix))
+                {
+                    var pgpLine = line.Substring(GpgSigPrefix.Length) + Environment.NewLine;
+                    PgpSignature = pgpLine;
+                    while (!pgpLine.Contains("END PGP SIGNATURE") && !pgpLine.Contains("END SSH SIGNATURE") && i + 1 < lines.Length)
+                    {
+                        i++;
+                        pgpLine = lines[i];
+                        PgpSignature += pgpLine + Environment.NewLine;
+                    }
+
+                    continue;
+                }
+
+                msgLines.Add(line.Trim());
             }
 
-            return lstConfig;
+            Message = string.Join(Environment.NewLine, msgLines);
         }
 
-        internal readonly struct GitCommitObject
+        public static bool TryGetFromObjectFile(string filePath, out GitCommitObject commitObject)
         {
-            public readonly string? Tree;
-            public readonly string? Parent;
-            public readonly string? AuthorName;
-            public readonly string? AuthorEmail;
-            public readonly DateTimeOffset? AuthorDate;
-            public readonly string? CommitterName;
-            public readonly string? CommitterEmail;
-            public readonly DateTimeOffset? CommitterDate;
-            public readonly string? PgpSignature;
-            public readonly string? Message;
-
-            private const string TreePrefix = "tree ";
-            private const string ParentPrefix = "parent ";
-            private const string AuthorPrefix = "author ";
-            private const string CommitterPrefix = "committer ";
-            private const string GpgSigPrefix = "gpgsig ";
-            private const long UnixEpochTicks = TimeSpan.TicksPerDay * 719162; // 621,355,968,000,000,000
-
-            private static readonly byte[] CommitByteArray = Encoding.UTF8.GetBytes("commit");
-
-            private GitCommitObject(string content)
+            commitObject = default;
+            try
             {
-                Tree = null;
-                Parent = null;
-                AuthorName = null;
-                AuthorEmail = null;
-                AuthorDate = null;
-                CommitterName = null;
-                CommitterEmail = null;
-                CommitterDate = null;
-                PgpSignature = null;
-                Message = null;
+                using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-                var lines = content.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                var msgLines = new List<string>();
-                for (var i = 0; i < lines.Length; i++)
+                // We skip the 2 bytes zlib header magic number.
+                fs.Seek(2, SeekOrigin.Begin);
+                using var defStream = new DeflateStream(fs, CompressionMode.Decompress);
+                var buffer = new byte[8192];
+                var readBytes = defStream.Read(buffer, 0, buffer.Length);
+                defStream.Close();
+
+                if (CommitByteArray.SequenceEqual(buffer.Take(CommitByteArray.Length)))
                 {
-                    var line = lines[i];
-
-                    if (line.StartsWith(TreePrefix))
-                    {
-                        Tree = line.Substring(TreePrefix.Length);
-                        continue;
-                    }
-
-                    if (line.StartsWith(ParentPrefix))
-                    {
-                        Parent = line.Substring(ParentPrefix.Length);
-                        continue;
-                    }
-
-                    if (line.StartsWith(AuthorPrefix))
-                    {
-                        var authorContent = line.Substring(AuthorPrefix.Length);
-                        var authorArray = authorContent.Split('<', '>');
-                        AuthorName = authorArray[0].Trim();
-                        AuthorEmail = authorArray[1].Trim();
-                        var authorDate = authorArray[2].Trim();
-                        var authorDateArray = authorDate.Split(' ');
-                        if (long.TryParse(authorDateArray[0], out var unixSeconds))
-                        {
-                            AuthorDate = new DateTimeOffset((unixSeconds * TimeSpan.TicksPerSecond) + UnixEpochTicks, TimeSpan.Zero);
-                        }
-
-                        continue;
-                    }
-
-                    if (line.StartsWith(CommitterPrefix))
-                    {
-                        var committerContent = line.Substring(CommitterPrefix.Length);
-                        var committerArray = committerContent.Split('<', '>');
-                        CommitterName = committerArray[0].Trim();
-                        CommitterEmail = committerArray[1].Trim();
-                        var committerDate = committerArray[2].Trim();
-                        var committerDateArray = committerDate.Split(' ');
-                        if (long.TryParse(committerDateArray[0], out var unixSeconds))
-                        {
-                            CommitterDate = new DateTimeOffset((unixSeconds * TimeSpan.TicksPerSecond) + UnixEpochTicks, TimeSpan.Zero);
-                        }
-
-                        continue;
-                    }
-
-                    if (line.StartsWith(GpgSigPrefix))
-                    {
-                        var pgpLine = line.Substring(GpgSigPrefix.Length) + Environment.NewLine;
-                        PgpSignature = pgpLine;
-                        while (!pgpLine.Contains("END PGP SIGNATURE") && !pgpLine.Contains("END SSH SIGNATURE") && i + 1 < lines.Length)
-                        {
-                            i++;
-                            pgpLine = lines[i];
-                            PgpSignature += pgpLine + Environment.NewLine;
-                        }
-
-                        continue;
-                    }
-
-                    msgLines.Add(line.Trim());
+                    var strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
+                    var dataContent = strContent.Substring(strContent.IndexOf('\0') + 1);
+                    commitObject = new GitCommitObject(dataContent);
+                    return true;
                 }
-
-                Message = string.Join(Environment.NewLine, msgLines);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error getting commit object from object file");
             }
 
-            public static bool TryGetFromObjectFile(string filePath, out GitCommitObject commitObject)
-            {
-                commitObject = default;
-                try
-                {
-                    using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-
-                    // We skip the 2 bytes zlib header magic number.
-                    fs.Seek(2, SeekOrigin.Begin);
-                    using var defStream = new DeflateStream(fs, CompressionMode.Decompress);
-                    var buffer = new byte[8192];
-                    var readBytes = defStream.Read(buffer, 0, buffer.Length);
-                    defStream.Close();
-
-                    if (CommitByteArray.SequenceEqual(buffer.Take(CommitByteArray.Length)))
-                    {
-                        var strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
-                        var dataContent = strContent.Substring(strContent.IndexOf('\0') + 1);
-                        commitObject = new GitCommitObject(dataContent);
-                        return true;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error getting commit object from object file");
-                }
-
-                return false;
-            }
-
-            public static bool TryGetFromPackageOffset(GitPackageOffset packageOffset, out GitCommitObject commitObject)
-            {
-                commitObject = default;
-                try
-                {
-                    var packFile = Path.ChangeExtension(packageOffset.FilePath, ".pack");
-                    if (File.Exists(packFile))
-                    {
-                        // packfile format explanation:
-                        // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#:~:text=idx%20file%20contains%20the%20index,pack%20file.&text=Objects%20in%20a%20packfile%20can,of%20storing%20the%20whole%20object.
-
-                        using var fs = new FileStream(packFile, FileMode.Open, FileAccess.Read, FileShare.Read);
-                        using var br = new BigEndianBinaryReader(fs);
-
-                        // Move to the offset of the object
-                        fs.Seek(packageOffset.Offset, SeekOrigin.Begin);
-                        var packData = br.ReadBytes(2);
-
-                        // Extract the object size (https://codewords.recurse.com/images/three/varint.svg)
-                        var objectSize = (int)(packData[0] & 0x0F);
-                        if (packData[0] >= 128)
-                        {
-                            int shift = 4;
-                            objectSize += (packData[1] & 0x7F) << shift;
-                            if (packData[1] >= 128)
-                            {
-                                byte pData;
-                                do
-                                {
-                                    shift += 7;
-                                    pData = br.ReadByte();
-                                    objectSize += (pData & 0x7F) << shift;
-                                }
-                                while (pData >= 128);
-                            }
-                        }
-
-                        // Check if the object size is in the aceptable range
-                        if (objectSize is > 0 and < ushort.MaxValue)
-                        {
-                            // Advance 2 bytes to skip the zlib magic number
-                            uint zlibMagicNumber = br.ReadUInt16();
-                            if ((byte)zlibMagicNumber == 0x78)
-                            {
-                                // Read the git commit object
-                                using var defStream = new DeflateStream(br.BaseStream, CompressionMode.Decompress);
-                                var buffer = new byte[objectSize];
-                                var readBytes = defStream.Read(buffer, 0, buffer.Length);
-                                defStream.Close();
-                                var strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
-                                commitObject = new GitCommitObject(strContent);
-                                return true;
-                            }
-                            else
-                            {
-                                Log.Warning("The commit data doesn't have a valid zlib header magic number. [Received: 0x{ZlibMagicNumber}, Expected: 0x78]", zlibMagicNumber.ToString("X2"));
-                            }
-                        }
-                        else
-                        {
-                            Log.Warning<int>("The object size is outside of an acceptable range: {ObjectSize}", objectSize);
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error loading commit information from package offset");
-                }
-
-                return false;
-            }
+            return false;
         }
 
-        internal readonly struct GitPackageOffset
+        public static bool TryGetFromPackageOffset(GitPackageOffset packageOffset, out GitCommitObject commitObject)
         {
-            public readonly string FilePath;
-            public readonly long Offset;
-
-            internal GitPackageOffset(string filePath, long offset)
+            commitObject = default;
+            try
             {
-                FilePath = filePath;
-                Offset = offset;
-            }
-
-            public static bool TryGetPackageOffset(string idxFilePath, string commitSha, out GitPackageOffset packageOffset)
-            {
-                packageOffset = default;
-
-                // packfile format explanation:
-                // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#:~:text=idx%20file%20contains%20the%20index,pack%20file.&text=Objects%20in%20a%20packfile%20can,of%20storing%20the%20whole%20object.
-
-                var index = commitSha.Substring(0, 2);
-                var folderIndex = int.Parse(index, System.Globalization.NumberStyles.HexNumber);
-                var previousIndex = folderIndex > 0 ? folderIndex - 1 : folderIndex;
-
-                try
+                var packFile = Path.ChangeExtension(packageOffset.FilePath, ".pack");
+                if (File.Exists(packFile))
                 {
-                    using var fs = new FileStream(idxFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    // packfile format explanation:
+                    // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#:~:text=idx%20file%20contains%20the%20index,pack%20file.&text=Objects%20in%20a%20packfile%20can,of%20storing%20the%20whole%20object.
+
+                    using var fs = new FileStream(packFile, FileMode.Open, FileAccess.Read, FileShare.Read);
                     using var br = new BigEndianBinaryReader(fs);
 
-                    // Skip header and version
-                    fs.Seek(8, SeekOrigin.Begin);
+                    // Move to the offset of the object
+                    fs.Seek(packageOffset.Offset, SeekOrigin.Begin);
+                    var packData = br.ReadBytes(2);
 
-                    // First layer: 256 4-byte elements, with number of elements per folder
-                    uint numberOfObjectsInPreviousIndex = 0;
-                    if (previousIndex > -1)
+                    // Extract the object size (https://codewords.recurse.com/images/three/varint.svg)
+                    var objectSize = (int)(packData[0] & 0x0F);
+                    if (packData[0] >= 128)
                     {
-                        // Seek to previous index position and read the number of objects
-                        fs.Seek(previousIndex * 4, SeekOrigin.Current);
-                        numberOfObjectsInPreviousIndex = br.ReadUInt32();
-                    }
-
-                    // In the fanout table, every index has its objects + the previous ones.
-                    // We need to subtract the previous index objects to know the correct
-                    // actual number of objects for this specific index.
-                    var numberOfObjectsInIndex = br.ReadUInt32() - numberOfObjectsInPreviousIndex;
-
-                    // Seek to last position. The last position contains the number of all objects.
-                    fs.Seek((255 - (folderIndex + 1)) * 4, SeekOrigin.Current);
-                    var totalNumberOfObjects = br.ReadUInt32();
-
-                    // Second layer: 20-byte elements with the names in order
-                    // Search the sha index in the second layer: the SHA listing.
-                    uint? indexOfCommit = null;
-                    fs.Seek(20 * (int)numberOfObjectsInPreviousIndex, SeekOrigin.Current);
-                    for (uint i = 0; i < numberOfObjectsInIndex; i++)
-                    {
-                        var str = BitConverter.ToString(br.ReadBytes(20)).Replace("-", string.Empty);
-                        if (str.Equals(commitSha, StringComparison.OrdinalIgnoreCase))
+                        int shift = 4;
+                        objectSize += (packData[1] & 0x7F) << shift;
+                        if (packData[1] >= 128)
                         {
-                            indexOfCommit = numberOfObjectsInPreviousIndex + i;
-
-                            // If we find the SHA, we skip all SHA listing table.
-                            fs.Seek(20 * (totalNumberOfObjects - (indexOfCommit.Value + 1)), SeekOrigin.Current);
-                            break;
+                            byte pData;
+                            do
+                            {
+                                shift += 7;
+                                pData = br.ReadByte();
+                                objectSize += (pData & 0x7F) << shift;
+                            }
+                            while (pData >= 128);
                         }
                     }
 
-                    if (indexOfCommit.HasValue)
+                    // Check if the object size is in the aceptable range
+                    if (objectSize is > 0 and < ushort.MaxValue)
                     {
-                        // Third layer: 4 byte CRC for each object. We skip it
-                        fs.Seek(4 * totalNumberOfObjects, SeekOrigin.Current);
-
-                        var indexOfCommitValue = indexOfCommit.Value;
-
-                        // Fourth layer: 4 byte per object of offset in pack file
-                        fs.Seek(4 * indexOfCommitValue, SeekOrigin.Current);
-                        var offset = br.ReadUInt32();
-
-                        ulong packOffset;
-                        if (((offset >> 31) & 1) == 0)
+                        // Advance 2 bytes to skip the zlib magic number
+                        uint zlibMagicNumber = br.ReadUInt16();
+                        if ((byte)zlibMagicNumber == 0x78)
                         {
-                            // offset is in the layer
-                            packOffset = (ulong)offset;
+                            // Read the git commit object
+                            using var defStream = new DeflateStream(br.BaseStream, CompressionMode.Decompress);
+                            var buffer = new byte[objectSize];
+                            var readBytes = defStream.Read(buffer, 0, buffer.Length);
+                            defStream.Close();
+                            var strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
+                            commitObject = new GitCommitObject(strContent);
+                            return true;
                         }
                         else
                         {
-                            // offset is not in this layer, clear first bit and look at it at the 5th layer
-                            offset &= 0x7FFFFFFF;
-                            // Skip complete fourth layer.
-                            fs.Seek(4 * (totalNumberOfObjects - (indexOfCommitValue + 1)), SeekOrigin.Current);
-                            // Use the offset from fourth layer, to find the actual pack file offset in the fifth layer.
-                            // In this case, the offset is 8 bytes long.
-                            fs.Seek(8 * offset, SeekOrigin.Current);
-                            packOffset = br.ReadUInt64();
+                            Log.Warning("The commit data doesn't have a valid zlib header magic number. [Received: 0x{ZlibMagicNumber}, Expected: 0x78]", zlibMagicNumber.ToString("X2"));
                         }
-
-                        packageOffset = new GitPackageOffset(idxFilePath, (long)packOffset);
-                        return true;
+                    }
+                    else
+                    {
+                        Log.Warning<int>("The object size is outside of an acceptable range: {ObjectSize}", objectSize);
                     }
                 }
-                catch (Exception ex)
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error loading commit information from package offset");
+            }
+
+            return false;
+        }
+    }
+
+    internal readonly struct GitPackageOffset
+    {
+        public readonly string FilePath;
+        public readonly long Offset;
+
+        internal GitPackageOffset(string filePath, long offset)
+        {
+            FilePath = filePath;
+            Offset = offset;
+        }
+
+        public static bool TryGetPackageOffset(string idxFilePath, string commitSha, out GitPackageOffset packageOffset)
+        {
+            packageOffset = default;
+
+            // packfile format explanation:
+            // https://codewords.recurse.com/issues/three/unpacking-git-packfiles#:~:text=idx%20file%20contains%20the%20index,pack%20file.&text=Objects%20in%20a%20packfile%20can,of%20storing%20the%20whole%20object.
+
+            var index = commitSha.Substring(0, 2);
+            var folderIndex = int.Parse(index, System.Globalization.NumberStyles.HexNumber);
+            var previousIndex = folderIndex > 0 ? folderIndex - 1 : folderIndex;
+
+            try
+            {
+                using var fs = new FileStream(idxFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var br = new BigEndianBinaryReader(fs);
+
+                // Skip header and version
+                fs.Seek(8, SeekOrigin.Begin);
+
+                // First layer: 256 4-byte elements, with number of elements per folder
+                uint numberOfObjectsInPreviousIndex = 0;
+                if (previousIndex > -1)
                 {
-                    Log.Error(ex, "Error getting package offset");
+                    // Seek to previous index position and read the number of objects
+                    fs.Seek(previousIndex * 4, SeekOrigin.Current);
+                    numberOfObjectsInPreviousIndex = br.ReadUInt32();
                 }
 
-                return false;
+                // In the fanout table, every index has its objects + the previous ones.
+                // We need to subtract the previous index objects to know the correct
+                // actual number of objects for this specific index.
+                var numberOfObjectsInIndex = br.ReadUInt32() - numberOfObjectsInPreviousIndex;
+
+                // Seek to last position. The last position contains the number of all objects.
+                fs.Seek((255 - (folderIndex + 1)) * 4, SeekOrigin.Current);
+                var totalNumberOfObjects = br.ReadUInt32();
+
+                // Second layer: 20-byte elements with the names in order
+                // Search the sha index in the second layer: the SHA listing.
+                uint? indexOfCommit = null;
+                fs.Seek(20 * (int)numberOfObjectsInPreviousIndex, SeekOrigin.Current);
+                for (uint i = 0; i < numberOfObjectsInIndex; i++)
+                {
+                    var str = BitConverter.ToString(br.ReadBytes(20)).Replace("-", string.Empty);
+                    if (str.Equals(commitSha, StringComparison.OrdinalIgnoreCase))
+                    {
+                        indexOfCommit = numberOfObjectsInPreviousIndex + i;
+
+                        // If we find the SHA, we skip all SHA listing table.
+                        fs.Seek(20 * (totalNumberOfObjects - (indexOfCommit.Value + 1)), SeekOrigin.Current);
+                        break;
+                    }
+                }
+
+                if (indexOfCommit.HasValue)
+                {
+                    // Third layer: 4 byte CRC for each object. We skip it
+                    fs.Seek(4 * totalNumberOfObjects, SeekOrigin.Current);
+
+                    var indexOfCommitValue = indexOfCommit.Value;
+
+                    // Fourth layer: 4 byte per object of offset in pack file
+                    fs.Seek(4 * indexOfCommitValue, SeekOrigin.Current);
+                    var offset = br.ReadUInt32();
+
+                    ulong packOffset;
+                    if (((offset >> 31) & 1) == 0)
+                    {
+                        // offset is in the layer
+                        packOffset = (ulong)offset;
+                    }
+                    else
+                    {
+                        // offset is not in this layer, clear first bit and look at it at the 5th layer
+                        offset &= 0x7FFFFFFF;
+                        // Skip complete fourth layer.
+                        fs.Seek(4 * (totalNumberOfObjects - (indexOfCommitValue + 1)), SeekOrigin.Current);
+                        // Use the offset from fourth layer, to find the actual pack file offset in the fifth layer.
+                        // In this case, the offset is 8 bytes long.
+                        fs.Seek(8 * offset, SeekOrigin.Current);
+                        packOffset = br.ReadUInt64();
+                    }
+
+                    packageOffset = new GitPackageOffset(idxFilePath, (long)packOffset);
+                    return true;
+                }
             }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error getting package offset");
+            }
+
+            return false;
+        }
+    }
+
+    internal class ConfigItem
+    {
+        public string? Type { get; set; }
+
+        public string? Name { get; set; }
+
+        public string? Url { get; set; }
+
+        public string? Remote { get; set; }
+
+        public string? Merge { get; set; }
+    }
+
+    internal class BigEndianBinaryReader(Stream stream) : BinaryReader(stream)
+    {
+        public override int ReadInt32()
+        {
+            var data = ReadBytes(4);
+            Array.Reverse(data);
+            return BitConverter.ToInt32(data, 0);
         }
 
-        internal class ConfigItem
+        public override short ReadInt16()
         {
-            public string? Type { get; set; }
-
-            public string? Name { get; set; }
-
-            public string? Url { get; set; }
-
-            public string? Remote { get; set; }
-
-            public string? Merge { get; set; }
+            var data = ReadBytes(2);
+            Array.Reverse(data);
+            return BitConverter.ToInt16(data, 0);
         }
 
-        internal class BigEndianBinaryReader(Stream stream) : BinaryReader(stream)
+        public override long ReadInt64()
         {
-            public override int ReadInt32()
-            {
-                var data = ReadBytes(4);
-                Array.Reverse(data);
-                return BitConverter.ToInt32(data, 0);
-            }
+            var data = ReadBytes(8);
+            Array.Reverse(data);
+            return BitConverter.ToInt64(data, 0);
+        }
 
-            public override short ReadInt16()
-            {
-                var data = ReadBytes(2);
-                Array.Reverse(data);
-                return BitConverter.ToInt16(data, 0);
-            }
-
-            public override long ReadInt64()
-            {
-                var data = ReadBytes(8);
-                Array.Reverse(data);
-                return BitConverter.ToInt64(data, 0);
-            }
-
-            public override uint ReadUInt32()
-            {
-                var data = ReadBytes(4);
-                Array.Reverse(data);
-                return BitConverter.ToUInt32(data, 0);
-            }
+        public override uint ReadUInt32()
+        {
+            var data = ReadBytes(4);
+            Array.Reverse(data);
+            return BitConverter.ToUInt32(data, 0);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/ManualParserGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/ManualParserGitInfoProvider.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -26,7 +27,7 @@ internal sealed class ManualParserGitInfoProvider : GitInfoProvider
 
     public static IGitInfoProvider Instance { get; } = new ManualParserGitInfoProvider();
 
-    protected override bool TryGetFrom(DirectoryInfo gitDirectory, out IGitInfo? gitInfo)
+    protected override bool TryGetFrom(DirectoryInfo gitDirectory, [NotNullWhen(true)] out IGitInfo? gitInfo)
     {
         if (gitDirectory == null)
         {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/TeamcityEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/TeamcityEnvironmentValues.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class TeamcityEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: TeamCity detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/TravisEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/TravisEnvironmentValues.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class TravisEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: Travis CI detected");
 

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 internal sealed class UnsupportedCIEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
     where TValueProvider : struct, IValueProvider
 {
-    protected override void OnInitialize(GitInfo gitInfo)
+    protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: CI could not be detected, using the git folder: {GitFolder}", gitInfo.SourceRoot);
         Branch = gitInfo.Branch;

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -28,9 +28,20 @@ namespace Datadog.Trace.Ci.Configuration
             var config = new ConfigurationBuilder(source, telemetry);
             Enabled = config.WithKeys(ConfigurationKeys.CIVisibility.Enabled).AsBool();
             Agentless = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessEnabled).AsBool(false);
+            Site = config.WithKeys(ConfigurationKeys.Site).AsString("datadoghq.com");
+
+            if (Enabled == false)
+            {
+                // If the CI Visibility is disabled we don't need to load the rest of the configuration
+                // and we can return early.
+                // This is useful to avoid loading the CIEnvironmentValues instance when calculating the test session name
+                // and avoid the overhead of loading the configuration.
+                TestSessionName = string.Empty;
+                return;
+            }
+
             Logs = config.WithKeys(ConfigurationKeys.CIVisibility.Logs).AsBool(false);
             ApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
-            Site = config.WithKeys(ConfigurationKeys.Site).AsString("datadoghq.com");
             AgentlessUrl = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessUrl).AsString();
 
             // By default intake payloads has a 5MB limit

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Ci.Configuration
                 // If the CI Visibility is disabled we don't need to load the rest of the configuration
                 // and we can return early.
                 // This is useful to avoid loading the CIEnvironmentValues instance when calculating the test session name
-                // and avoid the overhead of loading the configuration.
+                // and avoid the overhead of loading the configuration on normal no CI Visibility mode.
                 TestSessionName = string.Empty;
                 return;
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
@@ -144,18 +144,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [SkippableFact]
         public void GitCommandGitInfoProviderTest()
         {
-            Assert.True(GitCommandGitInfoProvider.Instance.TryGetFrom(Environment.CurrentDirectory, out var gitInfo));
-            Assert.NotNull(gitInfo.AuthorDate);
-            Assert.NotNull(gitInfo.AuthorEmail);
-            Assert.NotNull(gitInfo.AuthorName);
-            Assert.NotNull(gitInfo.Branch);
-            Assert.NotNull(gitInfo.Commit);
-            Assert.NotNull(gitInfo.CommitterDate);
-            Assert.NotNull(gitInfo.CommitterEmail);
-            Assert.NotNull(gitInfo.CommitterName);
-            Assert.NotNull(gitInfo.Message);
-            Assert.NotNull(gitInfo.Repository);
-            Assert.NotNull(gitInfo.SourceRoot);
+            if (GitCommandGitInfoProvider.Instance.TryGetFrom(Environment.CurrentDirectory, out var gitInfo))
+            {
+                Assert.NotNull(gitInfo.AuthorDate);
+                Assert.NotNull(gitInfo.AuthorEmail);
+                Assert.NotNull(gitInfo.AuthorName);
+                Assert.NotNull(gitInfo.Branch);
+                Assert.NotNull(gitInfo.Commit);
+                Assert.NotNull(gitInfo.CommitterDate);
+                Assert.NotNull(gitInfo.CommitterEmail);
+                Assert.NotNull(gitInfo.CommitterName);
+                Assert.NotNull(gitInfo.Message);
+                Assert.NotNull(gitInfo.Repository);
+                Assert.NotNull(gitInfo.SourceRoot);
+            }
+            else
+            {
+                var errors = string.Join(Environment.NewLine, gitInfo?.Errors ?? []);
+                throw new Exception($"Error parsing git info from provider: {nameof(GitCommandGitInfoProvider)}{Environment.NewLine}{errors}");
+            }
         }
 
         public class TestItem : IXunitSerializable

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Datadog.Trace.Ci.CiEnvironment;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,8 +20,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             string dataFolder = DataHelpers.GetCiDataDirectory();
 
             // gitdata-01 => Git clone
-            yield return new object[]
-            {
+            yield return
+            [
                 new TestItem(Path.Combine(dataFolder, "gitdata-01"))
                 {
                     AuthorDate = "2021-02-26 18:32:13Z",
@@ -33,12 +34,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     CommitterName = "GitHub",
                     Repository = "git@github.com:DataDog/dd-trace-dotnet.git",
                     SourceRoot = dataFolder
-                },
-            };
+                }
+            ];
 
             // gitdata-02 => Git clone  + git gc (force packs files)
-            yield return new object[]
-            {
+            yield return
+            [
                 new TestItem(Path.Combine(dataFolder, "gitdata-02"))
                 {
                     AuthorDate = "2021-02-26 18:32:13Z",
@@ -51,12 +52,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     CommitterName = "GitHub",
                     Repository = "git@github.com:DataDog/dd-trace-dotnet.git",
                     SourceRoot = dataFolder
-                },
-            };
+                }
+            ];
 
             // gitdata-03 => Git clone + git checkout [sha]
-            yield return new object[]
-            {
+            yield return
+            [
                 new TestItem(Path.Combine(dataFolder, "gitdata-03"))
                 {
                     AuthorDate = "2021-02-26 18:32:13Z",
@@ -69,8 +70,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     CommitterName = "GitHub",
                     Repository = "git@github.com:DataDog/dd-trace-dotnet.git",
                     SourceRoot = dataFolder
-                },
-            };
+                }
+            ];
 
             // gitdata-04 => Git clone + git checkout [sha] + git gc (force packs files)
             yield return new object[]
@@ -91,8 +92,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             };
 
             // gitdata-05 => Git clone + git gc + git checkout tag
-            yield return new object[]
-            {
+            yield return
+            [
                 new TestItem(Path.Combine(dataFolder, "gitdata-05"))
                 {
                     AuthorDate = "2021-02-19 12:59:01Z",
@@ -105,15 +106,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     CommitterName = "GitHub",
                     Repository = "git@github.com:DataDog/dd-trace-dotnet.git",
                     SourceRoot = dataFolder
-                },
-            };
+                }
+            ];
         }
 
         [SkippableTheory]
         [MemberData(nameof(GetData))]
         public void ExtractGitDataFromFolder(TestItem testItem)
         {
-            Assert.True(Directory.Exists(testItem.GitFolderPath));
+            Directory.Exists(testItem.GitFolderPath).Should().BeTrue();
 
             // Let's try with the git info provider based on manual parsing of the git folder
             if (!ManualParserGitInfoProvider.Instance.TryGetFrom(testItem.GitFolderPath, out var gitInfo))
@@ -127,17 +128,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
             static void AssertGitInfo(TestItem testItem, IGitInfo gitInfo)
             {
-                Assert.Equal(testItem.AuthorDate, gitInfo.AuthorDate.Value.ToString("u"));
-                Assert.Equal(testItem.AuthorEmail, gitInfo.AuthorEmail);
-                Assert.Equal(testItem.AuthorName, gitInfo.AuthorName);
-                Assert.Equal(testItem.Branch, gitInfo.Branch);
-                Assert.Equal(testItem.Commit, gitInfo.Commit);
-                Assert.Equal(testItem.CommitterDate, gitInfo.CommitterDate.Value.ToString("u"));
-                Assert.Equal(testItem.CommitterEmail, gitInfo.CommitterEmail);
-                Assert.Equal(testItem.CommitterName, gitInfo.CommitterName);
-                Assert.NotNull(gitInfo.Message);
-                Assert.Equal(testItem.Repository, gitInfo.Repository);
-                Assert.Equal(testItem.SourceRoot, gitInfo.SourceRoot);
+                gitInfo.AuthorDate.Should().NotBeNull();
+                gitInfo.AuthorDate!.Value.ToString("u").Should().Be(testItem.AuthorDate);
+                gitInfo.AuthorEmail.Should().Be(testItem.AuthorEmail);
+                gitInfo.AuthorName.Should().Be(testItem.AuthorName);
+                gitInfo.Branch.Should().Be(testItem.Branch);
+                gitInfo.Commit.Should().Be(testItem.Commit);
+                gitInfo.CommitterDate.Should().NotBeNull();
+                gitInfo.CommitterDate!.Value.ToString("u").Should().Be(testItem.CommitterDate);
+                gitInfo.CommitterEmail.Should().Be(testItem.CommitterEmail);
+                gitInfo.CommitterName.Should().Be(testItem.CommitterName);
+                gitInfo.Message.Should().NotBeNull();
+                gitInfo.Repository.Should().Be(testItem.Repository);
+                gitInfo.SourceRoot.Should().Be(testItem.SourceRoot);
             }
         }
 
@@ -146,17 +149,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             if (GitCommandGitInfoProvider.Instance.TryGetFrom(Environment.CurrentDirectory, out var gitInfo))
             {
-                Assert.NotNull(gitInfo.AuthorDate);
-                Assert.NotNull(gitInfo.AuthorEmail);
-                Assert.NotNull(gitInfo.AuthorName);
-                Assert.NotNull(gitInfo.Branch);
-                Assert.NotNull(gitInfo.Commit);
-                Assert.NotNull(gitInfo.CommitterDate);
-                Assert.NotNull(gitInfo.CommitterEmail);
-                Assert.NotNull(gitInfo.CommitterName);
-                Assert.NotNull(gitInfo.Message);
-                Assert.NotNull(gitInfo.Repository);
-                Assert.NotNull(gitInfo.SourceRoot);
+                gitInfo.AuthorDate.Should().NotBeNull();
+                gitInfo.AuthorEmail.Should().NotBeNull();
+                gitInfo.AuthorName.Should().NotBeNull();
+                gitInfo.Branch.Should().NotBeNull();
+                gitInfo.Commit.Should().NotBeNull();
+                gitInfo.CommitterDate.Should().NotBeNull();
+                gitInfo.CommitterEmail.Should().NotBeNull();
+                gitInfo.CommitterName.Should().NotBeNull();
+                gitInfo.Message.Should().NotBeNull();
+                gitInfo.Repository.Should().NotBeNull();
+                gitInfo.SourceRoot.Should().NotBeNull();
             }
             else
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkEvpTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkEvpTest.cs
@@ -280,7 +280,7 @@ public abstract class TestingFrameworkEvpTest : TestHelper
             [CIEnvironmentValues.Constants.AzureSystemTeamProjectId] = "TeamProjectId",
             [CIEnvironmentValues.Constants.AzureBuildBuildId] = "BuildId",
             [CIEnvironmentValues.Constants.AzureSystemJobId] = "JobId",
-            [CIEnvironmentValues.Constants.AzureBuildSourcesDirectory] = current.SourceRoot,
+            [CIEnvironmentValues.Constants.AzureBuildSourcesDirectory] = current.SourceRoot ?? string.Empty,
             [CIEnvironmentValues.Constants.AzureBuildDefinitionName] = "DefinitionName",
             [CIEnvironmentValues.Constants.AzureSystemTeamFoundationServerUri] = "https://foundation.server.url/",
             [CIEnvironmentValues.Constants.AzureSystemStageDisplayName] = "StageDisplayName",

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkTest.cs
@@ -224,7 +224,7 @@ public abstract class TestingFrameworkTest : TestHelper
             [CIEnvironmentValues.Constants.AzureSystemTeamProjectId] = "TeamProjectId",
             [CIEnvironmentValues.Constants.AzureBuildBuildId] = "BuildId",
             [CIEnvironmentValues.Constants.AzureSystemJobId] = "JobId",
-            [CIEnvironmentValues.Constants.AzureBuildSourcesDirectory] = current.SourceRoot,
+            [CIEnvironmentValues.Constants.AzureBuildSourcesDirectory] = current.SourceRoot ?? string.Empty,
             [CIEnvironmentValues.Constants.AzureBuildDefinitionName] = "DefinitionName",
             [CIEnvironmentValues.Constants.AzureSystemTeamFoundationServerUri] = "https://foundation.server.url/",
             [CIEnvironmentValues.Constants.AzureSystemStageDisplayName] = "StageDisplayName",


### PR DESCRIPTION
## Summary of changes

This PR is a complete refactor of the `GitInfo` class to a new structure to allow multiple providers `IGitInfoProvider`. It also contains two implementations:
1. GitInfoProvider based on calls to the git cli.
2. ManualParserGitInfoProvider based on manually parse the `.git` folder without any git dependency (Without support for Delta objects).

## Reason for change

The previous structure was hard to maintain and to create fallbacks in case a provider cannot read the git information. For example the ManualParserGitInfoProvider has some issue in certain git folders (with Delta objects), that's why we are using the one based on the git cli as a fallback.

## Test coverage

Existing tests were modified and a new test was added.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
