### PR TITLE
[Profiler] Use chrono types instead of integer type

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -174,30 +174,29 @@ bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
     return true;
 }
 
-uint64_t GetThreadCpuTime(IThreadInfo* pThreadInfo)
+std::chrono::milliseconds GetThreadCpuTime(IThreadInfo* pThreadInfo)
 {
     bool isRunning = false;
     uint64_t cpuTime = 0;
     if (!GetCpuInfo(pThreadInfo->GetOsThreadId(), isRunning, cpuTime))
     {
-        return 0;
+        return 0ms;
     }
 
-    return cpuTime;
+    return std::chrono::milliseconds(cpuTime);
 }
 
-bool IsRunning(IThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
+//    isRunning,        cpu time          , failed 
+std::tuple<bool, std::chrono::milliseconds, bool> IsRunning(IThreadInfo* pThreadInfo)
 {
     bool isRunning = false;
+    uint64_t cpuTime = 0;
     if (!GetCpuInfo(pThreadInfo->GetOsThreadId(), isRunning, cpuTime))
     {
-        cpuTime = 0;
-        failed = true;
-        return false;
+        return {false, 0ms, true};
     }
 
-    failed = false;
-    return isRunning;
+    return {isRunning, std::chrono::milliseconds(cpuTime), false};
 }
 
 // from https://linux.die.net/man/3/get_nprocs

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -244,7 +244,7 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
     rawCpuSample.AppDomainId = threadInfo->GetAppDomainId();
     rawCpuSample.Stack = std::move(callstack);
     rawCpuSample.ThreadInfo = std::move(threadInfo);
-    rawCpuSample.Duration = _samplingInterval.count();
+    rawCpuSample.Duration = _samplingInterval;
     _pProvider->Add(std::move(rawCpuSample));
 
     return true;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj
@@ -219,6 +219,7 @@
   <ItemGroup>
     <ClInclude Include="..\Datadog.Profiler.Native\DllMain.h" />
     <ClInclude Include="..\Datadog.Profiler.Native.Windows\resource.h" />
+    <ClInclude Include="chrono_helper.hpp" />
     <ClInclude Include="CrashReportingWindows.h" />
     <ClInclude Include="EtwEventsManager.h" />
     <ClInclude Include="ETW\EtwEventsHandler.h" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClInclude Include="CrashReportingWindows.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="chrono_helper.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Windows32BitStackFramesCollector.cpp">

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.cpp
@@ -5,6 +5,9 @@
 #include "Protocol.h"
 #include "IpcClient.h"
 #include "../../Datadog.Profiler.Native/ClrEventsParser.h"
+
+#include "../chrono_helper.hpp"
+
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -115,7 +118,7 @@ void EtwEventsHandler::OnConnect(HANDLE hPipe)
             uint64_t keyword = pHeader->EventDescriptor.Keyword;
             uint8_t level = pHeader->EventDescriptor.Level;
             uint16_t id = pHeader->EventDescriptor.Id;
-            uint64_t timestamp = pHeader->TimeStamp.QuadPart;
+            auto timestamp = etw_timestamp(pHeader->TimeStamp.QuadPart);
 
             ClrEventPayload* pPayload = (ClrEventPayload*)(&(message->Payload));
             uint16_t userDataLength = pPayload->EtwUserDataLength;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IEtwEventsReceiver.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IEtwEventsReceiver.h
@@ -5,12 +5,13 @@
 
 #include <cstdint>
 
+#include "../chrono_helper.hpp"
 
 class IEtwEventsReceiver
 {
 public:
     virtual void OnEvent(
-        uint64_t timestamp,  // the events timestamp is in System Time for GMT
+        etw_timestamp timestamp, // the events timestamp is in System Time for GMT
         uint32_t tid,
         uint32_t version,
         uint64_t keyword,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
@@ -10,6 +10,8 @@
 #include "Log.h"
 #include "OpSysTools.h"
 
+#include "chrono_helper.hpp"
+
 #include "Windows.h"
 
 #include <memory>
@@ -43,11 +45,11 @@ EtwEventsManager::EtwEventsManager(
     _IpcServer = nullptr;
 }
 
-
-uint64_t TimestampToEpochNS(uint64_t eventTimestamp)
+static std::chrono::nanoseconds TimestampToEpochNS(etw_timestamp evtTimestamp)
 {
     // the event timestamp is in 100ns units since 1601-01-01 in UTC
     FILETIME ft;
+    auto eventTimestamp = evtTimestamp.count();
     ft.dwLowDateTime = eventTimestamp & 0xFFFFFFFF;
     ft.dwHighDateTime = eventTimestamp >> 32;
 
@@ -69,11 +71,12 @@ uint64_t TimestampToEpochNS(uint64_t eventTimestamp)
     t.tm_isdst = -1; // don't mess with daylight saving time (already done by SystemTimeToTzSpecificLocalTime)
     time_t timeSinceEpoch = mktime(&t);
 
-    return timeSinceEpoch * 1000'000'000 + st.wMilliseconds * 1'000'000;  // don't loose the milliseconds accuracy
+    auto timestampNs = timeSinceEpoch * 1000'000'000 + st.wMilliseconds * 1'000'000;  // don't loose the milliseconds accuracy
+    return std::chrono::nanoseconds(timestampNs);
 }
 
 void EtwEventsManager::OnEvent(
-    uint64_t systemTimestamp,
+    etw_timestamp systemTimestamp,
     uint32_t tid,
     uint32_t version,
     uint64_t keyword,
@@ -158,13 +161,13 @@ void EtwEventsManager::OnEvent(
             if (pThreadInfo != nullptr)
             {
                 pThreadInfo->ClearLastEventId();
-                if (pThreadInfo->ContentionStartTimestamp != 0)
+                if (pThreadInfo->ContentionStartTimestamp != etw_timestamp::zero())
                 {
-                    auto timestamp = std::chrono::nanoseconds(TimestampToEpochNS(systemTimestamp));
-                    auto duration = (systemTimestamp - pThreadInfo->ContentionStartTimestamp) * 100;  // systemTimestamp is in 100ns units
-                    pThreadInfo->ContentionStartTimestamp = 0;
+                    auto timestamp = TimestampToEpochNS(systemTimestamp);
+                    std::chrono::nanoseconds duration = systemTimestamp - pThreadInfo->ContentionStartTimestamp;
+                    pThreadInfo->ContentionStartTimestamp = etw_timestamp::zero();
 
-                    _pContentionListener->OnContention(timestamp, tid, std::chrono::nanoseconds(duration), pThreadInfo->ContentionCallStack);
+                    _pContentionListener->OnContention(timestamp, tid, duration, pThreadInfo->ContentionCallStack);
                 }
             }
             else
@@ -214,7 +217,7 @@ void EtwEventsManager::OnEvent(
             // Since the events are received asynchronously, it is not even possible
             // to assume that the object that was stored at the received Adress field
             // is still there: it could have been moved by a garbage collection
-            AllocationTickV3Payload* pPayload = (AllocationTickV3Payload*)pEventData;
+            auto* pPayload = reinterpret_cast<AllocationTickV3Payload const*>(pEventData);
             pThreadInfo->AllocationTickTimestamp = timestamp;
             pThreadInfo->AllocationKind = pPayload->AllocationKind;
 
@@ -226,7 +229,7 @@ void EtwEventsManager::OnEvent(
             }
             else
             {
-                pThreadInfo->AllocationClassId = (uintptr_t)pPayload->TypeId;
+                pThreadInfo->AllocationClassId = pPayload->TypeId;
             }
 
             pThreadInfo->AllocationAmount = pPayload->AllocationAmount64;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
@@ -160,11 +160,11 @@ void EtwEventsManager::OnEvent(
                 pThreadInfo->ClearLastEventId();
                 if (pThreadInfo->ContentionStartTimestamp != 0)
                 {
-                    auto timestamp = TimestampToEpochNS(systemTimestamp); // systemTimestamp is in 100ns units
-                    auto duration = (systemTimestamp - pThreadInfo->ContentionStartTimestamp) * 100;
+                    auto timestamp = std::chrono::nanoseconds(TimestampToEpochNS(systemTimestamp));
+                    auto duration = (systemTimestamp - pThreadInfo->ContentionStartTimestamp) * 100;  // systemTimestamp is in 100ns units
                     pThreadInfo->ContentionStartTimestamp = 0;
 
-                    _pContentionListener->OnContention(timestamp, tid, duration, pThreadInfo->ContentionCallStack);
+                    _pContentionListener->OnContention(timestamp, tid, std::chrono::nanoseconds(duration), pThreadInfo->ContentionCallStack);
                 }
             }
             else

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.h
@@ -13,8 +13,12 @@
 
 
 #include "Configuration.h"
+#include "chrono_helper.hpp"
+
+#include <chrono>
 #include <memory>
 
+using namespace std::chrono_literals;
 
 enum class EventId : uint32_t
 {
@@ -22,7 +26,6 @@ enum class EventId : uint32_t
     ContentionStart = 1,
     AllocationTick = 2
 };
-
 
 struct ThreadInfo
 {
@@ -34,11 +37,11 @@ struct ThreadInfo
 
     // Lock contentions
     std::vector<uintptr_t> ContentionCallStack;
-    uint64_t ContentionStartTimestamp = 0;
+    etw_timestamp ContentionStartTimestamp = etw_timestamp(0);
 
     // Allocations
     std::vector<uintptr_t> AllocationCallStack;
-    uint64_t AllocationTickTimestamp = 0;
+    std::chrono::nanoseconds AllocationTickTimestamp = 0ns;
     uint32_t AllocationKind = 0;
     uintptr_t AllocationClassId = 0;
     std::string AllocatedType;
@@ -79,7 +82,7 @@ public:
 
 // Inherited via IEtwEventsReceiver
     void OnEvent(
-        uint64_t systemTimestamp,
+        etw_timestamp systemTimestamp,
         uint32_t tid,
         uint32_t version,
         uint64_t keyword,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.h
@@ -37,7 +37,7 @@ struct ThreadInfo
 
     // Lock contentions
     std::vector<uintptr_t> ContentionCallStack;
-    etw_timestamp ContentionStartTimestamp = etw_timestamp(0);
+    etw_timestamp ContentionStartTimestamp = etw_timestamp::zero();
 
     // Allocations
     std::vector<uintptr_t> AllocationCallStack;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/chrono_helper.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/chrono_helper.hpp
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <chrono>
+
+//
+// etw_timestamp represent the events timestamp in System Time for GMT
+// etw_time is a ratio used to convert between time types
+//
+
+// systemTimestamp == etw_timestamp
+// nanoseconds has      ratio<1, 1000000000> (nano)
+// since is in 100ns units
+// => etw_timestamp has ratio<1, 10000000> (etw_time)
+using etw_time = std::ratio<1, 10000000>;
+
+// the events timestamp is in System Time for GMT
+using etw_timestamp = std::chrono::duration<long long, etw_time>;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
@@ -3,7 +3,10 @@
 #include "Log.h"
 
 #include <algorithm>
+#include <chrono>
 #include <stdexcept>
+
+using namespace std::chrono_literals;
 
 void AdaptiveSampler::Counts::AddTest()
 {
@@ -83,7 +86,7 @@ AdaptiveSampler::AdaptiveSampler(
     _rng = std::mt19937(rd());
     _distribution = std::uniform_real_distribution<>(0.0, 1.0);
 
-    if (windowDuration != std::chrono::milliseconds::zero())
+    if (windowDuration != 0ms)
     {
         _timer.Start();
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -205,7 +205,7 @@ void AllocationsProvider::OnAllocation(std::chrono::nanoseconds timestamp,
 
     // We know that we don't have any span ID nor end point details
 
-    rawSample.Timestamp = std::chrono::nanoseconds(timestamp);
+    rawSample.Timestamp = timestamp;
     auto cs = _callstackProvider.Get();
     const auto nbFrames = std::min(stack.size(), static_cast<std::size_t>(cs.Capacity()));
     auto end_stack = stack.begin() + nbFrames;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -203,7 +203,7 @@ void AllocationsProvider::OnAllocation(uint64_t timestamp,
 
     // We know that we don't have any span ID nor end point details
 
-    rawSample.Timestamp = timestamp;
+    rawSample.Timestamp = std::chrono::nanoseconds(timestamp);
     auto cs = _callstackProvider.Get();
     const auto nbFrames = std::min(stack.size(), static_cast<std::size_t>(cs.Capacity()));
     auto end_stack = stack.begin() + nbFrames;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -18,6 +18,8 @@
 #include "OsSpecificApi.h"
 #include "SampleValueTypeProvider.h"
 
+#include <chrono>
+
 #include "shared/src/native-src/com_ptr.h"
 #include "shared/src/native-src/string.h"
 
@@ -167,7 +169,7 @@ void AllocationsProvider::OnAllocation(uint32_t allocationKind,
     _sampledAllocationsSizeMetric->Add((double_t)objectSize);
 }
 
-void AllocationsProvider::OnAllocation(uint64_t timestamp,
+void AllocationsProvider::OnAllocation(std::chrono::nanoseconds timestamp,
                                        uint32_t threadId,
                                        uint32_t allocationKind,
                                        ClassID classId,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
@@ -15,6 +15,7 @@
 
 #include "shared/src/native-src/dd_memory_resource.hpp"
 
+#include <chrono>
 #include <memory>
 
 class IConfiguration;
@@ -69,7 +70,7 @@ public:
                       uint64_t objectSize,
                       uint64_t allocationAmount) override;
 
-    void OnAllocation(uint64_t timestamp,
+    void OnAllocation(std::chrono::nanoseconds timestamp,
                       uint32_t threadId,
                       uint32_t allocationKind,
                       ClassID classId,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -3,6 +3,7 @@
 
 #include "ClrEventsParser.h"
 
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -13,6 +14,7 @@
 #include "ManagedThreadInfo.h"
 #include "OpSysTools.h"
 
+using namespace std::chrono_literals;
 
 // set to true for debugging purpose
 const bool LogGcEvents = false;
@@ -56,7 +58,7 @@ void ClrEventsParser::Register(IGarbageCollectionsListener* pGarbageCollectionsL
 
 
 void ClrEventsParser::ParseEvent(
-    uint64_t timestamp,
+    std::chrono::nanoseconds timestamp,
     DWORD version,
     INT64 keywords,
     DWORD id,
@@ -91,7 +93,7 @@ void ClrEventsParser::ParseEvent(
 __attribute__((no_sanitize("alignment")))
 #endif
 void
-ClrEventsParser::ParseGcEvent(uint64_t timestamp, DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData)
+ClrEventsParser::ParseGcEvent(std::chrono::nanoseconds timestamp, DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData)
 {
     // look for AllocationTick_V4
     if ((id == EVENT_ALLOCATION_TICK) && (version == 4))
@@ -286,7 +288,7 @@ void ClrEventsParser::ParseContentionEvent(DWORD id, DWORD version, ULONG cbEven
             return;
         }
 
-        _pContentionListener->OnContention(payload.DurationNs);
+        _pContentionListener->OnContention(std::chrono::nanoseconds(std::llround(payload.DurationNs)));
     }
 
     if ((id == EVENT_CONTENTION_START) && (version >= 2))
@@ -302,7 +304,7 @@ void ClrEventsParser::ParseContentionEvent(DWORD id, DWORD version, ULONG cbEven
     }
 }
 
-void ClrEventsParser::NotifySuspension(uint64_t timestamp, uint32_t number, uint32_t generation, uint64_t duration)
+void ClrEventsParser::NotifySuspension(std::chrono::nanoseconds timestamp, uint32_t number, uint32_t generation, std::chrono::nanoseconds duration)
 {
     if (_pGCSuspensionsListener != nullptr)
     {
@@ -310,7 +312,7 @@ void ClrEventsParser::NotifySuspension(uint64_t timestamp, uint32_t number, uint
     }
 }
 
-void ClrEventsParser::NotifyGarbageCollectionStarted(uint64_t timestamp, int32_t number, uint32_t generation, GCReason reason, GCType type)
+void ClrEventsParser::NotifyGarbageCollectionStarted(std::chrono::nanoseconds timestamp, int32_t number, uint32_t generation, GCReason reason, GCType type)
 {
     for (auto& pGarbageCollectionsListener : _pGarbageCollectionsListeners)
     {
@@ -328,9 +330,9 @@ void ClrEventsParser::NotifyGarbageCollectionEnd(
     GCReason reason,
     GCType type,
     bool isCompacting,
-    uint64_t pauseDuration,
-    uint64_t totalDuration,
-    uint64_t endTimestamp,
+    std::chrono::nanoseconds pauseDuration,
+    std::chrono::nanoseconds totalDuration,
+    std::chrono::nanoseconds endTimestamp,
     uint64_t gen2Size,
     uint64_t lohSize,
     uint64_t pohSize
@@ -371,11 +373,11 @@ void ClrEventsParser::ResetGC(GCDetails& gc)
 {
     gc.Number = -1;
     gc.Generation = 0;
-    gc.Reason = (GCReason)0;
-    gc.Type = (GCType)0;
+    gc.Reason = static_cast<GCReason>(0);
+    gc.Type = static_cast<GCType>(0);
     gc.IsCompacting = false;
-    gc.PauseDuration = 0;
-    gc.StartTimestamp = 0;
+    gc.PauseDuration = 0ns;
+    gc.StartTimestamp = 0ns;
     gc.HasGlobalHeapHistoryBeenReceived = false;
     gc.HasHeapStatsBeenReceived = false;
     gc.gen2Size = 0;
@@ -383,14 +385,14 @@ void ClrEventsParser::ResetGC(GCDetails& gc)
     gc.pohSize = 0;
 }
 
-void ClrEventsParser::InitializeGC(uint64_t timestamp, GCDetails& gc, GCStartPayload& payload)
+void ClrEventsParser::InitializeGC(std::chrono::nanoseconds timestamp, GCDetails& gc, GCStartPayload& payload)
 {
     gc.Number = payload.Count;
     gc.Generation = payload.Depth;
     gc.Reason = (GCReason)payload.Reason;
     gc.Type = (GCType)payload.Type;
     gc.IsCompacting = false;
-    gc.PauseDuration = 0;
+    gc.PauseDuration = 0ns;
     gc.StartTimestamp = timestamp;
     gc.HasGlobalHeapHistoryBeenReceived = false;
     gc.HasHeapStatsBeenReceived = false;
@@ -403,7 +405,7 @@ void ClrEventsParser::OnGCTriggered()
 {
 }
 
-void ClrEventsParser::OnGCStart(uint64_t timestamp, GCStartPayload& payload)
+void ClrEventsParser::OnGCStart(std::chrono::nanoseconds timestamp, GCStartPayload& payload)
 {
     NotifyGarbageCollectionStarted(
         timestamp,
@@ -428,32 +430,32 @@ void ClrEventsParser::OnGCEnd(GCEndPayload& payload)
 {
 }
 
-void ClrEventsParser::OnGCSuspendEEBegin(uint64_t timestamp)
+void ClrEventsParser::OnGCSuspendEEBegin(std::chrono::nanoseconds timestamp)
 {
     // we don't know yet what will be the next GC corresponding to this suspension
     // so it is kept until next GCStart
     _suspensionStart = timestamp;
 }
 
-void ClrEventsParser::OnGCRestartEEEnd(uint64_t timestamp)
+void ClrEventsParser::OnGCRestartEEEnd(std::chrono::nanoseconds timestamp)
 {
     GCDetails& gc = GetCurrentGC();
     if (gc.Number == -1)
     {
         // this might happen (seen in workstation + concurrent mode)
         // --> just skip the suspension because we can associate to a GC
-        _suspensionStart = 0;
+        _suspensionStart = 0ns;
         return;
     }
 
     // compute suspension time
-    uint64_t suspensionDuration = 0;
-    if (_suspensionStart != 0)
+    auto suspensionDuration = 0ns;
+    if (_suspensionStart != 0ns)
     {
         suspensionDuration = timestamp - _suspensionStart;
         NotifySuspension(timestamp, gc.Number, gc.Generation, suspensionDuration);
 
-        _suspensionStart = 0;
+        _suspensionStart = 0ns;
     }
     else
     {
@@ -485,7 +487,7 @@ void ClrEventsParser::OnGCRestartEEEnd(uint64_t timestamp)
     }
 }
 
-void ClrEventsParser::OnGCHeapStats(uint64_t timestamp, uint64_t gen2Size, uint64_t lohSize, uint64_t pohSize)
+void ClrEventsParser::OnGCHeapStats(std::chrono::nanoseconds timestamp, uint64_t gen2Size, uint64_t lohSize, uint64_t pohSize)
 {
     // Note: last event for non background GC (will be GcGlobalHeapHistory for background gen 2)
     GCDetails& gc = GetCurrentGC();
@@ -522,7 +524,7 @@ void ClrEventsParser::OnGCHeapStats(uint64_t timestamp, uint64_t gen2Size, uint6
     }
 }
 
-void ClrEventsParser::OnGCGlobalHeapHistory(uint64_t timestamp, GCGlobalHeapPayload& payload)
+void ClrEventsParser::OnGCGlobalHeapHistory(std::chrono::nanoseconds timestamp, GCGlobalHeapPayload& payload)
 {
     GCDetails& gc = GetCurrentGC();
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -74,11 +74,6 @@ void ClrEventsParser::ParseEvent(
     }
 }
 
-uint64_t ClrEventsParser::GetCurrentTimestamp()
-{
-    return OpSysTools::GetHighPrecisionTimestamp();
-}
-
 // TL;DR Deactivate the alignment check in the Undefined Behavior Sanitizers for the ParseGcEvent function
 // because events fields are not aligned in the bitstream sent by the CLR.
 //

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -468,7 +468,8 @@ void ClrEventsParser::OnGCRestartEEEnd(std::chrono::nanoseconds timestamp)
     if ((gc.Generation < 2) || (gc.Type == GCType::NonConcurrentGC))
     {
         std::stringstream buffer;
-        buffer << "   end of GC #" << gc.Number << " - " << (timestamp - gc.StartTimestamp) / 1000000 << "ms";
+        buffer << "   end of GC #" << gc.Number << " - "
+               << std::chrono::duration_cast<std::chrono::milliseconds>(timestamp - gc.StartTimestamp).count() << "ms";
         LOG_GC_EVENT(buffer.str());
 
         NotifyGarbageCollectionEnd(
@@ -504,7 +505,8 @@ void ClrEventsParser::OnGCHeapStats(std::chrono::nanoseconds timestamp, uint64_t
     if (gc.HasGlobalHeapHistoryBeenReceived && (gc.Generation == 2) && (gc.Type == GCType::BackgroundGC))
     {
             std::stringstream buffer;
-            buffer << "   end of GC #" << gc.Number << " - " << (timestamp - gc.StartTimestamp) / 1000000 << "ms";
+            buffer << "   end of GC #" << gc.Number << " - "
+                   << std::chrono::duration_cast<std::chrono::milliseconds>(timestamp - gc.StartTimestamp).count() << "ms";
             LOG_GC_EVENT(buffer.str());
 
             NotifyGarbageCollectionEnd(
@@ -542,7 +544,8 @@ void ClrEventsParser::OnGCGlobalHeapHistory(std::chrono::nanoseconds timestamp, 
     if (gc.HasHeapStatsBeenReceived && (gc.Generation == 2) && (gc.Type == GCType::BackgroundGC))
     {
         std::stringstream buffer;
-        buffer << "   end of GC #" << gc.Number << " - " << (timestamp - gc.StartTimestamp) / 1000000 << "ms";
+        buffer << "   end of GC #" << gc.Number << " - "
+               << std::chrono::duration_cast<std::chrono::milliseconds>(timestamp - gc.StartTimestamp).count() << "ms";
         LOG_GC_EVENT(buffer.str());
 
         NotifyGarbageCollectionEnd(

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -8,6 +8,7 @@
 #include "corprof.h"
 // end
 
+#include <chrono>
 #include <map>
 #include <math.h>
 #include <shared_mutex>
@@ -215,8 +216,8 @@ struct GCDetails
     GCReason Reason;
     GCType Type;
     bool IsCompacting;
-    uint64_t PauseDuration;
-    uint64_t StartTimestamp;
+    std::chrono::nanoseconds PauseDuration;
+    std::chrono::nanoseconds StartTimestamp;
 
     uint64_t gen2Size;
     uint64_t lohSize;
@@ -250,7 +251,7 @@ public:
     // Lock contention and AllocationTick are synchronous only here.
     //
     void ParseEvent(
-        uint64_t timestamp,
+        std::chrono::nanoseconds timestamp,
         DWORD version,
         INT64 keywords,
         DWORD id,
@@ -261,19 +262,19 @@ public:
     void Register(IGarbageCollectionsListener* pGarbageCollectionsListener);
 
 private:
-    void ParseGcEvent(uint64_t timestamp, DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData);
+    void ParseGcEvent(std::chrono::nanoseconds timestamp, DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData);
     void ParseContentionEvent(DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData);
 
     // garbage collection events processing
     void OnGCTriggered();
-    void OnGCStart(uint64_t timestamp, GCStartPayload& payload);
+    void OnGCStart(std::chrono::nanoseconds timestamp, GCStartPayload& payload);
     void OnGCEnd(GCEndPayload& payload);
-    void OnGCSuspendEEBegin(uint64_t timestamp);
-    void OnGCRestartEEEnd(uint64_t timestamp);
-    void OnGCHeapStats(uint64_t timestamp, uint64_t gen2Size, uint64_t lohSize, uint64_t pohSize);
-    void OnGCGlobalHeapHistory(uint64_t timestamp, GCGlobalHeapPayload& payload);
-    void NotifySuspension(uint64_t timestamp, uint32_t number, uint32_t generation, uint64_t duration);
-    void NotifyGarbageCollectionStarted(uint64_t timestamp, int32_t number, uint32_t generation, GCReason reason, GCType type);
+    void OnGCSuspendEEBegin(std::chrono::nanoseconds timestamp);
+    void OnGCRestartEEEnd(std::chrono::nanoseconds timestamp);
+    void OnGCHeapStats(std::chrono::nanoseconds timestamp, uint64_t gen2Size, uint64_t lohSize, uint64_t pohSize);
+    void OnGCGlobalHeapHistory(std::chrono::nanoseconds timestamp, GCGlobalHeapPayload& payload);
+    void NotifySuspension(std::chrono::nanoseconds timestamp, uint32_t number, uint32_t generation, std::chrono::nanoseconds duration);
+    void NotifyGarbageCollectionStarted(std::chrono::nanoseconds timestamp, int32_t number, uint32_t generation, GCReason reason, GCType type);
 
     void NotifyGarbageCollectionEnd(
         int32_t number,
@@ -281,15 +282,15 @@ private:
         GCReason reason,
         GCType type,
         bool isCompacting,
-        uint64_t pauseDuration,
-        uint64_t totalDuration,
-        uint64_t endTimestamp,
+        std::chrono::nanoseconds pauseDuration,
+        std::chrono::nanoseconds totalDuration,
+        std::chrono::nanoseconds endTimestamp,
         uint64_t gen2Size,
         uint64_t lohSize,
         uint64_t pohSize
         );
     GCDetails& GetCurrentGC();
-    void InitializeGC(uint64_t timestamp, GCDetails& gc, GCStartPayload& payload);
+    void InitializeGC(std::chrono::nanoseconds timestamp, GCDetails& gc, GCStartPayload& payload);
     static void ResetGC(GCDetails& gc);
 
 public:
@@ -329,7 +330,7 @@ private:
  // state for garbage collection details including Stop The World duration
 private:
     // set when GCSuspendEEBegin is received (usually no GC is known at that time)
-    uint64_t _suspensionStart;
+    std::chrono::nanoseconds _suspensionStart;
 
     // for concurrent mode, a background GC could be started
     GCDetails _currentBGC;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -291,8 +291,6 @@ private:
     GCDetails& GetCurrentGC();
     void InitializeGC(uint64_t timestamp, GCDetails& gc, GCStartPayload& payload);
     static void ResetGC(GCDetails& gc);
-    static uint64_t GetCurrentTimestamp();
-
 
 public:
     // Points to the UTF16, null terminated string from the given event data buffer

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -114,7 +114,7 @@ public:
     // with std::shared_ptr<Sample> as out parameter (avoid alloc/dealloc and add up overhead)
     std::shared_ptr<Sample> TransformRawSample(const TRawSample& rawSample)
     {
-        auto sample = std::make_shared<Sample>(0, std::string_view(), rawSample.Stack.Size());
+        auto sample = std::make_shared<Sample>(0ms, std::string_view(), rawSample.Stack.Size());
 
         TransformRawSample(rawSample, sample);
 
@@ -127,7 +127,7 @@ public:
     }
 
 protected:
-    uint64_t GetCurrentTimestamp()
+    std::chrono::nanoseconds GetCurrentTimestamp()
     {
         return OpSysTools::GetHighPrecisionTimestamp();
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -177,7 +177,7 @@ void ContentionProvider::AddContentionSample(uint64_t timestamp, uint32_t thread
 
         // We know that we don't have any span ID nor end point details
 
-        rawSample.Timestamp = timestamp;
+        rawSample.Timestamp = std::chrono::nanoseconds(timestamp);
         auto cs = _callstackProvider.Get();
         const auto nbFrames = std::min(stack.size(), static_cast<std::size_t>(cs.Capacity()));
         auto end_stack = stack.begin() + nbFrames;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -19,6 +19,7 @@
 
 #include <math.h>
 
+using namespace std::chrono_literals;
 
 std::vector<uintptr_t> ContentionProvider::_emptyStack;
 
@@ -57,24 +58,24 @@ ContentionProvider::ContentionProvider(
     _sampledLockContentionsDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_sampled_lock_contentions_duration");
 }
 
-std::string ContentionProvider::GetBucket(double contentionDurationNs)
+std::string ContentionProvider::GetBucket(std::chrono::nanoseconds contentionDuration)
 {
-    if (contentionDurationNs < 10'000'000.0)
+    if (contentionDuration < 10ms)
     {
         return "0 - 9 ms";
     }
 
-    if (contentionDurationNs < 50'000'000.0)
+    if (contentionDuration < 50ms)
     {
         return " 10 - 49 ms";
     }
 
-    if (contentionDurationNs < 100'000'000.0)
+    if (contentionDuration < 100ms)
     {
         return "50 - 99 ms";
     }
 
-    if (contentionDurationNs < 500'000'000.0)
+    if (contentionDuration < 500ms)
     {
         return "100 - 499 ms";
     }
@@ -83,9 +84,9 @@ std::string ContentionProvider::GetBucket(double contentionDurationNs)
 }
 
 // .NET Framework implementation
-void ContentionProvider::OnContention(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, const std::vector<uintptr_t>& stack)
+void ContentionProvider::OnContention(std::chrono::nanoseconds timestamp, uint32_t threadId, std::chrono::nanoseconds contentionDuration, const std::vector<uintptr_t>& stack)
 {
-    AddContentionSample(timestamp, threadId, contentionDurationNs, 0, WStr(""), stack);
+    AddContentionSample(timestamp, threadId, contentionDuration, 0, WStr(""), stack);
 }
 
 void ContentionProvider::SetBlockingThread(uint64_t osThreadId)
@@ -102,7 +103,7 @@ void ContentionProvider::SetBlockingThread(uint64_t osThreadId)
 
 // .NET synchronous implementation: we are expecting to be called from the same thread that is contending.
 // It means that the current thread will be stack walking itself.
-void ContentionProvider::OnContention(double contentionDurationNs)
+void ContentionProvider::OnContention(std::chrono::nanoseconds contentionDuration)
 {
     auto currentThreadInfo = ManagedThreadInfo::CurrentThreadInfo;
     if (currentThreadInfo == nullptr)
@@ -111,20 +112,20 @@ void ContentionProvider::OnContention(double contentionDurationNs)
     }
 
     auto [blockingThreadId, blockingThreadName] = currentThreadInfo->SetBlockingThread(0, WStr(""));
-    AddContentionSample(0, -1, contentionDurationNs, blockingThreadId, std::move(blockingThreadName), _emptyStack);
+    AddContentionSample(0ns, -1, contentionDuration, blockingThreadId, std::move(blockingThreadName), _emptyStack);
 }
 
-void ContentionProvider::AddContentionSample(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, uint64_t blockingThreadId, shared::WSTRING blockingThreadName, const std::vector<uintptr_t>& stack)
+void ContentionProvider::AddContentionSample(std::chrono::nanoseconds timestamp, uint32_t threadId, std::chrono::nanoseconds contentionDuration, uint64_t blockingThreadId, shared::WSTRING blockingThreadName, const std::vector<uintptr_t>& stack)
 {
     _lockContentionsCountMetric->Incr();
-    _lockContentionsDurationMetric->Add(contentionDurationNs);
+    _lockContentionsDurationMetric->Add(contentionDuration.count());
 
-    auto bucket = GetBucket(contentionDurationNs);
+    auto bucket = GetBucket(contentionDuration);
 
     {
         std::lock_guard lock(_contentionsLock);
 
-        if (!_sampler.Sample(bucket, static_cast<uint64_t>(contentionDurationNs)))
+        if (!_sampler.Sample(bucket, contentionDuration.count()))
         {
             return;
         }
@@ -135,7 +136,7 @@ void ContentionProvider::AddContentionSample(uint64_t timestamp, uint32_t thread
     // Synchronous case where the current thread is the contended thread
     // (i.e. receiving the contention events directly from ICorProfilerCallback)
     static uint64_t failureCount = 0;
-    if ((timestamp == 0) && (threadId == -1) && stack.empty())
+    if ((timestamp == 0ns) && (threadId == -1) && stack.empty())
     {
         std::shared_ptr<ManagedThreadInfo> threadInfo;
         CALL(_pManagedThreadList->TryGetCurrentThreadInfo(threadInfo))
@@ -177,7 +178,7 @@ void ContentionProvider::AddContentionSample(uint64_t timestamp, uint32_t thread
 
         // We know that we don't have any span ID nor end point details
 
-        rawSample.Timestamp = std::chrono::nanoseconds(timestamp);
+        rawSample.Timestamp = timestamp;
         auto cs = _callstackProvider.Get();
         const auto nbFrames = std::min(stack.size(), static_cast<std::size_t>(cs.Capacity()));
         auto end_stack = stack.begin() + nbFrames;
@@ -221,14 +222,14 @@ void ContentionProvider::AddContentionSample(uint64_t timestamp, uint32_t thread
         }
     }
 
-    rawSample.ContentionDuration = contentionDurationNs;
+    rawSample.ContentionDuration = contentionDuration;
     rawSample.Bucket = std::move(bucket);
     rawSample.BlockingThreadId = blockingThreadId;
     rawSample.BlockingThreadName = std::move(blockingThreadName);
 
     Add(std::move(rawSample));
     _sampledLockContentionsCountMetric->Incr();
-    _sampledLockContentionsDurationMetric->Add(contentionDurationNs);
+    _sampledLockContentionsDurationMetric->Add(contentionDuration.count());
 }
 
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -48,7 +48,7 @@ public:
         shared::pmr::memory_resource* memoryResource);
 
     // IContentionListener implementation
-    void OnContention(std::chrono::nanoseconds contentionDurationNs) override;
+    void OnContention(std::chrono::nanoseconds contentionDuration) override;
     void OnContention(
         std::chrono::nanoseconds timestamp,
         uint32_t threadId,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EventPipeEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EventPipeEventsManager.cpp
@@ -53,7 +53,7 @@ void EventPipeEventsManager::ParseEvent(EVENTPIPE_PROVIDER provider,
     }
 
     // the events are expected to be processed synchronously so the current time is used as timestamp
-    _parser->ParseEvent(OpSysTools::GetHighPrecisionTimestamp(), version, keywords, id, cbEventData, eventData);
+    _parser->ParseEvent(OpSysTools::GetHighPrecisionTimestamp().count(), version, keywords, id, cbEventData, eventData);
 }
 
 bool EventPipeEventsManager::TryGetEventInfo(LPCBYTE pMetadata, ULONG cbMetadata, WCHAR*& name, DWORD& id, INT64& keywords, DWORD& version)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EventPipeEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EventPipeEventsManager.cpp
@@ -53,7 +53,7 @@ void EventPipeEventsManager::ParseEvent(EVENTPIPE_PROVIDER provider,
     }
 
     // the events are expected to be processed synchronously so the current time is used as timestamp
-    _parser->ParseEvent(OpSysTools::GetHighPrecisionTimestamp().count(), version, keywords, id, cbEventData, eventData);
+    _parser->ParseEvent(OpSysTools::GetHighPrecisionTimestamp(), version, keywords, id, cbEventData, eventData);
 }
 
 bool EventPipeEventsManager::TryGetEventInfo(LPCBYTE pMetadata, ULONG cbMetadata, WCHAR*& name, DWORD& id, INT64& keywords, DWORD& version)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCBaseRawSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCBaseRawSample.h
@@ -55,7 +55,7 @@ public:
     // By default, use the Duration field
     virtual int64_t GetValue() const
     {
-        return Duration;
+        return Duration.count();
     }
 
     // Derived classes are expected to set the event type + any additional field as label
@@ -64,7 +64,7 @@ public:
 public:
     int32_t Number;
     uint32_t Generation;
-    int64_t Duration;
+    std::chrono::nanoseconds Duration;
 
 private:
     inline static void AddGenerationLabel(std::shared_ptr<Sample>& sample, uint32_t generation)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
@@ -73,7 +73,7 @@ std::vector<FrameInfoView> GCThreadsCpuProvider::GetFrames()
     };
 }
 
-void GCThreadsCpuProvider::OnCpuDuration(std::uint64_t cpuTime)
+void GCThreadsCpuProvider::OnCpuDuration(std::chrono::milliseconds cpuTime)
 {
-    _cpuDurationMetric->Add(static_cast<double>(cpuTime));
+    _cpuDurationMetric->Add(static_cast<double>(cpuTime.count()));
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.h
@@ -19,7 +19,7 @@ public:
     const char* GetName() override;
 
 protected:
-    void OnCpuDuration(std::uint64_t cpuTime) override;
+    void OnCpuDuration(std::chrono::milliseconds cpuTime) override;
 
 private:
     bool IsGcThread(std::shared_ptr<IThreadInfo> const& thread);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
@@ -100,7 +100,7 @@ void GarbageCollectionProvider::OnGarbageCollectionEnd(
     _pohSize = pohSize;
 
     RawGarbageCollectionSample rawSample;
-    rawSample.Timestamp = endTimestamp;
+    rawSample.Timestamp = std::chrono::nanoseconds(endTimestamp);
     rawSample.LocalRootSpanId = 0;
     rawSample.SpanId = 0;
     rawSample.AppDomainId = (AppDomainID) nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
@@ -49,14 +49,14 @@ void GarbageCollectionProvider::OnGarbageCollectionEnd(
     GCReason reason,
     GCType type,
     bool isCompacting,
-    uint64_t pauseDuration,
-    uint64_t totalDuration, // from start to end (includes pauses)
-    uint64_t endTimestamp,  // end of GC
+    std::chrono::nanoseconds pauseDuration,
+    std::chrono::nanoseconds totalDuration, // from start to end (includes pauses)
+    std::chrono::nanoseconds endTimestamp,  // end of GC
     uint64_t gen2Size,
     uint64_t lohSize,
     uint64_t pohSize)
 {
-    _suspensionDurationMetric->Add((double_t)pauseDuration);
+    _suspensionDurationMetric->Add((double_t)pauseDuration.count());
     if (generation == 0)
     {
         _gen0CountMetric->Incr();
@@ -118,7 +118,7 @@ void GarbageCollectionProvider::OnGarbageCollectionEnd(
 }
 
 void GarbageCollectionProvider::OnGarbageCollectionStart(
-    uint64_t timestamp,
+    std::chrono::nanoseconds timestamp,
     int32_t number,
     uint32_t generation,
     GCReason reason,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
@@ -33,7 +33,7 @@ public:
 
     // Inherited via IGarbageCollectionsListener
     void OnGarbageCollectionStart(
-        uint64_t timestamp,
+        std::chrono::nanoseconds timestamp,
         int32_t number,
         uint32_t generation,
         GCReason reason,
@@ -46,9 +46,9 @@ public:
         GCReason reason,
         GCType type,
         bool isCompacting,
-        uint64_t pauseDuration,
-        uint64_t totalDuration, // from start to end (includes pauses)
-        uint64_t endTimestamp,   // end of GC
+        std::chrono::nanoseconds pauseDuration,
+        std::chrono::nanoseconds totalDuration, // from start to end (includes pauses)
+        std::chrono::nanoseconds endTimestamp,   // end of GC
         uint64_t gen2Size,
         uint64_t lohSize,
         uint64_t pohSize) override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IAllocationsListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IAllocationsListener.h
@@ -6,6 +6,8 @@
 #include <cor.h>  // for WCHAR
 #include <cstdint>
 
+#include <chrono>
+
 class IAllocationsListener
 {
 public:
@@ -19,7 +21,7 @@ public:
     // for .NET Framework, events are received asynchronously
     // and the callstack is received as a sibling event
     // --> we cannot walk the stack of the current thread
-    virtual void OnAllocation(uint64_t timestamp,
+    virtual void OnAllocation(std::chrono::nanoseconds timestamp,
                               uint32_t threadId,
                               uint32_t allocationKind,
                               ClassID classId,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <vector>
 
 class IContentionListener
@@ -10,7 +11,7 @@ class IContentionListener
 public:
     virtual ~IContentionListener() = default;
 
-    virtual void OnContention(double contentionDurationNs) = 0;
-    virtual void OnContention(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, const std::vector<uintptr_t>& stack) = 0;
+    virtual void OnContention(std::chrono::nanoseconds contentionDurationNs) = 0;
+    virtual void OnContention(std::chrono::nanoseconds timestamp, uint32_t threadId, std::chrono::nanoseconds contentionDuration, const std::vector<uintptr_t>& stack) = 0;
     virtual void SetBlockingThread(uint64_t osThreadId) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
@@ -11,7 +11,7 @@ class IContentionListener
 public:
     virtual ~IContentionListener() = default;
 
-    virtual void OnContention(std::chrono::nanoseconds contentionDurationNs) = 0;
+    virtual void OnContention(std::chrono::nanoseconds contentionDuration) = 0;
     virtual void OnContention(std::chrono::nanoseconds timestamp, uint32_t threadId, std::chrono::nanoseconds contentionDuration, const std::vector<uintptr_t>& stack) = 0;
     virtual void SetBlockingThread(uint64_t osThreadId) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IEtwEventsManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IEtwEventsManager.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-
 class IGarbageCollectionsListener;
 
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IGCSuspensionsListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IGCSuspensionsListener.h
@@ -3,16 +3,17 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 
 class IGCSuspensionsListener
 {
 public:
     virtual void OnSuspension(
-        uint64_t timestamp,
+        std::chrono::nanoseconds timestamp,
         int32_t number,
         uint32_t generation,
-        uint64_t pauseDuration) = 0;
+        std::chrono::nanoseconds pauseDuration) = 0;
 
     virtual ~IGCSuspensionsListener() = default;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IGarbageCollectionsListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IGarbageCollectionsListener.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include "GarbageCollection.h"
 
@@ -11,7 +12,7 @@ class IGarbageCollectionsListener
 {
 public:
     virtual void OnGarbageCollectionStart(
-        uint64_t timestamp,
+        std::chrono::nanoseconds timestamp,
         int32_t number,
         uint32_t generation,
         GCReason reason,
@@ -24,9 +25,9 @@ public:
         GCReason reason,
         GCType type,
         bool isCompacting,
-        uint64_t pauseDuration,
-        uint64_t totalDuration, // from start to end (includes pauses)
-        uint64_t endTimestamp,  // end of GC
+        std::chrono::nanoseconds pauseDuration,
+        std::chrono::nanoseconds totalDuration, // from start to end (includes pauses)
+        std::chrono::nanoseconds endTimestamp,  // end of GC
         uint64_t gen2Size,
         uint64_t lohSize,
         uint64_t pohSize) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
@@ -6,7 +6,7 @@
 std::atomic<uint64_t> LiveObjectInfo::s_nextObjectId = 1;
 
 
-LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, int64_t timestamp)
+LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, std::chrono::nanoseconds timestamp)
     :
     _address(address),
     _weakHandle(nullptr),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 
 #include "cor.h"
@@ -14,7 +15,7 @@
 class LiveObjectInfo
 {
 public:
-    LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, int64_t timestamp);
+    LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, std::chrono::nanoseconds timestamp);
 
     // accessors
     void SetHandle(ObjectHandleID handle);
@@ -28,9 +29,9 @@ private:
     std::shared_ptr<Sample> _sample;
     uintptr_t _address;
     ObjectHandleID _weakHandle;
-    // TODO This field is not yet used because the current implementation is incomple.
+    // TODO This field is not yet used because the current implementation is incomplete.
     // Just keep to remind us to finish the implementation.
-    int64_t _timestamp;
+    std::chrono::nanoseconds _timestamp;
     uint64_t _gcCount;
 
     static std::atomic<uint64_t> s_nextObjectId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
 {
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 
-    int64_t currentTimestamp = OpSysTools::GetHighPrecisionTimestamp();
+    auto currentTimestamp = OpSysTools::GetHighPrecisionTimestamp();
     std::size_t nbSamples = 0;
 
     // OPTIM maybe use an allocator
@@ -152,7 +152,7 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
         auto sample = info.GetSample();
 
         // update samples lifetime
-        sample->ReplaceLabel(Label{Sample::ObjectLifetimeLabel, std::to_string(sample->GetTimeStamp() - currentTimestamp)});
+        sample->ReplaceLabel(Label{Sample::ObjectLifetimeLabel, std::to_string((sample->GetTimeStamp() - currentTimestamp).count())});
         sample->ReplaceLabel(Label{Sample::ObjectGenerationLabel, info.IsGen2() ? Gen2 : Gen1});
 
         samples->Add(sample);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -59,7 +59,7 @@ const char* LiveObjectsProvider::GetName()
 }
 
 void LiveObjectsProvider::OnGarbageCollectionStart(
-    uint64_t timestamp,
+    std::chrono::nanoseconds timestamp,
     int32_t number,
     uint32_t generation,
     GCReason reason,
@@ -78,9 +78,9 @@ void LiveObjectsProvider::OnGarbageCollectionEnd(
     GCReason reason,
     GCType type,
     bool isCompacting,
-    uint64_t pauseDuration,
-    uint64_t totalDuration,
-    uint64_t endTimestamp,
+    std::chrono::nanoseconds pauseDuration,
+    std::chrono::nanoseconds totalDuration,
+    std::chrono::nanoseconds endTimestamp,
     uint64_t gen2Size,
     uint64_t lohSize,
     uint64_t pohSize)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -54,20 +54,21 @@ public:
 
     // Inherited via IGarbageCollectionsListener
     void OnGarbageCollectionStart(
-        uint64_t timestamp,
+        std::chrono::nanoseconds timestamp,
         int32_t number,
         uint32_t generation,
         GCReason reason,
         GCType type) override;
+
     void OnGarbageCollectionEnd(
         int32_t number,
         uint32_t generation,
         GCReason reason,
         GCType type,
         bool isCompacting,
-        uint64_t pauseDuration,
-        uint64_t totalDuration,
-        uint64_t endTimestamp,
+        std::chrono::nanoseconds pauseDuration,
+        std::chrono::nanoseconds totalDuration,
+        std::chrono::nanoseconds endTimestamp,
         uint64_t gen2Size,
         uint64_t lohSize,
         uint64_t pohSize) override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
@@ -4,6 +4,10 @@
 #include "ManagedThreadInfo.h"
 #include "shared/src/native-src/string.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 std::atomic<std::uint32_t> ManagedThreadInfo::s_nextProfilerThreadInfoId{1};
 thread_local std::shared_ptr<ManagedThreadInfo> ManagedThreadInfo::CurrentThreadInfo{nullptr};
 
@@ -31,13 +35,9 @@ ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, ICorProfilerInfo4* pC
     _osThreadId(osThreadId),
     _osThreadHandle(osThreadHandle),
     _pThreadName(std::move(pThreadName)),
-    _lastSampleHighPrecisionTimestampNanoseconds{0},
-    _cpuConsumptionMilliseconds{0},
-    _timestamp{0},
-    _lastKnownSampleUnixTimeUtc{0},
-    _highPrecisionNanosecsAtLastUnixTimeUpdate{0},
-    _snapshotsPerformedSuccessCount{0},
-    _snapshotsPerformedFailureCount{0},
+    _lastSampleHighPrecisionTimestamp{0ns},
+    _cpuConsumption{0ms},
+    _timestamp{0ns},
     _deadlockTotalCount{0},
     _deadlockInPeriodCount{0},
     _deadlockDetectionPeriod{0},

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "IFrameStore.h"
 #include "ISamplesProvider.h"
 #include "IThreadInfo.h"
@@ -17,7 +19,7 @@ public:
     NativeThreadsCpuProviderBase(CpuTimeProvider* cpuTimeProvider);
 
 protected:
-    virtual void OnCpuDuration(std::uint64_t cpuTime);
+    virtual void OnCpuDuration(std::chrono::milliseconds cpuTime);
 
 private:
 
@@ -26,5 +28,5 @@ private:
     virtual std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() = 0;
 
     CpuTimeProvider* _cpuTimeProvider;
-    std::uint64_t _previousTotalCpuTime;
+    std::chrono::milliseconds _previousTotalCpuTime;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -5,6 +5,7 @@
 
 #include "shared/src/native-src/string.h"
 
+#include <chrono>
 #include <string>
 #include <thread>
 
@@ -109,18 +110,18 @@ public:
     ///
     /// This function get the current timestamp in a signal-safe manner
     ///
-    static inline std::uint64_t GetTimestampSafe()
+    static inline std::chrono::nanoseconds GetTimestampSafe()
     {
         struct timespec ts;
         // TODO error handling ?
         clock_gettime(CLOCK_MONOTONIC, &ts);
-        return (std::uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec;
+        return std::chrono::nanoseconds((std::uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec);
     }
 
 #endif
 
     static bool IsSafeToStartProfiler(double coresThreshold, double& cpuLimit);
-    static std::int64_t GetHighPrecisionTimestamp();
+    static std::chrono::nanoseconds GetHighPrecisionTimestamp();
     static std::int64_t ConvertTicks(uint64_t ticks);
 
     static void Sleep(std::chrono::nanoseconds duration);
@@ -148,12 +149,11 @@ private:
 #endif
 };
 
-inline std::int64_t OpSysTools::GetHighPrecisionTimestamp()
+inline std::chrono::nanoseconds OpSysTools::GetHighPrecisionTimestamp()
 {
     auto now = std::chrono::system_clock::now();
 
-    int64_t totalNanosecs = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-    return static_cast<std::int64_t>(totalNanosecs);
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
 }
 
 inline std::int64_t OpSysTools::GetHighPrecisionNanoseconds()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -8,6 +8,9 @@
 #include "MetricsRegistry.h"
 #include "StackFramesCollectorBase.h"
 
+#include <chrono>
+#include <tuple>
+
 // forward declarations
 namespace shared {
 struct LoaderResourceMonikerIDs;
@@ -30,9 +33,10 @@ namespace OsSpecificApi
         CallstackProvider* callstackProvider,
         MetricsRegistry& metricsRegistry);
 
-    uint64_t GetThreadCpuTime(IThreadInfo* pThreadInfo);
+    std::chrono::milliseconds GetThreadCpuTime(IThreadInfo* pThreadInfo);
 
-    bool IsRunning(IThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
+    //    isRunning,        cpu time          , failed 
+    std::tuple<bool, std::chrono::milliseconds, bool> IsRunning(IThreadInfo* pThreadInfo);
 
     int32_t GetProcessorCount();
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
@@ -9,7 +9,11 @@
 #include "ProfileImpl.hpp"
 #include "Sample.h"
 
+#include <chrono>
+
 namespace libdatadog {
+
+using namespace std::chrono_literals;
 
 libdatadog::profile_unique_ptr CreateProfile(std::vector<SampleValueType> const& valueTypes, std::string const& periodType, std::string const& periodUnit);
 
@@ -77,7 +81,7 @@ libdatadog::Success Profile::Add(std::shared_ptr<Sample> const& sample)
     ffiSample.values = {values.data(), values.size()};
 
     // add timestamp
-    std::int64_t timestamp = 0;
+    auto timestamp = 0ns;
     if (_addTimestampOnSample)
     {
         // All timestamps give the time when "something" ends and the associated duration
@@ -85,7 +89,7 @@ libdatadog::Success Profile::Add(std::shared_ptr<Sample> const& sample)
         timestamp = sample->GetTimeStamp();
     }
 
-    auto add_res = ddog_prof_Profile_add(&profile, ffiSample, timestamp);
+    auto add_res = ddog_prof_Profile_add(&profile, ffiSample, timestamp.count());
     if (add_res.tag == DDOG_PROF_PROFILE_RESULT_ERR)
     {
         return make_error(add_res.err);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -50,8 +50,8 @@ public:
         sample->AddLabel(Label{BucketLabelName, std::move(Bucket)});
         sample->AddValue(1, contentionCountIndex);
         sample->AddNumericLabel(NumericLabel{RawCountLabelName, 1});
-        sample->AddNumericLabel(NumericLabel{RawDurationLabelName, static_cast<uint64_t>(ContentionDuration)});
-        sample->AddValue(static_cast<std::int64_t>(ContentionDuration), contentionDurationIndex);
+        sample->AddNumericLabel(NumericLabel{RawDurationLabelName, ContentionDuration.count()});
+        sample->AddValue(ContentionDuration.count(), contentionDurationIndex);
         if (BlockingThreadId != 0)
         {
             sample->AddNumericLabel(NumericLabel{BlockingThreadIdLabelName, BlockingThreadId});
@@ -59,7 +59,7 @@ public:
         }
     }
 
-    double ContentionDuration;
+    std::chrono::nanoseconds ContentionDuration;
     std::string Bucket;
     uint64_t BlockingThreadId;
     shared::WSTRING BlockingThreadName;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
@@ -6,6 +6,8 @@
 #include "RawSample.h"
 #include "Sample.h"
 
+#include <chrono>
+
 class RawCpuSample : public RawSample
 {
 public:
@@ -31,8 +33,8 @@ public:
     inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
         assert(valueOffsets.size() == 1);
-        sample->AddValue(Duration * 1000000, valueOffsets[0]);
+        sample->AddValue(Duration.count(), valueOffsets[0]);
     }
 
-    std::uint64_t Duration; // in milliseconds
+    std::chrono::nanoseconds Duration;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawGarbageCollectionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawGarbageCollectionSample.h
@@ -43,7 +43,7 @@ public:
 
     inline int64_t GetValue() const override
     {
-        return TotalDuration;
+        return TotalDuration.count();
     }
 
     inline void DoAdditionalTransform(std::shared_ptr<Sample> sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
@@ -60,8 +60,8 @@ public:
     GCReason Reason;
     GCType Type;
     bool IsCompacting;
-    uint64_t PauseDuration; // not used today
-    uint64_t TotalDuration;
+    std::chrono::nanoseconds PauseDuration; // not used today
+    std::chrono::nanoseconds TotalDuration;
 
 private:
     inline std::string GetReasonText() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSample.h
@@ -32,7 +32,7 @@ public:
     virtual void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffset) const = 0;
 
 public:
-    std::uint64_t Timestamp;        // _unixTimeUtc;
+    std::chrono::nanoseconds Timestamp;
     AppDomainID AppDomainId;
     std::uint64_t LocalRootSpanId;  // _localRootSpanId;
     std::uint64_t SpanId;           // _spanId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawWallTimeSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawWallTimeSample.h
@@ -33,8 +33,8 @@ public:
     inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
         assert(valueOffsets.size() == 1);
-        sample->AddValue(Duration, valueOffsets[0]);
+        sample->AddValue(Duration.count(), valueOffsets[0]);
     }
 
-    std::uint64_t Duration; // in nanoseconds
+    std::chrono::nanoseconds Duration;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
@@ -36,7 +36,7 @@ const std::string Sample::ObjectGenerationLabel = "object generation";
 size_t Sample::ValuesCount = 16;  // should be set BEFORE any sample gets created
 
 
-Sample::Sample(uint64_t timestamp, std::string_view runtimeId, size_t framesCount) :
+Sample::Sample(std::chrono::nanoseconds timestamp, std::string_view runtimeId, size_t framesCount) :
     Sample(runtimeId)
 {
     _timestamp = timestamp;
@@ -56,7 +56,7 @@ Sample::Sample(std::string_view runtimeId) :
 {
 }
 
-uint64_t Sample::GetTimeStamp() const
+std::chrono::nanoseconds Sample::GetTimeStamp() const
 {
     return _timestamp;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -6,6 +6,7 @@
 #include "IFrameStore.h"
 
 #include <array>
+#include <chrono>
 #include <iostream>
 #include <list>
 #include <string>
@@ -27,13 +28,15 @@ typedef std::pair<std::string_view, int64_t> NumericLabel;
 typedef std::pair<std::string_view, uint64_t> SpanLabel;
 typedef std::vector<NumericLabel> NumericLabels;
 
+using namespace std::chrono_literals;
+
 class Sample
 {
 public:
     static size_t ValuesCount;
 
 public:
-    Sample(uint64_t timestamp, std::string_view runtimeId, size_t framesCount);
+    Sample(std::chrono::nanoseconds timestamp, std::string_view runtimeId, size_t framesCount);
     Sample(std::string_view runtimeId); // only for tests
 
 #ifndef DD_TEST
@@ -46,7 +49,7 @@ private:
     Sample& operator=(Sample&& other) noexcept = default;
 
 public:
-    uint64_t GetTimeStamp() const;
+    std::chrono::nanoseconds GetTimeStamp() const;
     const Values& GetValues() const;
     const std::vector<FrameInfoView>& GetCallstack() const;
     const Labels& GetLabels() const;
@@ -127,7 +130,7 @@ public:
         AddLabel(Label{ThreadNameLabel, std::forward<T>(name)});
     }
 
-    void SetTimestamp(std::uint64_t timestamp)
+    void SetTimestamp(std::chrono::nanoseconds timestamp)
     {
         _timestamp = timestamp;
     }
@@ -139,7 +142,7 @@ public:
 
     void Reset()
     {
-        _timestamp = 0;
+        _timestamp = 0ns;
         _callstack.clear();
         _runtimeId = {};
         _numericLabels.clear();
@@ -172,7 +175,7 @@ public:
     static const std::string ObjectGenerationLabel;
 
 private:
-    uint64_t _timestamp;
+    std::chrono::nanoseconds _timestamp;
     std::vector<FrameInfoView> _callstack;
     Values _values;
     Labels _labels;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
@@ -7,6 +7,10 @@
 #include "OpSysTools.h"
 #include "SamplesEnumerator.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 SamplesCollector::SamplesCollector(
     IConfiguration* configuration,
     IThreadsCpuManager* pThreadsCpuManager,
@@ -16,7 +20,7 @@ SamplesCollector::SamplesCollector(
     _pThreadsCpuManager{pThreadsCpuManager},
     _metricsSender{metricsSender},
     _exporter{exporter},
-    _cachedSample{std::make_shared<Sample>(0, std::string_view{}, 2048)}
+    _cachedSample{std::make_shared<Sample>(0ns, std::string_view{}, 2048)}
 {
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -177,8 +177,8 @@ void StackSamplerLoop::MainLoop()
 
 void StackSamplerLoop::MainLoopIteration()
 {
-    int64_t timestampNanosecs1 = 0;
-    int64_t timestampNanosecs2 = 0;
+    auto timestampNanosecs1 = 0ns;
+    auto timestampNanosecs2 = 0ns;
 
     // In each iteration, a few threads are sampled to compute wall time.
     if (_isWalltimeEnabled)
@@ -196,7 +196,8 @@ void StackSamplerLoop::MainLoopIteration()
         if (_areInternalMetricsEnabled)
         {
             timestampNanosecs2 = OpSysTools::GetHighPrecisionTimestamp();
-            _walltimeDurationMetric->Add(static_cast<double>(timestampNanosecs2 - timestampNanosecs1));
+            auto duration = (timestampNanosecs2 - timestampNanosecs1).count();
+            _walltimeDurationMetric->Add(static_cast<double>(duration));
         }
     }
 
@@ -206,8 +207,8 @@ void StackSamplerLoop::MainLoopIteration()
     {
         if (_areInternalMetricsEnabled)
         {
-            // avoid an unnecessary call to OpSysTools::GetHighPrecisionTimestamp() if possible
-            if (timestampNanosecs2 == 0)
+            // avoid an unnecessary call to OpSysTools::GetHighPrecisionTimestamp().count() if possible
+            if (timestampNanosecs2 == 0ns)
             {
                 timestampNanosecs2 = OpSysTools::GetHighPrecisionTimestamp();
             }
@@ -218,7 +219,8 @@ void StackSamplerLoop::MainLoopIteration()
         if (_areInternalMetricsEnabled)
         {
             timestampNanosecs1 = OpSysTools::GetHighPrecisionTimestamp();
-            _cpuDurationMetric->Add(static_cast<double>(timestampNanosecs1 - timestampNanosecs2));
+            auto duration = (timestampNanosecs1 - timestampNanosecs2).count();
+            _cpuDurationMetric->Add(static_cast<double>(duration));
         }
     }
 }
@@ -267,11 +269,11 @@ void StackSamplerLoop::WalltimeProfilingIteration()
             continue;
         }
 
-        int64_t thisSampleTimestampNanosecs = OpSysTools::GetHighPrecisionTimestamp();
-        int64_t prevSampleTimestampNanosecs = _targetThread->SetLastSampleHighPrecisionTimestampNanoseconds(thisSampleTimestampNanosecs);
-        int64_t duration = ComputeWallTime(thisSampleTimestampNanosecs, prevSampleTimestampNanosecs);
+        auto thisSampleTimestamp = OpSysTools::GetHighPrecisionTimestamp();
+        auto prevSampleTimestamp = _targetThread->SetLastSampleTimestamp(thisSampleTimestamp);
+        auto duration = ComputeWallTime(thisSampleTimestamp, prevSampleTimestamp);
 
-        CollectOneThreadStackSample(_targetThread, thisSampleTimestampNanosecs, duration, PROFILING_TYPE::WallTime);
+        CollectOneThreadStackSample(_targetThread, thisSampleTimestamp, duration, PROFILING_TYPE::WallTime);
 
         _targetThread.reset();
         i++;
@@ -291,16 +293,14 @@ void StackSamplerLoop::CpuProfilingIteration()
         _targetThread = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (_targetThread != nullptr)
         {
-            // detect Windows API call failure
-            bool failure = false;
-
             // sample only if the thread is currently running on a core
-            uint64_t currentConsumption = 0;
-            uint64_t lastConsumption = _targetThread->GetCpuConsumptionMilliseconds();
-            bool isRunning = OsSpecificApi::IsRunning(_targetThread.get(), currentConsumption, failure);
+            auto lastConsumption = _targetThread->GetCpuConsumption();
+            auto [isRunning, currentConsumption, failure] = OsSpecificApi::IsRunning(_targetThread.get());
+
             // Note: it is not possible to get this information on Windows 32-bit or in some cases in 64-bit
             //       so isRunning should be true if this thread consumed some CPU since the last iteration
 #if _WINDOWS
+            // detect Windows API call failure
     #if BIT64  // Windows 64-bit
             if (failure)
             {
@@ -314,28 +314,31 @@ void StackSamplerLoop::CpuProfilingIteration()
 
             if (isRunning)
             {
-                uint64_t cpuForSample = currentConsumption - lastConsumption;
+                auto cpuForSample = currentConsumption - lastConsumption;
 
                 // we don't collect a sample for this thread is no CPU was consumed since the last check
-                if (cpuForSample > 0)
+                if (cpuForSample > 0ms)
                 {
-                    int64_t lastCpuTimestamp = _targetThread->GetCpuTimestamp();
-                    int64_t thisSampleTimestampNanosecs = OpSysTools::GetHighPrecisionTimestamp();
+                    auto lastCpuTimestamp = _targetThread->GetCpuTimestamp();
+                    auto thisSampleTimestamp = OpSysTools::GetHighPrecisionTimestamp();
 
                     // detect overlapping CPU usage
-                    if ((int64_t)(lastCpuTimestamp + cpuForSample * 1000000) > thisSampleTimestampNanosecs)
+                    auto threshold =  lastCpuTimestamp + cpuForSample;
+                    if (threshold > thisSampleTimestamp)
                     {
 #ifndef NDEBUG
-                        int64_t cpuOverlap = (lastCpuTimestamp + cpuForSample * 1000000 - thisSampleTimestampNanosecs) / 1000000;
+                        // auto cpuOverlap = std::chrono::duraction_cast<std::chrono::milliseconds>(lastCpuTimestamp + cpuForSample  - thisSampleTimestamp);
                         // TODO: uncomment when debugging this issue
                         // Log::Warn("Overlapping CPU samples off ", cpuOverlap, " ms (", currentConsumption, " - ", lastConsumption, ")");
 #endif
                         // ensure that we don't overlap
                         // -> only the largest possibly CPU consumption is accounted = diff between the 2 timestamps
-                        cpuForSample = (thisSampleTimestampNanosecs - lastCpuTimestamp - 1000) / 1000000; // removing 1 microsecond to be sure
+
+                        cpuForSample = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            thisSampleTimestamp - lastCpuTimestamp - 1us); // removing 1 microsecond to be sure;
                     }
-                    _targetThread->SetCpuConsumptionMilliseconds(currentConsumption, thisSampleTimestampNanosecs);
-                    CollectOneThreadStackSample(_targetThread, thisSampleTimestampNanosecs, cpuForSample, PROFILING_TYPE::CpuTime);
+                    _targetThread->SetCpuConsumption(currentConsumption, thisSampleTimestamp);
+                    CollectOneThreadStackSample(_targetThread, thisSampleTimestamp, cpuForSample, PROFILING_TYPE::CpuTime);
 
                     // don't scan more threads than nb logical cores
                     sampledThreads++;
@@ -394,11 +397,11 @@ void StackSamplerLoop::CodeHotspotIteration()
             continue;
         }
 
-        int64_t thisSampleTimestampNanosecs = OpSysTools::GetHighPrecisionTimestamp();
-        int64_t prevSampleTimestampNanosecs = _targetThread->SetLastSampleHighPrecisionTimestampNanoseconds(thisSampleTimestampNanosecs);
-        int64_t duration = ComputeWallTime(thisSampleTimestampNanosecs, prevSampleTimestampNanosecs);
+        auto thisSampleTimestamp = OpSysTools::GetHighPrecisionTimestamp();
+        auto prevSampleTimestamp = _targetThread->SetLastSampleTimestamp(thisSampleTimestamp);
+        auto duration = ComputeWallTime(thisSampleTimestamp, prevSampleTimestamp);
 
-        CollectOneThreadStackSample(_targetThread, thisSampleTimestampNanosecs, duration, PROFILING_TYPE::WallTime);
+        CollectOneThreadStackSample(_targetThread, thisSampleTimestamp, duration, PROFILING_TYPE::WallTime);
 
         _targetThread.reset();
         i++;
@@ -407,8 +410,8 @@ void StackSamplerLoop::CodeHotspotIteration()
 
 void StackSamplerLoop::CollectOneThreadStackSample(
     std::shared_ptr<ManagedThreadInfo>& pThreadInfo,
-    int64_t thisSampleTimestampNanosecs,
-    int64_t duration,
+    std::chrono::nanoseconds thisSampleTimestampNanosecs,
+    std::chrono::nanoseconds duration,
     PROFILING_TYPE profilingType)
 {
     HANDLE osThreadHandle = pThreadInfo->GetOsThreadHandle();
@@ -445,14 +448,6 @@ void StackSamplerLoop::CollectOneThreadStackSample(
 
         // block used to ensure that NotifyIterationFinished gets called
         {
-            // Get the timestamp of the current collection
-            // /!\ Must not be called while the thread is suspended:
-            // current implementation uses time function which allocates
-            time_t currentUnixTimestamp = GetCurrentTimestamp();
-
-            // Get the high-precision timestamp for this sample (this is a time-unit counter, not a real time value).
-            pThreadInfo->SetLastKnownSampleUnixTimestamp(currentUnixTimestamp, thisSampleTimestampNanosecs);
-
             // Notify the loop manager that we are starting a stack collection, and set up a finalizer to notify the manager when we finsih it.
             // This will enable the manager to monitor if this collection freezes due to a deadlock.
 
@@ -494,9 +489,6 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             countCollectedStackFrames = pStackSnapshotResult->GetFramesCount();
             bool isStackSnapshotSuccessful = (countCollectedStackFrames > 0);
 
-            // Keep track of how many times we sampled this thread:
-            pThreadInfo->IncSnapshotsPerformedCount(isStackSnapshotSuccessful);
-
             if (isStackSnapshotSuccessful)
             {
                 UpdateSnapshotInfos(pStackSnapshotResult, duration, thisSampleTimestampNanosecs);
@@ -530,46 +522,31 @@ void StackSamplerLoop::CollectOneThreadStackSample(
     PersistStackSnapshotResults(pStackSnapshotResult, pThreadInfo, profilingType);
 }
 
-void StackSamplerLoop::UpdateSnapshotInfos(StackSnapshotResultBuffer* const pStackSnapshotResult, int64_t representedDurationNanosecs, time_t currentUnixTimestamp)
+void StackSamplerLoop::UpdateSnapshotInfos(StackSnapshotResultBuffer* const pStackSnapshotResult, std::chrono::nanoseconds representedDuration, std::chrono::nanoseconds currentUnixTimestamp)
 {
-    pStackSnapshotResult->SetRepresentedDurationNanoseconds(representedDurationNanosecs);
-    pStackSnapshotResult->SetUnixTimeUtc(static_cast<int64_t>(currentUnixTimestamp));
+    pStackSnapshotResult->SetRepresentedDuration(representedDuration);
+    pStackSnapshotResult->SetUnixTimeUtc(currentUnixTimestamp);
 }
 
-time_t StackSamplerLoop::GetCurrentTimestamp()
+std::chrono::nanoseconds StackSamplerLoop::ComputeWallTime(std::chrono::nanoseconds currentTimestampNs, std::chrono::nanoseconds prevTimestampNs)
 {
-    // /!\ time function allocates so we *MUST* not call it while the thread is suspended
-
-    time_t currentUnixTimestamp;
-    time(&currentUnixTimestamp);
-
-    if (currentUnixTimestamp == static_cast<time_t>(-1))
-    {
-        currentUnixTimestamp = 0;
-    }
-
-    return currentUnixTimestamp;
-}
-
-int64_t StackSamplerLoop::ComputeWallTime(int64_t currentTimestampNs, int64_t prevTimestampNs)
-{
-    if (prevTimestampNs == 0)
+    if (prevTimestampNs == 0ns)
     {
         // prevTimestampNs = 0 means that it is the first time the wall time is computed for a given thread
         // --> at least one sampling period has elapsed
-        return static_cast<int64_t>(_samplingPeriod.count());
+        return _samplingPeriod;
     }
 
-    if (prevTimestampNs > 0)
+    if (prevTimestampNs > 0ns)
     {
         auto durationNs = currentTimestampNs - prevTimestampNs;
-        return (std::max)(static_cast<int64_t>(0), durationNs);
+        return (std::max)(0ns, durationNs);
     }
     else
     {
         // this should never happen
         // count at least one sampling period
-        return static_cast<int64_t>(_samplingPeriod.count());
+        return _samplingPeriod;
     }
 }
 
@@ -594,7 +571,7 @@ void StackSamplerLoop::PersistStackSnapshotResults(
         rawSample.AppDomainId = pThreadInfo->GetAppDomainId();
         rawSample.Stack = std::move(callstack);
         rawSample.ThreadInfo = pThreadInfo;
-        rawSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();
+        rawSample.Duration = pSnapshotResult->GetRepresentedDuration();
         _pWallTimeCollector->Add(std::move(rawSample));
     }
     else
@@ -608,7 +585,7 @@ void StackSamplerLoop::PersistStackSnapshotResults(
         rawCpuSample.AppDomainId = pThreadInfo->GetAppDomainId();
         rawCpuSample.Stack = std::move(callstack);
         rawCpuSample.ThreadInfo = pThreadInfo;
-        rawCpuSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();
+        rawCpuSample.Duration = pSnapshotResult->GetRepresentedDuration();
         _pCpuTimeCollector->Add(std::move(rawCpuSample));
     }
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -102,13 +102,11 @@ private:
     void WalltimeProfilingIteration();
     void CodeHotspotIteration();
     void CollectOneThreadStackSample(std::shared_ptr<ManagedThreadInfo>& pThreadInfo,
-                                     int64_t thisSampleTimestampNanosecs,
-                                     int64_t duration,
+                                     std::chrono::nanoseconds thisSampleTimestampNanosecs,
+                                     std::chrono::nanoseconds duration,
                                      PROFILING_TYPE profilingType);
-    int64_t ComputeWallTime(int64_t currentTimestampNs, int64_t prevTimestampNs);
-    static void UpdateSnapshotInfos(StackSnapshotResultBuffer* pStackSnapshotResult, int64_t representedDurationNanosecs, time_t currentUnixTimestamp);
-    void UpdateStatistics(HRESULT hrCollectStack, std::size_t countCollectedStackFrames);
-    static time_t GetCurrentTimestamp();
+    std::chrono::nanoseconds ComputeWallTime(std::chrono::nanoseconds currentTimestampNs, std::chrono::nanoseconds prevTimestampNs);
+    static void UpdateSnapshotInfos(StackSnapshotResultBuffer* pStackSnapshotResult, std::chrono::nanoseconds representedDuration, std::chrono::nanoseconds currentUnixTimestamp);
     void PersistStackSnapshotResults(StackSnapshotResultBuffer* pSnapshotResult,
                                      std::shared_ptr<ManagedThreadInfo>& pThreadInfo,
                                      PROFILING_TYPE profilingType);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
@@ -3,9 +3,13 @@
 
 #include "StackSnapshotResultBuffer.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 StackSnapshotResultBuffer::StackSnapshotResultBuffer() :
     _unixTimeUtc{0},
-    _representedDurationNanoseconds{0},
+    _representedDuration{0},
     _localRootSpanId{0},
     _spanId{0},
     _callstack{}
@@ -14,8 +18,8 @@ StackSnapshotResultBuffer::StackSnapshotResultBuffer() :
 
 StackSnapshotResultBuffer::~StackSnapshotResultBuffer()
 {
-    _unixTimeUtc = 0;
-    _representedDurationNanoseconds = 0;
+    _unixTimeUtc = 0ns;
+    _representedDuration = 0ns;
     _localRootSpanId = 0;
     _spanId = 0;
 }
@@ -24,7 +28,7 @@ void StackSnapshotResultBuffer::Reset()
 {
     _localRootSpanId = 0;
     _spanId = 0;
-    _representedDurationNanoseconds = 0;
-    _unixTimeUtc = 0;
+    _representedDuration = 0ns;
+    _unixTimeUtc = 0ns;
     _callstack = {};
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
@@ -9,6 +9,7 @@
 // end
 
 #include <array>
+#include <chrono>
 #include <vector>
 #include <cstdint>
 #include <utility>
@@ -26,11 +27,11 @@
 class StackSnapshotResultBuffer
 {
 public:
-    inline std::uint64_t GetUnixTimeUtc() const;
-    inline std::uint64_t SetUnixTimeUtc(std::uint64_t value);
+    inline std::chrono::nanoseconds GetUnixTimeUtc() const;
+    inline std::chrono::nanoseconds SetUnixTimeUtc(std::chrono::nanoseconds value);
 
-    inline std::uint64_t GetRepresentedDurationNanoseconds() const;
-    inline std::uint64_t SetRepresentedDurationNanoseconds(std::uint64_t value);
+    inline std::chrono::nanoseconds GetRepresentedDuration() const;
+    inline std::chrono::nanoseconds SetRepresentedDuration(std::chrono::nanoseconds value);
 
     inline std::uint64_t GetLocalRootSpanId() const;
     inline std::uint64_t SetLocalRootSpanId(std::uint64_t value);
@@ -55,8 +56,8 @@ public:
 
 protected:
 
-    std::uint64_t _unixTimeUtc;
-    std::uint64_t _representedDurationNanoseconds;
+    std::chrono::nanoseconds _unixTimeUtc;
+    std::chrono::nanoseconds _representedDuration;
     Callstack _callstack;
 
     std::uint64_t _localRootSpanId;
@@ -65,27 +66,27 @@ protected:
 
 // ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- -----------
 
-inline std::uint64_t StackSnapshotResultBuffer::GetUnixTimeUtc() const
+inline std::chrono::nanoseconds StackSnapshotResultBuffer::GetUnixTimeUtc() const
 {
     return _unixTimeUtc;
 }
 
-inline std::uint64_t StackSnapshotResultBuffer::SetUnixTimeUtc(std::uint64_t value)
+inline std::chrono::nanoseconds StackSnapshotResultBuffer::SetUnixTimeUtc(std::chrono::nanoseconds value)
 {
-    std::uint64_t prevValue = _unixTimeUtc;
+    auto prevValue = _unixTimeUtc;
     _unixTimeUtc = value;
     return prevValue;
 }
 
-inline std::uint64_t StackSnapshotResultBuffer::GetRepresentedDurationNanoseconds() const
+inline std::chrono::nanoseconds StackSnapshotResultBuffer::GetRepresentedDuration() const
 {
-    return _representedDurationNanoseconds;
+    return _representedDuration;
 }
 
-inline std::uint64_t StackSnapshotResultBuffer::SetRepresentedDurationNanoseconds(std::uint64_t value)
+inline std::chrono::nanoseconds StackSnapshotResultBuffer::SetRepresentedDuration(std::chrono::nanoseconds value)
 {
-    std::uint64_t prevValue = _representedDurationNanoseconds;
-    _representedDurationNanoseconds = value;
+    auto prevValue = _representedDuration;
+    _representedDuration = value;
     return prevValue;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
@@ -33,10 +33,10 @@ StopTheWorldGCProvider::StopTheWorldGCProvider(
 {
 }
 
-void StopTheWorldGCProvider::OnSuspension(uint64_t timestamp, int32_t number, uint32_t generation, uint64_t pauseDuration)
+void StopTheWorldGCProvider::OnSuspension(std::chrono::nanoseconds timestamp, int32_t number, uint32_t generation, std::chrono::nanoseconds pauseDuration)
 {
     RawStopTheWorldSample rawSample;
-    rawSample.Timestamp = std::chrono::nanoseconds(timestamp);
+    rawSample.Timestamp = timestamp;
     rawSample.LocalRootSpanId = 0;
     rawSample.SpanId = 0;
     rawSample.AppDomainId = (AppDomainID)nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
@@ -36,7 +36,7 @@ StopTheWorldGCProvider::StopTheWorldGCProvider(
 void StopTheWorldGCProvider::OnSuspension(uint64_t timestamp, int32_t number, uint32_t generation, uint64_t pauseDuration)
 {
     RawStopTheWorldSample rawSample;
-    rawSample.Timestamp = timestamp;
+    rawSample.Timestamp = std::chrono::nanoseconds(timestamp);
     rawSample.LocalRootSpanId = 0;
     rawSample.SpanId = 0;
     rawSample.AppDomainId = (AppDomainID)nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.h
@@ -33,5 +33,5 @@ public:
         shared::pmr::memory_resource* memoryResource);
 
     // Inherited via IGCSuspensionsListener
-    void OnSuspension(uint64_t timestamp, int32_t number, uint32_t generation, uint64_t pauseDuration) override;
+    void OnSuspension(std::chrono::nanoseconds timestamp, int32_t number, uint32_t generation, std::chrono::nanoseconds pauseDuration) override;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.cpp
@@ -36,7 +36,7 @@ void ThreadLifetimeProvider::OnThreadStop(std::shared_ptr<ManagedThreadInfo> pTh
 RawThreadLifetimeSample ThreadLifetimeProvider::CreateSample(std::shared_ptr<ManagedThreadInfo> pThreadInfo, ThreadEventKind kind)
 {
     RawThreadLifetimeSample rawSample;
-    rawSample.Timestamp = GetCurrentTimestamp();
+    rawSample.Timestamp = OpSysTools::GetHighPrecisionTimestamp();
     rawSample.LocalRootSpanId = 0;
     rawSample.SpanId = 0;
     rawSample.AppDomainId = pThreadInfo->GetAppDomainId();
@@ -44,9 +44,4 @@ RawThreadLifetimeSample ThreadLifetimeProvider::CreateSample(std::shared_ptr<Man
     rawSample.Kind = kind;
 
     return rawSample;
-}
-
-uint64_t ThreadLifetimeProvider::GetCurrentTimestamp()
-{
-    return OpSysTools::GetHighPrecisionTimestamp();
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
@@ -5,7 +5,9 @@
 
 #include "gtest/gtest.h"
 
-constexpr std::chrono::seconds WindowDuration = std::chrono::seconds(1);
+using namespace std::chrono_literals;
+
+constexpr std::chrono::seconds WindowDuration = 1s;
 
 TEST(AdaptiveSamplerTest, TestKeep)
 {
@@ -37,7 +39,7 @@ TEST(AdaptiveSamplerTest, TestDrop)
 
 TEST(AdaptiveSamplerTest, TestRollWindow)
 {
-    AdaptiveSampler sampler(std::chrono::milliseconds::zero(), 2, 1, 1, nullptr);
+    AdaptiveSampler sampler(0ms, 2, 1, 1, nullptr);
 
     auto state = sampler.GetInternalState();
 
@@ -107,7 +109,7 @@ TEST(AdaptiveSamplerTest, TestRollWindow)
 TEST(AdaptiveSamplerTest, TestStop)
 {
     bool callbackCalled = false;
-    AdaptiveSampler sampler(std::chrono::milliseconds::zero(), 2, 1, 1, [&callbackCalled]() { callbackCalled = true; });
+    AdaptiveSampler sampler(0ms, 2, 1, 1, [&callbackCalled]() { callbackCalled = true; });
 
     sampler.RollWindow();
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ChronoHelperTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ChronoHelperTest.cpp
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/chrono_helper.hpp"
+
+using namespace std::chrono_literals;
+
+TEST(ChronoHelper, First)
+{
+    ASSERT_EQ(etw_timestamp::zero().count(), 0);
+
+    auto v = 99ns;
+    auto result = std::chrono::duration_cast<etw_timestamp>(v);
+    auto expectedZero = etw_timestamp(0);
+
+    ASSERT_EQ(result, expectedZero);
+
+    auto w = 100ns;
+    auto result2 = std::chrono::duration_cast<etw_timestamp>(w);
+    auto expectedOne = etw_timestamp(1);
+    ASSERT_EQ(result2, expectedOne);
+
+    auto z = 1us;
+    auto result3 = std::chrono::duration_cast<etw_timestamp>(z);
+    auto expectedTen = etw_timestamp(10);
+    ASSERT_EQ(result3, expectedTen);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ClrEventsParserTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ClrEventsParserTest.cpp
@@ -114,7 +114,7 @@ uint64_t Write(std::uint8_t* buffer, std::uint64_t offset, T const& value)
     return offset + sizeof(T);
 }
 
-std::pair<std::unique_ptr<std::uint8_t[]>, std::size_t> CreateAllockationTickEvent(
+std::pair<std::unique_ptr<std::uint8_t[]>, std::size_t> CreateAllocationTickEvent(
     WCHAR const* typeName,
     std::uint32_t kind,
     std::uint64_t allocationAmount,
@@ -153,7 +153,7 @@ TEST(ClrEventsParserTest, AllocationTickV4)
 
     auto typeName = WStr("MyType");
 
-    auto [buffer, eventSize] = CreateAllockationTickEvent(typeName, 0x0, 42, 12, 123456789, 999);
+    auto [buffer, eventSize] = CreateAllocationTickEvent(typeName, 0x0, 42, 12, 123456789, 999);
 
     EXPECT_CALL(mockAllocationListener, OnAllocation(0, 12, GenericStrEq(typeName), 123456789, 999, 42)).Times(1);
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ClrEventsParserTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ClrEventsParserTest.cpp
@@ -1,0 +1,161 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ClrEventsParser.h"
+
+#include "ProfilerMockedInterface.h"
+
+#include <chrono>
+
+using testing::_;
+using testing::StrEq;
+
+using namespace std::chrono_literals;
+
+template <typename CharT>
+class GenericStrEqMatcher : public testing::MatcherInterface<const CharT*>
+{
+public:
+    explicit GenericStrEqMatcher(const std::basic_string<CharT>& expected) :
+        expected_(expected)
+    {
+    }
+
+    bool MatchAndExplain(const CharT* actual,
+                         testing::MatchResultListener* listener) const override
+    {
+        if (actual == nullptr)
+        {
+            *listener << "which is null";
+            return false;
+        }
+        return std::basic_string<CharT>(actual) == expected_;
+    }
+
+    void DescribeTo(std::ostream* os) const override
+    {
+        *os << "is equal to " << testing::PrintToString(expected_);
+    }
+
+    void DescribeNegationTo(std::ostream* os) const override
+    {
+        *os << "is not equal to " << testing::PrintToString(expected_);
+    }
+
+private:
+    const std::basic_string<CharT> expected_;
+};
+
+template <typename CharT>
+testing::Matcher<const CharT*> GenericStrEq(const std::basic_string<CharT>& str)
+{
+    return testing::MakeMatcher(new GenericStrEqMatcher<CharT>(str));
+}
+
+// Overloads for string literals
+template <typename CharT>
+testing::Matcher<const CharT*> GenericStrEq(const CharT* str)
+{
+    return GenericStrEq(std::basic_string<CharT>(str));
+}
+
+TEST(ClrEventsParserTest, ContentionStopV1)
+{
+    auto [contentionListener, mockContentionListener] = CreateMockForUniquePtr<IContentionListener, MockContentionListener>();
+    auto parser = ClrEventsParser(nullptr, contentionListener.get(), nullptr);
+
+    auto expectedDuration = 21ns;
+    ContentionStopV1Payload payload{0};
+
+    payload.ContentionFlags = 0;
+    payload.ClrInstanceId = 1;
+    payload.DurationNs = static_cast<double_t>(expectedDuration.count());
+
+    EXPECT_CALL(mockContentionListener, OnContention(expectedDuration));
+    parser.ParseEvent(42ns, 1, KEYWORD_CONTENTION, EVENT_CONTENTION_STOP, sizeof(ContentionStopV1Payload), reinterpret_cast<LPCBYTE>(&payload));
+}
+
+TEST(ClrEventsParserTest, DoNothingForContentionStartV1)
+{
+    auto [contentionListener, mockContentionListener] = CreateMockForUniquePtr<IContentionListener, MockContentionListener>();
+    auto parser = ClrEventsParser(nullptr, contentionListener.get(), nullptr);
+
+    EXPECT_CALL(mockContentionListener, SetBlockingThread(_)).Times(0);
+
+    parser.ParseEvent(42ns, 1, KEYWORD_CONTENTION, EVENT_CONTENTION_START, 0, nullptr);
+}
+
+TEST(ClrEventsParserTest, ContentionStartV2)
+{
+    auto [contentionListener, mockContentionListener] = CreateMockForUniquePtr<IContentionListener, MockContentionListener>();
+    auto parser = ClrEventsParser(nullptr, contentionListener.get(), nullptr);
+
+    std::uint64_t expectedOwnerThreadId = 43;
+
+    ContentionStartV2Payload payload{0};
+    payload.ContentionFlags = 0;
+    payload.ClrInstanceId = 1;
+    payload.LockId = 42;
+    payload.AssociatedObjectID = 21;
+    payload.LockOwnerThreadID = expectedOwnerThreadId;
+
+    EXPECT_CALL(mockContentionListener, SetBlockingThread(expectedOwnerThreadId)).Times(1);
+
+    parser.ParseEvent(1234ns, 2, KEYWORD_CONTENTION, EVENT_CONTENTION_START, sizeof(ContentionStartV2Payload), reinterpret_cast<LPCBYTE>(&payload));
+}
+
+template <typename T>
+uint64_t Write(std::uint8_t* buffer, std::uint64_t offset, T const& value)
+{
+    *reinterpret_cast<T*>(buffer + offset) = value;
+    return offset + sizeof(T);
+}
+
+std::pair<std::unique_ptr<std::uint8_t[]>, std::size_t> CreateAllockationTickEvent(
+    WCHAR const* typeName,
+    std::uint32_t kind,
+    std::uint64_t allocationAmount,
+    std::uintptr_t typeId,
+    std::uintptr_t address,
+    std::uint64_t objectSize)
+{
+    auto typeNbBytes = (std::char_traits<WCHAR>::length(typeName) + 1) * sizeof(WCHAR);
+    std::size_t eventSize = sizeof(AllocationTickV4Payload) + typeNbBytes + 1;
+
+    auto payload = std::make_unique<std::uint8_t[]>(eventSize);
+    auto buffer = reinterpret_cast<AllocationTickV4Payload*>(payload.get());
+
+    buffer->AllocationAmount = 21112; // do not care / ignored
+    buffer->AllocationKind = kind;
+    buffer->ClrInstanceId = 1; // do not care / ignored
+    buffer->AllocationAmount64 = allocationAmount;
+    buffer->TypeId = typeId;
+
+    memcpy(&buffer->TypeName, typeName, typeNbBytes);
+
+    std::uint64_t nextOffset =
+        offsetof(AllocationTickV4Payload, TypeName) + typeNbBytes;
+
+    nextOffset = Write<decltype(AllocationTickV4Payload::HeapIndex)>(payload.get(), nextOffset, 2); // do not care
+    nextOffset = Write<decltype(AllocationTickV4Payload::Address)>(payload.get(), nextOffset, address);
+    nextOffset = Write<decltype(AllocationTickV4Payload::ObjectSize)>(payload.get(), nextOffset, objectSize);
+
+    return std::make_pair(std::move(payload), eventSize);
+}
+
+TEST(ClrEventsParserTest, AllocationTickV4)
+{
+    auto [allocationListener, mockAllocationListener] = CreateMockForUniquePtr<IAllocationsListener, MockAllocationListener>();
+    auto parser = ClrEventsParser(allocationListener.get(), nullptr, nullptr);
+
+    auto typeName = WStr("MyType");
+
+    auto [buffer, eventSize] = CreateAllockationTickEvent(typeName, 0x0, 42, 12, 123456789, 999);
+
+    EXPECT_CALL(mockAllocationListener, OnAllocation(0, 12, GenericStrEq(typeName), 123456789, 999, 42)).Times(1);
+
+    parser.ParseEvent(12345ns, 4, KEYWORD_GC, EVENT_ALLOCATION_TICK, eventSize, buffer.get());
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="AppDomainStoreHelper.cpp" />
     <ClCompile Include="ApplicationStoreTest.cpp" />
     <ClCompile Include="CallstackTest.cpp" />
+    <ClCompile Include="ClrEventsParserTest.cpp" />
     <ClCompile Include="ConfigurationTest.cpp" />
     <ClCompile Include="CpuProfilerTypeTest.cpp" />
     <ClCompile Include="CrashReportingTest.cpp" />
@@ -91,6 +92,7 @@
     <ClCompile Include="TagsHelperTest.cpp" />
     <ClCompile Include="ProviderTest.cpp" />
     <ClCompile Include="ThreadsCpuManagerHelper.cpp" />
+    <ClCompile Include="ChronoHelperTest.cpp" />
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\SecurityDescriptorHelpers.h" />
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h" />
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.cpp" />
@@ -103,7 +105,6 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="RuntimeIdStoreHelper.h" />
     <ClInclude Include="RuntimeInfoHelper.h" />
-    <ClInclude Include="ThreadsCpuManagerHelper.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="HResultConverterTest.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -63,6 +63,7 @@
     <ClCompile Include="EnabledProfilersTest.cpp" />
     <ClCompile Include="EnvironmentHelper.cpp" />
     <ClCompile Include="ErrorCodeTest.cpp" />
+    <ClCompile Include="EtwEventsManagerTest.cpp" />
     <ClCompile Include="ExporterTest.cpp" />
     <ClCompile Include="FakeSamples.cpp" />
     <ClCompile Include="FrameStoreHelper.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -181,6 +181,12 @@
     <ClCompile Include="EtwEventsManagerTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="ClrEventsParserTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="ChronoHelperTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -19,7 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="..\..\..\..\..\Temp\Datadog.Trace.Manual.dll" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="HResultConverterTest.cpp">
@@ -178,6 +177,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\CrashReportingWindows.cpp">
       <Filter>External Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="EtwEventsManagerTest.cpp">
+      <Filter>Tests</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/profiler/test/Datadog.Profiler.Native.Tests/EtwEventsManagerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/EtwEventsManagerTest.cpp
@@ -1,0 +1,140 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+#ifdef _WINDOWS
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ClrEventsParser.h"
+#include "FrameStore.h"
+#include "IAllocationsListener.h"
+#include "IContentionListener.h"
+
+#include "ProfilerMockedInterface.h"
+
+#include "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.h"
+
+#include <chrono>
+
+using ::testing::_;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+using namespace std::chrono_literals;
+
+TEST(EtwEventsManagerTest, ContentionEventWithoutCallstack)
+{
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+
+    EXPECT_CALL(mockConfiguration, IsEtwLoggingEnabled()).WillRepeatedly(Return(false));
+    std::string replayEndpoint = "not empty to simulate replay";
+    EXPECT_CALL(mockConfiguration, GetEtwReplayEndpoint()).WillRepeatedly(ReturnRef(replayEndpoint));
+
+    auto [contentionListener, mockContentionListener] = CreateMockForUniquePtr<IContentionListener, MockContentionListener>();
+    //                                                 epoch timestamp    , tid, duration, stack
+    EXPECT_CALL(mockContentionListener, OnContention(1601910785587000000ns, 2  , 14300ns , IsEmpty()));
+    auto manager = EtwEventsManager(nullptr, contentionListener.get(), nullptr, configuration.get());
+
+    manager.OnEvent(etw_timestamp(132463843855875757), 2, 1, KEYWORD_CONTENTION, 1, EVENT_CONTENTION_START, 0, nullptr);
+    manager.OnEvent(etw_timestamp(132463843855875900), 2, 1, KEYWORD_CONTENTION, 1, EVENT_CONTENTION_STOP, 0, nullptr);
+}
+
+TEST(EtwEventsManagerTest, ContentionEventWithCallstack)
+{
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+
+    EXPECT_CALL(mockConfiguration, IsEtwLoggingEnabled()).WillRepeatedly(Return(false));
+    std::string replayEndpoint = "not empty to simulate replay";
+    EXPECT_CALL(mockConfiguration, GetEtwReplayEndpoint()).WillRepeatedly(ReturnRef(replayEndpoint));
+
+    auto [contentionListener, mockContentionListener] = CreateMockForUniquePtr<IContentionListener, MockContentionListener>();
+
+    //                                               epoch timestamp      , tid, duration, stack
+    EXPECT_CALL(mockContentionListener, OnContention(1601910785587000000ns, 2  , 14300ns , ElementsAre(FrameStore::FakeLockContentionIP)));
+    auto manager = EtwEventsManager(nullptr, contentionListener.get(), nullptr, configuration.get());
+
+    manager.OnEvent(etw_timestamp(132463843855875757), 2, 1, KEYWORD_CONTENTION, 1, EVENT_CONTENTION_START, 0, nullptr);
+    manager.OnEvent(etw_timestamp(132463843855875800), 2, 1, KEYWORD_STACKWALK, 1, -1, 0, nullptr);
+    manager.OnEvent(etw_timestamp(132463843855875900), 2, 1, KEYWORD_CONTENTION, 1, EVENT_CONTENTION_STOP, 0, nullptr);
+}
+
+TEST(EtwEventsManagerTest, AllocationTickEventWithCallstack)
+{
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+
+    EXPECT_CALL(mockConfiguration, IsEtwLoggingEnabled()).WillRepeatedly(Return(false));
+    std::string replayEndpoint = "not empty to simulate replay";
+    EXPECT_CALL(mockConfiguration, GetEtwReplayEndpoint()).WillRepeatedly(ReturnRef(replayEndpoint));
+
+    auto [allocationListener, mockAllocationListener] = CreateMockForUniquePtr<IAllocationsListener, MockAllocationListener>();
+
+    auto manager = EtwEventsManager(allocationListener.get(), nullptr, nullptr, configuration.get());
+
+    constexpr auto typeName = WStr("MyType");
+    constexpr auto typeNbBytes = std::char_traits<WCHAR>::length(typeName) * sizeof(WCHAR);
+    std::uint8_t buffer[sizeof(AllocationTickV3Payload) + typeNbBytes + 1] = {0};
+
+    auto* payload = (AllocationTickV3Payload*)&buffer;
+
+    payload->AllocationAmount = 21;
+    payload->AllocationKind = 0x0;
+    payload->ClrInstanceId = 1;
+    payload->AllocationAmount64 = 42;
+    memcpy(&payload->FirstCharInName, typeName, typeNbBytes);
+    (&payload->FirstCharInName)[typeNbBytes] = WStr('\0');
+
+    EXPECT_CALL(mockAllocationListener,
+                OnAllocation(
+                    1601910785587000000ns,
+                    2,
+                    payload->AllocationKind,
+                    0, // replay mode ClassID is 0
+                    "MyType",
+                    payload->AllocationAmount64,
+                    ElementsAre(FrameStore::FakeAllocationIP)));
+
+    manager.OnEvent(etw_timestamp(132463843855875757), 2, 1, KEYWORD_GC, 1, EVENT_ALLOCATION_TICK, 0, reinterpret_cast<const uint8_t*>(&buffer));
+    manager.OnEvent(etw_timestamp(132463843855875800), 2, 1, KEYWORD_STACKWALK, 1, -1, 0, nullptr);
+}
+
+TEST(EtwEventsManagerTest, AllocationTickEventWithoutCallstack)
+{
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+
+    EXPECT_CALL(mockConfiguration, IsEtwLoggingEnabled()).WillRepeatedly(Return(false));
+    std::string replayEndpoint = "not empty to simulate replay";
+    EXPECT_CALL(mockConfiguration, GetEtwReplayEndpoint()).WillRepeatedly(ReturnRef(replayEndpoint));
+
+    auto [allocationListener, mockAllocationListener] = CreateMockForUniquePtr<IAllocationsListener, MockAllocationListener>();
+
+    auto manager = EtwEventsManager(allocationListener.get(), nullptr, nullptr, configuration.get());
+
+    constexpr auto typeName = WStr("MyType");
+    constexpr auto typeNbBytes = std::char_traits<WCHAR>::length(typeName) * sizeof(WCHAR);
+    std::uint8_t buffer[sizeof(AllocationTickV3Payload) + typeNbBytes + 1] = {0};
+
+    auto* payload = reinterpret_cast<AllocationTickV3Payload*>(&buffer);
+
+    payload->AllocationAmount = 21;
+    payload->AllocationKind = 0x0;
+    payload->ClrInstanceId = 1;
+    payload->AllocationAmount64 = 42;
+    memcpy(&payload->FirstCharInName, typeName, typeNbBytes);
+    (&payload->FirstCharInName)[typeNbBytes] = WStr('\0');
+
+    EXPECT_CALL(mockAllocationListener,
+                OnAllocation(
+                    1601910785587000000ns,
+                    2,
+                    payload->AllocationKind,
+                    0, // replay mode ClassID is 0
+                    "MyType",
+                    payload->AllocationAmount64,
+                    ElementsAre(FrameStore::FakeAllocationIP)))
+        .Times(0);
+
+    manager.OnEvent(etw_timestamp(132463843855875757), 2, 1, KEYWORD_GC, 1, EVENT_ALLOCATION_TICK, 0, reinterpret_cast<const uint8_t*>(&buffer));
+}
+#endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/EtwEventsManagerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/EtwEventsManagerTest.cpp
@@ -81,7 +81,7 @@ TEST(EtwEventsManagerTest, AllocationTickEventWithCallstack)
     payload->AllocationAmount = 21;
     payload->AllocationKind = 0x0;
     payload->ClrInstanceId = 1;
-    payload->AllocationAmount64 = 42;
+    payload->AllocationAmount64 = 21;
     memcpy(&payload->FirstCharInName, typeName, typeNbBytes);
     (&payload->FirstCharInName)[typeNbBytes] = WStr('\0');
 
@@ -120,7 +120,7 @@ TEST(EtwEventsManagerTest, AllocationTickEventWithoutCallstack)
     payload->AllocationAmount = 21;
     payload->AllocationKind = 0x0;
     payload->ClrInstanceId = 1;
-    payload->AllocationAmount64 = 42;
+    payload->AllocationAmount64 = 21;
     memcpy(&payload->FirstCharInName, typeName, typeNbBytes);
     (&payload->FirstCharInName)[typeNbBytes] = WStr('\0');
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfileTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfileTest.cpp
@@ -27,7 +27,7 @@ TEST(ProfileTest, AddSample)
     auto p = CreateProfile(configuration);
 
     Sample::ValuesCount = 1;
-    auto s = std::make_shared<Sample>(1, "1", 2);
+    auto s = std::make_shared<Sample>(1ns, "1", 2);
     s->AddFrame({"", "", "", 1});
     s->AddFrame({"", "", "", 2});
     s->AddValue(42, 0);
@@ -69,7 +69,7 @@ TEST(ProfileTest, EnsureAddFailIfWrongNumberOfValues)
 
     // change number of values to fail the Add
     Sample::ValuesCount = 2;
-    auto s = std::make_shared<Sample>(1, "1", 2);
+    auto s = std::make_shared<Sample>(1ns, "1", 2);
     s->AddFrame({"", "", "", 1});
     s->AddFrame({"", "", "", 2});
     s->AddValue(42, 0);

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -2,11 +2,16 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "cor.h"
+#include "corprof.h"
+
 #include "shared/src/native-src/dd_filesystem.hpp"
 // namespace fs is an alias defined in "dd_filesystem.hpp"
 
 #include "Configuration.h"
+#include "IAllocationsListener.h"
 #include "IApplicationStore.h"
+#include "IContentionListener.h"
 #include "IExporter.h"
 #include "IMetricsSender.h"
 #include "IRuntimeIdStore.h"
@@ -19,6 +24,7 @@
 #include "SamplesEnumerator.h"
 #include "TagsHelper.h"
 
+#include <chrono>
 #include <memory>
 
 class MockConfiguration : public IConfiguration
@@ -191,6 +197,36 @@ public:
 
 private:
     bool _hasBeenStarted = false;
+};
+
+class MockContentionListener : public IContentionListener
+{
+public:
+    MOCK_METHOD(void, OnContention, (std::chrono::nanoseconds contentionDurationNs), (override));
+    MOCK_METHOD(void, OnContention, (std::chrono::nanoseconds timestamp, uint32_t threadId, std::chrono::nanoseconds contentionDurationNs, const std::vector<uintptr_t>& stack), (override));
+    MOCK_METHOD(void, SetBlockingThread, (uint64_t osThreadId), (override));
+};
+
+class MockAllocationListener : public IAllocationsListener
+{
+public:
+    MOCK_METHOD(void, OnAllocation, (uint32_t allocationKind,
+                              ClassID classId,
+                              const WCHAR* typeName,
+                              uintptr_t address,
+                              uint64_t objectSize,
+                              uint64_t allocationAmount), (override));
+
+    // for .NET Framework, events are received asynchronously
+    // and the callstack is received as a sibling event
+    // --> we cannot walk the stack of the current thread
+    MOCK_METHOD(void, OnAllocation, (std::chrono::nanoseconds timestamp,
+                              uint32_t threadId,
+                              uint32_t allocationKind,
+                              ClassID classId,
+                              const std::string& typeName,
+                              uint64_t allocationAmount,
+                              const std::vector<uintptr_t>& stack), (override));
 };
 
 template <typename T, typename U, typename... Args>

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -30,8 +30,8 @@ using namespace std::chrono_literals;
 CallstackProvider callstackProvider(MemoryResourceManager::GetDefault());
 
 RawWallTimeSample GetWallTimeRawSample(
-    std::uint64_t timeStamp,
-    std::uint64_t duration,
+    std::chrono::nanoseconds timeStamp,
+    std::chrono::nanoseconds duration,
     AppDomainID appDomainId,
     std::uint64_t traceId,
     std::uint64_t spanId,
@@ -57,8 +57,8 @@ RawWallTimeSample GetWallTimeRawSample(
 }
 
 RawCpuSample GetRawCpuSample(
-    std::uint64_t timeStamp,
-    std::uint64_t duration,
+    std::chrono::nanoseconds timeStamp,
+    std::chrono::nanoseconds duration,
     AppDomainID appDomainId,
     std::uint64_t traceId,
     std::uint64_t spanId,
@@ -134,10 +134,10 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
 
     std::vector<size_t> expectedAppDomainId{1, 2, 2, 1};
     //                                                       V-- check the appdomains are correct
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(expectedAppDomainId[0]), 0, 0, 1));
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(expectedAppDomainId[1]), 0, 0, 2));
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(expectedAppDomainId[2]), 0, 0, 3));
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(expectedAppDomainId[3]), 0, 0, 4));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(expectedAppDomainId[0]), 0, 0, 1));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(expectedAppDomainId[1]), 0, 0, 2));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(expectedAppDomainId[2]), 0, 0, 3));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(expectedAppDomainId[3]), 0, 0, 4));
 
     // wait for the provider to collect raw samples
     std::this_thread::sleep_for(200ms);
@@ -146,7 +146,7 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
     provider.Stop();
 
     size_t currentSample = 0;
-    auto sample = std::make_shared<Sample>(0, std::string_view{}, 10);
+    auto sample = std::make_shared<Sample>(0ns, std::string_view{}, 10);
 
     while (samples->MoveNext(sample))
     {
@@ -214,10 +214,10 @@ TEST(WallTimeProviderTest, CheckFrames)
     provider.Start();
 
     //                                                                 V-- check the frames are correct
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(1), 0, 0, 1));
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(1), 0, 0, 2));
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(1), 0, 0, 3));
-    provider.Add(GetWallTimeRawSample(0, 0, static_cast<AppDomainID>(1), 0, 0, 4));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(1), 0, 0, 2));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(1), 0, 0, 3));
+    provider.Add(GetWallTimeRawSample(0ns, 0ns, static_cast<AppDomainID>(1), 0, 0, 4));
 
     // wait for the provider to collect raw samples
     std::this_thread::sleep_for(200ms);
@@ -241,7 +241,7 @@ TEST(WallTimeProviderTest, CheckFrames)
             "module #4",
         };
 
-    auto sample = std::make_shared<Sample>(0, std::string_view{}, 10);
+    auto sample = std::make_shared<Sample>(0ns, std::string_view{}, 10);
 
     while (samples->MoveNext(sample))
     {
@@ -275,10 +275,10 @@ TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
     provider.Start();
 
     //                                V-----V-- check these values are correct
-    provider.Add(GetWallTimeRawSample(1000, 10, static_cast<AppDomainID>(1), 0, 0, 1));
-    provider.Add(GetWallTimeRawSample(2000, 20, static_cast<AppDomainID>(1), 0, 0, 1));
-    provider.Add(GetWallTimeRawSample(3000, 30, static_cast<AppDomainID>(1), 0, 0, 1));
-    provider.Add(GetWallTimeRawSample(4000, 40, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetWallTimeRawSample(1000ns, 10ns, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetWallTimeRawSample(2000ns, 20ns, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetWallTimeRawSample(3000ns, 30ns, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetWallTimeRawSample(4000ns, 40ns, static_cast<AppDomainID>(1), 0, 0, 1));
 
     // wait for the provider to collect raw samples
     std::this_thread::sleep_for(200ms);
@@ -286,8 +286,8 @@ TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
     auto samples = provider.GetSamples();
     provider.Stop();
 
-    size_t currentSample = 1;
-    auto sample = std::make_shared<Sample>(0, std::string_view{}, 10);
+    auto currentSample = 1ns;
+    auto sample = std::make_shared<Sample>(0ns, std::string_view{}, 10);
 
     while (samples->MoveNext(sample))
     {
@@ -297,7 +297,7 @@ TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
         ASSERT_EQ(values.size(), 1);
         for (size_t current = 0; current < values.size(); current++)
         {
-            ASSERT_EQ(currentSample * 10, values[current]);
+            ASSERT_EQ(currentSample * 10, std::chrono::nanoseconds(values[current]));
         }
 
         currentSample++;
@@ -319,10 +319,10 @@ TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
     provider.Start();
 
     //                           V-----V-- check these values are correct
-    provider.Add(GetRawCpuSample(1000, 10, static_cast<AppDomainID>(1), 0, 0, 1));
-    provider.Add(GetRawCpuSample(2000, 20, static_cast<AppDomainID>(1), 0, 0, 1));
-    provider.Add(GetRawCpuSample(3000, 30, static_cast<AppDomainID>(1), 0, 0, 1));
-    provider.Add(GetRawCpuSample(4000, 40, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetRawCpuSample(1000ns, 10ns, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetRawCpuSample(2000ns, 20ns, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetRawCpuSample(3000ns, 30ns, static_cast<AppDomainID>(1), 0, 0, 1));
+    provider.Add(GetRawCpuSample(4000ns, 40ns, static_cast<AppDomainID>(1), 0, 0, 1));
 
     // wait for the provider to collect raw samples
     std::this_thread::sleep_for(200ms);
@@ -331,8 +331,8 @@ TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
     ASSERT_EQ(4, samples->size());
     provider.Stop();
 
-    size_t currentSample = 1;
-    auto sample = std::make_shared<Sample>(0, std::string_view{}, 10);
+    auto currentSample = 1ns;
+    auto sample = std::make_shared<Sample>(0ns, std::string_view{}, 10);
 
     while (samples->MoveNext(sample))
     {
@@ -342,8 +342,7 @@ TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
         ASSERT_EQ(values.size(), 1);
         for (size_t current = 0; current < values.size(); current++)
         {
-            //                             V-- in nanoseconds
-            ASSERT_EQ(currentSample * 10 * 1000000, values[current]);
+            ASSERT_EQ(currentSample * 10, std::chrono::nanoseconds(values[current]));
         }
 
         currentSample++;


### PR DESCRIPTION
## Summary of changes

Use time types (`std::chrono::nanoseconds, std::chrono::milliseconds...) instead of integer type.

## Reason for change

Make the code more readable and give more semantic to variable and functions.
We faced a few times situations where we were asking ourselves `is it nanoseconds ? is it milliseconds ? does need to be converted ?...`

## Implementation details

Replace wherever it makes sense integer types by time type.
For etw, introduce a `etw_timestamp`.

## Test coverage
- current tests.
- Checked the pprof to see if the value are of the same order of magnitude
- Add new unit tests
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
