### PR TITLE
[Profiler] Add metrics for cpu and walltime profilers

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardMetrics.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardMetrics.cpp
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "DiscardMetrics.h"
+
+DiscardMetrics::DiscardMetrics(std::string name) :
+    MetricBase(std::move(name)), _metrics{0}
+{
+}
+
+std::list<MetricBase::Metric> DiscardMetrics::GetMetrics()
+{
+    std::list<MetricBase::Metric> result;
+    for (std::size_t idx = 0; idx < _metrics.size(); idx++)
+    {
+        auto& metric = _metrics[idx];
+        result.emplace_back(
+            std::make_pair(_name + to_string(static_cast<DiscardReason>(idx)),
+                           metric.exchange(0)));
+    }
+    return result;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardMetrics.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardMetrics.h
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <list>
+#include <string>
+#include <utility>
+
+#include "MetricBase.h"
+#include "DiscardReason.h"
+
+class DiscardMetrics : public MetricBase
+{
+private:
+    static constexpr std::size_t array_size = static_cast<std::size_t>(DiscardReason::GuardItem);
+
+public:
+    explicit DiscardMetrics(std::string name);
+
+    template <DiscardReason TType>
+    void Incr()
+    {
+        static_assert(TType != DiscardReason::GuardItem, "You must not use DiscardReason::GuardItem");
+        constexpr auto offset = static_cast<int>(TType);
+        static_assert(offset <= array_size, "Unknown TType");
+        static_assert(0 <= offset, "Unknown TType (offset is negative)");
+        _metrics[offset]++;
+    }
+
+    std::list<MetricBase::Metric> GetMetrics() override;
+
+private:
+    std::array<std::atomic<std::uint64_t>, array_size> _metrics;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardMetrics.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardMetrics.hpp
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma
+
+#include <list>
+#include <string>
+#include <utility>
+
+#include "MetricBase.h"
+
+enum class DiscardReason
+{
+    InSegvHandler = 0,
+    InsideWrappedFunction,
+    ExternalSignal,
+    UnknownThread,
+    WrongManagedThread,
+    UnsufficientSpace,
+    EmptyBacktrace,
+
+    // This item must be the last one
+    GuardItem
+};
+
+// This pragma forces a compilation error if we forgot to add an enum item
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wswitch"
+#else
+#pragma warning(error : 4062)
+#endif
+static const char* to_string(DiscardReason type)
+{
+    switch (type)
+    {
+        case DiscardReason::InSegvHandler:
+            return "_in_sigsegv_handler";
+        case DiscardReason::InsideWrappedFunction:
+            return "_inside_wrapped_function";
+        case DiscardReason::ExternalSignal:
+            return "_external_signal";
+        case DiscardReason::UnknownThread:
+            return "_unknown_thread";
+        case DiscardReason::WrongManagedThread:
+            return "_wrong_managed_thread";
+        case DiscardReason::UnsufficientSpace:
+            return "_unsufficient_space";
+        case DiscardReason::EmptyBacktrace:
+            return "_empty_backtrace";
+        case DiscardReason::GuardItem:
+            // pass through
+            break;
+    }
+    return "unknown_discard_type";
+}
+#if __clang__
+#pragma clang diagnostic pop
+#else
+#pragma warning(default : 4062)
+#endif
+
+class DiscardMetrics : public MetricBase
+{
+private:
+    static constexpr std::size_t array_size = static_cast<std::size_t>(DiscardReason::GuardItem);
+
+public:
+    DiscardMetrics(std::string name) :
+        MetricBase(std::move(name)), _metrics{0}
+    {
+    }
+
+    template <DiscardReason TType>
+    void Incr()
+    {
+        static_assert(TType != DiscardReason::GuardItem, "You must not use DiscardReason::GuardItem");
+        constexpr auto offset = static_cast<int>(TType);
+        static_assert(offset <= array_size, "");
+        _metrics[offset]++;
+    }
+
+    std::list<MetricBase::Metric> GetMetrics() override
+    {
+        std::list<MetricBase::Metric> result;
+        for (std::size_t idx = 0; idx < _metrics.size(); idx++)
+        {
+            auto& metric = _metrics[idx];
+            result.emplace_back(
+                std::make_pair(_name + to_string(static_cast<DiscardReason>(idx)),
+                metric.exchange(0)));
+        }
+        return result;
+    }
+
+private:
+    std::array<std::atomic<std::uint64_t>, array_size> _metrics;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardReason.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DiscardReason.h
@@ -12,6 +12,7 @@ enum class DiscardReason
     WrongManagedThread,
     UnsufficientSpace,
     EmptyBacktrace,
+    FailedAcquiringLock,
 
     // This item must be the last one
     GuardItem
@@ -42,6 +43,8 @@ static const char* to_string(DiscardReason type)
             return "_unsufficient_space";
         case DiscardReason::EmptyBacktrace:
             return "_empty_backtrace";
+        case DiscardReason::FailedAcquiringLock:
+            return "_failed_acquiring_lock";
         case DiscardReason::GuardItem:
             // pass through
             break;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -13,7 +13,7 @@
 #include <unordered_map>
 
 #include "CallstackProvider.h"
-#include "DiscardMetrics.hpp"
+#include "DiscardMetrics.h"
 #include "IConfiguration.h"
 #include "Log.h"
 #include "ManagedThreadInfo.h"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -60,9 +60,11 @@ std::pair<DWORD, std::string> GetLastErrorMessage()
 std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(
     ICorProfilerInfo4* pCorProfilerInfo,
     IConfiguration const* const pConfiguration,
-    CallstackProvider* callstackProvider)
+    CallstackProvider* callstackProvider,
+    MetricsRegistry& metricsRegistry)
 {
-    return std::make_unique<LinuxStackFramesCollector>(ProfilerSignalManager::Get(SIGUSR1), pConfiguration, callstackProvider);
+    return std::make_unique<LinuxStackFramesCollector>(
+        ProfilerSignalManager::Get(SIGUSR1), pConfiguration, callstackProvider, metricsRegistry);
 }
 
 // https://linux.die.net/man/5/proc

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -4,7 +4,7 @@
 #include "TimerCreateCpuProfiler.h"
 
 #include "CpuTimeProvider.h"
-#include "DiscardMetrics.hpp"
+#include "DiscardMetrics.h"
 #include "IManagedThreadList.h"
 #include "Log.h"
 #include "OpSysTools.h"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -35,7 +35,7 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     Log::Info("Cpu profiling interval: ", _samplingInterval.count(), "ms");
     Log::Info("timer_create Cpu profiler is enabled");
     _totalSampling = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_cpu_sampling_requests");
-    _discardMetrics = metricsRegistry.GetOrRegister<DiscardMetrics>("dotnet_cpu_sample_discard");
+    _discardMetrics = metricsRegistry.GetOrRegister<DiscardMetrics>("dotnet_cpu_sample_discarded");
 }
 
 TimerCreateCpuProfiler::~TimerCreateCpuProfiler()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -4,6 +4,7 @@
 #include "TimerCreateCpuProfiler.h"
 
 #include "CpuTimeProvider.h"
+#include "DiscardMetrics.hpp"
 #include "IManagedThreadList.h"
 #include "Log.h"
 #include "OpSysTools.h"
@@ -22,7 +23,8 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     ProfilerSignalManager* pSignalManager,
     IManagedThreadList* pManagedThreadsList,
     CpuTimeProvider* pProvider,
-    CallstackProvider callstackProvider) noexcept
+    CallstackProvider callstackProvider,
+    MetricsRegistry& metricsRegistry) noexcept
     :
     _pSignalManager{pSignalManager}, // put it as parameter for better testing
     _pManagedThreadsList{pManagedThreadsList},
