### PR TITLE
[ASM] Restore IAST unit tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ReflectionInjection/AssemblyTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ReflectionInjection/AssemblyTests.cs
@@ -64,14 +64,18 @@ public class AssemblyTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnAssembly_LoadFromTaintedHash_VulnerabilityIsReported()
     {
+#pragma warning disable SYSLIB0056 // Type or member is obsolete
         try { Assembly.LoadFrom(taintedAssembly, null, System.Configuration.Assemblies.AssemblyHashAlgorithm.SHA1); } catch { /* ignore */ }
+#pragma warning restore SYSLIB0056 // Type or member is obsolete
         AssertVulnerable();
     }
     
     [Fact]
     public void GivenAnAssembly_LoadFromNotTaintedHash_NotVulnerable()
     {
+#pragma warning disable SYSLIB0056 // Type or member is obsolete
         try { Assembly.LoadFrom(notTaintedAssembly, null, System.Configuration.Assemblies.AssemblyHashAlgorithm.SHA1); } catch { /* ignore */ }
+#pragma warning restore SYSLIB0056 // Type or member is obsolete
         AssertNotVulnerable();
     }
     

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringConcatTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringConcatTests.cs
@@ -83,7 +83,7 @@ public class StringConcatTests : InstrumentationTestsBase
     [Fact]
     public void GivenAStringConcatOneString_WhenPerformed_ResultIsOK()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", String.Concat(taintedValue), () => String.Concat(new[] { taintedValue }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", String.Concat(taintedValue), () => String.Concat(taintedValue));
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public class StringConcatTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedString_WhenCallingConcat_ResultIsTainted()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", String.Concat(taintedValue), () => String.Concat(new[] { taintedValue }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", String.Concat(taintedValue), () => String.Concat(taintedValue));
     }
 
     [Fact]
@@ -419,7 +419,7 @@ public class StringConcatTests : InstrumentationTestsBase
         AssertTaintedFormatWithOriginalCallCheck(
             ":+-TaintedObject-+:UntaintedObject:+-OtherTaintedObject-+:OtherUntaintedObject",
             String.Concat(TaintedObject, UntaintedObject, OtherTaintedObject, OtherUntaintedObject),
-            () => String.Concat(new [] { TaintedObject, UntaintedObject, OtherTaintedObject, OtherUntaintedObject }));
+            () => String.Concat(TaintedObject, UntaintedObject, OtherTaintedObject, OtherUntaintedObject));
 
     }
 
@@ -429,7 +429,7 @@ public class StringConcatTests : InstrumentationTestsBase
         AssertTaintedFormatWithOriginalCallCheck(
             "UntaintedObject:+-TaintedObject-+:OtherUntaintedObject:+-OtherTaintedObject-+:",
             String.Concat(UntaintedObject, TaintedObject, OtherUntaintedObject, OtherTaintedObject),
-            () => String.Concat(new [] { UntaintedObject, TaintedObject, OtherUntaintedObject, OtherTaintedObject }));
+            () => String.Concat(UntaintedObject, TaintedObject, OtherUntaintedObject, OtherTaintedObject));
     }
 
     [Fact]
@@ -493,7 +493,7 @@ public class StringConcatTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedObject_WhenCallingConcatWith4ObjectParams_ResultIsTainted()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-TAINTED2-+:concat:+-tainted-+:concat2", String.Concat(taintedValue2, (object)"concat", taintedValue, (object)"concat2"), () => String.Concat(new object[] { taintedValue2, (object)"concat", taintedValue, (object)"concat2" }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-TAINTED2-+:concat:+-tainted-+:concat2", String.Concat(taintedValue2, (object)"concat", taintedValue, (object)"concat2"), () => String.Concat(taintedValue2, (object)"concat", taintedValue, (object)"concat2"));
     }
 
     [Fact]
