### PR TITLE
[Dynamic Instrumentation] DEBUG-3105 Add code origin for entry spans

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Caching/ConcurrentAdaptiveCache.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Caching/ConcurrentAdaptiveCache.cs
@@ -242,6 +242,11 @@ namespace Datadog.Trace.Debugger.Caching
             _lock.EnterWriteLock();
             try
             {
+                if (_cache.TryGetValue(key, out var item))
+                {
+                    return value;
+                }
+
                 value = valueFactory(key);
                 AddOrUpdate(key, value, slidingExpiration);
                 return value;

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -39,6 +39,7 @@ internal static class EndpointDetector
         "Microsoft.AspNetCore.Mvc.HttpPatchAttribute",
         "Microsoft.AspNetCore.Mvc.HttpHeadAttribute",
         "Microsoft.AspNetCore.Mvc.HttpOptionsAttribute",
+        "Microsoft.AspNetCore.Mvc.Routing.HttpMethodAttribute"
     ];
 
     private static readonly HashSet<string> SignalRHubBaseNames =
@@ -64,7 +65,9 @@ internal static class EndpointDetector
                 continue;
             }
 
-            bool isPageModel = false, isSignalRHub = false, isCompilerGeneratedType = false;
+            bool isPageModel = false;
+            bool isSignalRHub = false;
+            bool isCompilerGeneratedType = false;
             var isController = IsInheritFromTypesOrHasAttribute(typeDef, metadataReader, ControllerAttributes, ControllerBaseNames);
             if (!isController)
             {

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -165,10 +165,24 @@ internal static class EndpointDetector
     {
         foreach (var attributeHandle in attributes)
         {
+            string fullName;
             var attribute = reader.GetCustomAttribute(attributeHandle);
-            var ctor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
-            var attributeType = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
-            var fullName = GetFullTypeName(attributeType.Namespace, attributeType.Name, reader);
+            if (attribute.Constructor.Kind == HandleKind.MemberReference)
+            {
+                var ctor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                var attributeType = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
+                fullName = GetFullTypeName(attributeType.Namespace, attributeType.Name, reader);
+            }
+            else if (attribute.Constructor.Kind == HandleKind.MethodDefinition)
+            {
+                var ctor = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                var attributeType = reader.GetTypeDefinition(ctor.GetDeclaringType());
+                fullName = GetFullTypeName(attributeType.Namespace, attributeType.Name, reader);
+            }
+            else
+            {
+                continue;
+            }
 
             if (attributeNames.Contains(fullName))
             {

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
@@ -13,28 +13,41 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 
 namespace Datadog.Trace.Debugger.SpanCodeOrigin
 {
     internal class SpanCodeOriginManager
     {
-        private const string CodeOriginTag = "_dd.code_origin";
-
-        private const string FramesPrefix = "frames";
-
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SpanCodeOriginManager));
 
-        private readonly DebuggerSettings _settings = LiveDebugger.Instance?.Settings ?? DebuggerSettings.FromDefaultSource();
+        private readonly int _maxUserFrames;
 
-        // replace cache when this will be merged: https://github.com/DataDog/dd-trace-dotnet/pull/6093
-        private readonly ConcurrentDictionary<string, DatadogMetadataReader.DatadogSequencePoint?> _typeToFileName = new();
+        private readonly bool _isCodeOriginEnabled;
+
+        private readonly ConcurrentDictionary<Assembly, AssemblyPdbInfo?> _assemblyPdbCache = new();
+
+        private readonly CodeOriginTags _tags;
+
+        private readonly ImmutableHashSet<string> _thirdPartyDetectionExcludes;
+
+        private readonly ImmutableHashSet<string> _thirdPartyDetectionIncludes;
+
+        private SpanCodeOriginManager()
+        {
+            var settings = LiveDebugger.Instance?.Settings ?? DebuggerSettings.FromDefaultSource();
+            _maxUserFrames = settings.CodeOriginMaxUserFrames;
+            _isCodeOriginEnabled = settings.CodeOriginForSpansEnabled;
+            _tags = new CodeOriginTags(_maxUserFrames);
+            _thirdPartyDetectionExcludes = settings.ThirdPartyDetectionExcludes;
+            _thirdPartyDetectionIncludes = settings.ThirdPartyDetectionIncludes;
+        }
 
         internal static SpanCodeOriginManager Instance { get; } = new();
 
         internal void SetCodeOriginForExitSpan(Span? span)
         {
-            if (span == null ||
-                !_settings.CodeOriginForSpansEnabled)
+            if (span == null || !_isCodeOriginEnabled)
             {
                 return;
             }
@@ -42,13 +55,13 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             if (span.Tags is WebTags { SpanKind: SpanKinds.Server })
             {
                 // entry span
-                Log.Debug("Skipping span {SpanID}, we will add entry span code origin for it later", span.SpanId);
+                Log.Debug("Skipping span {SpanID}, we will add entry span code origin for it later. Resource: {ResourceName}, Operation: {OperationName}", span.SpanId, span.ResourceName, span.OperationName);
                 return;
             }
 
-            if (span.GetTag($"{CodeOriginTag}.type") != null)
+            if (span.GetTag(_tags.Type) != null)
             {
-                Log.Debug("Span {SpanID} has already code origin tags", span.SpanId);
+                Log.Debug("Span {SpanID} has already code origin tags. Resource: {ResourceName}, Operation: {OperationName}", span.SpanId, span.ResourceName, span.OperationName);
                 return;
             }
 
@@ -57,64 +70,107 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
         internal void SetCodeOriginForEntrySpan(Span? span, Type? type, MethodInfo? method)
         {
-            if (span == null || !_settings.CodeOriginForSpansEnabled)
+            if (span == null ||
+                type == null ||
+                method == null ||
+                !this._isCodeOriginEnabled)
             {
                 return;
             }
 
-            if (span.GetTag($"{CodeOriginTag}.type") != null)
+            if (span.GetTag(_tags.Type) != null)
             {
-                Log.Debug("Span {SpanID} has already code origin tags", span.SpanId);
+                Log.Debug("Span {SpanID} has already code origin tags. Resource: {ResourceName}, Operation: {OperationName}", span.SpanId, span.ResourceName, span.OperationName);
                 return;
             }
 
             AddEntrySpanTags(span, type, method);
         }
 
-        private void AddEntrySpanTags(Span span, Type? type, MethodInfo? method)
+        private void AddEntrySpanTags(Span span, Type type, MethodInfo method)
         {
-            var methodName = method?.Name;
-            var typeFullName = type?.FullName;
-            if (methodName == null || typeFullName == null)
+            try
             {
-                return;
+                var methodName = method.Name;
+                var typeFullName = type.FullName;
+                if (typeFullName == null)
+                {
+                    return;
+                }
+
+                var assembly = type.Assembly;
+                if (AssemblyFilter.ShouldSkipAssembly(assembly, _thirdPartyDetectionExcludes, _thirdPartyDetectionIncludes))
+                {
+                    // use cache when this will be merged: https://github.com/DataDog/dd-trace-dotnet/pull/6093
+                    return;
+                }
+
+                span.Tags.SetTag(_tags.Type, "entry");
+                span.Tags.SetTag(_tags.Index[0], "0");
+                span.Tags.SetTag(_tags.Method[0], methodName);
+                span.Tags.SetTag(_tags.TypeName[0], typeFullName);
+
+                var sp = GetPdbInfo(assembly, method!);
+                if (sp != null)
+                {
+                    span.Tags.SetTag(_tags.File[0], sp.Value.URL);
+                    span.Tags.SetTag(_tags.Line[0], sp.Value.StartLine.ToString());
+                    span.Tags.SetTag(_tags.Column[0], sp.Value.StartColumn.ToString());
+                }
             }
-
-            var assembly = type!.Assembly;
-            if (AssemblyFilter.ShouldSkipAssembly(assembly, _settings.ThirdPartyDetectionExcludes, _settings.ThirdPartyDetectionIncludes))
+            catch (Exception ex)
             {
-                // use cache when this will be merged: https://github.com/DataDog/dd-trace-dotnet/pull/6093
-                return;
-            }
-
-            var sp = this._typeToFileName.GetOrAdd(typeFullName, s => GetFilePath(assembly, method!));
-            if (sp != null)
-            {
-                span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{0}.index", 0.ToString());
-                span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{0}.method", methodName);
-                span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{0}.type", typeFullName);
-
-                span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{0}.file", sp.Value.URL);
-                span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{0}.line", sp.Value.StartLine.ToString());
-                span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{0}.line", sp.Value.StartColumn.ToString());
-                span.Tags.SetTag($"{CodeOriginTag}.type", "entry");
+                Log.Error(ex, "Failed to create entry span tag for {Span}. Resource: {ResourceName}, Operation: {OperationName}", span.SpanId, span.ResourceName, span.OperationName);
             }
         }
 
-        private DatadogMetadataReader.DatadogSequencePoint? GetFilePath(Assembly assembly, MethodInfo method)
+        private DatadogMetadataReader.DatadogSequencePoint? GetPdbInfo(Assembly assembly, MethodInfo method)
         {
-            using var reader = DatadogMetadataReader.CreatePdbReader(assembly);
-            if (reader is { IsPdbExist: true })
-            {
-                return reader.GetMethodSourceLocation(method!.MetadataToken);
-            }
+            var pdbInfo = _assemblyPdbCache.GetOrAdd(
+                assembly,
+                asm =>
+                {
+                    using var reader = DatadogMetadataReader.CreatePdbReader(asm);
+                    if (reader is not { IsPdbExist: true })
+                    {
+                        return null;
+                    }
 
-            return null;
+                    try
+                    {
+                        var endpointMethodTokens = EndpointDetector.GetEndpointMethodTokens(reader.MetadataReader);
+
+                        // Build dictionary of sequence points only for endpoint methods
+                        var builder = ImmutableDictionary.CreateBuilder<int, DatadogMetadataReader.DatadogSequencePoint?>();
+
+                        foreach (var token in endpointMethodTokens)
+                        {
+                            try
+                            {
+                                var sequencePoint = reader.GetMethodSourceLocation(token);
+                                builder.Add(token, sequencePoint);
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Error(ex, "Failed to get sequence point for method token {Token} in assembly {AssemblyName}", property0: token, asm.FullName);
+                            }
+                        }
+
+                        return new AssemblyPdbInfo(builder.ToImmutable());
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Failed to load PDB info for assembly {AssemblyName}", asm.Location);
+                        return null;
+                    }
+                });
+
+            return pdbInfo?.MethodSequencePoints.GetValueOrDefault<DatadogMetadataReader.DatadogSequencePoint?>(method.MetadataToken);
         }
 
         private void AddExitSpanTags(Span span)
         {
-            var frames = ArrayPool<FrameInfo>.Shared.Rent(_settings.CodeOriginMaxUserFrames);
+            var frames = ArrayPool<FrameInfo>.Shared.Rent(this._maxUserFrames);
             try
             {
                 var framesLength = PopulateUserFrames(frames);
@@ -123,54 +179,45 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                     return;
                 }
 
-                bool tagAdded = false;
                 for (var i = 0; i < framesLength; i++)
                 {
                     ref var info = ref frames[i];
 
                     // PopulateUserFrames returns only frames that have method
                     var method = info.Frame.GetMethod()!;
-                    var type = method.DeclaringType?.FullName ?? method.DeclaringType?.Name;
-                    if (string.IsNullOrEmpty(type))
+                    var typeName = method.DeclaringType?.FullName ?? method.DeclaringType?.Name;
+                    if (string.IsNullOrEmpty(typeName))
                     {
                         continue;
                     }
+
+                    span.Tags.SetTag(_tags.Type, "exit");
+                    span.Tags.SetTag(_tags.Index[i], info.FrameIndex.ToString());
+                    span.Tags.SetTag(_tags.Method[i], method.Name);
+                    span.Tags.SetTag(_tags.TypeName[i], typeName);
 
                     var fileName = info.Frame.GetFileName();
-                    if (!string.IsNullOrEmpty(fileName))
+                    if (string.IsNullOrEmpty(fileName))
                     {
                         continue;
                     }
 
-                    span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{i}.index", info.FrameIndex.ToString());
-                    span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{i}.method", method.Name);
-                    span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{i}.type", type);
-
-                    span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{i}.file", fileName);
+                    span.Tags.SetTag(_tags.File[i], fileName);
 
                     var line = info.Frame.GetFileLineNumber();
-                    span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{i}.line", line.ToString());
+                    span.Tags.SetTag(_tags.Line[i], line.ToString());
 
                     var column = info.Frame.GetFileColumnNumber();
-                    span.Tags.SetTag($"{CodeOriginTag}.{FramesPrefix}.{i}.column", column.ToString());
-                    tagAdded = true;
-                }
-
-                if (tagAdded)
-                {
-                    span.Tags.SetTag($"{CodeOriginTag}.type", "exit");
+                    span.Tags.SetTag(_tags.Column[i], column.ToString());
                 }
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Failed to create exit span tag for {Span}", span.SpanId);
+                Log.Error(ex, "Failed to create exit span tag for {Span}. Resource: {ResourceName}, Operation: {OperationName}", span.SpanId, span.ResourceName, span.OperationName);
             }
             finally
             {
-                if (frames != null!)
-                {
-                    ArrayPool<FrameInfo>.Shared.Return(frames);
-                }
+                ArrayPool<FrameInfo>.Shared.Return(frames);
             }
         }
 
@@ -179,13 +226,13 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             var stackTrace = new StackTrace(fNeedFileInfo: true);
             var stackFrames = stackTrace.GetFrames();
 
-            if (stackFrames == null!)
+            if (stackFrames == null)
             {
                 return 0;
             }
 
             var count = 0;
-            for (var walkIndex = 0; walkIndex < stackFrames.Length && count < _settings.CodeOriginMaxUserFrames; walkIndex++)
+            for (var walkIndex = 0; walkIndex < stackFrames.Length && count < this._maxUserFrames; walkIndex++)
             {
                 var frame = stackFrames[walkIndex];
 
@@ -195,7 +242,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                     continue;
                 }
 
-                if (AssemblyFilter.ShouldSkipAssembly(assembly, _settings.ThirdPartyDetectionExcludes, _settings.ThirdPartyDetectionIncludes))
+                if (AssemblyFilter.ShouldSkipAssembly(assembly, _thirdPartyDetectionExcludes, _thirdPartyDetectionIncludes))
                 {
                     // use cache when this will be merged: https://github.com/DataDog/dd-trace-dotnet/pull/6093
                     continue;
@@ -208,5 +255,49 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
         }
 
         private readonly record struct FrameInfo(int FrameIndex, StackFrame Frame);
+
+        private sealed class AssemblyPdbInfo(ImmutableDictionary<int, DatadogMetadataReader.DatadogSequencePoint?> sequencePoints)
+        {
+            public ImmutableDictionary<int, DatadogMetadataReader.DatadogSequencePoint?> MethodSequencePoints { get; } = sequencePoints;
+        }
+
+        /// <summary>
+        /// avoid string concatenations and reduce GC pressure in hot path
+        /// </summary>
+        internal class CodeOriginTags
+        {
+            private const string CodeOriginTag = "_dd.code_origin";
+            private const string FramesPrefix = "frames";
+
+#pragma warning disable SA1401
+            internal readonly string Type = $"{CodeOriginTag}.type";
+            internal readonly string[] Index;
+            internal readonly string[] Method;
+            internal readonly string[] TypeName;
+            internal readonly string[] File;
+            internal readonly string[] Line;
+            internal readonly string[] Column;
+#pragma warning restore SA1401
+
+            internal CodeOriginTags(int maxFrames)
+            {
+                Index = new string[maxFrames];
+                Method = new string[maxFrames];
+                TypeName = new string[maxFrames];
+                File = new string[maxFrames];
+                Line = new string[maxFrames];
+                Column = new string[maxFrames];
+
+                for (var i = 0; i < maxFrames; i++)
+                {
+                    Index[i] = $"{CodeOriginTag}.{FramesPrefix}.{i}.index";
+                    Method[i] = $"{CodeOriginTag}.{FramesPrefix}.{i}.method";
+                    TypeName[i] = $"{CodeOriginTag}.{FramesPrefix}.{i}.type";
+                    File[i] = $"{CodeOriginTag}.{FramesPrefix}.{i}.file";
+                    Line[i] = $"{CodeOriginTag}.{FramesPrefix}.{i}.line";
+                    Column[i] = $"{CodeOriginTag}.{FramesPrefix}.{i}.column";
+                }
+            }
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
@@ -21,13 +21,13 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SpanCodeOriginManager));
 
-        private readonly int _maxUserFrames;
-
-        private readonly bool _isCodeOriginEnabled;
-
         private readonly ConcurrentDictionary<Assembly, AssemblyPdbInfo?> _assemblyPdbCache = new();
 
         private readonly CodeOriginTags _tags;
+
+        private readonly int _maxUserFrames;
+
+        private readonly bool _isCodeOriginEnabled;
 
         private readonly ImmutableHashSet<string> _thirdPartyDetectionExcludes;
 
@@ -35,10 +35,10 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
         private SpanCodeOriginManager()
         {
+            _tags = new CodeOriginTags(_maxUserFrames);
             var settings = LiveDebugger.Instance?.Settings ?? DebuggerSettings.FromDefaultSource();
             _maxUserFrames = settings.CodeOriginMaxUserFrames;
             _isCodeOriginEnabled = settings.CodeOriginForSpansEnabled;
-            _tags = new CodeOriginTags(_maxUserFrames);
             _thirdPartyDetectionExcludes = settings.ThirdPartyDetectionExcludes;
             _thirdPartyDetectionIncludes = settings.ThirdPartyDetectionIncludes;
         }

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
@@ -138,7 +138,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
                     try
                     {
-                        var endpointMethodTokens = EndpointDetector.GetEndpointMethodTokens(reader.MetadataReader);
+                        var endpointMethodTokens = EndpointDetector.GetEndpointMethodTokens(reader);
 
                         // Build dictionary of sequence points only for endpoint methods
                         var builder = ImmutableDictionary.CreateBuilder<int, DatadogMetadataReader.DatadogSequencePoint?>();

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
@@ -5,9 +5,9 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using Datadog.Trace.Debugger.Caching;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SpanCodeOriginManager));
 
-        private readonly ConcurrentDictionary<Assembly, AssemblyPdbInfo?> _assemblyPdbCache = new();
+        private readonly ConcurrentAdaptiveCache<Assembly, AssemblyPdbInfo?> _assemblyPdbCache = new();
 
         private readonly CodeOriginTags _tags;
 

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
@@ -35,9 +35,9 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
         private SpanCodeOriginManager()
         {
-            _tags = new CodeOriginTags(_maxUserFrames);
             var settings = LiveDebugger.Instance?.Settings ?? DebuggerSettings.FromDefaultSource();
             _maxUserFrames = settings.CodeOriginMaxUserFrames;
+            _tags = new CodeOriginTags(_maxUserFrames);
             _isCodeOriginEnabled = settings.CodeOriginForSpansEnabled;
             _thirdPartyDetectionExcludes = settings.ThirdPartyDetectionExcludes;
             _thirdPartyDetectionIncludes = settings.ThirdPartyDetectionIncludes;
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             if (span == null ||
                 type == null ||
                 method == null ||
-                !this._isCodeOriginEnabled)
+                !_isCodeOriginEnabled)
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -794,7 +794,7 @@ namespace Datadog.Trace.DiagnosticListeners
         }
 
         /// <summary>
-        /// https://github1s.com/dotnet/aspnetcore/blob/v3.0.3/src/Mvc/Mvc.Core/src/Controllers/ControllerActionDescriptor.cs
+        /// https://github.com/dotnet/aspnetcore/blob/v3.0.3/src/Mvc/Mvc.Core/src/Controllers/ControllerActionDescriptor.cs
         /// </summary>
         [DuckCopy]
         internal struct ControllerActionDescriptorStruct
@@ -807,7 +807,7 @@ namespace Datadog.Trace.DiagnosticListeners
         }
 
         /// <summary>