@@ -32,6 +34,8 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
 {
     Log::Info("Cpu profiling interval: ", _samplingInterval.count(), "ms");
     Log::Info("timer_create Cpu profiler is enabled");
+    _totalSampling = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_cpu_sampling_requests");
+    _discardMetrics = metricsRegistry.GetOrRegister<DiscardMetrics>("dotnet_cpu_sample_discard");
 }
 
 TimerCreateCpuProfiler::~TimerCreateCpuProfiler()
@@ -122,6 +126,7 @@ bool TimerCreateCpuProfiler::CanCollect(void* ctx)
     // TODO (in another PR): add metrics about reasons we could not collect
     if (dd_inside_wrapped_functions != nullptr && dd_inside_wrapped_functions() != 0)
     {
+        _discardMetrics->Incr<DiscardReason::InsideWrappedFunction>();
         return false;
     }
 
@@ -131,6 +136,7 @@ bool TimerCreateCpuProfiler::CanCollect(void* ctx)
     // but that less likely)
     if (sigismember(&(context->uc_sigmask), SIGSEGV) == 1)
     {
+        _discardMetrics->Incr<DiscardReason::InSegvHandler>();
         return false;
     }
 
@@ -184,9 +190,12 @@ private:
 
 bool TimerCreateCpuProfiler::Collect(void* ctx)
 {
+    _totalSampling->Incr();
+
     auto threadInfo = ManagedThreadInfo::CurrentThreadInfo;
     if (threadInfo == nullptr)
     {
+        _discardMetrics->Incr<DiscardReason::UnknownThread>();
         // Ooops should never happen
         return false;
     }
@@ -209,6 +218,7 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
 
     if (callstack.Capacity() <= 0)
     {
+        _discardMetrics->Incr<DiscardReason::UnsufficientSpace>();
         return false;
     }
 
@@ -219,12 +229,14 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
 
     if (count == 0)
     {
-        // TODO a metric on event without callstack ?
+        _discardMetrics->Incr<DiscardReason::EmptyBacktrace>();
         return false;
     }
 
     RawCpuSample rawCpuSample;
 
+    // TO FIX this breaks the CI Visibility.
+    // No Cpu samples will have the predefined span id, root local span id
     std::tie(rawCpuSample.LocalRootSpanId, rawCpuSample.SpanId) = threadInfo->GetTracingContext();
 
     rawCpuSample.Timestamp = OpSysTools::GetTimestampSafe();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -203,6 +203,7 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
     StackWalkLock l(threadInfo);
     if (!l.IsLockAcquired())
     {
+        _discardMetrics->Incr<DiscardReason::FailedAcquiringLock>();
         return false;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include "CallstackProvider.h"
+#include "CounterMetric.h"
 #include "ManagedThreadInfo.h"
+#include "MetricsRegistry.h"
 #include "ServiceBase.h"
 
 #include <signal.h>
@@ -15,6 +17,7 @@
 #include <shared_mutex>
 #include <unordered_set>
 
+class DiscardMetrics;
 class IConfiguration;
 class IThreadInfo;
 class IManagedThreadList;
@@ -30,7 +33,8 @@ public:
         ProfilerSignalManager* pSignalManager,
         IManagedThreadList* pManagedThreadsList,
         CpuTimeProvider* pProvider,
-        CallstackProvider calstackProvider) noexcept;
+        CallstackProvider calstackProvider,
+        MetricsRegistry& metricsRegistry) noexcept;
 
     ~TimerCreateCpuProfiler();
 
