### PR TITLE
Fix R2R build for OSX-ARM64

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -54,6 +54,10 @@ public class ManualInstrumentationTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ReadyToRunManualAndAutomatic()
     {
+#if !NET6_OR_GREATER
+        // osx-arm64 doesn't work with Ready2Run
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.MacOs, SkipOn.ArchitectureValue.ARM64);
+#endif
         SetEnvironmentVariable("READY2RUN_ENABLED", "1");
         await RunTest(usePublishWithRID: true);
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -54,7 +54,7 @@ public class ManualInstrumentationTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ReadyToRunManualAndAutomatic()
     {
-#if !NET6_OR_GREATER
+#if !NET6_0_OR_GREATER
         // osx-arm64 doesn't work with Ready2Run
         SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.MacOs, SkipOn.ArchitectureValue.ARM64);
 #endif

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
@@ -1,9 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <PropertyGroup>
+    <IsOsxArm64 Condition="$([MSBuild]::IsOsPlatform('OSX')) And $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == Arm64">true</IsOsxArm64>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <TargetFrameworks Condition="$(IsOsxArm64) == true AND $(PublishReadyToRun) == true">net6.0;net7.0;net8.0</TargetFrameworks>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Polyfill" Version="1.32.1" />
   </ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Polyfill" Version="1.32.1" />
   </ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj" />
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Polyfill" Version="1.32.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of changes

Fix R2R build for OSX-ARM64

## Reason for change

Currently if we try to build `Samples.ManualInstrumentation` project with R2R on osx-arm64 it will fail.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
