### PR TITLE
[ASM] Fix benchmarks AppSecBodyBenchmarks: have a trace context to avoid null reference exceptions

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -73,7 +73,10 @@ namespace Benchmarks.Trace.Asm
 
         private void ExecuteCycle(object body)
         {
-            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow);
+            var traceContext = new Datadog.Trace.TraceContext(new EmptyDatadogTracer(), null);
+            var spanContext = new SpanContext(parent: null, traceContext, serviceName: "My Service Name", traceId: (TraceId)100, spanId: 200);
+            var span = new Span(spanContext, DateTimeOffset.Now);
+
 #if !NETFRAMEWORK
             _security.CheckBody(_httpContext, span, body, false);
             var context = _httpContext.Features.Get<IContext>();

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/EmptyDatadogTracer.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/EmptyDatadogTracer.cs
@@ -1,0 +1,33 @@
+// <copyright file="EmptyDatadogTracer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+// <copyright file="EmptyDatadogTracer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace;
+using Datadog.Trace.Configuration;
+
+namespace Benchmarks.Trace.Asm
+{
+    public class EmptyDatadogTracer : IDatadogTracer
+    {
+        public string DefaultServiceName => "My Service Name";
+
+        public ImmutableTracerSettings Settings => throw new NotImplementedException();
+
+        IGitMetadataTagsProvider IDatadogTracer.GitMetadataTagsProvider => throw new NotImplementedException();
+
+        PerTraceSettings IDatadogTracer.PerTraceSettings => throw new NotImplementedException();
+
+        void IDatadogTracer.Write(ArraySegment<Span> span)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Not having a trace context generates a crash at https://github.com/DataDog/dd-trace-dotnet/blob/748ade8d70e2a66bf21694485f6daf2565423327/tracer/src/Datadog.Trace/AppSec/ApiSecurity.cs#L38
which in turn generates a huge amount of error logs saturating the server's disk

## Reason for change

Fix benchmark creating a trace context.
https://datadoghq.atlassian.net/browse/APPSEC-55826

## Implementation details

## Test coverage

## Other details

Would be nice to monitor error logs in benchmarks in CI
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