@@ -41,9 +45,9 @@ public:
 
 private:
     static bool CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext);
-    static bool CanCollect(void* context);
     static TimerCreateCpuProfiler* Instance;
 
+    bool CanCollect(void* context);
     bool Collect(void* ucontext);
     void RegisterThreadImpl(ManagedThreadInfo* thread);
     void UnregisterThreadImpl(ManagedThreadInfo* threadInfo);
@@ -57,4 +61,6 @@ private:
     CallstackProvider _callstackProvider;
     std::chrono::milliseconds _samplingInterval;
     std::shared_mutex _registerLock;
+    std::shared_ptr<CounterMetric> _totalSampling;
+    std::shared_ptr<DiscardMetrics> _discardMetrics;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -66,7 +66,11 @@ std::pair<DWORD, std::string> GetLastErrorMessage()
     return std::make_pair(errorCode, message);
 }
 
-std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* const pConfiguration, CallstackProvider* callstackProvider)
+std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(
+    ICorProfilerInfo4* pCorProfilerInfo,
+    IConfiguration const* const pConfiguration,
+    CallstackProvider* callstackProvider,
+    MetricsRegistry&)
 {
 #ifdef BIT64
     static_assert(8 * sizeof(void*) == 64);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -84,7 +84,8 @@ AllocationsProvider::AllocationsProvider(
     _sampler(pConfiguration->AllocationSampleLimit(), pConfiguration->GetUploadInterval()),
     _sampleLimit(pConfiguration->AllocationSampleLimit()),
     _pConfiguration(pConfiguration),
-    _callstackProvider{std::move(pool)}
+    _callstackProvider{std::move(pool)},
+    _metricsRegistry{metricsRegistry}
 {
     _allocationsCountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_allocations");
     _allocationsSizeMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_allocations_size");
@@ -119,7 +120,8 @@ void AllocationsProvider::OnAllocation(uint32_t allocationKind,
     std::shared_ptr<ManagedThreadInfo> threadInfo;
     CALL(_pManagedThreadList->TryGetCurrentThreadInfo(threadInfo))
 
-    const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, _pConfiguration, &_callstackProvider);
+    const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(
+        _pCorProfilerInfo, _pConfiguration, &_callstackProvider, _metricsRegistry);
     pStackFramesCollector->PrepareForNextCollection();
 
     uint32_t hrCollectStack = E_FAIL;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
@@ -95,4 +95,5 @@ private:
     std::shared_ptr<MeanMaxMetric> _sampledAllocationsSizeMetric;
     std::shared_ptr<SumMetric> _totalAllocationsSizeMetric;
     CallstackProvider _callstackProvider;
+    MetricsRegistry& _metricsRegistry;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -48,7 +48,8 @@ ContentionProvider::ContentionProvider(
     _contentionDurationThreshold{pConfiguration->ContentionDurationThreshold()},
     _sampleLimit{pConfiguration->ContentionSampleLimit()},
     _pConfiguration{pConfiguration},
-    _callstackProvider{std::move(callstackProvider)}
+    _callstackProvider{std::move(callstackProvider)},
+    _metricsRegistry{metricsRegistry}
 {
     _lockContentionsCountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_lock_contentions");
     _lockContentionsDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_lock_contentions_duration");
@@ -130,7 +131,8 @@ void ContentionProvider::AddContentionSample(uint64_t timestamp, uint32_t thread
         std::shared_ptr<ManagedThreadInfo> threadInfo;
         CALL(_pManagedThreadList->TryGetCurrentThreadInfo(threadInfo))
 
-        const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, _pConfiguration, &_callstackProvider);
+        const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(
+            _pCorProfilerInfo, _pConfiguration, &_callstackProvider, _metricsRegistry);
         pStackFramesCollector->PrepareForNextCollection();
 
         uint32_t hrCollectStack = E_FAIL;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -75,6 +75,6 @@ private:
     std::shared_ptr<CounterMetric> _sampledLockContentionsCountMetric;
     std::shared_ptr<MeanMaxMetric> _sampledLockContentionsDurationMetric;
     std::mutex _contentionsLock;
-
+    MetricsRegistry& _metricsRegistry;
     CallstackProvider _callstackProvider;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -487,7 +487,8 @@ void CorProfilerCallback::InitializeServices()
             ProfilerSignalManager::Get(SIGPROF),
             _pManagedThreadList,
             _pCpuTimeProvider,
-            CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize, useMmap)));
+            CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize, useMmap)),
+            _metricsRegistry);
     }
 #endif
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
@@ -45,7 +45,8 @@ ExceptionsProvider::ExceptionsProvider(
     _loggedMscorlibError(false),
     _sampler(pConfiguration->ExceptionSampleLimit(), pConfiguration->GetUploadInterval(), true),
     _pConfiguration(pConfiguration),
-    _callstackProvider{std::move(callstackProvider)}
+    _callstackProvider{std::move(callstackProvider)},
+    _metricsRegistry{metricsRegistry}
 {
     _exceptionsCountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_exceptions");
     _sampledExceptionsCountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_sampled_exceptions");
@@ -143,7 +144,8 @@ bool ExceptionsProvider::OnExceptionThrown(ObjectID thrownObjectId)
     INVOKE(_pManagedThreadList->TryGetCurrentThreadInfo(threadInfo))
 
     uint32_t hrCollectStack = E_FAIL;
-    const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, _pConfiguration, &_callstackProvider);
+    const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(
+        _pCorProfilerInfo, _pConfiguration, &_callstackProvider, _metricsRegistry);
 
     pStackFramesCollector->PrepareForNextCollection();
     const auto result = pStackFramesCollector->CollectStackSample(threadInfo.get(), &hrCollectStack);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
@@ -79,4 +79,5 @@ private:
     std::shared_ptr<CounterMetric> _exceptionsCountMetric;
     std::shared_ptr<CounterMetric> _sampledExceptionsCountMetric;
     CallstackProvider _callstackProvider;
+    MetricsRegistry& _metricsRegistry;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -5,6 +5,7 @@
 #include "cor.h"
 #include "corprof.h"
 
+#include "MetricsRegistry.h"
 #include "StackFramesCollectorBase.h"
 
 // forward declarations
@@ -26,18 +27,27 @@ namespace OsSpecificApi
     std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(
         ICorProfilerInfo4* pCorProfilerInfo,
         IConfiguration const* pConfiguration,
-        CallstackProvider* callstackProvider);
+        CallstackProvider* callstackProvider,
+        MetricsRegistry& metricsRegistry);
+
     uint64_t GetThreadCpuTime(IThreadInfo* pThreadInfo);
