### PR TITLE
[ASM] Serialize ASM tags and metrics

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Processors;
 using Datadog.Trace.Propagators;
@@ -75,6 +76,12 @@ namespace Datadog.Trace.Agent.MessagePack
         private readonly byte[] _processIdNameBytes = StringEncoding.UTF8.GetBytes(Metrics.ProcessId);
 
         private readonly byte[] _apmEnabledBytes = StringEncoding.UTF8.GetBytes(Metrics.ApmEnabled);
+
+        // ASM tags
+        private readonly byte[] _appSecEnabledBytes = StringEncoding.UTF8.GetBytes(Metrics.AppSecEnabled);
+        private readonly byte[] _wafRuleFileVersionBytes = StringEncoding.UTF8.GetBytes(Tags.AppSecRuleFileVersion);
+        private readonly byte[] _runtimeFamilyBytes = StringEncoding.UTF8.GetBytes(Tags.RuntimeFamily);
+        private Dictionary<string, byte[]> _wafRuleFileVersionValues = new();
 
         // Azure App Service tag names and values
         private byte[] _aasSiteNameTagNameBytes;
@@ -459,6 +466,17 @@ namespace Datadog.Trace.Agent.MessagePack
                 }
             }
 
+            if (Security.Instance.AppsecEnabled && model.IsLocalRoot)
+            {
+                count++;
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeFamilyBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageValueBytes);
+
+                count++;
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _wafRuleFileVersionBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, GetAppSecRulesetVersion(Security.Instance.WafRuleFileVersion));
+            }
+
             // AAS tags need to be set on any span for the backend to properly handle the billing.
             // That said, it's more intuitive to find it on the local root for the customer.
             if (model.TraceChunk.IsRunningInAzureAppService && model.TraceChunk.AzureAppServiceSettings is { } azureAppServiceSettings)
@@ -644,6 +662,13 @@ namespace Datadog.Trace.Agent.MessagePack
                 offset += MessagePackBinary.WriteDouble(ref bytes, offset, 0);
             }
 
+            if (Security.Instance.AppsecEnabled && model.IsLocalRoot)
+            {
+                count++;
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _appSecEnabledBytes);
+                offset += MessagePackBinary.WriteDouble(ref bytes, offset, 1.0);
+            }
+
             // add "_sampling_priority_v1" tag to all "chunk orphans"
             // (spans whose parents are not found in the same chunk)
             if (model.IsChunkOrphan && model.TraceChunk.SamplingPriority is { } samplingPriority)
@@ -705,6 +730,20 @@ namespace Datadog.Trace.Agent.MessagePack
         TraceChunkModel IMessagePackFormatter<TraceChunkModel>.Deserialize(byte[] bytes, int offset, IFormatterResolver formatterResolver, out int readSize)
         {
             throw new NotSupportedException($"{nameof(SpanMessagePackFormatter)} does not support deserialization. For testing purposes, deserialize using the MessagePack NuGet package.");
+        }
+
+        private byte[] GetAppSecRulesetVersion(string version)
+        {
+            if (_wafRuleFileVersionValues.TryGetValue(version, out byte[] bytes))
+            {
+                return bytes;
+            }
+            else
+            {
+                bytes = StringEncoding.UTF8.GetBytes(version);
+                _wafRuleFileVersionValues.Add(version, bytes);
+                return bytes;
+            }
         }
 
         private void InitializeAasTags()

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -466,7 +466,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 }
             }
 
-            if (Security.Instance.AppsecEnabled && model.IsLocalRoot)
+            if (Security.Instance.AppsecEnabled && model.IsLocalRoot && span.Context.TraceContext?.WafExecuted is true)
             {
                 count++;
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeFamilyBytes);
@@ -662,7 +662,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 offset += MessagePackBinary.WriteDouble(ref bytes, offset, 0);
             }
 
-            if (Security.Instance.AppsecEnabled && model.IsLocalRoot)
+            if (Security.Instance.AppsecEnabled && model.IsLocalRoot && span.Context.TraceContext?.WafExecuted is true)
             {
                 count++;
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _appSecEnabledBytes);

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -122,6 +122,11 @@ internal readonly partial struct SecurityCoordinator
             Log.Error(ex, "Call into the security module failed with arguments {Args}", stringBuilder.ToString());
         }
 
+        if (_localRootSpan.Context.TraceContext is not null)
+        {
+            _localRootSpan.Context.TraceContext.WafExecuted = true;
+        }
+
         return result;
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -121,13 +121,6 @@ internal readonly partial struct SecurityCoordinator
 
             Log.Error(ex, "Call into the security module failed with arguments {Args}", stringBuilder.ToString());
         }
-        finally
-        {
-            // annotate span
-            _localRootSpan.SetMetric(Metrics.AppSecEnabled, 1.0);
-            _localRootSpan.SetTag(Tags.AppSecRuleFileVersion, _security.WafRuleFileVersion);
-            _localRootSpan.SetTag(Tags.RuntimeFamily, TracerConstants.Language);
-        }
 
         return result;
     }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -116,6 +116,8 @@ namespace Datadog.Trace
             }
         }
 
+        internal bool WafExecuted { get; set; }
+
         internal static TraceContext? GetTraceContext(in ArraySegment<Span> spans) =>
             spans.Count > 0 ?
                 spans.Array![spans.Offset].Context.TraceContext :


### PR DESCRIPTION
## Summary of changes

Some of the ASM tags and metrics that are added to the span can be added during the span's serialization. This change would increase the performance of such operations.

## Reason for change

## Implementation details

## Test coverage

The integration tests already test the presence of such tags and metrics, so passing them with this approach would validate the implementation.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