@@ -637,7 +637,7 @@ public class StringConcatTests : InstrumentationTestsBase
     [Fact]
     public void GivenAListOfObjects_WhenCallingConcat_ThenNoExceptionIsThrown()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:4str2", String.Concat(taintedValue, 4, null, "str2"), () => String.Concat(new object[] { taintedValue, 4, null, "str2" }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:4str2", String.Concat(taintedValue, 4, null, "str2"), () => String.Concat(taintedValue, 4, null, "str2"));
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringFormatTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringFormatTests.cs
@@ -54,7 +54,7 @@ public class StringFormatTests : InstrumentationTestsBase
         string str = "Literal with tainteds {0}{1} and untainted {2} and tainted {3} and another untainted {4}";
         AssertTaintedFormatWithOriginalCallCheck(":+-Literal with tainteds taintedcustomformatTAINTED2customformat and untainted UntaintedStringcustomformat and tainted TAINTED2customformat and another untainted OtherUntaintedStringcustomformat-+:",
             String.Format(new FormatProviderForTest(), str, _taintedValue, _taintedValue2, _untaintedString, _taintedValue2, _otherUntaintedString),
-            () => String.Format(new FormatProviderForTest(), str, new object[] { _taintedValue, _taintedValue2, _untaintedString, _taintedValue2, _otherUntaintedString }));
+            () => String.Format(new FormatProviderForTest(), str, _taintedValue, _taintedValue2, _untaintedString, _taintedValue2, _otherUntaintedString));
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
@@ -37,7 +37,7 @@ public class StringJoinTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedObject_WhenCallingJoinWithObjectArray_ResultIsTainted2()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:,:+-TAINTED2-+:", String.Join(",", taintedValue, taintedValue2), () => String.Join(",", new[] { taintedValue , taintedValue2 }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:,:+-TAINTED2-+:", String.Join(",", taintedValue, taintedValue2), () => String.Join(",", taintedValue , taintedValue2));
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class StringJoinTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedObject_WhenCallingJoinWithStringArray_ResultIsTainted2()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:,:+-TAINTED2-+:", String.Join(",", taintedValue, taintedValue2), () => String.Join(",", new[] { taintedValue, taintedValue2 }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:,:+-TAINTED2-+:", String.Join(",", taintedValue, taintedValue2), () => String.Join(",", taintedValue, taintedValue2));
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class StringJoinTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedObject_WhenCallingJoinWithStringArrayOneNullParams_ResultIsTainted2()
     {
-        AssertTaintedFormatWithOriginalCallCheck(",:+-TAINTED2-+:", String.Join(",", null, taintedValue2), () => String.Join(",", new[] { null, taintedValue2 }));
+        AssertTaintedFormatWithOriginalCallCheck(",:+-TAINTED2-+:", String.Join(",", null, taintedValue2), () => String.Join(",", null, taintedValue2));
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class StringJoinTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedObject_WhenCallingJoinWithStringArrayNullSeparator_ResultIsTainted2()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+::+-TAINTED2-+:", String.Join(null, taintedValue, taintedValue2), () => String.Join(null, new[] { taintedValue, taintedValue2 }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+::+-TAINTED2-+:", String.Join(null, taintedValue, taintedValue2), () => String.Join(null, taintedValue, taintedValue2));
     }
 
     [Fact]
@@ -216,7 +216,7 @@ public class StringJoinTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedStringInStruct_WhenCallingJoin_ResultIsTainted3()
     {
-        AssertTaintedFormatWithOriginalCallCheck("UntaintedString,:+-tainted-+:", String.Join(",", new StructForStringTest("UntaintedString"), new StructForStringTest(taintedValue)), () => String.Join(",", new object[] { new StructForStringTest("UntaintedString"), new StructForStringTest(taintedValue) }));
+        AssertTaintedFormatWithOriginalCallCheck("UntaintedString,:+-tainted-+:", String.Join(",", new StructForStringTest("UntaintedString"), new StructForStringTest(taintedValue)), () => String.Join(",", new StructForStringTest("UntaintedString"), new StructForStringTest(taintedValue)));
     }
 
     [Fact]
@@ -234,19 +234,19 @@ public class StringJoinTests : InstrumentationTestsBase
     [Fact]
     public void GivenATaintedStringInClass_WhenCallingJoin_ResultIsTainted3()
     {
-        AssertTaintedFormatWithOriginalCallCheck("UntaintedString,:+-tainted-+:", String.Join(",", new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue)), () => String.Join(",", new object[] { new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue) }));
+        AssertTaintedFormatWithOriginalCallCheck("UntaintedString,:+-tainted-+:", String.Join(",", new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue)), () => String.Join(",", new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue)));
     }
 
     [Fact]
     public void GivenATaintedStringInClass_WhenCallingJoin_ResultIsTainted4()
     {
-        AssertTaintedFormatWithOriginalCallCheck("UntaintedString,:+-tainted-+:", String.Join(",", new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue)), () => String.Join(",", new object[] { new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue) }));
+        AssertTaintedFormatWithOriginalCallCheck("UntaintedString,:+-tainted-+:", String.Join(",", new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue)), () => String.Join(",", new ClassForStringTest("UntaintedString"), new ClassForStringTest(taintedValue)));
     }
 
     [Fact]
     public void GivenATaintedStringInClass_WhenCallingJoin_ResultIsTainted5()
     {
-        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", String.Join(",", new ClassForStringTest(taintedValue)), () => String.Join(",", new object[] { new ClassForStringTest(taintedValue) }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", String.Join(",", new ClassForStringTest(taintedValue)), () => String.Join(",", new ClassForStringTest(taintedValue)));
     }
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -296,7 +296,7 @@ public class StringJoinTests : InstrumentationTestsBase
         String.Concat(taintedValue, "eee");
         AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:a:+-tainted-+:",
             String.Join('a', taintedValue, taintedValue),