-        /// https://github1s.com/dotnet/aspnetcore/blob/v3.0.3/src/Mvc/Mvc.RazorPages/src/CompiledPageActionDescriptor.cs
+        /// https://github.com/dotnet/aspnetcore/blob/v3.0.3/src/Mvc/Mvc.RazorPages/src/CompiledPageActionDescriptor.cs
         /// </summary>
         [DuckCopy]
         internal struct CompiledPageActionDescriptorStruct
@@ -820,7 +820,7 @@ namespace Datadog.Trace.DiagnosticListeners
         }
 
         /// <summary>
-        /// https://github1s.com/dotnet/aspnetcore/blob/v3.0.3/src/Mvc/Mvc.RazorPages/src/Infrastructure/HandlerMethodDescriptor.cs
+        /// https://github.com/dotnet/aspnetcore/blob/v3.0.3/src/Mvc/Mvc.RazorPages/src/Infrastructure/HandlerMethodDescriptor.cs
         /// </summary>
         [DuckCopy]
         internal struct HandlerMethodDescriptorStruct

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.DiagnosticListeners
         private readonly Security _security;
         private readonly Iast.Iast _iast;
         private readonly LiveDebugger _liveDebugger;
-        private readonly SpanCodeOriginManager _spanOrigin;
+        private readonly SpanCodeOriginManager _spanOriginManager;
         private string _hostingHttpRequestInStartEventKey;
         private string _mvcBeforeActionEventKey;
         private string _mvcAfterActionEventKey;
