### PR TITLE
[Dynamic Instrumentation] DEBUG-3132 Add Memoization Cache for Redaction Logic

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
             // Set configs relevant for DI and Exception Debugging, using DI's environment keys.
             DebuggerSnapshotSerializer.SetConfig(debuggerSettings);
-            Redaction.SetConfig(debuggerSettings.RedactedIdentifiers, debuggerSettings.RedactedExcludedIdentifiers, debuggerSettings.RedactedTypes);
+            Redaction.Instance.SetConfig(debuggerSettings.RedactedIdentifiers, debuggerSettings.RedactedExcludedIdentifiers, debuggerSettings.RedactedTypes);
 
             // Set up the snapshots sink.
             var snapshotSlicer = SnapshotSlicer.Create(debuggerSettings);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -109,7 +109,7 @@ internal partial class ProbeExpressionParser<T>
 
             if (indexOrKey.Type == typeof(string) &&
                 indexOrKey is ConstantExpression expr &&
-                Redaction.ShouldRedact(expr.Value?.ToString(), expr.Type, out _))
+                Redaction.Instance.ShouldRedact(expr.Value?.ToString(), expr.Type, out _))
             {
                 AddError($"{source?.ToString() ?? "N/A"}[{indexOrKey?.ToString() ?? "N/A"}]", "The property or field is redacted.");
                 return RedactedValue();

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -209,7 +209,7 @@ internal partial class ProbeExpressionParser<T>
 
             var constantValue = constant.Value?.ToString();
 
-            if (Redaction.ShouldRedact(constantValue, constant.Type, out _))
+            if (Redaction.Instance.ShouldRedact(constantValue, constant.Type, out _))
             {
                 AddError(reader.Value?.ToString() ?? "N/A", "The property or field is redacted.");
                 return RedactedValue();
@@ -242,7 +242,7 @@ internal partial class ProbeExpressionParser<T>
 
         try
         {
-            if (Redaction.ShouldRedact(propertyOrFieldValue, propertyOrField.Type, out _))
+            if (Redaction.Instance.ShouldRedact(propertyOrFieldValue, propertyOrField.Type, out _))
             {
                 AddError($"{expression}.{propertyOrFieldValue}", "The property or field is redacted.");
                 return RedactedValue();

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -142,7 +142,7 @@ namespace Datadog.Trace.Debugger
                 _subscriptionManager.SubscribeToChanges(_subscription);
 
                 DebuggerSnapshotSerializer.SetConfig(Settings);
-                Redaction.SetConfig(Settings.RedactedIdentifiers, Settings.RedactedExcludedIdentifiers, Settings.RedactedTypes);
+                Redaction.Instance.SetConfig(Settings.RedactedIdentifiers, Settings.RedactedExcludedIdentifiers, Settings.RedactedTypes);
                 AppDomain.CurrentDomain.AssemblyLoad += (sender, args) => CheckUnboundProbes();
 
                 await StartAsync().ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Debugger.Snapshots
         {
             try
             {
-                if (Redaction.ShouldRedact(variableName, type, out var redactionReason))
+                if (Redaction.Instance.ShouldRedact(variableName, type, out var redactionReason))
                 {
                     if (variableName != null)
                     {

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -173,9 +173,9 @@ namespace Datadog.Trace.Debugger.Snapshots
             "xsrftoken"
         ];
 
-        private static ConcurrentAdaptiveCache<Type, bool> _redactedTypesCache = new(evictionPolicyKind:EvictionPolicy.LFU);
+        private static ConcurrentAdaptiveCache<Type, bool> _redactedTypesCache = new(evictionPolicyKind: EvictionPolicy.Lfu);
 
-        private static ConcurrentAdaptiveCache<string, bool> _redactedKeywordsCache = new(evictionPolicyKind: EvictionPolicy.LFU);
+        private static ConcurrentAdaptiveCache<string, bool> _redactedKeywordsCache = new(evictionPolicyKind: EvictionPolicy.Lfu);
 
         internal static bool IsSafeToCallToString(Type type)
         {

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -28,9 +28,10 @@ namespace Datadog.Trace.Debugger.Snapshots
         Type
     }
 
-    internal static class Redaction
+    internal class Redaction
     {
         private const int MaxStackAlloc = 512;
+
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(Redaction));
 
         private static readonly Type[] AllowedCollectionTypes =
@@ -63,6 +64,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         private static readonly string[] AllowedSpecialCasedCollectionTypeNames = []; // "RangeIterator"
 
+        private static readonly Type[] DeniedTypes =
+        [
+            typeof(SecureString)
+        ];
+
         internal static readonly Type[] AllowedTypesSafeToCallToString =
         [
             typeof(DateTime),
@@ -75,107 +81,115 @@ namespace Datadog.Trace.Debugger.Snapshots
             typeof(StringBuilder)
         ];
 
-        private static readonly Type[] DeniedTypes =
-        [
-            typeof(SecureString)
-        ];
+        private static Redaction _instnace = new();
 
-        private static readonly Trie TypeTrie = new();
+        private readonly Trie _typeTrie;
 
-        private static readonly HashSet<string> RedactedTypes = [];
+        private readonly HashSet<string> _redactedTypes;
 
-        private static readonly HashSet<string> RedactKeywords =
-        [
-            "2fa",
-            "accesstoken",
-            "aiohttpsession",
-            "apikey",
-            "appkey",
-            "apisecret",
-            "apisignature",
-            "applicationkey",
-            "auth",
-            "authorization",
-            "authtoken",
-            "ccnumber",
-            "certificatepin",
-            "cipher",
-            "clientid",
-            "clientsecret",
-            "connectionstring",
-            "connectsid",
-            "cookie",
-            "credentials",
-            "creditcard",
-            "csrf",
-            "csrftoken",
-            "cvv",
-            "databaseurl",
-            "dburl",
-            "encryptionkey",
-            "encryptionkeyid",
-            "geolocation",
-            "gpgkey",
-            "ipaddress",
-            "jti",
-            "jwt",
-            "licensekey",
-            "masterkey",
-            "mysqlpwd",
-            "nonce",
-            "oauth",
-            "oauthtoken",
-            "otp",
-            "passhash",
-            "passwd",
-            "password",
-            "passwordb",
-            "pemfile",
-            "pgpkey",
-            "phpsessid",
-            "pin",
-            "pincode",
-            "pkcs8",
-            "privatekey",
-            "publickey",
-            "pwd",
-            "recaptchakey",
-            "refreshtoken",
-            "routingnumber",
-            "salt",
-            "secret",
-            "secretkey",
-            "secrettoken",
-            "securityanswer",
-            "securitycode",
-            "securityquestion",
-            "serviceaccountcredentials",
-            "session",
-            "sessionid",
-            "sessionkey",
-            "setcookie",
-            "signature",
-            "signaturekey",
-            "sshkey",
-            "ssn",
-            "symfony",
-            "token",
-            "transactionid",
-            "twiliotoken",
-            "usersession",
-            "voterid",
-            "xapikey",
-            "xauthtoken",
-            "xcsrftoken",
-            "xforwardedfor",
-            "xrealip",
-            "xsrf",
-            "xsrftoken"
-        ];
+        private readonly HashSet<string> _redactKeywords;
 
-        private static ConcurrentAdaptiveCache<Type, bool> _redactedTypesCache = new(evictionPolicyKind: EvictionPolicy.Lfu);
+        private readonly ConcurrentAdaptiveCache<Type, bool> _redactedTypesCache;
 
-        private static ConcurrentAdaptiveCache<string, bool> _redactedKeywordsCache = new(evictionPolicyKind: EvictionPolicy.Lfu);
+        private readonly ConcurrentAdaptiveCache<string, bool> _redactedKeywordsCache;
+
+        private Redaction()
+        {
+            _typeTrie = new Trie();
+            _redactedTypes = [];
+            _redactKeywords =
+            [
+                "2fa",
+                "accesstoken",
+                "aiohttpsession",
+                "apikey",
+                "appkey",
+                "apisecret",
+                "apisignature",
+                "applicationkey",
+                "auth",
+                "authorization",
+                "authtoken",
+                "ccnumber",
+                "certificatepin",
+                "cipher",
+                "clientid",
+                "clientsecret",
+                "connectionstring",
+                "connectsid",
+                "cookie",
+                "credentials",
+                "creditcard",
+                "csrf",
+                "csrftoken",
+                "cvv",
+                "databaseurl",
+                "dburl",
+                "encryptionkey",
+                "encryptionkeyid",
+                "geolocation",
+                "gpgkey",
+                "ipaddress",
+                "jti",
+                "jwt",
+                "licensekey",
+                "masterkey",
+                "mysqlpwd",
+                "nonce",
+                "oauth",
+                "oauthtoken",
+                "otp",
+                "passhash",
+                "passwd",
+                "password",
+                "passwordb",
+                "pemfile",
+                "pgpkey",
+                "phpsessid",
+                "pin",
+                "pincode",
+                "pkcs8",
+                "privatekey",
+                "publickey",
+                "pwd",
+                "recaptchakey",
+                "refreshtoken",
+                "routingnumber",
+                "salt",
+                "secret",
+                "secretkey",
+                "secrettoken",
+                "securityanswer",
+                "securitycode",
+                "securityquestion",
+                "serviceaccountcredentials",
+                "session",
+                "sessionid",
+                "sessionkey",
+                "setcookie",
+                "signature",
+                "signaturekey",
+                "sshkey",
+                "ssn",
+                "symfony",
+                "token",
+                "transactionid",
+                "twiliotoken",
+                "usersession",
+                "voterid",
+                "xapikey",
+                "xauthtoken",
+                "xcsrftoken",
+                "xforwardedfor",
+                "xrealip",
+                "xsrf",
+                "xsrftoken"
+            ];
+            _redactedTypesCache = new(evictionPolicyKind: EvictionPolicy.Lfu);
+            _redactedKeywordsCache = new(evictionPolicyKind: EvictionPolicy.Lfu);
+        }
+
+        internal static Redaction Instance => _instnace;
 
         internal static bool IsSafeToCallToString(Type type)
         {
@@ -221,18 +235,17 @@ namespace Datadog.Trace.Debugger.Snapshots
                    AllowedSpecialCasedCollectionTypeNames.Any(white => white.Equals(type.Name, StringComparison.OrdinalIgnoreCase));
         }
 
-        internal static bool IsRedactedType(Type? type)
+        internal bool IsRedactedType(Type? type)
         {
             if (type == null)
             {
                 return false;
             }
 
-            var redactedType = _redactedTypesCache.GetOrAdd(type, CheckForRedactedType);
-            return redactedType;
+            return _redactedTypesCache.GetOrAdd(type, CheckForRedactedType);
         }
 
-        private static bool CheckForRedactedType(Type type)
+        private bool CheckForRedactedType(Type type)
         {
             Type? genericDefinition = null;
             if (type.IsGenericType)
@@ -256,35 +269,36 @@ namespace Datadog.Trace.Debugger.Snapshots
                 return false;
             }
 
-            if (RedactedTypes.Contains(typeFullName))
+            if (_redactedTypes.Contains(typeFullName))
             {
                 return true;
             }
 
-            if (TypeTrie.HasMatchingPrefix(typeFullName))
+            if (_typeTrie.HasMatchingPrefix(typeFullName))
             {
-                var stringStartsWith = TypeTrie.GetStringStartingWith(typeFullName);
+                var stringStartsWith = _typeTrie.GetStringStartingWith(typeFullName);
                 return string.IsNullOrEmpty(stringStartsWith) || stringStartsWith.Length == typeFullName.Length;
             }
 
             return false;
         }
 
-        internal static bool IsRedactedKeyword(string name)
+        internal bool IsRedactedKeyword(string name)
         {
             if (string.IsNullOrEmpty(name))
             {
                 return false;
             }
 
-            var redactedKeyword = _redactedKeywordsCache.GetOrAdd(
-                name,
-                n => !TryNormalize(n, out var result) || RedactKeywords.Contains(result));
-
-            return redactedKeyword;
+            return _redactedKeywordsCache.GetOrAdd(name, this.CheckForRedactedKeyword);
         }
 
-        internal static bool ShouldRedact(string name, Type type, out RedactionReason redactionReason)
+        internal bool CheckForRedactedKeyword(string keyword)
+        {
+            return TryNormalize(keyword, out var result) && _redactKeywords.Contains(result);
+        }
+
+        internal bool ShouldRedact(string name, Type type, out RedactionReason redactionReason)
         {
             if (IsRedactedKeyword(name))
             {
@@ -353,16 +367,16 @@ namespace Datadog.Trace.Debugger.Snapshots
             return c is '_' or '-' or '$' or '@';
         }
 
-        internal static void SetConfig(HashSet<string> redactedIdentifiers, HashSet<string> redactedExcludedIdentifiers, HashSet<string> redactedTypes)
+        internal void SetConfig(HashSet<string> redactedIdentifiers, HashSet<string> redactedExcludedIdentifiers, HashSet<string> redactedTypes)
         {
 #if NET6_0_OR_GREATER
-            RedactKeywords.EnsureCapacity(RedactKeywords.Count + redactedIdentifiers.Count);
+            _redactKeywords.EnsureCapacity(_redactKeywords.Count + redactedIdentifiers.Count);
 #endif
             foreach (var identifier in redactedIdentifiers)
             {
                 if (TryNormalize(identifier, out var result))
                 {
-                    RedactKeywords.Add(result);
+                    _redactKeywords.Add(result);
                 }
                 else
                 {
@@ -374,7 +388,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             {
                 if (TryNormalize(excluded, out var result))
                 {
-                    RedactKeywords.Remove(result);
+                    _redactKeywords.Remove(result);
                 }
                 else
                 {
@@ -387,17 +401,25 @@ namespace Datadog.Trace.Debugger.Snapshots
                 if (type.EndsWith("*"))
                 {
 #if NETCOREAPP3_1_OR_GREATER
-                    TypeTrie.Insert(type[..^1]);
+                    _typeTrie.Insert(type[..^1]);
 #else
                     var newTypeName = type.Substring(0, type.Length - 1);
-                    TypeTrie.Insert(newTypeName);
+                    _typeTrie.Insert(newTypeName);
 #endif
                 }
                 else
                 {
-                    RedactedTypes.Add(type);
+                    redactedTypes.Add(type);
                 }
             }
+        }
+
+        /// <summary>
+        /// For unit tests only!
+        /// </summary>
+        internal void ResetInstance()
+        {
+           System.Threading.Interlocked.Exchange(ref _instnace, new());
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -409,7 +409,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                 }
                 else
                 {
-                    redactedTypes.Add(type);
+                    _redactedTypes.Add(type);
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/RedactionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/RedactionTests.cs
@@ -215,7 +215,8 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Theory]
-        [InlineData("password", typeof(System.Security.SecureString), RedactionReason.Type)]
+        [InlineData("", typeof(System.Security.SecureString), RedactionReason.Type)]
+        [InlineData("password", typeof(System.Security.SecureString), RedactionReason.Identifier)]
         [InlineData("api_key", typeof(string), RedactionReason.Identifier)]
         [InlineData("normal", typeof(string), RedactionReason.None)]
         internal void ShouldRedact_CombinedScenarios_Test(string name, Type type, RedactionReason expectedReason)


### PR DESCRIPTION
## Summary of changes
This PR introduces caching functionality to optimize redaction decisions by implementing memoization using our Adaptive Cache system.

## Reason for change
Redaction decision-making can be computationally expensive.