### PR TITLE
[CI Visibility] Fix GitCommandParser test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
@@ -152,7 +152,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 gitInfo.AuthorDate.Should().NotBeNull();
                 gitInfo.AuthorEmail.Should().NotBeNull();
                 gitInfo.AuthorName.Should().NotBeNull();
-                gitInfo.Branch.Should().NotBeNull();
                 gitInfo.Commit.Should().NotBeNull();
                 gitInfo.CommitterDate.Should().NotBeNull();
                 gitInfo.CommitterEmail.Should().NotBeNull();


### PR DESCRIPTION
## Summary of changes

The PR fixes the GitCommand Parser test

## Reason for change

The test is failing on some platforms because we work with a detached Head, and that makes the Branch to be null.

## Implementation details

Removes the branch assertion.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