@@ -76,13 +76,13 @@ namespace Datadog.Trace.DiagnosticListeners
         {
         }
 
-        public AspNetCoreDiagnosticObserver(Tracer tracer, Security security, Iast.Iast iast, LiveDebugger liveDebugger, SpanCodeOriginManager spanOrigin)
+        public AspNetCoreDiagnosticObserver(Tracer tracer, Security security, Iast.Iast iast, LiveDebugger liveDebugger, SpanCodeOriginManager spanOriginManager)
         {
             _tracer = tracer;
             _security = security;
             _iast = iast;
             _liveDebugger = liveDebugger;
-            _spanOrigin = spanOrigin;
+            _spanOriginManager = spanOriginManager;
         }
 
         protected override string ListenerName => DiagnosticListenerName;
@@ -95,7 +95,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private LiveDebugger CurrentLiveDebugger => _liveDebugger ?? LiveDebugger.Instance;
 
-        private SpanCodeOriginManager CurrentCodeOriginManager => this._spanOrigin ?? SpanCodeOriginManager.Instance;
+        private SpanCodeOriginManager CurrentCodeOriginManager => _spanOriginManager ?? SpanCodeOriginManager.Instance;
 
 #if NETCOREAPP
         protected override void OnNext(string eventName, object arg)

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -582,7 +582,7 @@ namespace Datadog.Trace.DiagnosticListeners
             var shouldTrace = tracer.Settings.IsIntegrationEnabled(IntegrationId);
             var shouldSecure = security.AppsecEnabled;
             var shouldUseIast = CurrentIast.Settings.Enabled;
-            var isCodeOriginEnabled = LiveDebugger.Instance.Settings.CodeOriginForSpansEnabled;
+            var isCodeOriginEnabled = LiveDebugger.Instance?.Settings.CodeOriginForSpansEnabled ?? false;
 
             if (!shouldTrace && !shouldSecure && !shouldUseIast && !isCodeOriginEnabled)
             {

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.DiagnosticListeners
         private static readonly AspNetCoreHttpRequestHandler AspNetCoreRequestHandler = new AspNetCoreHttpRequestHandler(Log, HttpRequestInOperationName, IntegrationId);
         private readonly Tracer _tracer;
         private readonly Security _security;
-		private readonly Iast.Iast _iast;
+        private readonly Iast.Iast _iast;
         private readonly LiveDebugger _liveDebugger;
         private readonly SpanCodeOriginManager _spanOrigin;
         private string _hostingHttpRequestInStartEventKey;
@@ -80,7 +80,7 @@ namespace Datadog.Trace.DiagnosticListeners
         {
             _tracer = tracer;
             _security = security;
-			_iast = iast;
+            _iast = iast;
             _liveDebugger = liveDebugger;
             _spanOrigin = spanOrigin;
         }
@@ -90,8 +90,8 @@ namespace Datadog.Trace.DiagnosticListeners
         private Tracer CurrentTracer => _tracer ?? Tracer.Instance;
 
         private Security CurrentSecurity => _security ?? Security.Instance;
-		
-		private Iast.Iast CurrentIast => _iast ?? Iast.Iast.Instance;
+
+        private Iast.Iast CurrentIast => _iast ?? Iast.Iast.Instance;
 
         private LiveDebugger CurrentLiveDebugger => _liveDebugger ?? LiveDebugger.Instance;
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -526,9 +526,17 @@ namespace Datadog.Trace.DiagnosticListeners
                 }
 
                 var isCodeOriginEnabled = CurrentLiveDebugger?.Settings.CodeOriginForSpansEnabled ?? false;
-                if (isCodeOriginEnabled && routeEndpoint?.RequestDelegate?.Target is { Handler: { } handler })
+                if (isCodeOriginEnabled)
                 {
-                    CurrentCodeOriginManager.SetCodeOriginForEntrySpan(rootSpan, handler.Target?.GetType(), handler.Method);
+                    var method = routeEndpoint?.RequestDelegate?.Method;
+                    if (method != null)
+                    {
+                        CurrentCodeOriginManager.SetCodeOriginForEntrySpan(rootSpan, routeEndpoint?.RequestDelegate?.Target?.GetType() ?? method.DeclaringType, method);
+                    }
+                    else if (routeEndpoint?.RequestDelegate?.TryDuckCast<Target>(out var target) == true && target is { Handler: { } handler })
+                    {
+                        CurrentCodeOriginManager.SetCodeOriginForEntrySpan(rootSpan, handler.Target?.GetType(), handler.Method);
+                    }
                 }
 
                 if (isFirstExecution)

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
@@ -1,0 +1,21 @@
+// <copyright file="RequestDelegate.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.DiagnosticListeners;
+
+/// <summary>
+/// RequestDelegate for duck typing
+/// https://github1s.com/dotnet/aspnetcore/blob/v3.0.3/src/Http/Http.Abstractions/src/RequestDelegate.cs
+/// </summary>
+[DuckCopy]
+internal struct RequestDelegate
+{
+    /// <summary>
+    /// Delegate to RequestDelegate.Target
+    /// </summary>
+    public Target? Target;
+}

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
@@ -5,6 +5,8 @@
 
 using Datadog.Trace.DuckTyping;
 
+#nullable enable
+
 namespace Datadog.Trace.DiagnosticListeners;
 
 /// <summary>

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.DiagnosticListeners;
 
 /// <summary>
 /// RequestDelegate for duck typing
-/// https://github1s.com/dotnet/aspnetcore/blob/v3.0.3/src/Http/Http.Abstractions/src/RequestDelegate.cs
+/// https://github.com/dotnet/aspnetcore/blob/v3.0.3/src/Http/Http.Abstractions/src/RequestDelegate.cs
 /// </summary>
 [DuckCopy]
 internal struct RequestDelegate

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/RequestDelegate.cs
@@ -17,7 +17,12 @@ namespace Datadog.Trace.DiagnosticListeners;
 internal struct RequestDelegate
 {
     /// <summary>
+    /// Delegate to RequestDelegate.Method
+    /// </summary>
+    public System.Reflection.MethodInfo? Method;
+
+    /// <summary>
     /// Delegate to RequestDelegate.Target
     /// </summary>
-    public Target? Target;
+    public object? Target;
 }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/RouteEndpoint.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/RouteEndpoint.cs
