### PR TITLE
Make snapshot tests compatible with running on Docker v2

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1,5 +1,5 @@
 # Change the default BuildId to not include a '.' in the name (use '_' instead)
-name: $(Date:yyyyMMdd)_$(Rev:rr)
+name: $(Date:yyyyMMdd)-$(Rev:rr)
 
 trigger:
   branches:
@@ -141,7 +141,7 @@ variables:
   IncludeAllTestFrameworks: $[or(eq(variables['run_all_test_frameworks'], 'true'), and(or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hostfix/')), not(eq(variables['Build.Reason'], 'Schedule'))))]
   IntegrationTestSampleName:  $(TEST_SAMPLE_NAME)
   IntegrationTestFilter:  $(TEST_FILTER)
-  DockerComposeProjectName: ddtrace_$(Build.BuildNumber)
+  DockerComposeProjectName: ddtrace-$(Build.BuildNumber)
   # Logger variables
   DD_LOGGER_DD_API_KEY: $(DD_API_KEY)
   DD_LOGGER_DD_SERVICE: dd-trace-dotnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -829,9 +829,9 @@ services:
     environment:
     - ENABLED_CHECKS=trace_count_header,meta_tracer_version_header,trace_content_length
     - SNAPSHOT_CI=1
-    # meta.network.client.ip differs between docker compose v1 and v2 - once we're migrated to v2 completely we can remove it from here
+    # network.client.ip and http.client_ip differs between docker compose v1 and v2 - once we're migrated to v2 completely we can remove it from here
     # api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
-    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,meta.network.client.ip,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,meta.network.client.ip,meta.http.client_ip,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers
 
   smoke-tests:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -829,7 +829,9 @@ services:
     environment:
     - ENABLED_CHECKS=trace_count_header,meta_tracer_version_header,trace_content_length
     - SNAPSHOT_CI=1
-    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers #api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
+    # meta.network.client.ip differs between docker compose v1 and v2 - once we're migrated to v2 completely we can remove it from here
+    # api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,meta.network.client.ip,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers
 
   smoke-tests:
     build:


### PR DESCRIPTION
## Summary of changes

Makes the snapshot tests (and build) compatible with docker compose v2

## Reason for change

We're still using docker compose v1 in the snapshot tests currently, but the latest .NET 9 images using noble will crash when running on these. This is a preparatory step for updating to docker compose v2

## Implementation details

- Replace `_` with `-` in the docker-compose project names (`_` isn't valid)
- Exclude comparing `network.client.ip` and `http.client_ip` in the snapshots
  - They have different values in v1 and v2
  - Once we've moved everything to v2, we can remove the exclude and update the snapshots

## Test coverage

This is the test

