### PR TITLE
baggage propagator clean up

### DIFF
--- a/tracer/src/Datadog.Trace/ExtensionMethods/StringBuilderExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/StringBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="StringBuilderExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Text;
+
+#if !NETCOREAPP3_1_OR_GREATER
+
+namespace Datadog.Trace.ExtensionMethods;
+
+internal static class StringBuilderExtensions
+{
+    // .NET Core 3.1 and later has this StringBuilder.Append(ReadOnlySpan<char>) method overload built-in
+    public static StringBuilder Append(this StringBuilder sb, ReadOnlySpan<char> value)
+    {
+        foreach (var c in value)
+        {
+            sb.Append(c);
+        }
+
+        return sb;
+    }
+}
+
+#endif

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
@@ -163,10 +164,9 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
 
         for (var index = 0; index < bytes.Length; index++)
         {
-            var b = bytes[index];
-            var c = (char)b;
+            var c = (char)bytes[index];
 
-            if (b < 0x20 || b > 0x7E || char.IsWhiteSpace(c) || charsToEncode.Contains(c))
+            if (CharRequiresEncoding(c, charsToEncode))
             {
                 // encode byte as "%FF" (hexadecimal)
                 var byteToEncode = bytes.Slice(index, 1);
@@ -186,11 +186,17 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
 #endif
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool CharRequiresEncoding(char c, HashSet<char> charsToEncode)
+    {
+        return c < 0x20 || c > 0x7E || char.IsWhiteSpace(c) || charsToEncode.Contains(c);
+    }
+
     private static bool AnyCharRequiresEncoding(string source, HashSet<char> charsToEncode)
     {
         foreach (var c in source)
         {
-            if (c < 0x20 || c > 0x7E || char.IsWhiteSpace(c) || charsToEncode.Contains(c))
+            if (CharRequiresEncoding(c, charsToEncode))
             {
                 return true;
             }

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -160,7 +160,20 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
             if (b < 0x20 || b > 0x7E || char.IsWhiteSpace((char)b) || charsToEncode.Contains((char)b))
             {
                 // encode byte as '%XX'
+#if NET6_0_OR_GREATER
+                Span<char> buffer = stackalloc char[2];
+                if (b.TryFormat(buffer, out var chars, format: "X2") && chars == 2)
+                {
+                    sb.Append('%').Append(buffer);
+                }
+                else
+                {
+                    // fallback
+                    sb.Append($"%{b:X2}");
+                }
+#else
                 sb.Append($"%{b:X2}");
+#endif                
             }
             else
             {

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -151,7 +151,7 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
         }
     }
 
-    private static void EncodeBytesAndAppend(StringBuilder sb, Span<byte> bytes, HashSet<char> charsToEncode)
+    private static void EncodeBytesAndAppend(StringBuilder sb, ReadOnlySpan<byte> bytes, HashSet<char> charsToEncode)
     {
         // allocate a buffer on the stack (or rent one) for hexadecimal strings
 #if NETCOREAPP3_1_OR_GREATER

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -328,7 +328,7 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
 
             EncodeStringAndAppend(_sb, item.Key, KeyCharsToEncode);
             _sb.Append(KeyAndValueSeparator);
-            EncodeStringAndAppend(_sb, item.Value, ValueCharsToEncode);
+            EncodeStringAndAppend(_sb, item.Value!, ValueCharsToEncode);
 
             // it's all ASCII here after encoding, so we can use the string
             // length directly instead of using Encoding.UTF8.GetByteCount().

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -164,8 +164,9 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
         for (var index = 0; index < bytes.Length; index++)
         {
             var b = bytes[index];
+            var c = (char)b;
 
-            if (b < 0x20 || b > 0x7E || char.IsWhiteSpace((char)b) || charsToEncode.Contains((char)b))
+            if (b < 0x20 || b > 0x7E || char.IsWhiteSpace(c) || charsToEncode.Contains(c))
             {
                 // encode byte as "%FF" (hexadecimal)
                 var byteToEncode = bytes.Slice(index, 1);
@@ -176,7 +177,7 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
             else
             {
                 // append the byte as a character
-                sb.Append((char)b);
+                sb.Append(c);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Util/HexString.cs
+++ b/tracer/src/Datadog.Trace/Util/HexString.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using Datadog.Trace.DataStreamsMonitoring.Utils;
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Binary;
 #if NETCOREAPP
 using BitConverter = System.BitConverter;
 using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
@@ -28,7 +28,7 @@ internal static class HexString
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ulong ReverseIfLittleEndian(ulong value)
     {
-        return BitConverter.IsLittleEndian ? BinaryPrimitivesHelper.ReverseEndianness(value) : value;
+        return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value;
     }
 
     [Pure]
@@ -37,8 +37,8 @@ internal static class HexString
     {
         if (BitConverter.IsLittleEndian)
         {
-            var upper = BinaryPrimitivesHelper.ReverseEndianness(value.Upper);
-            var lower = BinaryPrimitivesHelper.ReverseEndianness(value.Lower);
+            var upper = BinaryPrimitives.ReverseEndianness(value.Upper);
+            var lower = BinaryPrimitives.ReverseEndianness(value.Lower);
 
             // We're intentionally not flipping upper/lower around. This struct doesn't act like a UInt128,
             // where the order of the field needs to be reversed. Instead, Upper is always Upper

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
+using System.Text;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using FluentAssertions;
@@ -76,16 +75,12 @@ public class W3CBaggagePropagatorTests
     [InlineData("abcd", new[] { 'x' }, "abcd")]                                      // encode a char that is not in the string
     [InlineData("abcd", new[] { 'b', 'd' }, "a%62c%64")]                             // encode chars that are in the string
     [InlineData("José 🐶\t我", new char[0], "Jos%C3%A9%20%F0%9F%90%B6%09%E6%88%91")] // always encode whitespace and unicode chars
-    public void Encode(string value, char[] charsToEncode, string expected)
+    public void EncodeAndAppend(string value, char[] charsToEncode, string expected)
     {
-        var result = W3CBaggagePropagator.Encode(value, [..charsToEncode]);
-        result.Should().Be(expected);
+        var sb = new StringBuilder();
+        W3CBaggagePropagator.EncodeStringAndAppend(sb, value, [..charsToEncode]);
 
-        if (value == expected)
-        {
-            // ensure that the method returns the same string instance when no encoding is needed
-            ReferenceEquals(value, result).Should().BeTrue();
-        }
+        sb.ToString().Should().Be(expected);
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -69,17 +69,22 @@ public class W3CBaggagePropagatorTests
         };
 
     [Theory]
-    [InlineData(null, new char[0], "")]                                              // null
-    [InlineData("", new char[0], "")]                                                // empty string
-    [InlineData("abcd", new char[0], "abcd")]                                        // no chars to encode
-    [InlineData("abcd", new[] { 'x' }, "abcd")]                                      // encode a char that is not in the string
-    [InlineData("abcd", new[] { 'b', 'd' }, "a%62c%64")]                             // encode chars that are in the string
-    [InlineData("José 🐶\t我", new char[0], "Jos%C3%A9%20%F0%9F%90%B6%09%E6%88%91")] // always encode whitespace and unicode chars
-    public void EncodeStringAndAppend(string value, char[] charsToEncode, string expected)
+    // keys
+    [InlineData(null, true, "")]                                                                     // null
+    [InlineData("", true, "")]                                                                       // empty string
+    [InlineData("abcd", true, "abcd")]                                                               // no chars to encode
+    [InlineData("José 🐶\t我", true, "Jos%C3%A9%20%F0%9F%90%B6%09%E6%88%91")]                         // always encode whitespace and Unicode chars
+    [InlineData("\",;\\()/:<=>?@[]{}", true, "%22%2C%3B%5C%28%29%2F%3A%3C%3D%3E%3F%40%5B%5D%7B%7D")] // other chars (NOTE: different from value)
+    // values
+    [InlineData(null, false, "")]                                             // null
+    [InlineData("", false, "")]                                               // empty string
+    [InlineData("abcd", false, "abcd")]                                       // no chars to encode
+    [InlineData("José 🐶\t我", false, "Jos%C3%A9%20%F0%9F%90%B6%09%E6%88%91")] // always encode whitespace and Unicode chars
+    [InlineData("\",;\\()/:<=>?@[]{}", false, "%22%2C%3B%5C()/:<=>?@[]{}")]   // other chars (NOTE: different from key)
+    public void EncodeStringAndAppend(string value, bool isKey, string expected)
     {
         var sb = new StringBuilder();
-        W3CBaggagePropagator.EncodeStringAndAppend(sb, value, [..charsToEncode]);
-
+        W3CBaggagePropagator.EncodeStringAndAppend(sb, value, isKey);
         sb.ToString().Should().Be(expected);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -75,7 +75,7 @@ public class W3CBaggagePropagatorTests
     [InlineData("abcd", new[] { 'x' }, "abcd")]                                      // encode a char that is not in the string
     [InlineData("abcd", new[] { 'b', 'd' }, "a%62c%64")]                             // encode chars that are in the string
     [InlineData("José 🐶\t我", new char[0], "Jos%C3%A9%20%F0%9F%90%B6%09%E6%88%91")] // always encode whitespace and unicode chars
-    public void EncodeAndAppend(string value, char[] charsToEncode, string expected)
+    public void EncodeStringAndAppend(string value, char[] charsToEncode, string expected)
     {
         var sb = new StringBuilder();
         W3CBaggagePropagator.EncodeStringAndAppend(sb, value, [..charsToEncode]);


### PR DESCRIPTION
## Summary of changes

Refactored how we generated the `baggage` header value in `W3CBaggagePropagator` to be faster and minimize heap allocations.

## Reason for change

Performance

## Implementation details

#### 1. `string` and `StringBuilder` management

We now use a single `StringBuilder` (from `StringBuilderCache`) to build the entire `baggage` header. Previously the code was trying to acquire a builder to encode keys and values while _already_ holding another builder for the header itself. With this change, we no longer allocate multiple `StringBuilder` instances that don't get reused, and we no longer allocation individual strings for:
- keys that need encoding
- values that need encoding
- every key/value pair (the string was built first to measure its length in UTF-8 bytes, but we don't need that anymore)

#### 2. checking earlier if string needs encoding

Before this PR, we always converted every key and value into UTF-8 bytes before checking if any bytes needed percent-encoding (aka url-encoding). When encoding was not needed (the common case), we could avoid the conversion and use the original string directly.

Now we check if the string's characters need encoding _before_ converting them to bytes. When encoding is not needed (the common case), we skip the conversion from string to UTF-8 bytes.

## Benchmarks

<details>
<summary>With allowed characters only (no percent-encoding required)</summary>

| Method | Runtime              | ItemCount | Mean        | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
|------- |--------------------- |---------- |------------:|---------:|---------:|------:|-------:|----------:|------------:|
| Before | .NET 6.0             | 1         |    91.63 ns | 0.309 ns | 0.289 ns |  1.00 | 0.0050 |      64 B |        1.00 |
| After  | .NET 6.0             | 1         |    49.84 ns | 0.162 ns | 0.152 ns |  0.54 | 0.0025 |      32 B |        0.50 |
|        |                      |           |             |          |          |       |        |           |             |
| Before | .NET Framework 4.6.1 | 1         |   253.30 ns | 1.867 ns | 1.655 ns |  1.00 | 0.0215 |     136 B |        1.00 |
| After  | .NET Framework 4.6.1 | 1         |   101.09 ns | 0.368 ns | 0.326 ns |  0.40 | 0.0063 |      40 B |        0.29 |
|        |                      |           |             |          |          |       |        |           |             |
| Before | .NET 6.0             | 5         |   343.57 ns | 1.953 ns | 1.731 ns |  1.00 | 0.0215 |     272 B |        1.00 |
| After  | .NET 6.0             | 5         |   139.36 ns | 2.696 ns | 3.104 ns |  0.41 | 0.0062 |      80 B |        0.29 |
|        |                      |           |             |          |          |       |        |           |             |
| Before | .NET Framework 4.6.1 | 5         | 1,303.19 ns | 6.138 ns | 5.742 ns |  1.00 | 0.1602 |    1019 B |        1.00 |
| After  | .NET Framework 4.6.1 | 5         |   328.44 ns | 0.956 ns | 0.848 ns |  0.25 | 0.0138 |      88 B |        0.09 |

</details>

<details>
<summary>With characters that require percent-encoding (whitespace and Unicode)</summary>

| Method | Runtime              | ItemCount | Mean       | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
|------- |--------------------- |---------- |-----------:|---------:|---------:|------:|-------:|----------:|------------:|
| Before | .NET 6.0             | 1         |   229.4 ns |  2.07 ns |  1.73 ns |  1.00 | 0.0815 |    1024 B |        1.00 |
| After  | .NET 6.0             | 1         |   105.5 ns |  0.76 ns |  0.71 ns |  0.46 | 0.0063 |      80 B |        0.08 |
|        |                      |           |            |          |          |       |        |           |             |
| Before | .NET Framework 4.6.1 | 1         |   990.2 ns |  2.04 ns |  1.60 ns |  1.00 | 0.4215 |    2656 B |        1.00 |
| After  | .NET Framework 4.6.1 | 1         |   279.9 ns |  1.46 ns |  1.37 ns |  0.28 | 0.0124 |      80 B |        0.03 |
|        |                      |           |            |          |          |       |        |           |             |
| Before | .NET 6.0             | 5         |   989.9 ns |  6.25 ns |  5.22 ns |  1.00 | 0.1469 |    1848 B |        1.00 |
| After  | .NET 6.0             | 5         |   438.5 ns |  4.18 ns |  3.91 ns |  0.44 | 0.0234 |     296 B |        0.16 |
|        |                      |           |            |          |          |       |        |           |             |
| Before | .NET Framework 4.6.1 | 5         | 4,989.7 ns | 50.79 ns | 45.02 ns |  1.00 | 1.6556 |   10447 B |        1.00 |
| After  | .NET Framework 4.6.1 | 5         | 1,243.1 ns |  7.70 ns |  7.20 ns |  0.25 | 0.0458 |     297 B |        0.03 |

</details>

## Test coverage

All `W3CBaggagePropagatorTests` are passing.

## Other details
Follow-up from #6158.
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
