### PR TITLE
Exclude Paket from exploration tests for now

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -537,7 +537,7 @@ public enum ExplorationTestUseCase
 
 public enum ExplorationTestName
 {
-    eShopOnWeb, protobuf, cake, swashbuckle, paket, RestSharp, serilog, polly, automapper
+    eShopOnWeb, protobuf, cake, swashbuckle, RestSharp, serilog, polly, automapper, // paket, FIXME: .NET 9 - Paket doesn't support .NET 9 yet
 }
 
 class ExplorationTestDescription
@@ -643,17 +643,18 @@ class ExplorationTestDescription
                 // Workaround for https://github.com/dotnet/runtime/issues/95653
                 EnvironmentVariables = new[] { ("DD_CLR_ENABLE_INLINING", "0") },
             },
-            ExplorationTestName.paket => new ExplorationTestDescription()
-            {
-                Name = ExplorationTestName.paket,
-                GitRepositoryUrl = "https://github.com/fsprojects/Paket.git",
-                GitRepositoryTag = "6.2.1",
-                IsGitShallowCloneSupported = true,
-                PathToUnitTestProject = "tests/Paket.Tests",
-                TestsToIgnore = new[] { "Loading assembly metadata works", "task priorization works" /* fails on timing */, "should normalize home path", "should parse config with home path in cache" },
-                SupportedFrameworks = new[] { TargetFramework.NET461 },
-                ShouldRun = false // Dictates that this exploration test should not take part in the CI
-            },
+            // FIXME: .NET 9 - Paket doesn't support .NET 9 yet
+            // ExplorationTestName.paket => new ExplorationTestDescription()
+            // {
+            //     Name = ExplorationTestName.paket,
+            //     GitRepositoryUrl = "https://github.com/fsprojects/Paket.git",
+            //     GitRepositoryTag = "6.2.1",
+            //     IsGitShallowCloneSupported = true,
+            //     PathToUnitTestProject = "tests/Paket.Tests",
+            //     TestsToIgnore = new[] { "Loading assembly metadata works", "task priorization works" /* fails on timing */, "should normalize home path", "should parse config with home path in cache" },
+            //     SupportedFrameworks = new[] { TargetFramework.NET461 },
+            //     ShouldRun = false // Dictates that this exploration test should not take part in the CI
+            // },
             ExplorationTestName.RestSharp => new ExplorationTestDescription()
             {
                 Name = ExplorationTestName.RestSharp,


### PR DESCRIPTION
## Summary of changes

Excludes Paket from exploration tests

## Reason for change

Paket apparently doesn't work with .NET 9, it fails to restore:

```
[ERR] SetUpExplorationTest: D:\a\1\s\exploration-tests\paket\.paket\Paket.Restore.targets(171,5): error MSB3073: The command ""D:\a\1\s\exploration-tests\paket\.paket\paket.exe" restore" exited with code -1. [D:\a\1\s\exploration-tests\paket\src\Paket.Core\Paket.Core.fsproj]
[ERR] SetUpExplorationTest: D:\a\1\s\exploration-tests\paket\.paket\Paket.Restore.targets(171,3): error MSB3073: The command ""D:\a\1\s\exploration-tests\paket\.paket\paket.exe" restore" exited with code -1. [D:\a\1\s\exploration-tests\paket\src\Paket\Paket.fsproj]
```

## Implementation details

Just exclude Paket from the tests for now

## Test coverage

Less

## Other details

I didn't notice that this was a genuine failure in the .NET 9 PR because these fail so much that I never pay them any attention 🙈 