@@ -22,5 +22,10 @@ namespace Datadog.Trace.DiagnosticListeners
         /// Delegates to Endpoint.DisplayName;
         /// </summary>
         public string DisplayName;
+
+        /// <summary>
+        /// Delegates to Endpoint.RequestDelegate;
+        /// </summary>
+        public RequestDelegate? RequestDelegate;
     }
 }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
@@ -20,5 +20,5 @@ internal struct Target
     /// Delegate to RequestDelegate.Target.handler
     /// </summary>
     [DuckField(Name = "handler")]
-    public Delegate Handler;
+    public Delegate? Handler;
 }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
@@ -6,6 +6,8 @@
 using System;
 using Datadog.Trace.DuckTyping;
 
+#nullable enable
+
 namespace Datadog.Trace.DiagnosticListeners;
 
 /// <summary>

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
@@ -19,6 +19,6 @@ internal struct Target
     /// <summary>
     /// Delegate to RequestDelegate.Target.handler
     /// </summary>
-    [Duck(Kind = DuckKind.Field, Name = "handler")]
+    [DuckField(Name = "handler")]
     public Delegate Handler;
 }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/Target.cs
@@ -1,0 +1,22 @@
+// <copyright file="Target.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.DiagnosticListeners;
+
+/// <summary>
+/// RequestDelegate.Target for duck typing
+/// </summary>
+[DuckCopy]
+internal struct Target
+{
+    /// <summary>
+    /// Delegate to RequestDelegate.Target.handler
+    /// </summary>
+    [Duck(Kind = DuckKind.Field, Name = "handler")]
+    public Delegate Handler;
+}

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -528,7 +528,7 @@ namespace Datadog.Trace
             // write them directly to the <see cref="TraceChunkModel"/>.
             TracerManager.GitMetadataTagsProvider.TryExtractGitMetadata(out _);
 
-            SpanCodeOriginManager.Instance.SetCodeOrigin(span);
+            SpanCodeOriginManager.Instance.SetCodeOriginForExitSpan(span);
 
             return span;
         }

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -16,6 +16,7 @@ using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Debugger;
 using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.Sampling;
@@ -430,7 +431,8 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
             var security = new AppSec.Security();
             var iast = new Iast.Iast(new IastSettings(configSource, NullConfigurationTelemetry.Instance), NullDiscoveryService.Instance);
-            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security, iast) };
+            var liveDebugger = GetLiveDebugger();
+            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security, iast, liveDebugger, null) };
 
             using (var diagnosticManager = new DiagnosticManager(observers))
             {
@@ -535,6 +537,11 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             var samplerMock = new Mock<ITraceSampler>();
 
             return new Tracer(settings, agentWriter, samplerMock.Object, scopeManager: null, statsd: null);
+        }
+
+        private static LiveDebugger GetLiveDebugger()
+        {
+            return LiveDebuggerFactory.Create(null, null, new TracerSettings(), null, null, DebuggerSettings.FromDefaultSource(), null);
         }
 
         private class AgentWriterStub : IAgentWriter

--- a/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="AgileObjects.ReadableExpressions" Version="3.3.0" />
     <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="Serilog" Version="2.5.0" />

