### PR TITLE
Add additional exclusions for dependency collection

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -176,15 +176,19 @@ namespace Datadog.Trace.Telemetry
 
         private static bool IsZeroVersionAssemblyPattern(string assemblyName)
         {
-            return assemblyName.Length == 8
-                && IsBase32Char(assemblyName[0])
-                && IsBase32Char(assemblyName[1])
-                && IsBase32Char(assemblyName[2])
-                && IsBase32Char(assemblyName[3])
-                && IsBase32Char(assemblyName[4])
-                && IsBase32Char(assemblyName[5])
-                && IsBase32Char(assemblyName[6])
-                && IsBase32Char(assemblyName[7]);
+            // e.g.
+            //    454845b558934321ad350977dd095960
+            //    akkynf62
+            return (assemblyName.Length == 8
+                 && IsBase32Char(assemblyName[0])
+                 && IsBase32Char(assemblyName[1])
+                 && IsBase32Char(assemblyName[2])
+                 && IsBase32Char(assemblyName[3])
+                 && IsBase32Char(assemblyName[4])
+                 && IsBase32Char(assemblyName[5])
+                 && IsBase32Char(assemblyName[6])
+                 && IsBase32Char(assemblyName[7]))
+                || (assemblyName.Length == 32 && IsHexString(assemblyName, 0));
         }
 
         private static bool IsBase32Char(char c)

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -188,7 +188,7 @@ namespace Datadog.Trace.Telemetry
                  && IsBase32Char(assemblyName[5])
                  && IsBase32Char(assemblyName[6])
                  && IsBase32Char(assemblyName[7]))
-                || (assemblyName.Length == 32 && IsHexString(assemblyName, 0));
+                || (assemblyName.Length >= 32 && IsHexString(assemblyName, 0));
         }
 
         private static bool IsBase32Char(char c)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -184,6 +184,24 @@ namespace Datadog.Trace.Tests.Telemetry
             }
         }
 
+        [Theory]
+        [InlineData("454845b558934321ad350977dd095960")]
+        [InlineData("41e68894e3e54239abe61eb16cb0e158")]
+        [InlineData("a1bc683e730d425c9de5fdf00dbdc003")]
+        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndHas32CharName(string name)
+        {
+            var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
+
+            var collector = new DependencyTelemetryCollector();
+            collector.AssemblyLoaded(ignoredName, "some-guid");
+
+            collector.HasChanges().Should().BeFalse($"{name} has a zero version");
+
+            var nonIgnoredName = CreateAssemblyName(new Version(1, 0, 0, 0), name: name);
+            collector.AssemblyLoaded(nonIgnoredName, "some-guid");
+            collector.HasChanges().Should().BeTrue($"{nonIgnoredName} has a non-zero version");
+        }
+
         [Fact]
         public void HasChangesWhenAddingSameAssemblyWithDifferentVersion()
         {


### PR DESCRIPTION
## Summary of changes

Excludes 32-long hex strings with a 0.0.0.0 version number

## Reason for change

We recently saw an explosion of these (we're not sure exactly what's generating them) 

## Implementation details

Add additional exclusion pattern for 0 version dependencies

## Test coverage

Added some test cases

## Other details

We could make this more general (i.e. don't worry about the 0.0.0.0 version bit), my concern is excluding "valid" assemblies accidentally