### PR TITLE
[CI Visibility] Catch some gitinfo exceptions.

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
@@ -165,7 +165,7 @@ internal class GitInfo : IGitInfo
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Error getting directory info");
+            Log.Warning(ex, "Error getting directory info");
             return null;
         }
 
@@ -189,17 +189,17 @@ internal class GitInfo : IGitInfo
             }
             catch (DirectoryNotFoundException ex)
             {
-                Log.Error(ex, "Get directories failed with DirectoryNotFoundException");
+                Log.Warning(ex, "Get directories failed with DirectoryNotFoundException");
                 return null;
             }
             catch (UnauthorizedAccessException ex)
             {
-                Log.Error(ex, "Get directories failed with UnauthorizedAccessException");
+                Log.Warning(ex, "Get directories failed with UnauthorizedAccessException");
                 return null;
             }
             catch (SecurityException ex)
             {
-                Log.Error(ex, "Get directories or parent directory failed with SecurityException");
+                Log.Warning(ex, "Get directories or parent directory failed with SecurityException");
                 return null;
             }
         }


### PR DESCRIPTION
## Summary of changes

This PR ensures we capture all possible exception while doing `GetParentGitFolder`

## Reason for change

I've seen some exceptions in the Error tracking page.

## Implementation details

try/catch everywhere....
