### PR TITLE
[CI Visibility] Add support for coverlet.msbuild coverage reporting

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/CoverageGetCoverageResultIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/CoverageGetCoverageResultIntegration.cs
@@ -35,7 +35,7 @@ public class CoverageGetCoverageResultIntegration
 {
     internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
     {
-        if (!DotnetCommon.IsDataCollectorDomain)
+        if (!DotnetCommon.IsDataCollectorDomain && !DotnetCommon.IsMsBuildTask)
         {
             return new CallTargetReturn<TReturn>(returnValue);
         }
@@ -64,7 +64,6 @@ public class CoverageGetCoverageResultIntegration
             var percentage = coverageDetails.Percent;
             DotnetCommon.Log.Information("CoverageGetCoverageResult.Percentage: {Value}", percentage);
 
-            // Extract session variables (from out of process sessions)
             var context = SpanContextPropagator.Instance.Extract(
                 EnvironmentHelpers.GetEnvironmentVariables(),
                 new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -28,6 +29,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
 
         internal static readonly IDatadogLogger Log = Ci.CIVisibility.Log;
         private static bool? _isDataCollectorDomainCache;
+        private static bool? _isMsBuildTaskCache;
 
         internal static bool DotnetTestIntegrationEnabled => CIVisibility.IsRunning && Tracer.Instance.Settings.IsIntegrationEnabled(DotnetTestIntegrationId);
 
@@ -40,7 +42,43 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
                     return value;
                 }
 
+                // If the AppDomainName contains "DataCollector" we are in the data collector domain
                 return (_isDataCollectorDomainCache = DomainMetadata.Instance.AppDomainName.ToLowerInvariant().Contains("datacollector")).Value;
+            }
+        }
+
+        internal static bool IsMsBuildTask
+        {
+            get
+            {
+                if (_isMsBuildTaskCache is { } value)
+                {
+                    return value;
+                }
+
+                // Let's try to detect if we are in the MSBuild task scenario
+                // the process name is not guaranteed so we need to check the stack trace
+                // to see if we are getting called from the Coverlet.MSbuild.Tasks namespace
+                // because we don't need any symbols this should be fast enough.
+                if (new StackTrace(3, false).GetFrames() is { } frames)
+                {
+                    foreach (var stackFrame in frames)
+                    {
+                        if (stackFrame is null)
+                        {
+                            continue;
+                        }
+
+                        if (stackFrame.GetMethod()?.DeclaringType?.FullName?.Contains("Coverlet.MSbuild.Tasks") == true)
+                        {
+                            return (_isMsBuildTaskCache = true).Value;
+                        }
+                    }
+
+                    _isMsBuildTaskCache = false;
+                }
+
+                return _isMsBuildTaskCache ?? false;
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
@@ -69,9 +69,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
                             continue;
                         }
 
-                        if (stackFrame.GetMethod()?.DeclaringType?.FullName?.Contains("Coverlet.MSbuild.Tasks") == true)
+                        if (stackFrame.GetMethod()?.DeclaringType?.FullName?.StartsWith("Coverlet.MSbuild.Tasks") == true)
                         {
-                            return (_isMsBuildTaskCache = true).Value;
+                            _isMsBuildTaskCache = true;
+                            return true;
                         }
                     }
 

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.DuckTyping
                         DuckTypeTargetMethodNotFoundException.Throw(proxyMethodDefinition);
                     }
 
-                    targetMethod = targetMethod.MakeGenericMethod(proxyDuckAttribute.GenericParameterTypeNames.Select(name => Type.GetType(name, throwOnError: true)!).ToArray());
+                    targetMethod = targetMethod.MakeGenericMethod(proxyDuckAttribute.GenericParameterTypeNames.Select(name => GetTypeFromPartialName(name, throwOnError: true)!).ToArray());
                 }
 
                 // Gets target method parameters
@@ -383,7 +383,7 @@ namespace Datadog.Trace.DuckTyping
                 }
 
                 Type[] parameterTypes = proxyMethodDuckAttributeParameterTypeNames
-                                                                .Select(pName => Type.GetType(pName, throwOnError: false))
+                                                                .Select(pName => GetTypeFromPartialName(pName))
                                                                 .Where(type => type is not null)
                                                                 .ToArray()!;
                 if (parameterTypes.Length == proxyMethodDuckAttributeParameterTypeNames.Length)

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -12,7 +12,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 
 // ReSharper disable InconsistentNaming
 

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -12,7 +12,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-
 // ReSharper disable InconsistentNaming
 
 namespace Datadog.Trace.DuckTyping


### PR DESCRIPTION
## Summary of changes

This PR add support to automatic reporting code coverage percentage from the `coverlet.msbuild` package.

## Reason for change

We added support to automatic reporting from the coverlet datacollector but we were missing the automatic reporting from the coverlet msbuild task.

## Implementation details

For some reason we are hitting an edge case in the DuckType library were `Type.GetType` returns null when using a partial type name and not a qualified one. I did a modification to the ducktype library to handle this edge case.

## Test coverage

Works on my machine 🤷🏻  🤣 .

Now seriously... creating a test for this specific feature will require a refactor to the way we run/publish the samples apps. Currently we build a publish them in a different step to the artifacts folder and run them later in the test. `coverlet.msbuild` is not compatible with that because it contains a series of msbuild tasks that applies new targets to build the covered binary and then get the coverage values after the execution. Something that we cannot do right now.

Because this is a niche, best effort, and easy to test locally functionality. I decided to skip a custom test for this one. I'm evaluating on adding the test in the Test Visibility test-environment that it would be easier to do.

For the ducktyping change if this PR passes we are ok to go because a change of behaviour in the normal case is not expected.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