--- a/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
@@ -1,0 +1,578 @@
+// <copyright file="EndpointDetectorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Datadog.Trace.Debugger.SpanCodeOrigin;
+using Datadog.Trace.Pdb;
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Tests.Debugger
+{
+    public class EndpointDetectorTests : IDisposable
+    {
+        private const string TestAssemblyName = "EndpointDetectorTestAssembly";
+        private readonly ITestOutputHelper _output;
+        private string _assemblyPath;
+        private Assembly _assembly;
+
+        public EndpointDetectorTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _assemblyPath = CreateTestAssembly();
+            _assembly = Assembly.LoadFile(_assemblyPath);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(_assemblyPath) && File.Exists(_assemblyPath))
+                {
+                    File.Delete(_assemblyPath);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        [Fact]
+        public void GetEndpointMethodTokens_FindsAllEndpoints()
+        {
+            // Arrange
+            var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
+
+            // Act
+            var endpointTokens = EndpointDetector.GetEndpointMethodTokens(datadogMetadataReader);
+
+            // Create a mapping of method tokens to more friendly names for debugging
+            var tokenToMethodMap = new Dictionary<int, string>();
+            var expectedEndpoints = new HashSet<int>();
+
+            var namespace_ = "EndpointDetectorTestNamespace";
+            foreach (var type in _assembly.GetTypes().Where(t => t.Namespace == namespace_))
+            {
+                foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+                {
+                    var token = method.MetadataToken;
+                    var fullMethodName = $"{type.Name}.{method.Name}";
+                    tokenToMethodMap[token] = fullMethodName;
+
+                    // Add to expected endpoints for the types and methods we expect to be detected
+                    bool isExpectedEndpoint = false;
+
+                    // Controllers with action attributes
+                    if (type.Name is "ControllerAttributeController" or "ApiControllerAttributeController" or "RouteAttributeController" &&
+                        method.Name == "Get")
+                    {
+                        isExpectedEndpoint = true;
+                    }
+
+                    // Controllers inheriting from base classes
+                    else if (type.Name is "ControllerBaseInheritanceController" or "ControllerInheritanceController" &&
+                             method.Name == "Get")
+                    {
+                        isExpectedEndpoint = true;
+                    }
+
+                    // Controller with HTTP methods
+                    else if (type.Name == "HttpMethodController" &&
+                            method.Name is "Get" or "Post" or "Put" or "Delete" or "Patch" or "Head" or "Options" or "Custom")
+                    {
+                        isExpectedEndpoint = true;
+                    }
+
+                    // PageModel handlers
+                    else if (type.Name == "TestPageModel" &&
+                            method.Name is "OnGet" or "OnGetAsync" or "OnPost" or "OnPostAsync" or "OnPut" or "OnPutAsync" or "OnDelete" or "OnDeleteAsync" or "OnHead" or "OnHeadAsync" or "OnPatch" or "OnPatchAsync" or "OnOptions" or "OnOptionsAsync" &&
+                            method.Name != "OnGetWithNonHandlerAttribute")
+                    {
+                        isExpectedEndpoint = true;
+                    }
+
+                    // SignalR hub methods
+                    else if (type.Name is "TestHub" or "TestGenericHub" &&
+                             method.Name is "Send" or "Receive" &&
+                             !method.IsStatic)
+                    {
+                        isExpectedEndpoint = true;
+                    }
+
+                    // minimal api endpoints
+                    else if (type.Name.Contains("<>") || type.Name.Contains("__DisplayClass"))
+                    {
+                        if (method.Name.Contains("b__"))
+                        {
+                            isExpectedEndpoint = true;
+                        }
+                    }
+
+                    if (isExpectedEndpoint)
+                    {
+                        expectedEndpoints.Add(token);
+                    }
+                }
+            }
+
+            // Log and assert
+            LogEndpointDetails(endpointTokens, tokenToMethodMap, expectedEndpoints);
+
+            endpointTokens.Count.Should().BeGreaterThanOrEqualTo(expectedEndpoints.Count, "The EndpointDetector should find all controller, page handler, and SignalR hub methods");
+        }
+
+        [Fact]
+        public void GetEndpointMethodTokens_DoesNotDetectNonEndpoints()
+        {
+            // Arrange
+            var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
+
+            // Act
+            var endpointTokens = EndpointDetector.GetEndpointMethodTokens(datadogMetadataReader);
+
+            // Create a list of methods that should NOT be endpoints
+            var nonEndpointTokens = new List<int>();
+            var nonEndpointMethods = new List<(string TypeName, string MethodName, int Token)>();
+
+            var namespace_ = "EndpointDetectorTestNamespace";
+            foreach (var type in _assembly.GetTypes().Where(t => t.Namespace == namespace_))
+            {
+                foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+                {
+                    var token = method.MetadataToken;
+                    bool shouldNotBeEndpoint = false;
+
+                    // Abstract controllers
+                    if (type.Name == "AbstractController")
+                    {
+                        shouldNotBeEndpoint = true;
+                    }
+
+                    // Interface methods
+                    else if (type.Name == "ControllerInterface")
+                    {
+                        shouldNotBeEndpoint = true;
+                    }
+
+                    // Private methods
+                    else if (method.IsPrivate)
+                    {
+                        shouldNotBeEndpoint = true;
+                    }
+
+                    // Static methods
+                    else if (method.IsStatic)
+                    {
+                        shouldNotBeEndpoint = true;
+                    }
+
+                    // Regular methods with no HTTP attribute
+                    else if (type.Name == "ValidController" && method.Name == "RegularMethod")
+                    {
+                        shouldNotBeEndpoint = true;
+                    }
+
+                    // PageModel methods with NonHandler attribute
+                    else if (type.Name == "TestPageModel" && method.Name == "OnGetWithNonHandlerAttribute")
+                    {
+                        shouldNotBeEndpoint = true;
+                    }
+
+                    // Regular methods in PageModels
+                    else if (type.Name == "TestPageModel" && method.Name == "RegularMethod")
+                    {
+                        shouldNotBeEndpoint = true;
+                    }
+
+                    if (shouldNotBeEndpoint)
+                    {
+                        nonEndpointTokens.Add(token);
+                        nonEndpointMethods.Add((type.Name, method.Name, token));
+                    }
+                }
+            }
+
+            // Log which non-endpoints were incorrectly detected
+            var incorrectlyDetectedEndpoints = nonEndpointMethods
+                .Where(e => endpointTokens.Contains(e.Token))
+                .ToList();
+
+            _output.WriteLine($"Found {incorrectlyDetectedEndpoints.Count} incorrectly detected endpoints:");
+            foreach (var endpoint in incorrectlyDetectedEndpoints)
+            {
+                _output.WriteLine($"  {endpoint.TypeName}.{endpoint.MethodName} (Token: {endpoint.Token})");
+            }
+
+            // Assert that none of the non-endpoints were detected
+            nonEndpointTokens.Should().NotContain(token => endpointTokens.Contains(token), "Non-endpoints should not be detected as endpoints");
+        }
+
+        private void LogEndpointDetails(ImmutableHashSet<int> endpointTokens, Dictionary<int, string> tokenToMethodMap, HashSet<int> expectedEndpoints)
+        {
+            // Log expected endpoints (using the HashSet to avoid duplicates)
+            _output.WriteLine($"\nExpected {expectedEndpoints.Count} endpoints:");
+            foreach (var token in expectedEndpoints)
+            {
+                bool found = endpointTokens.Contains(token);
+                string methodName = tokenToMethodMap.TryGetValue(token, out var value) ? value : $"Unknown ({token})";
+                _output.WriteLine($"  {methodName} (Token: {token}) - {(found ? "FOUND" : "NOT FOUND")}");
+            }
+
+            // Log which expected endpoints were not found
+            var missingEndpoints = expectedEndpoints.Where(e => !endpointTokens.Contains(e)).ToList();
+            if (missingEndpoints.Any())
+            {
+                _output.WriteLine($"\nMissing endpoints ({missingEndpoints.Count}):");
+                foreach (var token in missingEndpoints)
+                {
+                    string methodName = tokenToMethodMap.TryGetValue(token, out var value) ? value : $"Unknown ({token})";
+                    _output.WriteLine($"  {methodName} (Token: {token})");
+                }
+            }
+
+            // Log unexpected endpoints that were found
+            var unexpectedEndpoints = endpointTokens.Where(t => !expectedEndpoints.Contains(t)).ToList();
+            if (unexpectedEndpoints.Any())
+            {
+                // due to the way we are identifying minimal api endpoints, we are getting also unexpected method, if this number is too high we might want to rethink our minimal api endpoints detection
+                _output.WriteLine($"\nUnexpected endpoints ({unexpectedEndpoints.Count}):");
+                foreach (var token in unexpectedEndpoints)
+                {
+                    string methodName = tokenToMethodMap.TryGetValue(token, out var value) ? value : $"Unknown ({token})";
+                    _output.WriteLine($"  {methodName} (Token: {token})");
+                }
+            }
+        }
+
+        private string CreateTestAssembly()
+        {
+            var compilation = CSharpCompilation.Create(
+                TestAssemblyName,
+                syntaxTrees: new[] { CSharpSyntaxTree.ParseText(GetTestAssemblyCode()) },
+                references: GetMetadataReferences(),
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var uniqueId = Guid.NewGuid().ToString("N").Substring(0, 8);
+            var assemblyPath = Path.Combine(Path.GetTempPath(), $"{TestAssemblyName}_{uniqueId}.dll");
+
+            EmitResult emitResult = compilation.Emit(assemblyPath);
+            if (!emitResult.Success)
+            {
+                string errors = string.Join(
+                    Environment.NewLine,
+                    emitResult.Diagnostics
+                              .Where(d => d.Severity == DiagnosticSeverity.Error)
+                              .Select(d => $"{d.Id}: {d.GetMessage()}"));
+
+                throw new InvalidOperationException($"Failed to create test assembly: {errors}");
+            }
+
+            return assemblyPath;
+        }
+
+        private MetadataReference[] GetMetadataReferences()
+        {
+            return
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location), "System.Runtime.dll"))
+            ];
+        }
+
+        private SourceText GetTestAssemblyCode()
+        {
+            return SourceText.From(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ControllerAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ApiControllerAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class RouteAttribute : Attribute
+    {
+        public RouteAttribute(string template = null) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HttpGetAttribute : Attribute 
+    {
+        public HttpGetAttribute() { }
+        public HttpGetAttribute(string template) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HttpPostAttribute : Attribute 
+    {
+        public HttpPostAttribute() { }
+        public HttpPostAttribute(string template) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HttpPutAttribute : Attribute 
+    {
+        public HttpPutAttribute() { }
+        public HttpPutAttribute(string template) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HttpDeleteAttribute : Attribute 
+    {
+        public HttpDeleteAttribute() { }
+        public HttpDeleteAttribute(string template) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HttpPatchAttribute : Attribute 
+    {
+        public HttpPatchAttribute() { }
+        public HttpPatchAttribute(string template) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HttpHeadAttribute : Attribute 
+    {
+        public HttpHeadAttribute() { }
+        public HttpHeadAttribute(string template) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HttpOptionsAttribute : Attribute 
+    {
+        public HttpOptionsAttribute() { }
+        public HttpOptionsAttribute(string template) { }
+    }
+
+    namespace Routing
+    {
+        [AttributeUsage(AttributeTargets.Method)]
+        public class HttpMethodAttribute : Attribute 
+        {
+            public HttpMethodAttribute() { }
+            public HttpMethodAttribute(string template) { }
+        }
+    }
+
+    public class ControllerBase { }
+
+    public class Controller : ControllerBase { }
+}
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class NonHandlerAttribute : Attribute { }
+
+    public class PageModel { }
+}
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    public class Hub { }
+
+    public class Hub<T> { }
+}
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static class MinimalApiExtensions
+    {
+        [AttributeUsage(AttributeTargets.Method)]
+        public class HttpMethodAttribute : Attribute
+        {
+            public HttpMethodAttribute(string httpMethod) { }
+        }
+        
+        public static void MapGet(this object app, string pattern, Delegate handler) { }
+        public static void MapPost(this object app, string pattern, Delegate handler) { }
+    }
+}
+
+namespace EndpointDetectorTestNamespace
+{
+    // Controller with ControllerAttribute
+    [Microsoft.AspNetCore.Mvc.Controller]
+    public class ControllerAttributeController
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public object Get() => null;
+    }
+
+    // Controller with ApiControllerAttribute
+    [Microsoft.AspNetCore.Mvc.ApiControllerAttribute]
+    public class ApiControllerAttributeController
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public object Get() => null;
+    }
+
+    // Controller with RouteAttribute
+    [Microsoft.AspNetCore.Mvc.Route(""api/test"")]
+    public class RouteAttributeController
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public object Get() => null;
+    }
+
+    // Controller inheriting from ControllerBase
+    public class ControllerBaseInheritanceController : Microsoft.AspNetCore.Mvc.ControllerBase
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public object Get() => null;
+    }
+
+    // Controller inheriting from Controller
+    public class ControllerInheritanceController : Microsoft.AspNetCore.Mvc.Controller
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public object Get() => null;
+    }
+
+    // Controller with various HTTP method attributes
+    public class HttpMethodController : Microsoft.AspNetCore.Mvc.ControllerBase
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public object Get() => null;
+
+        [Microsoft.AspNetCore.Mvc.HttpPost]
+        public object Post() => null;
+
+        [Microsoft.AspNetCore.Mvc.HttpPut]
+        public object Put() => null;
+
+        [Microsoft.AspNetCore.Mvc.HttpDelete]
+        public object Delete() => null;
+
+        [Microsoft.AspNetCore.Mvc.HttpPatch]
+        public object Patch() => null;
+
+        [Microsoft.AspNetCore.Mvc.HttpHead]
+        public object Head() => null;
+
+        [Microsoft.AspNetCore.Mvc.HttpOptions]
+        public object Options() => null;
+
+        [Microsoft.AspNetCore.Mvc.Routing.HttpMethodAttribute]
+        public object Custom() => null;
+    }
+
+    // PageModel with handler methods
+    public class TestPageModel : Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+    {
+        public void OnGet() { }
+        public Task OnGetAsync() => Task.CompletedTask;
+        public void OnPost() { }
+        public Task OnPostAsync() => Task.CompletedTask;
+        public void OnPut() { }
+        public Task OnPutAsync() => Task.CompletedTask;
+        public void OnDelete() { }
+        public Task OnDeleteAsync() => Task.CompletedTask;
+        public void OnHead() { }
+        public Task OnHeadAsync() => Task.CompletedTask;
+        public void OnPatch() { }
+        public Task OnPatchAsync() => Task.CompletedTask;
+        public void OnOptions() { }
+        public Task OnOptionsAsync() => Task.CompletedTask;
+
+        [Microsoft.AspNetCore.Mvc.RazorPages.NonHandler]
+        public void OnGetWithNonHandlerAttribute() { }
+        
+        // Regular method - should not be detected
+        public void RegularMethod() { }
+    }
+
+    // SignalR Hub
+    public class TestHub : Microsoft.AspNetCore.SignalR.Hub
+    {
+        public void Send(string message) { }
+        public void Receive() { }
+        public static void StaticMethod() { }
+    }
+
+    // Generic SignalR Hub
+    public class TestGenericHub : Microsoft.AspNetCore.SignalR.Hub<string>
+    {
+        public void Send(string message) { }
+        public void Receive() { }
+    }
+
+    // Abstract controller - should be ignored
+    [Microsoft.AspNetCore.Mvc.ApiControllerAttribute]
+    public abstract class AbstractController
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public abstract object Get();
+    }
+
+    // Interface controller - should be ignored
+    public interface ControllerInterface
+    {
+        // Even though we can't apply the ApiControllerAttribute to an interface,
+        // the EndpointDetector should still ignore interfaces
+        object Get();
+    }
+
+    // Valid controller with methods that should be excluded
+    public class ValidController : Microsoft.AspNetCore.Mvc.ControllerBase
+    {
+        // Private method - should be excluded
+        [Microsoft.AspNetCore.Mvc.HttpGet(""private"")]
+        private object PrivateMethod() => null;
+
+        // Static method - should be excluded
+        [Microsoft.AspNetCore.Mvc.HttpGet(""static"")]
+        public static object StaticMethod() => null;
+
+        // Regular method with no HTTP attribute - should be excluded
+        public object RegularMethod() => null;
+    }
+
+    // Minimal API setup to generate compiler-generated methods
+    public static class MinimalApiProgram
+    {
+        // Define some delegate types for our handlers
+        public delegate object RequestHandler();
+        public delegate object RequestHandlerWithInput(object input);
+        
+        public static void SetupEndpoints()
+        {
+            // These lambdas will compile into methods with names like ""<SetupEndpoints>b__0_0""
+            RequestHandler getHandler = () => ""Hello World"";
+            RequestHandlerWithInput postHandler = (input) => $""Received {input}"";
+            
+            // Use the handlers to prevent compiler optimizations
+            var app = new object();
+            UseHandlers(app, getHandler, postHandler);
+        }
+        
+        // Method to use the handlers (prevents compiler from optimizing away)
+        public static void UseHandlers(object app, RequestHandler handler1, RequestHandlerWithInput handler2)
+        {
+            // This empty method ensures the delegates are used
+        }
+    }
+}");
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
@@ -5,15 +5,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Datadog.Trace.Configuration;
-using Datadog.Trace.Configuration.Telemetry;
-using Datadog.Trace.Debugger;
+using System.Threading.Tasks;
 using Datadog.Trace.Debugger.SpanCodeOrigin;
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 using FluentAssertions;
+#if !NETFRAMEWORK
+using Microsoft.AspNetCore.Mvc;
+#endif
 using Xunit;
 
 namespace Datadog.Trace.Tests.Debugger
