### PR TITLE
Add more smoke testing for .NET 9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   # ARM64 dependencies
   localstack_arm64:
@@ -844,6 +843,7 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - INSTALL_CMD=
     image: dd-trace-dotnet/${dockerTag:-not-set}-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
     - ./:/project
     - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -867,6 +867,7 @@ services:
         # - RELATIVE_PROFILER_PATH=
         # - RELATIVE_API_WRAPPER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-nuget-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
     - ./:/project
     - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -890,6 +891,7 @@ services:
         # - RELATIVE_PROFILER_PATH=
         # - RELATIVE_API_WRAPPER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-nuget-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
     - ./:/project
     - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -911,6 +913,7 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - TOOL_VERSION=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
     - ./:/project
     - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -932,6 +935,7 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - INSTALL_CMD=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-self-instrument-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
     - ./:/project
     - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -953,6 +957,7 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - TOOL_VERSION=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-nuget-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
     - ./:/project
     - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -974,6 +979,7 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - INSTALL_CMD=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dd-dotnet-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
       - ./:/project
       - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -995,6 +1001,7 @@ services:
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
     image: dd-trace-dotnet/${dockerTag:-not-set}-chiseled-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
       - ./:/project
       - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -1017,6 +1024,7 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - RUNTIME_ID=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dd-dotnet-chiseled-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
       - ./:/project
       - ./artifacts/build_data/logs:/var/log/datadog/dotnet
@@ -1039,6 +1047,7 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - RUNTIME_ID=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dd-dotnet-arm64-chiseled-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
     volumes:
       - ./:/project
       - ./artifacts/build_data/logs:/var/log/datadog/dotnet

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -460,7 +460,7 @@ partial class Build : NukeBuild
                         "fedora",
                         new SmokeTestImage[]
                         {
-                            new (publishFramework: TargetFramework.NET9_0, "40-9.0"),
+                            // new (publishFramework: TargetFramework.NET9_0, "40-9.0"), // Not updated to GA .NET 9 yet
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "35-5.0"),
@@ -575,7 +575,7 @@ partial class Build : NukeBuild
                         "centos-stream",
                         new SmokeTestImage[]
                         {
-                            new (publishFramework: TargetFramework.NET9_0, "9-9.0"),
+                            // new (publishFramework: TargetFramework.NET9_0, "9-9.0"), // Not updated to GA .NET 9 yet
                             new (publishFramework: TargetFramework.NET6_0, "9-6.0"),
                             new (publishFramework: TargetFramework.NET6_0, "8-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "8-5.0"),
@@ -793,7 +793,7 @@ partial class Build : NukeBuild
                         "fedora",
                         new SmokeTestImage[]
                         {
-                            new (publishFramework: TargetFramework.NET9_0, "40-9.0"),
+                            // new (publishFramework: TargetFramework.NET9_0, "40-9.0"),  // Not updated to GA .NET 9 yet
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
@@ -964,7 +964,7 @@ partial class Build : NukeBuild
                         "fedora",
                         new SmokeTestImage[]
                         {
-                            new (publishFramework: TargetFramework.NET9_0, "40-9.0"),
+                            // new (publishFramework: TargetFramework.NET9_0, "40-9.0"),  // Not updated to GA .NET 9 yet
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "33-5.0"),

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -460,6 +460,7 @@ partial class Build : NukeBuild
                         "fedora",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET9_0, "40-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "35-5.0"),
@@ -555,6 +556,8 @@ partial class Build : NukeBuild
                         "rhel",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET9_0, "9-9.0"),
+                            new (publishFramework: TargetFramework.NET9_0, "8-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "8-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "8-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "8-5.0"),
@@ -572,7 +575,7 @@ partial class Build : NukeBuild
                         "centos-stream",
                         new SmokeTestImage[]
                         {
-                            // (publishFramework: TargetFramework.NET7_0, "9-7.0"), Not updated from RC1 yet
+                            new (publishFramework: TargetFramework.NET9_0, "9-9.0"),
                             new (publishFramework: TargetFramework.NET6_0, "9-6.0"),
                             new (publishFramework: TargetFramework.NET6_0, "8-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "8-5.0"),
@@ -590,6 +593,7 @@ partial class Build : NukeBuild
                         "opensuse",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET9_0, "15-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
@@ -664,6 +668,7 @@ partial class Build : NukeBuild
                         "fedora",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET9_0, "40-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
                             // https://github.com/dotnet/runtime/issues/66707
@@ -788,6 +793,7 @@ partial class Build : NukeBuild
                         "fedora",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET9_0, "40-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
@@ -840,6 +846,7 @@ partial class Build : NukeBuild
                         "opensuse",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET7_0, "15-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
@@ -957,6 +964,7 @@ partial class Build : NukeBuild
                         "fedora",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET9_0, "40-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
@@ -1006,6 +1014,7 @@ partial class Build : NukeBuild
                         "opensuse",
                         new SmokeTestImage[]
                         {
+                            new (publishFramework: TargetFramework.NET9_0, "15-9.0"),
                             new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
                             new (publishFramework: TargetFramework.NET5_0, "15-5.0"),

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -433,9 +433,8 @@ partial class Build : NukeBuild
                         "debian",
                         new SmokeTestImage[]
                         {
-                            // FIXME: .NET 9 crash tracking hangs on x64 debian, we should investigate and enable this ASAP
-                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble", runCrashTest: false),
-                            new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
+                            new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
@@ -618,9 +617,8 @@ partial class Build : NukeBuild
                         "debian",
                         new SmokeTestImage[]
                         {
-                            // FIXME: .NET 9 crash tracking hangs on x64 debian, we should investigate and enable this ASAP
-                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble-chiseled", runCrashTest: false),
-                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble-chiseled-composite", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble-chiseled"),
+                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble-chiseled-composite"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
                         },
@@ -645,8 +643,7 @@ partial class Build : NukeBuild
                         "debian",
                         new SmokeTestImage[]
                         {
-                            // FIXME: .NET 9 crash tracking hangs on x64 debian, we should investigate and enable this ASAP
-                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
@@ -771,9 +768,8 @@ partial class Build : NukeBuild
                         "debian",
                         new SmokeTestImage[]
                         {
-                            // FIXME: .NET 9 crash tracking hangs on x64 debian, we should investigate and enable this ASAP
-                            new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim", runCrashTest: false),
-                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),


### PR DESCRIPTION
## Summary of changes

- Unskip the .NET 9 crashtracking tests by using workaround
- Test more .NET 9 distros

## Reason for change

We want to run smoke tests on supported distros

## Implementation details

We had to disable the crash tracking tests for the .NET 9 smoke tests on debian x64 because they would hang ([due to a bug in the runtime](https://github.com/dotnet/runtime/issues/109779#issuecomment-2477592057), not related to our instrumentation). That issue mentions that using `--init` solves the issue, so added that as a temporary fix and the crash tracking tests pass (so can unskip them)

Also added testing for 
- `fedora:40` (~x64~ and arm64) - x64 is still using rc2 currently
- `rhel:8` and `rhel:9`
- ~`centos-stream:9`~ still using preview 7
- `opensuse:15`

## Test coverage

More now - [did a full installer run here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=167973&view=results).

## Other details

This doesn't cover _all_ the supported distros, but it's a good start