+
     bool IsRunning(IThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
+
     int32_t GetProcessorCount();
+
     std::vector<std::shared_ptr<IThreadInfo>> GetProcessThreads();
+
     std::pair<DWORD, std::string> GetLastErrorMessage();
+
     std::string GetProcessStartTime();
+
     std::unique_ptr<IEtwEventsManager> CreateEtwEventsManager(
         IAllocationsListener* pAllocationListener,
         IContentionListener* pContentionListener,
         IGCSuspensionsListener* pGCSuspensionsListener,
         IConfiguration* pConfiguration
         );
+
     double GetProcessLifetime();
  } // namespace OsSpecificApi

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -63,7 +63,8 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     _callstackProvider{std::move(callstackProvider)}
 {
     _pCorProfilerInfo->AddRef();
-    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, pConfiguration, &_callstackProvider);
+    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(
+        _pCorProfilerInfo, pConfiguration, &_callstackProvider, _metricsRegistry);
 
     _currentStatistics = std::make_unique<Statistics>();
     _statisticCollectionStartNs = OpSysTools::GetHighPrecisionNanoseconds();

--- a/profiler/test/Datadog.Profiler.Native.Tests/DiscardMetricsTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/DiscardMetricsTest.cpp
@@ -4,7 +4,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "DiscardMetrics.hpp"
+#include "DiscardMetrics.h"
 #include "MetricsRegistry.h"
 
 TEST(DiscardMetricsTest, CheckDefaultValue)