@@ -22,110 +23,337 @@ namespace Datadog.Trace.Tests.Debugger
     {
         private const string CodeOriginTag = "_dd.code_origin";
 
-        [Fact]
-        public void SetCodeOrigin_WhenSpanIsNull_DoesNotThrow()
+        private static IDisposable SetCodeOriginManagerSettings(bool isEnable = false, int numberOfFrames = 8, string excludeFromFilter = "Datadog.Trace.Tests")
         {
-            // Should not throw
-            SpanCodeOriginManager spanCodeOriginManager = new();
-            spanCodeOriginManager.SetCodeOriginForExitSpan(null);
+            var setter = new CodeOriginSettingsSetter();
+            setter.Set(isEnable, numberOfFrames, excludeFromFilter);
+            return setter;
         }
 
-        [Fact]
-        public void SetCodeOrigin_WhenDisabled_DoesNotSetTags()
+        public class EntrySpanTests
         {
-            // Arrange
+            [Fact]
+            public void SetCodeOriginForEntrySpan_WhenSpanIsNull_ShouldNotThrow()
+            {
+                var action = () => SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(null, typeof(string), typeof(string).GetMethod(nameof(string.ToString), Type.EmptyTypes));
+
+                action.Should().NotThrow();
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_WhenTypeIsNull_ShouldNotThrow()
+            {
+                var span = CreateSpan();
+                var action = () => SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, null, typeof(string).GetMethod(nameof(string.ToString), Type.EmptyTypes));
+
+                action.Should().NotThrow();
+                span.GetTag($"{CodeOriginTag}.type").Should().BeNull();
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_WhenMethodIsNull_ShouldNotThrow()
+            {
+                var span = CreateSpan();
+                var action = () => SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, typeof(string), null);
+
+                action.Should().NotThrow();
+                span.GetTag($"{CodeOriginTag}.type").Should().BeNull();
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_WhenSpanAlreadyHasCodeOrigin_ShouldNotModifyTags()
+            {
+                // Arrange
+                using var settingsSetter = SetCodeOriginManagerSettings(true);
+                var span = CreateSpan();
+                span.SetTag($"{CodeOriginTag}.type", "existing");
+
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, GetType(), GetType().GetMethod(nameof(SetCodeOriginForEntrySpan_WhenSpanAlreadyHasCodeOrigin_ShouldNotModifyTags)));
+
+                // Assert
+                span.GetTag($"{CodeOriginTag}.type").Should().BeEquivalentTo("existing");
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_WithValidInputs_ShouldSetCorrectTags()
+            {
+                // Arrange
+                using var settingsSetter = SetCodeOriginManagerSettings(true);
+                var span = CreateSpan();
+                var type = GetType();
+                var method = type.GetMethod(nameof(this.TestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
+
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, type, method);
+
+                // Assert
+                span.GetTag($"{CodeOriginTag}.type").Should().Be("entry");
+                span.GetTag($"{CodeOriginTag}.frames.0.index").Should().Be("0");
+                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(this.TestMethod));
+                span.GetTag($"{CodeOriginTag}.frames.0.type").Should().Be(type.FullName);
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_WithThirdPartyAssembly_ShouldNotSetTags()
+            {
+                // Arrange
+                using var settingsSetter = SetCodeOriginManagerSettings(true);
+                var span = CreateSpan();
+                var method = typeof(string).GetMethod(nameof(string.ToString), Type.EmptyTypes);
+                var type = method.DeclaringType;
+
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, type, method);
+
+                // Assert
+                span.GetTag($"{CodeOriginTag}.type").Should().BeNull();
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_ForNonControllerAction_ShouldNotSetTags()
+            {
+                // Arrange
+                using var settingsSetter = SetCodeOriginManagerSettings(true);
+                var span = CreateSpan();
+                var type = GetType();
+                var method = type.GetMethod(nameof(this.TestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
+
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, type, method);
+
+                // Assert
+                span.GetTag($"{CodeOriginTag}.type").Should().Be("entry");
+                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(this.TestMethod));
+                span.GetTag($"{CodeOriginTag}.frames.{0}.file").Should().BeNull();
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_ForNonControllerAction_WithAsyncMethod_ShouldSetCorrectTags()
+            {
+                // Arrange
+                using var settingsSetter = SetCodeOriginManagerSettings(true);
+                var span = CreateSpan();
+                var method = GetType().GetMethod(nameof(AsyncTestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
+                var type = method.DeclaringType;
+
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, type, method);
+
+                // Assert
+                span.GetTag($"{CodeOriginTag}.type").Should().Be("entry");
+                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(AsyncTestMethod));
+                span.GetTag($"{CodeOriginTag}.frames.{0}.file").Should().BeNull();
+            }
+
+            [Fact]
+            public void SetCodeOriginForEntrySpan_ForNonControllerAction_WithGenericMethod_ShouldSetCorrectTags()
+            {
+                // Arrange
+                using var settingsSetter = SetCodeOriginManagerSettings(true);
+                var span = CreateSpan();
+                var method = GetType().GetMethod(nameof(GenericTestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
+                var type = method.DeclaringType;
+
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, type, method);
+
+                // Assert
+                span.GetTag($"{CodeOriginTag}.type").Should().Be("entry");
+                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(GenericTestMethod));
+                span.GetTag($"{CodeOriginTag}.frames.{0}.file").Should().BeNull();
+            }
+
+#if !NETFRAMEWORK
+            [Fact]
+            public void SetCodeOriginForEntrySpan_ForControllerAction_ShouldSetTags()
+            {
+                // Arrange
+                using var settingsSetter = SetCodeOriginManagerSettings(true);
+                var span = CreateSpan();
+                var controllerType = typeof(TestController);
+                var method = controllerType.GetMethod(nameof(TestController.Get));
+
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, controllerType, method);
+
+                // Assert
+                span.GetTag("_dd.code_origin.type").Should().Be("entry");
+                span.GetTag("_dd.code_origin.frames.0.method").Should().Be(nameof(TestController.Get));
+                span.GetTag("_dd.code_origin.frames.0.type").Should().Be("Datadog.Trace.Tests.Debugger.SpanCodeOriginTests+TestController");
+                span.GetTag($"{CodeOriginTag}.frames.{0}.file").Should().EndWithEquivalentOf("SpanCodeOriginTests.cs");
+            }
+#endif
+
+            private Span CreateSpan()
+            {
+                var spanContext = new SpanContext(1234, 5678);
+                return new Span(spanContext, DateTimeOffset.UtcNow);
+            }
+
+            private int TestMethod() => 42;
+
+            private async Task AsyncTestMethod()
+            {
+                await Task.Delay(1);
+            }
+
+            private T GenericTestMethod<T>(T input)
+                where T : class
+            {
+                return input;
+            }
+        }
+
+        public class ExitSpanTests
+        {
+            [Fact]
+            public void SetCodeOrigin_WhenSpanIsNull_DoesNotThrow()
+            {
+                // Should not throw
+            SpanCodeOriginManager spanCodeOriginManager = new();
+            spanCodeOriginManager.SetCodeOriginForExitSpan(null);
+            }
+
+            [Fact]
+            public void SetCodeOrigin_WhenDisabled_DoesNotSetTags()
+            {
+                // Arrange
             SpanCodeOriginManager spanCodeOriginManager = new();
             var settingsSetter = SetCodeOriginManagerSettings(spanCodeOriginManager);
 
-            var span = new Span(new SpanContext(1, 2, SamplingPriority.UserKeep), DateTimeOffset.UtcNow);
+                var span = new Span(new SpanContext(1, 2, SamplingPriority.UserKeep), DateTimeOffset.UtcNow);
 
-            // Act
-            SpanCodeOriginManager.Instance.SetCodeOriginForExitSpan(span);
+                // Act
+                SpanCodeOriginManager.Instance.SetCodeOriginForExitSpan(span);
 
-            // Assert
-            span.Tags.GetTag(CodeOriginTag + ".type").Should().BeNull();
-        }
+                // Assert
+                span.Tags.GetTag(CodeOriginTag + ".type").Should().BeNull();
+            }
 
-        [Fact]
-        public void SetCodeOrigin_WhenEnabled_SetsCorrectTags()
-        {
-            // Arrange
+            [Fact]
+            public void SetCodeOrigin_WhenEnabled_SetsCorrectTags()
+            {
+                // Arrange
             SpanCodeOriginManager spanCodeOriginManager = new();
             var settingsSetter = SetCodeOriginManagerSettings(spanCodeOriginManager, true);
 
-            var span = new Span(new SpanContext(1, 2, SamplingPriority.UserKeep), DateTimeOffset.UtcNow);
+                var span = new Span(new SpanContext(1, 2, SamplingPriority.UserKeep), DateTimeOffset.UtcNow);
 
-            // Act
+                // Act
             TestMethod(spanCodeOriginManager, span);
 
-            // Assert
-            var codeOriginType = span.Tags.GetTag($"{CodeOriginTag}.type");
-            codeOriginType.Should().Be("exit");
-            var frame0Method = span.Tags.GetTag($"{CodeOriginTag}.frames.0.method");
-            frame0Method.Should().Be(nameof(TestMethod));
-            var frame0Type = span.Tags.GetTag($"{CodeOriginTag}.frames.0.type");
-            frame0Type.Should().Be(GetType().FullName);
-            var file = span.Tags.GetTag($"{CodeOriginTag}.frames.0.file");
-            file.Should().EndWith($"{nameof(SpanCodeOriginTests)}.cs");
-            var line = span.Tags.GetTag($"{CodeOriginTag}.frames.0.line");
-            line.Should().NotBeNullOrEmpty();
-            var column = span.Tags.GetTag($"{CodeOriginTag}.frames.0.column");
-            column.Should().NotBeNullOrEmpty();
-        }
+                // Assert
+                var codeOriginType = span.Tags.GetTag($"{CodeOriginTag}.type");
+                codeOriginType.Should().Be("exit");
+                var frame0Method = span.Tags.GetTag($"{CodeOriginTag}.frames.0.method");
+                frame0Method.Should().Be(nameof(TestMethod));
+                var frame0Type = span.Tags.GetTag($"{CodeOriginTag}.frames.0.type");
+                frame0Type.Should().Be(GetType().FullName);
+                var file = span.Tags.GetTag($"{CodeOriginTag}.frames.0.file");
+                file.Should().EndWith($"{nameof(SpanCodeOriginTests)}.cs");
+                var line = span.Tags.GetTag($"{CodeOriginTag}.frames.0.line");
+                line.Should().NotBeNullOrEmpty();
+                var column = span.Tags.GetTag($"{CodeOriginTag}.frames.0.column");
+                column.Should().NotBeNullOrEmpty();
+            }
 
-        [Fact]
-        public void SetCodeOrigin_WithMaxFramesLimit_RespectsLimit()
-        {
-            // Arrange
+            [Fact]
+            public void SetCodeOrigin_WithMaxFramesLimit_RespectsLimit()
+            {
+                // Arrange
             SpanCodeOriginManager spanCodeOriginManager = new();
             var settingsSetter = SetCodeOriginManagerSettings(spanCodeOriginManager, true, 2);
 
-            var span = new Span(new SpanContext(1, 2, SamplingPriority.UserKeep), DateTimeOffset.UtcNow);
+                var span = new Span(new SpanContext(1, 2, SamplingPriority.UserKeep), DateTimeOffset.UtcNow);
 
-            // Act
+                // Act
             DeepTestMethod1(span, spanCodeOriginManager);
 
-            // Assert
-            var tags = ((List<KeyValuePair<string, string>>)(typeof(Datadog.Trace.Tagging.TagsList).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(span.Tags))).Select(i => i.Key).ToList();
-            tags.Should().Contain(s => s.StartsWith($"{CodeOriginTag}.frames.0"));
-            tags.Should().Contain(s => s.StartsWith($"{CodeOriginTag}.frames.1"));
-            tags.Should().NotContain(s => s.StartsWith($"{CodeOriginTag}.frames.2"));
-        }
-
-        private static CodeOriginSettingsSetter SetCodeOriginManagerSettings(SpanCodeOriginManager instance, bool isEnable = false, int numberOfFrames = 8, string excludeFromFilter = "Datadog.Trace.Tests")
+                // Assert
+                var tags = ((List<KeyValuePair<string, string>>)(typeof(Datadog.Trace.Tagging.TagsList).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(span.Tags))).Select(i => i.Key).ToList();
+                tags.Should().Contain(s => s.StartsWith($"{CodeOriginTag}.frames.0"));
+                tags.Should().Contain(s => s.StartsWith($"{CodeOriginTag}.frames.1"));
+                tags.Should().NotContain(s => s.StartsWith($"{CodeOriginTag}.frames.2"));
+            }
+			
+			private static CodeOriginSettingsSetter SetCodeOriginManagerSettings(SpanCodeOriginManager instance, bool isEnable = false, int numberOfFrames = 8, string excludeFromFilter = "Datadog.Trace.Tests")
         {
             var setter = new CodeOriginSettingsSetter();
             setter.Set(isEnable, numberOfFrames, excludeFromFilter, instance);
             return setter;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+            [MethodImpl(MethodImplOptions.NoInlining)]
         private void TestMethod(SpanCodeOriginManager instance, Span span)
-        {
+            {
             instance.SetCodeOriginForExitSpan(span);
-        }
+            }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+            [MethodImpl(MethodImplOptions.NoInlining)]
         private void DeepTestMethod1(Span span, SpanCodeOriginManager instance)
-        {
+            {
             DeepTestMethod2(span, instance);
-        }
+            }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+            [MethodImpl(MethodImplOptions.NoInlining)]
         private void DeepTestMethod2(Span span, SpanCodeOriginManager instance)
-        {
+            {
             DeepTestMethod3(span, instance);
-        }
+            }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+            [MethodImpl(MethodImplOptions.NoInlining)]
         private void DeepTestMethod3(Span span, SpanCodeOriginManager instance)
-        {
+            {
             instance.SetCodeOriginForExitSpan(span);
+            }
         }
 
-        internal class CodeOriginSettingsSetter
+        internal class CodeOriginSettingsSetter : IDisposable
         {
-            internal void Set(bool isEnable, int numberOfFrames, string excludeFromFilter, SpanCodeOriginManager instance)
+            private int _maxUserFrames;
+
+            private bool _isCodeOriginEnabled;
+
+            private ImmutableHashSet<string> _thirdPartyDetectionExcludes;
+
+            private SpanCodeOriginManager.CodeOriginTags _tags;
+
+            public void Dispose()
+            {
+                var instance = SpanCodeOriginManager.Instance;
+                var maxUserFrameField = instance.GetType().GetField("_maxUserFrames", BindingFlags.NonPublic | BindingFlags.Instance);
+                var isCodeOriginEnabledField = instance.GetType().GetField("_isCodeOriginEnabled", BindingFlags.NonPublic | BindingFlags.Instance);
+                var thirdPartyDetectionExcludesField = instance.GetType().GetField("_thirdPartyDetectionExcludes", BindingFlags.NonPublic | BindingFlags.Instance);
+                var tagsField = instance.GetType().GetField("_tags", BindingFlags.NonPublic | BindingFlags.Instance);
+                maxUserFrameField.SetValue(instance, this._maxUserFrames);
+                isCodeOriginEnabledField.SetValue(instance, _isCodeOriginEnabled);
+                thirdPartyDetectionExcludesField.SetValue(instance, _thirdPartyDetectionExcludes);
+                tagsField.SetValue(instance, _tags);
+            }
+
+            internal void Set(bool isEnable, int numberOfFrames, string excludeFromFilter)
+            {
+                var instance = SpanCodeOriginManager.Instance;
+                var maxUserFrameField = instance.GetType().GetField("_maxUserFrames", BindingFlags.NonPublic | BindingFlags.Instance);
+                var isCodeOriginEnabledField = instance.GetType().GetField("_isCodeOriginEnabled", BindingFlags.NonPublic | BindingFlags.Instance);
+                var thirdPartyDetectionExcludesField = instance.GetType().GetField("_thirdPartyDetectionExcludes", BindingFlags.NonPublic | BindingFlags.Instance);
+                var tagsField = instance.GetType().GetField("_tags", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                // save to restore later
+                _maxUserFrames = (int)maxUserFrameField.GetValue(instance);
+                _isCodeOriginEnabled = (bool)isCodeOriginEnabledField.GetValue(instance);
+                _thirdPartyDetectionExcludes = (ImmutableHashSet<string>)thirdPartyDetectionExcludesField.GetValue(instance);
+                _tags = (SpanCodeOriginManager.CodeOriginTags)tagsField.GetValue(instance);
+
+                // set test values
+                maxUserFrameField.SetValue(instance, numberOfFrames);
+                isCodeOriginEnabledField.SetValue(instance, isEnable);
+                thirdPartyDetectionExcludesField.SetValue(instance, new[] { excludeFromFilter }.ToImmutableHashSet());
+                tagsField.SetValue(instance, new SpanCodeOriginManager.CodeOriginTags(numberOfFrames));
+            }
+			
+			internal void Set(bool isEnable, int numberOfFrames, string excludeFromFilter, SpanCodeOriginManager instance)
             {
                 var overrideSettings = DebuggerSettings.FromSource(
                     new NameValueConfigurationSource(
@@ -140,5 +368,17 @@ namespace Datadog.Trace.Tests.Debugger
                 instance.GetType().GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(instance, overrideSettings);
             }
         }
+
+        internal class GenericType<T>
+        {
+        }
+
+#if !NETFRAMEWORK
+        internal class TestController : Microsoft.AspNetCore.Mvc.ControllerBase
+        {
+            [HttpGet]
+            public object Get() => null;
+        }
+#endif
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tests.Debugger
                 using var settingsSetter = SetCodeOriginManagerSettings(true);
                 var span = CreateSpan();
                 var type = GetType();
-                var method = type.GetMethod(nameof(this.TestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
+                var method = type.GetMethod(nameof(TestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
 
                 // Act
                 SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, type, method);
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tests.Debugger
                 // Assert
                 span.GetTag($"{CodeOriginTag}.type").Should().Be("entry");
                 span.GetTag($"{CodeOriginTag}.frames.0.index").Should().Be("0");
-                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(this.TestMethod));
+                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(TestMethod));
                 span.GetTag($"{CodeOriginTag}.frames.0.type").Should().Be(type.FullName);
             }
 
@@ -117,14 +117,14 @@ namespace Datadog.Trace.Tests.Debugger
                 using var settingsSetter = SetCodeOriginManagerSettings(true);
                 var span = CreateSpan();
                 var type = GetType();
-                var method = type.GetMethod(nameof(this.TestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
+                var method = type.GetMethod(nameof(TestMethod), BindingFlags.Instance | BindingFlags.NonPublic);
 
                 // Act
                 SpanCodeOriginManager.Instance.SetCodeOriginForEntrySpan(span, type, method);
 
                 // Assert
                 span.GetTag($"{CodeOriginTag}.type").Should().Be("entry");
-                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(this.TestMethod));
+                span.GetTag($"{CodeOriginTag}.frames.0.method").Should().Be(nameof(TestMethod));
                 span.GetTag($"{CodeOriginTag}.frames.{0}.file").Should().BeNull();
             }
 
@@ -326,7 +326,7 @@ namespace Datadog.Trace.Tests.Debugger
                 var isCodeOriginEnabledField = instance.GetType().GetField("_isCodeOriginEnabled", BindingFlags.NonPublic | BindingFlags.Instance);
                 var thirdPartyDetectionExcludesField = instance.GetType().GetField("_thirdPartyDetectionExcludes", BindingFlags.NonPublic | BindingFlags.Instance);
                 var tagsField = instance.GetType().GetField("_tags", BindingFlags.NonPublic | BindingFlags.Instance);
-                maxUserFrameField.SetValue(instance, this._maxUserFrames);
+                maxUserFrameField.SetValue(instance, _maxUserFrames);
                 isCodeOriginEnabledField.SetValue(instance, _isCodeOriginEnabled);
                 thirdPartyDetectionExcludesField.SetValue(instance, _thirdPartyDetectionExcludes);
                 tagsField.SetValue(instance, _tags);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Tests.Debugger
         {
             // Should not throw
             SpanCodeOriginManager spanCodeOriginManager = new();
-            spanCodeOriginManager.SetCodeOrigin(null);
+            spanCodeOriginManager.SetCodeOriginForExitSpan(null);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace Datadog.Trace.Tests.Debugger
             var span = new Span(new SpanContext(1, 2, SamplingPriority.UserKeep), DateTimeOffset.UtcNow);
 
             // Act
-            SpanCodeOriginManager.Instance.SetCodeOrigin(span);
+            SpanCodeOriginManager.Instance.SetCodeOriginForExitSpan(span);
 
             // Assert
             span.Tags.GetTag(CodeOriginTag + ".type").Should().BeNull();
@@ -102,7 +102,7 @@ namespace Datadog.Trace.Tests.Debugger
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void TestMethod(SpanCodeOriginManager instance, Span span)
         {
-            instance.SetCodeOrigin(span);
+            instance.SetCodeOriginForExitSpan(span);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -120,7 +120,7 @@ namespace Datadog.Trace.Tests.Debugger
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void DeepTestMethod3(Span span, SpanCodeOriginManager instance)
         {
-            instance.SetCodeOrigin(span);
+            instance.SetCodeOriginForExitSpan(span);
         }
 
         internal class CodeOriginSettingsSetter

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Debugger;
 using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.RemoteConfigurationManagement;
@@ -47,7 +48,8 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
             var client = testServer.CreateClient();
             var tracer = GetTracer();
             var (security, iast) = GetSecurity();
-            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security, iast) };
+			var liveDebugger = GetLiveDebugger();
+            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security, iast, liveDebugger, null) };
             string retValue = null;
 
             using (var diagnosticManager = new DiagnosticManager(observers))
@@ -71,8 +73,9 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
         {
             var tracer = GetTracer();
             var (security, iast) = GetSecurity();
+			var liveDebugger = GetLiveDebugger();
 
-            IObserver<KeyValuePair<string, object>> observer = new AspNetCoreDiagnosticObserver(tracer, security, iast);
+            IObserver<KeyValuePair<string, object>> observer = new AspNetCoreDiagnosticObserver(tracer, security, iast, liveDebugger, null);
 
             var context = new HostingApplication.Context { HttpContext = GetHttpContext() };
 
@@ -121,6 +124,11 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
                 rcmSubscriptionManager: Mock.Of<IRcmSubscriptionManager>());
             var iast = new Iast.Iast(new IastSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance), NullDiscoveryService.Instance);
             return (security, iast);
+        }
+		
+		private static LiveDebugger GetLiveDebugger()
+        {
+            return LiveDebuggerFactory.Create(null, null, new TracerSettings(), null, null, DebuggerSettings.FromDefaultSource(), null);
         }
 
         private static HttpContext GetHttpContext()

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
             var client = testServer.CreateClient();
             var tracer = GetTracer();
             var (security, iast) = GetSecurity();
-			var liveDebugger = GetLiveDebugger();
+            var liveDebugger = GetLiveDebugger();
             var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security, iast, liveDebugger, null) };
             string retValue = null;
 
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
         {
             var tracer = GetTracer();
             var (security, iast) = GetSecurity();
-			var liveDebugger = GetLiveDebugger();
+            var liveDebugger = GetLiveDebugger();
 
             IObserver<KeyValuePair<string, object>> observer = new AspNetCoreDiagnosticObserver(tracer, security, iast, liveDebugger, null);
 
@@ -125,8 +125,8 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
             var iast = new Iast.Iast(new IastSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance), NullDiscoveryService.Instance);
             return (security, iast);
         }
-		
-		private static LiveDebugger GetLiveDebugger()
+
+        private static LiveDebugger GetLiveDebugger()
         {
             return LiveDebuggerFactory.Create(null, null, new TracerSettings(), null, null, DebuggerSettings.FromDefaultSource(), null);
         }


### PR DESCRIPTION
## Summary of changes
This PR extends our code origin capabilities by adding source code information to entry spans in ASP.NET Core applications.
In a previous PR, we implemented code origin for exit spans. This PR completes the feature by adding similar capabilities to entry spans, providing a comprehensive view of code execution paths.

## Implementation details
The code origin information is injected when ASP.NET Core is about to execute the endpoint handler.

### Performance Optimization
The implementation employs several techniques to minimize performance impact while maintaining robust functionality:

- Assembly metadata is processed only upon first encounter, with subsequent operations utilizing cached data
- Only essential endpoint information is retained
- Utilizes `System.Reflection.Metadata` for efficient assembly inspection without loading full type information into memory
- Employs pre-computed constant strings to reduce GC pressure and string allocations in hot paths


## Test coverage
`SpanCodeOriginTests`
