### PR TITLE
Stop hiding build files in github search

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -66,3 +66,7 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# Stop hiding the build subfolders in the github file search
+# https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files
+build/** linguist-generated=false


### PR DESCRIPTION
## Summary of changes

By default, when using the "Go to file" on Github, files in a `build` folder or subfolder are excluded. This PR removes the exclusion.

## Reason for change

Keeping my (our?) sanity.

## Implementation details

Apparently we control this by editing the `.gitattributes` file: https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files
