### PR TITLE
Skip Ready2Run tests on macOS

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1922,7 +1922,8 @@ partial class Build
                     return project?.Name switch
                     {
                         "Samples.Trimming" => (project, include: Framework.IsGreaterThanOrEqualTo(TargetFramework.NET6_0), r2r: false),
-                        "Samples.ManualInstrumentation" => (project, include: Framework.IsGreaterThanOrEqualTo(TargetFramework.NETCOREAPP2_1), r2r: true),
+                        // Ready2run doesn't work on OSX, apparently
+                        "Samples.ManualInstrumentation" => (project, include: IsLinux && Framework.IsGreaterThanOrEqualTo(TargetFramework.NETCOREAPP2_1), r2r: true),
                         _ => (project, include: false, r2r: false),
                     };
                 })

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -54,6 +54,8 @@ public class ManualInstrumentationTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ReadyToRunManualAndAutomatic()
     {
+        // MacOs doesn't work with Ready2Run apparently
+        SkipOn.Platform(SkipOn.PlatformValue.MacOs);
         SetEnvironmentVariable("READY2RUN_ENABLED", "1");
         await RunTest(usePublishWithRID: true);
     }


### PR DESCRIPTION
## Summary of changes

Skips the Ready2Run tests on macOS

## Reason for change

The build is breaking on macos with

```
error NETSDK1084: There is no application host available for the specified RuntimeIdentifier 'osx-arm64'. [.../dd-trace-dotnet/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj::TargetFramework=netcoreapp3.0]
```

It seems like Ready2Run isn't working properly here on macOS. As we don't support macos other than in CI anyway, this isn't a priority to look into right now

## Implementation details

Skip the r2r build and test on macos

## Test coverage

Manual testing