@@ -13,7 +13,7 @@ TEST(DiscardMetricsTest, CheckDefaultValue)
 
     auto m = registry.GetOrRegister<DiscardMetrics>("my_discard_");
     auto metrics = m->GetMetrics();
-    ASSERT_EQ(metrics.size(), 7);
+    ASSERT_EQ(metrics.size(), 8);
 
     for (auto [name, value] : m->GetMetrics())
     {
@@ -59,10 +59,11 @@ TEST(DiscardMetricsTest, CheckAllDiscardReasons)
         m->Incr<DiscardReason::WrongManagedThread>();
         m->Incr<DiscardReason::UnsufficientSpace>();
         m->Incr<DiscardReason::EmptyBacktrace>();
+        m->Incr<DiscardReason::FailedAcquiringLock>();
     }
 
     auto metrics = m->GetMetrics();
-    ASSERT_EQ(7, metrics.size());
+    ASSERT_EQ(8, metrics.size());
 
     for (auto const& [_, value] : metrics)
     {

--- a/profiler/test/Datadog.Profiler.Native.Tests/DiscardMetricsTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/DiscardMetricsTest.cpp
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "DiscardMetrics.hpp"
+#include "MetricsRegistry.h"
+
+TEST(DiscardMetricsTest, CheckDefaultValue)
+{
+    auto registry = MetricsRegistry{};
+
+    auto m = registry.GetOrRegister<DiscardMetrics>("my_discard_");
+    auto metrics = m->GetMetrics();
+    ASSERT_EQ(metrics.size(), 7);
+
+    for (auto [name, value] : m->GetMetrics())
+    {
+        ASSERT_EQ(value, 0);
+    }
+}
+
+TEST(DiscardMetricsTest, CheckOnlyOneIsIncremented)
+{
+    auto registry = MetricsRegistry{};
+
+    auto m = registry.GetOrRegister<DiscardMetrics>("my_discard_");
+
+    m->Incr<DiscardReason::ExternalSignal>();
+
+    auto metricName = std::string("my_discard_") +  to_string(DiscardReason::ExternalSignal);
+    for (auto [name, value] : m->GetMetrics())
+    {
+        if (metricName == name)
+        {
+            ASSERT_EQ(value, 1);
+        }
+        else
+        {
+            ASSERT_EQ(value, 0);
+        }
+    }
+}
+
+TEST(DiscardMetricsTest, CheckAllDiscardReasons)
+{
+    auto registry = MetricsRegistry{};
+
+    auto m = registry.GetOrRegister<DiscardMetrics>("my_discard_");
+
+    const std::size_t expectedMetricValue = 10;
+    for (std::size_t i = 0; i < expectedMetricValue; i++)
+    {
+        m->Incr<DiscardReason::InSegvHandler>();
+        m->Incr<DiscardReason::InsideWrappedFunction>();
+        m->Incr<DiscardReason::ExternalSignal>();
+        m->Incr<DiscardReason::UnknownThread>();
+        m->Incr<DiscardReason::WrongManagedThread>();
+        m->Incr<DiscardReason::UnsufficientSpace>();
+        m->Incr<DiscardReason::EmptyBacktrace>();
+    }
+
+    auto metrics = m->GetMetrics();
+    ASSERT_EQ(7, metrics.size());
+
+    for (auto const& [_, value] : metrics)
+    {
+        ASSERT_EQ(value, expectedMetricValue);
+    }
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -249,9 +249,9 @@ public:
         return ProfilerSignalManager::Get(SIGUSR1);
     }
 
-    static LinuxStackFramesCollector CreateStackFramesCollector(ProfilerSignalManager* signalManager, IConfiguration* configuration, CallstackProvider* p)
+    static LinuxStackFramesCollector CreateStackFramesCollector(ProfilerSignalManager* signalManager, IConfiguration* configuration, CallstackProvider* p, MetricsRegistry& metricsRegistry)
     {
-        return LinuxStackFramesCollector(signalManager, configuration, p);
+        return LinuxStackFramesCollector(signalManager, configuration, p, metricsRegistry);
     }
 
 private:
@@ -325,7 +325,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckSamplingThreadCollectCallStack)
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)GetWorkerThreadId(), (HANDLE)0);
@@ -350,7 +351,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckSamplingThreadCollectCallStackWith
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(false));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)GetWorkerThreadId(), (HANDLE)0);
@@ -377,7 +379,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckCollectionAbortIfInPthreadCreateCa
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)GetWorkerThreadId(), (HANDLE)0);
@@ -399,7 +402,8 @@ TEST_F(LinuxStackFramesCollectorFixture, MustNotCollectIfUnknownThreadId)
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo(0, (HANDLE)0);
@@ -422,7 +426,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerSignalHandlerIsRestoredIfA
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     // Validate the profiler is working correctly
     auto threadId = (DWORD)GetWorkerThreadId();
