### PR TITLE
[Profiler] Fix crash at shutdown with the `timer_create`-based CPU profiler

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
@@ -36,6 +36,18 @@ __attribute__((visibility("hidden"))) inline int is_interrupted_by_profiler(int 
     return rc == -1L && error_code == EINTR && interrupted_by_profiler != 0;
 }
 
+
+void (*volatile dd_on_thread_routine_finished)() = NULL;
+__attribute__((visibility("hidden"))) inline void __dd_on_thread_routine_finished()
+{
+    void (*volatile on_thread_routine_finished)() = dd_on_thread_routine_finished;
+
+    if (on_thread_routine_finished == NULL)
+        return;
+
+    on_thread_routine_finished();
+}
+
 char* dlerror(void) __attribute__((weak));
 static void* s_libdl_handle = NULL;
 static void* s_libpthread_handle = NULL;

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.h
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.h
@@ -36,5 +36,6 @@ extern int (*volatile dd_set_shared_memory)(volatile int*);
 int is_interrupted_by_profiler(int rc, int error_code, int interrupted_by_profiler);
 int __dd_set_shared_memory(volatile int* mem);
 void __dd_notify_libraries_cache_update();
+void __dd_on_thread_routine_finished();
 
 void *__dd_dlsym(void *handle, const char *symbol);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1320,6 +1320,13 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown()
 {
     Log::Info("CorProfilerCallback::Shutdown()");
 
+#ifdef LINUX
+    if (_pCpuProfiler != nullptr)
+    {
+        _pCpuProfiler->Stop();
+    }
+#endif
+
     // A final .pprof should be generated before exiting
     // The aggregator must be stopped before the provider, since it will call them to get the last samples
     _pStackSamplerLoopManager->Stop();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -283,6 +283,7 @@ private:
     static void InspectProcessorInfo();
     static const char* SysInfoProcessorArchitectureToStr(WORD wProcArch);
     static void PrintEnvironmentVariables();
+    static void OnThreadRoutineFinished();
 
     void InspectRuntimeVersion(ICorProfilerInfo5* pCorProfilerInfo, USHORT& major, USHORT& minor, COR_PRF_RUNTIME_TYPE& runtimeType);
     void DisposeInternal();


### PR DESCRIPTION
## Summary of changes

Make sure the profiler does not crash at shutdown.

## Reason for change

For the `timer_create`-based CPU profiler, each managed thread is associated to timer so that every 9ms, a callback is called and we collect the thread snapshot (metadata + callstack). To store in a signal-safe manner the thread snapshot we use a  `synchronized_pool_resource`(https://en.cppreference.com/w/cpp/memory/synchronized_pool_resource) + `mmap` as an upstream (when the pool needs more memory, it calls into `mmap` and not `malloc`). As an optimization, this resource uses a thread local variable so each native thread has its own pools (reduce lock contention).

When an application is shutting down, the CLR follows a sequence of steps to stop and clean the resources it used. One of those steps is to notify the ICorprofiler profilers (through the callbacks). When a managed thread is terminated, it cleans up the associated resource, call the `ThreadDestroyed` callback... When the CLR is done with the thread clean up (the routine passed to the native thread ends), the libc takes on and cleans up the native resources (clean up thread local storage...).

But sometimes, those `ThreadDestroyed` is not called and it happens when the Execution Engine has started to shutdown https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/threads.cpp#L2777
This leads up to a crash situation where:
- The timer associated is still here
- Libc is destroying thread local storage for this thread
- The timer kicks in, starts collecting the thread snapshot and use the pools associated to the thread (which are being destroyed) to store it.


## Implementation details

- Use the `pthread_create` wrapping to wrap the thread entrypoint.
- Add a callback into `CorProfilerCallback` to do extra cleanup.

## Test coverage

Current tests should not crash at shutdown
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
