### PR TITLE
Filter out dead threads in runtime metrics

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -157,8 +157,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
                 actualNumberOfThreads.Should().NotBeNull();
 
-                // A margin of 500 threads seem like a lot, but we have tests that spawn a large number of threads to try to find race conditions
-                actualNumberOfThreads.Should().NotBeNull().And.BeGreaterThan(0).And.BeInRange(expectedNumberOfThreads - 500, expectedNumberOfThreads + 500);
+                actualNumberOfThreads.Should().NotBeNull().And.BeGreaterThan(0).And.BeInRange(expectedNumberOfThreads - 100, expectedNumberOfThreads + 100);
 
                 // CPU time and memory usage can vary wildly, so don't try too hard to validate
                 userCpuTime.Should().NotBeNull().And.BeGreaterThan(0);


### PR DESCRIPTION
## Summary of changes

Filter out the dead threads in the runtime metrics when using process snapshot.

## Reason for change

We originally relied only on the count in the `PSS_THREAD_INFORMATION` instance returned by `PssQuerySnapshot`. However, it does not only count threads that are alive, but also dead threads which handle isn't closed (the handle for dead managed threads is closed during finalization after a garbage collection, so they can hang around for a while, especially since threads tend to reach generation 2).

This can be demonstrated by this simple code:

```csharp
internal class Program
{
    static void Main()
    {
        var threads = new Thread[50];

        for (var i = 0; i < threads.Length; i++)
        {
            threads[i] = new Thread(() => Thread.Sleep(1));
            threads[i].Start();
        }

        Thread.Sleep(1000);

        ProcessSnapshotRuntimeInformation.GetCurrentProcessMetrics(out _, out _, out var threadCount, out _);

        Console.WriteLine($"Thread count: {threadCount}");
    }
}
```

With the old code, this would display 58, even thought the task manager shows only 8 threads.

## Implementation details

We now use `PssWalkSnapshot` to walk the snapshot and filter out the dead threads. I had to use a custom `FILETIME` struct to get the alignment correct in both 32/64 bits. In hindsight, this might have worked for `PSS_PROCESS_INFORMATION` as well (avoiding the need to have separate `PSS_PROCESS_INFORMATION_32`/`PSS_PROCESS_INFORMATION_64`), I might try to improve that in a future PR.

## Test coverage

The runtime metrics are already covered by tests. We don't test for dead threads, but it seems hard to do in a reliable way (and I think we can all agree our CI is flaky enough at the moment).
Also, the existing test has a tolerance of 500 threads. Back then I couldn't explain why we got so much variation in the results, I guess now we have a reasonable explanation (it was changed in https://github.com/DataDog/dd-trace-dotnet/pull/5329, shortly after adding PSS support).

Because we add additional calls for each thread, it has an impact on performance so I ran some benchmarks.

With 50 threads (realistic):

```
| Method  | Mean       | Error    | StdDev   | Ratio | RatioSD |
|-------- |-----------:|---------:|---------:|------:|--------:|
| Process | 6,466.2 us | 71.57 us | 63.45 us | 63.15 |    9.80 |
| Old     |   104.9 us |  5.67 us | 16.71 us |  1.02 |    0.23 |
| New     |   127.1 us |  2.48 us |  2.65 us |  1.24 |    0.19 |
```

With 250 threads (extreme):

```
| Method  | Mean         | Error      | StdDev     | Ratio  | RatioSD |
|-------- |-------------:|-----------:|-----------:|-------:|--------:|
| Process | 17,621.58 us | 349.413 us | 564.238 us | 183.31 |   20.11 |
| Old     |     97.27 us |   3.801 us |  11.028 us |   1.01 |    0.16 |
| New     |    129.39 us |   2.299 us |   2.823 us |   1.35 |    0.14 |
```

We're 25 to 35% slower, but we're still orders of magnitude faster than using the .NET `Process` object.

## Other details

Fixes https://github.com/DataDog/dd-trace-dotnet/issues/6172