@@ -488,7 +493,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerHandlerIsInstalledCorrectl
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     std::uint32_t hr;
     StackSnapshotResultBuffer* buffer;
@@ -532,7 +538,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerHandlerIsInstalledCorrectl
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     std::uint32_t hr;
     StackSnapshotResultBuffer* buffer;
@@ -576,7 +583,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerHandlerIsInstalledCorrectl
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     std::uint32_t hr;
     StackSnapshotResultBuffer* buffer;
@@ -618,7 +626,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckNoCrashIfPreviousHandlerWasMarkedA
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     EXPECT_EQ(sigaction(SIGUSR1, nullptr, &currentAction), 0) << "Unable to get current action.";
     EXPECT_NE(currentAction.sa_handler, SIG_DFL);
@@ -642,7 +651,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckThatProfilerHandlerAndOtherHandler
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     // 3rd now point to the profiler handler
     InstallHandler(SA_SIGINFO, true);
@@ -681,7 +691,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckNoCrashIfNoPreviousHandlerInstalle
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     EXPECT_EQ(sigaction(SIGUSR1, nullptr, &currentAction), 0) << "Unable to get current action.";
     EXPECT_NE(currentAction.sa_handler, SIG_DFL);
@@ -701,7 +712,8 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckTheProfilerStopWorkingIfSignalHand
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
 
     CallstackProvider p(MemoryResourceManager::GetDefault());
-    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p);
+    MetricsRegistry metricsRegistry;
+    auto collector = CreateStackFramesCollector(signalManager, configuration.get(), &p, metricsRegistry);
 
     const auto threadId = GetWorkerThreadId();
     auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);


### PR DESCRIPTION
## Summary of changes

Add metrics on signal-based profilers.

## Reason for change

The goal is to provide visibility on discarded or failing at collecting samples for CPU and walltime profilers (signal-based profilers)

## Implementation details

- Add an enum `DiscardReason`  which reflects the reason a sample could be discarded
- Add a class `DiscardMetrics` which is partially templated on `DiscardReason` and encapsulates one metrics per enum item

## Test coverage

Add unit tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
