### PR TITLE
Add first documentation on how to update the deny list

### DIFF
--- a/docs/deny-list-update.md
+++ b/docs/deny-list-update.md
@@ -1,0 +1,20 @@
+# What is the deny-list?
+
+With SSI, we have introduced deny-list mechanisms to avoid injecting certain processes. Part of the deny list is handled in the injector itself.
+
+Then there are language-specific deny-lists built into the libraries (which are loaded by the tracer), loaded via `requirements.json`. These are only run for processes which are detected as the given language
+The `requirements.json` file specifies two things: 
+- Which architectures and glibc/musl combination the tracer version supports
+- Additional processes to deny
+
+The deny lists in `requirements.json` block based on a combination of
+- executable path (glob match)
+- command arguments (pretty flexible, some limitations)
+- environment variables (we should be very wary of these as we've seen)
+
+Finally, the libraries themselves have built-in deny-lists that apply in all cases, i.e. including outside of SSI. The implementations of these vary significantly by library
+
+# How to block additional processes?
+
+Directly add an entry in the `/tracer/build/artifacts/requiremements.json`. The entry has to be added in the `deny` json array. Refer to the RFC for more details of the content.   
+From there, you just have to open a PR.


### PR DESCRIPTION
## Summary of changes

Adds a quick documentation on how to add an item to the deny list. 
The document is located at the root of the `docs` folder as I'd like to use the same location across repo. But I can also maybe add it to a `prod` or `operations` folder)? 

## Reason for change
Not all tracers use the same method, so documenting per repo is important. 

## Implementation details
Just a md.

## Test coverage
N/A

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