-            () => String.Join('a', new[] { taintedValue, taintedValue }));
+            () => String.Join('a', taintedValue, taintedValue));
     }
 
     [Fact]
@@ -304,7 +304,7 @@ public class StringJoinTests : InstrumentationTestsBase
     {
         AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:a:+-tainted-+:",
             String.Join('a', (object)taintedValue, (object)taintedValue),
-            () => String.Join('a', new object[] { (object)taintedValue, (object)taintedValue }));
+            () => String.Join('a', (object)taintedValue, (object)taintedValue));
     }
 
     [Fact]
@@ -312,7 +312,7 @@ public class StringJoinTests : InstrumentationTestsBase
     {
         AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:a:+-tainted-+:a1",
             String.Join('a', (object)taintedValue, (object)taintedValue, 1),
-            () => String.Join('a', new object[] { (object)taintedValue, (object)taintedValue, 1 }));
+            () => String.Join('a', (object)taintedValue, (object)taintedValue, 1));
     }
 
     [Fact]
@@ -371,9 +371,9 @@ public class StringJoinTests : InstrumentationTestsBase
         string testString1 = (string) AddTainted("01");
         string testString2 = (string) AddTainted("abc");
 
-        AssertTaintedFormatWithOriginalCallCheck(":+-01-+:", String.Join("-", testString1), () => String.Join("-", new[] { testString1 }));
-        AssertTaintedFormatWithOriginalCallCheck(":+-01-+:", String.Join(separator, testString1), () => String.Join(separator, new[] { testString1 }));
-        AssertTaintedFormatWithOriginalCallCheck(":+-01-+:-:+-abc-+:", String.Join("-", testString1, testString2), () => String.Join("-", new[] { testString1, testString2 }));
+        AssertTaintedFormatWithOriginalCallCheck(":+-01-+:", String.Join("-", testString1), () => String.Join("-",testString1));
+        AssertTaintedFormatWithOriginalCallCheck(":+-01-+:", String.Join(separator, testString1), () => String.Join(separator, testString1));
+        AssertTaintedFormatWithOriginalCallCheck(":+-01-+:-:+-abc-+:", String.Join("-", testString1, testString2), () => String.Join("-", testString1, testString2));
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringMaxRangesTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringMaxRangesTests.cs
@@ -22,7 +22,7 @@ public class StringMaxRangesTests : InstrumentationTestsBase
         
         AssertTaintedFormatWithOriginalCallCheck(":+-1-+:|:+-2-+:|:+-3-+:|:+-4-+:|:+-5-+:|:+-6-+:|:+-7-+:|:+-8-+:|:+-9-+:|:+-10-+:|", 
             string.Concat(testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10, UntaintedString),
-            () => string.Concat(new[] { testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10, UntaintedString }));
+            () => string.Concat(testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10, UntaintedString));
     }
     
     // same but with 11 tainted strings
@@ -44,7 +44,7 @@ public class StringMaxRangesTests : InstrumentationTestsBase
 
         AssertTaintedFormatWithOriginalCallCheck(":+-1-+:|:+-2-+:|:+-3-+:|:+-4-+:|:+-5-+:|:+-6-+:|:+-7-+:|:+-8-+:|:+-9-+:|:+-10-+:|11|12",
                                                  string.Concat(testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10, UntaintedString, testString11, UntaintedString, testString12),
-                                                 () => string.Concat(new[] { testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10, UntaintedString, testString11, UntaintedString, testString12 }));
+                                                 () => string.Concat(testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10, UntaintedString, testString11, UntaintedString, testString12));
     }
     
     [Fact]
@@ -64,6 +64,6 @@ public class StringMaxRangesTests : InstrumentationTestsBase
         
         AssertTaintedFormatWithOriginalCallCheck(":+-11-+::+-1-+:|:+-2-+:|:+-3-+:|:+-4-+:|:+-5-+:|:+-6-+:|:+-7-+:|:+-8-+:|:+-9-+:|10",
                                                  string.Concat(testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10).Insert(0, testString11),
-                                                 () => string.Concat(new[] { testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10 }).Insert(0, testString11));
+                                                 () => string.Concat(testString1, UntaintedString, testString2, UntaintedString, testString3, UntaintedString, testString4, UntaintedString, testString5, UntaintedString, testString6, UntaintedString, testString7, UntaintedString, testString8, UntaintedString, testString9, UntaintedString, testString10).Insert(0, testString11));
     }
 }


### PR DESCRIPTION
## Summary of changes

Some IAST string tests were failing under the prerelease version of .Net 9. It seems that they don't fail with the official .net 9 release version, which suggest that the optimizations that were are added to the prerelease were finally discarded. That means that the changed IAST tests can be safely restored.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
