### PR TITLE
[ASM][ATO] Adapt v3 new login tags and fix signup tags

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -551,7 +551,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Npgsql/NpgsqlDefinition
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Oracle/OracleDefinitions.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/SqlClient/SqlClientDefinitions.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Sqlite/SqliteDefinitions.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/IIdentityResult.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/IIdentityUser.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/ISignInResult.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
                 var span = scope.Span;
                 var foundUserId = false;
                 var foundLogin = false;
-                Func<string, string> processPii;
+                Func<string, string>? processPii = null;
                 string successAutoMode;
                 if (security.IsAnonUserTrackingMode)
                 {
@@ -77,7 +77,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
                 }
                 else
                 {
-                    processPii = val => val;
                     successAutoMode = SecuritySettings.UserTrackingIdentMode;
                 }
 
@@ -93,14 +92,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
                     if (claim.Type is ClaimTypes.NameIdentifier && !foundUserId)
                     {
                         foundUserId = true;
-                        var userId = processPii(claim.Value);
+                        var userId = processPii?.Invoke(claim.Value) ?? claim.Value;
                         tryAddTag(Tags.User.Id, userId);
                         setTag(Tags.AppSec.EventsUsers.InternalUserId, userId);
                     }
                     else if (LoginsClaimsToTest.Contains(claim.Type) && !foundLogin)
                     {
                         foundLogin = true;
-                        var login = processPii(claim.Value);
+                        var login = processPii?.Invoke(claim.Value) ?? claim.Value;
                         setTag(Tags.AppSec.EventsUsers.InternalLogin, login);
                         tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, login);
                     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
@@ -90,14 +90,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
                         continue;
                     }
 
-                    if (claim.Type is ClaimTypes.NameIdentifier)
+                    if (claim.Type is ClaimTypes.NameIdentifier && !foundUserId)
                     {
                         foundUserId = true;
                         var userId = processPii(claim.Value);
                         tryAddTag(Tags.User.Id, userId);
                         setTag(Tags.AppSec.EventsUsers.InternalUserId, userId);
                     }
-                    else if (LoginsClaimsToTest.Contains(claim.Type))
+                    else if (LoginsClaimsToTest.Contains(claim.Type) && !foundLogin)
                     {
                         foundLogin = true;
                         var login = processPii(claim.Value);
@@ -118,7 +118,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
                     setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessAutoMode, successAutoMode);
                 }
 
-                UserEventsCommon.RecordMetricsIfNotFound(foundUserId, foundLogin);
+                UserEventsCommon.RecordMetricsLoginSuccessIfNotFound(foundUserId, foundLogin);
                 SecurityCoordinator.CollectHeaders(span);
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 #if !NETFRAMEWORK
 using System;
@@ -12,8 +13,6 @@ using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.Telemetry;
-using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
 {
@@ -41,7 +40,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
         private const string HttpContextExtensionsTypeName = "Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions";
 
         // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-        private static readonly HashSet<string> ClaimsToTest = [ClaimTypes.NameIdentifier, ClaimTypes.Name, "sub", ClaimTypes.Email, ClaimTypes.Name];
+        private static readonly HashSet<string> LoginsClaimsToTest =
+        [
+            ClaimTypes.Name,
+            ClaimTypes.Email,
+            "sub",
+        ];
 
         internal static CallTargetState OnMethodBegin<TTarget>(object httpContext, string scheme, ClaimsPrincipal claimPrincipal, object authProperties)
         {
@@ -59,46 +63,62 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
         internal static object OnAsyncMethodEnd<TTarget>(object returnValue, Exception exception, in CallTargetState state)
         {
             var claimsPrincipal = state.State as ClaimsPrincipal;
-            if (claimsPrincipal?.Claims != null && Security.Instance is { IsTrackUserEventsEnabled: true } security)
+            if (claimsPrincipal?.Claims is not null && Security.Instance is { IsTrackUserEventsEnabled: true } security && state.Scope is { } scope)
             {
-                var span = state.Scope.Span;
+                var span = scope.Span;
+                var foundUserId = false;
+                var foundLogin = false;
+                Func<string, string> processPii;
+                string successAutoMode;
+                if (security.IsAnonUserTrackingMode)
+                {
+                    processPii = UserEventsCommon.Anonymize;
+                    successAutoMode = SecuritySettings.UserTrackingAnonMode;
+                }
+                else
+                {
+                    processPii = val => val;
+                    successAutoMode = SecuritySettings.UserTrackingIdentMode;
+                }
+
                 var setTag = TaggingUtils.GetSpanSetter(span, out _);
                 var tryAddTag = TaggingUtils.GetSpanSetter(span, out _, replaceIfExists: false);
-
-                var foundUserId = false;
-
                 foreach (var claim in claimsPrincipal.Claims)
                 {
-                    if (ClaimsToTest.Contains(claim.Type))
+                    if (string.IsNullOrEmpty(claim.Value))
                     {
-                        if (security.IsAnonUserTrackingMode)
-                        {
-                            var anonId = UserEventsCommon.GetAnonId(claim.Value);
-                            tryAddTag(Tags.User.Id, anonId);
-                            setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessAutoMode, SecuritySettings.UserTrackingAnonMode);
-                        }
-                        else
-                        {
-                            tryAddTag(Tags.User.Id, claim.Value);
-                            setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessAutoMode, SecuritySettings.UserTrackingIdentMode);
-                        }
+                        continue;
+                    }
 
+                    if (claim.Type is ClaimTypes.NameIdentifier)
+                    {
                         foundUserId = true;
+                        var userId = processPii(claim.Value);
+                        tryAddTag(Tags.User.Id, userId);
+                        setTag(Tags.AppSec.EventsUsers.InternalUserId, userId);
+                    }
+                    else if (LoginsClaimsToTest.Contains(claim.Type))
+                    {
+                        foundLogin = true;
+                        var login = processPii(claim.Value);
+                        setTag(Tags.AppSec.EventsUsers.InternalLogin, login);
+                        tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, login);
+                    }
 
+                    if (foundLogin && foundUserId)
+                    {
                         break;
                     }
                 }
 
-                if (foundUserId)
+                if (foundUserId || foundLogin)
                 {
                     security.SetTraceSamplingPriority(span);
                     setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessTrack, Tags.AppSec.EventsUsers.True);
-                }
-                else
-                {
-                    TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
+                    setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessAutoMode, successAutoMode);
                 }
 
+                UserEventsCommon.RecordMetricsIfNotFound(foundUserId, foundLogin);
                 SecurityCoordinator.CollectHeaders(span);
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInIntegration.cs
@@ -85,14 +85,14 @@ public static class SignInManagerPasswordSignInIntegration
             if (security.IsAnonUserTrackingMode)
             {
                 var loginAnon = UserEventsCommon.Anonymize(login);
-                tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, loginAnon!);
-                setTag(Tags.AppSec.EventsUsers.InternalLogin, loginAnon!);
+                tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, loginAnon);
+                setTag(Tags.AppSec.EventsUsers.InternalLogin, loginAnon);
                 setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureAutoMode, SecuritySettings.UserTrackingAnonMode);
             }
             else
             {
                 tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, login);
-                setTag(Tags.AppSec.EventsUsers.InternalLogin, login!);
+                setTag(Tags.AppSec.EventsUsers.InternalLogin, login);
                 setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureAutoMode, SecuritySettings.UserTrackingIdentMode);
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInIntegration.cs
@@ -72,7 +72,7 @@ public static class SignInManagerPasswordSignInIntegration
             // here as it's the first login step, state.State is the username, db hasn't been hit yet.
             if (state.State is not string login || string.IsNullOrEmpty(login))
             {
-                TelemetryFactory.Metrics.RecordCountMissingUserLogin(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
+                UserEventsCommon.RecordMetricsLoginFailureIfNotFound(true, foundLogin: false);
                 return returnValue;
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents;
     AssemblyName = AssemblyName,
     TypeName = "Microsoft.AspNetCore.Identity.SignInManager`1",
     MethodName = "PasswordSignInAsync",
-    ParameterTypeNames = new[] { "!0", ClrNames.String, ClrNames.Bool, ClrNames.Bool },
+    ParameterTypeNames = ["!0", ClrNames.String, ClrNames.Bool, ClrNames.Bool],
     ReturnTypeName = "System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Identity.SignInResult]",
     MinimumVersion = "2",
     MaximumVersion = SupportedVersions.LatestDotNet,
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents;
     AssemblyName = AssemblyName,
     TypeName = "Microsoft.AspNetCore.Identity.SignInManager`1",
     MethodName = "PasswordSignInAsync",
-    ParameterTypeNames = new[] { ClrNames.String, ClrNames.String, ClrNames.Bool, ClrNames.Bool },
+    ParameterTypeNames = [ClrNames.String, ClrNames.String, ClrNames.Bool, ClrNames.Bool],
     ReturnTypeName = "System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Identity.SignInResult]",
     MinimumVersion = "2",
     MaximumVersion = SupportedVersions.LatestDotNet,
@@ -69,54 +69,72 @@ public static class SignInManagerPasswordSignInUserIntegration
         {
             var userExists = (state.State as IDuckType)?.Instance is not null;
             var user = state.State as IIdentityUser;
-            var id = UserEventsCommon.GetId(user);
-
-            if (id == null)
+            if (user is null)
             {
-                TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
+                UserEventsCommon.RecordMetricsIfNotFound(false, false);
                 return returnValue;
+            }
+
+            var foundUserId = false;
+            var foundLogin = false;
+            Func<string, string?> processPii;
+            string autoMode;
+            if (security.IsAnonUserTrackingMode)
+            {
+                processPii = UserEventsCommon.Anonymize;
+                autoMode = SecuritySettings.UserTrackingAnonMode;
+            }
+            else
+            {
+                processPii = val => val;
+                autoMode = SecuritySettings.UserTrackingIdentMode;
             }
 
             var setTag = TaggingUtils.GetSpanSetter(span, out _);
             var tryAddTag = TaggingUtils.GetSpanSetter(span, out _, replaceIfExists: false);
+
             if (!returnValue.Succeeded)
             {
-                setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureTrack, Tags.AppSec.EventsUsers.True);
-                setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureAutoMode, security.Settings.UserEventsAutoInstrumentationMode);
-                tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserExists, userExists ? Tags.AppSec.EventsUsers.True : Tags.AppSec.EventsUsers.False);
+                setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureTrack, "true");
+                setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureAutoMode, autoMode);
 
-                if (security.IsAnonUserTrackingMode)
+                var userId = UserEventsCommon.GetId(user);
+                var userLogin = UserEventsCommon.GetLogin(user);
+                if (!string.IsNullOrEmpty(userId))
                 {
-                    var anonId = UserEventsCommon.GetAnonId(id);
-                    if (!string.IsNullOrEmpty(anonId))
-                    {
-                        tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId, anonId!);
-                    }
-                }
-                else
-                {
-                    tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId, id);
+                    foundUserId = true;
+                    userId = processPii(userId!);
+                    setTag(Tags.AppSec.EventsUsers.InternalUserId, userId!);
+                    setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId, userId!);
                 }
 
+                if (!string.IsNullOrEmpty(userLogin))
+                {
+                    foundLogin = true;
+                    var login = processPii(userLogin!);
+                    setTag(Tags.AppSec.EventsUsers.InternalLogin, login!);
+                    setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, login!);
+                }
+
+                UserEventsCommon.RecordMetricsIfNotFound(foundUserId, foundLogin);
+                tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserExists, userExists ? "true" : "false");
                 SecurityCoordinator.CollectHeaders(span);
             }
+#if !NETCOREAPP3_1_OR_GREATER
             else if (userExists)
             {
-                // AuthenticatedHttpcontExtextensions should fill these, but on core <3.1 email doesnt appear in claims
+                // AuthenticatedHttpcontExtextensions should fill these, but on core <3.1 email doesn't appear in claims
                 // so let's try to fill these up here if we have the chance to come here
-                if (security.IsAnonUserTrackingMode)
+                var userLogin = UserEventsCommon.GetLogin(user);
+
+                if (!string.IsNullOrEmpty(userLogin))
                 {
-                    var anonId = UserEventsCommon.GetAnonId(id);
-                    if (!string.IsNullOrEmpty(anonId))
-                    {
-                        tryAddTag(Tags.User.Id, anonId!);
-                    }
-                }
-                else
-                {
-                    tryAddTag(Tags.User.Id, id);
+                    var login = processPii(userLogin!);
+                    setTag(Tags.AppSec.EventsUsers.InternalLogin, login!);
+                    setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, login!);
                 }
             }
+#endif
 
             security.SetTraceSamplingPriority(span);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
@@ -77,7 +77,7 @@ public static class SignInManagerPasswordSignInUserIntegration
 
             var foundUserId = false;
             var foundLogin = false;
-            Func<string, string?> processPii;
+            Func<string, string?>? processPii = null;
             string autoMode;
             if (security.IsAnonUserTrackingMode)
             {
@@ -86,7 +86,6 @@ public static class SignInManagerPasswordSignInUserIntegration
             }
             else
             {
-                processPii = val => val;
                 autoMode = SecuritySettings.UserTrackingIdentMode;
             }
 
@@ -103,7 +102,7 @@ public static class SignInManagerPasswordSignInUserIntegration
                 if (!string.IsNullOrEmpty(userId))
                 {
                     foundUserId = true;
-                    userId = processPii(userId!);
+                    userId = processPii?.Invoke(userId!) ?? userId;
                     setTag(Tags.AppSec.EventsUsers.InternalUserId, userId!);
                     setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId, userId!);
                 }
@@ -111,7 +110,7 @@ public static class SignInManagerPasswordSignInUserIntegration
                 if (!string.IsNullOrEmpty(userLogin))
                 {
                     foundLogin = true;
-                    var login = processPii(userLogin!);
+                    var login = processPii?.Invoke(userLogin!) ?? userLogin;
                     setTag(Tags.AppSec.EventsUsers.InternalLogin, login!);
                     setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, login!);
                 }
@@ -129,9 +128,9 @@ public static class SignInManagerPasswordSignInUserIntegration
 
                 if (!string.IsNullOrEmpty(userLogin))
                 {
-                    var login = processPii(userLogin!);
-                    setTag(Tags.AppSec.EventsUsers.InternalLogin, login!);
-                    setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, login!);
+                    var login = processPii?.Invoke(userLogin!) ?? userLogin!;
+                    setTag(Tags.AppSec.EventsUsers.InternalLogin, login);
+                    setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, login);
                 }
             }
 #endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
@@ -71,7 +71,7 @@ public static class SignInManagerPasswordSignInUserIntegration
             var user = state.State as IIdentityUser;
             if (user is null)
             {
-                UserEventsCommon.RecordMetricsIfNotFound(false, false);
+                UserEventsCommon.RecordMetricsLoginFailureIfNotFound(false, false);
                 return returnValue;
             }
 
@@ -116,7 +116,7 @@ public static class SignInManagerPasswordSignInUserIntegration
                     setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, login!);
                 }
 
-                UserEventsCommon.RecordMetricsIfNotFound(foundUserId, foundLogin);
+                UserEventsCommon.RecordMetricsLoginFailureIfNotFound(foundUserId, foundLogin);
                 tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserExists, userExists ? "true" : "false");
                 SecurityCoordinator.CollectHeaders(span);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
@@ -63,16 +63,42 @@ internal static class UserEventsCommon
         return string.Empty;
     }
 
-    internal static void RecordMetricsIfNotFound(bool foundUserId, bool foundLogin)
+    internal static void RecordMetricsLoginSuccessIfNotFound(bool foundUserId, bool foundLogin)
     {
         if (!foundUserId)
         {
-            TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
+            TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFrameworkWithEventType.AspNetCoreIdentityLoginSuccess);
         }
 
         if (!foundLogin)
         {
-            TelemetryFactory.Metrics.RecordCountMissingUserLogin(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
+            TelemetryFactory.Metrics.RecordCountMissingUserLogin(MetricTags.AuthenticationFrameworkWithEventType.AspNetCoreIdentityLoginSuccess);
+        }
+    }
+
+    internal static void RecordMetricsLoginFailureIfNotFound(bool foundUserId, bool foundLogin)
+    {
+        if (!foundUserId)
+        {
+            TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFrameworkWithEventType.AspNetCoreIdentityLoginFailure);
+        }
+
+        if (!foundLogin)
+        {
+            TelemetryFactory.Metrics.RecordCountMissingUserLogin(MetricTags.AuthenticationFrameworkWithEventType.AspNetCoreIdentityLoginFailure);
+        }
+    }
+
+    internal static void RecordMetricsSignupIfNotFound(bool foundUserId, bool foundLogin)
+    {
+        if (!foundUserId)
+        {
+            TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFrameworkWithEventType.AspNetCoreIdentitySignup);
+        }
+
+        if (!foundLogin)
+        {
+            TelemetryFactory.Metrics.RecordCountMissingUserLogin(MetricTags.AuthenticationFrameworkWithEventType.AspNetCoreIdentitySignup);
         }
     }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
@@ -29,11 +29,9 @@ internal static class UserEventsCommon
         const int bytesToUse = 16;
         #if NET6_0_OR_GREATER
         Span<byte> destination = stackalloc byte[32];
-        var destinationBytes = new Span<byte>();
-        var source = new ReadOnlySpan<char>(id.ToCharArray());
         var utf8 = new UTF8Encoding();
-        utf8.GetBytes(source, destinationBytes);
-        var successfullyHashed = SHA256.TryHashData(destinationBytes, destination, out var bytesWritten);
+        var sourceBytes = utf8.GetBytes(id.ToCharArray());
+        var successfullyHashed = SHA256.TryHashData(sourceBytes, destination, out var bytesWritten);
         #else
         var encodedBytes = Encoding.UTF8.GetBytes(id);
         using var hash = SHA256.Create();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
@@ -23,7 +23,7 @@ internal static class UserEventsCommon
 
     internal static string? GetLogin(IIdentityUser? user) => user?.UserName ?? user?.Email;
 
-    internal static unsafe string Anonymize(string id)
+    internal static string Anonymize(string id)
     {
         // spec says take first half of the hash
         const int bytesToUse = 16;
@@ -44,7 +44,7 @@ internal static class UserEventsCommon
             // we want to end up with a string of the form anon_0c76692372ebf01a7da6e9570fb7d0a1
             // 37 is 5 prefix character plus 32 hexadecimal digits (presenting 16 bytes)
             // stackalloc to avoid intermediate heap allocation
-            var stringChars = stackalloc char[37];
+            Span<char> stringChars = stackalloc char[37];
             stringChars[0] = 'a';
             stringChars[1] = 'n';
             stringChars[2] = 'o';
@@ -58,7 +58,7 @@ internal static class UserEventsCommon
                 stringChars[iChars + 6] = ByteDigitToChar(b & 0x0F);
             }
 
-            return new string(stringChars, 0, 37);
+            return new string(stringChars.ToArray(), 0, 37);
         }
 
         Log.Debug<int>("Couldn't anonymize user information (login or id), byteArray length was {BytesWritten}", bytesWritten);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserEventsCommon.cs
@@ -9,25 +9,35 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents;
 
 internal static class UserEventsCommon
 {
-    internal static string? GetId(IIdentityUser? user)
-    {
-        return user?.Id?.ToString() ?? user?.Email ?? user?.UserName;
-    }
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(UserEventsCommon));
 
-    internal static unsafe string? GetAnonId(string id)
-    {
-        using var hash = SHA256.Create();
-        var byteArray = hash.ComputeHash(Encoding.UTF8.GetBytes(id));
+    internal static string? GetId(IIdentityUser? user) => user?.Id?.ToString();
 
+    internal static string? GetLogin(IIdentityUser? user) => user?.UserName ?? user?.Email;
+
+    internal static unsafe string Anonymize(string id)
+    {
         // spec says take first half of the hash
         const int bytesToUse = 16;
-
-        if (byteArray.Length >= bytesToUse)
+        var encodedBytes = Encoding.UTF8.GetBytes(id);
+        #if NET6_0_OR_GREATER
+        var destination = new Span<byte>(new byte[32]);
+        var successfullyHashed = SHA256.TryHashData(new ReadOnlySpan<byte>(encodedBytes), destination, out var bytesWritten);
+        #else
+        using var hash = SHA256.Create();
+        var destination = hash.ComputeHash(encodedBytes);
+        var bytesWritten = destination.Length;
+        var successfullyHashed = bytesWritten > bytesToUse;
+        #endif
+        if (successfullyHashed)
         {
             // we want to end up with a string of the form anon_0c76692372ebf01a7da6e9570fb7d0a1
             // 37 is 5 prefix character plus 32 hexadecimal digits (presenting 16 bytes)
@@ -40,7 +50,7 @@ internal static class UserEventsCommon
             stringChars[4] = '_';
             for (var iBytes = 0; iBytes < bytesToUse; iBytes++)
             {
-                var b = byteArray[iBytes];
+                var b = destination[iBytes];
                 var iChars = iBytes * 2;
                 stringChars[iChars + 5] = ByteDigitToChar(b >> 4);
                 stringChars[iChars + 6] = ByteDigitToChar(b & 0x0F);
@@ -49,7 +59,21 @@ internal static class UserEventsCommon
             return new string(stringChars, 0, 37);
         }
 
-        return null;
+        Log.Warning<int>("Couldn't anonymize user information (login or id), byteArray length was {BytesWritten}", bytesWritten);
+        return string.Empty;
+    }
+
+    internal static void RecordMetricsIfNotFound(bool foundUserId, bool foundLogin)
+    {
+        if (!foundUserId)
+        {
+            TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
+        }
+
+        if (!foundLogin)
+        {
+            TelemetryFactory.Metrics.RecordCountMissingUserLogin(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
+        }
     }
 
     // assumes byteDigit < 15

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
@@ -66,55 +66,48 @@ public static class UserManagerCreateIntegration
     {
         var security = Security.Instance;
         var user = state.State as IIdentityUser;
-        if (security.IsTrackUserEventsEnabled
-            && state.Scope is { Span: { } span })
+        if (security.IsTrackUserEventsEnabled && state.Scope is { Span: { } span })
         {
-            var id = UserEventsCommon.GetId(user);
-            if (id is null)
-            {
-                TelemetryFactory.Metrics.RecordCountMissingUserId(MetricTags.AuthenticationFramework.AspNetCoreIdentity);
-                return returnValue;
-            }
-
-            var setTag = TaggingUtils.GetSpanSetter(span, out _);
-            var tryAddTag = TaggingUtils.GetSpanSetter(span, out _, replaceIfExists: false);
-
+            var userId = UserEventsCommon.GetId(user);
+            var userLogin = UserEventsCommon.GetLogin(user);
+            var foundUserId = !string.IsNullOrEmpty(userId);
+            var foundLogin = !string.IsNullOrEmpty(userLogin);
+            UserEventsCommon.RecordMetricsIfNotFound(foundUserId, foundLogin);
             if (returnValue.Succeeded)
             {
-                setTag(Tags.AppSec.EventsUsers.SignUpEvent.SuccessTrack, "true");
+                Func<string, string> processPii;
+                string successAutoMode;
                 if (security.IsAnonUserTrackingMode)
                 {
-                    var anonId = UserEventsCommon.GetAnonId(id);
-                    if (!string.IsNullOrEmpty(anonId))
-                    {
-                        tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.SuccessUserId, anonId!);
-                    }
-
-                    setTag(Tags.AppSec.EventsUsers.SignUpEvent.SuccessAutoMode, SecuritySettings.UserTrackingAnonMode);
+                    processPii = UserEventsCommon.Anonymize;
+                    successAutoMode = SecuritySettings.UserTrackingAnonMode;
                 }
                 else
                 {
-                    tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.SuccessUserId, id);
-                    setTag(Tags.AppSec.EventsUsers.SignUpEvent.SuccessAutoMode, SecuritySettings.UserTrackingIdentMode);
+                    processPii = val => val;
+                    successAutoMode = SecuritySettings.UserTrackingIdentMode;
                 }
-            }
-            else
-            {
-                setTag(Tags.AppSec.EventsUsers.SignUpEvent.FailureTrack, "true");
-                if (security.IsAnonUserTrackingMode)
-                {
-                    var anonId = UserEventsCommon.GetAnonId(id);
-                    if (anonId != null)
-                    {
-                        tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.FailureUserId, anonId);
-                    }
 
-                    setTag(Tags.AppSec.EventsUsers.SignUpEvent.FailureAutoMode, SecuritySettings.UserTrackingAnonMode);
-                }
-                else
+                var setTag = TaggingUtils.GetSpanSetter(span, out _);
+                var tryAddTag = TaggingUtils.GetSpanSetter(span, out _, replaceIfExists: false);
+
+                setTag(Tags.AppSec.EventsUsers.SignUpEvent.Track, "true");
+                setTag(Tags.AppSec.EventsUsers.SignUpEvent.AutoMode, successAutoMode);
+                tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.UserId, userId!);
+                tryAddTag(Tags.AppSec.EventsUsers.InternalUserId, userId!);
+
+                if (foundUserId)
                 {
-                    tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.FailureUserId, id);
-                    setTag(Tags.AppSec.EventsUsers.SignUpEvent.FailureAutoMode, SecuritySettings.UserTrackingIdentMode);
+                    var processedUserId = processPii(userId!);
+                    tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.UserId, processedUserId);
+                    tryAddTag(Tags.AppSec.EventsUsers.InternalUserId, processedUserId);
+                }
+
+                if (foundLogin)
+                {
+                    var processedUserLogin = processPii(userLogin!);
+                    tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.Login, processedUserLogin);
+                    tryAddTag(Tags.AppSec.EventsUsers.InternalLogin, processedUserLogin);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
@@ -75,7 +75,7 @@ public static class UserManagerCreateIntegration
             UserEventsCommon.RecordMetricsSignupIfNotFound(foundUserId, foundLogin);
             if (returnValue.Succeeded)
             {
-                Func<string, string> processPii;
+                Func<string, string>? processPii = null;
                 string successAutoMode;
                 if (security.IsAnonUserTrackingMode)
                 {
@@ -84,7 +84,6 @@ public static class UserManagerCreateIntegration
                 }
                 else
                 {
-                    processPii = val => val;
                     successAutoMode = SecuritySettings.UserTrackingIdentMode;
                 }
 
@@ -93,19 +92,17 @@ public static class UserManagerCreateIntegration
 
                 setTag(Tags.AppSec.EventsUsers.SignUpEvent.Track, "true");
                 setTag(Tags.AppSec.EventsUsers.SignUpEvent.AutoMode, successAutoMode);
-                tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.UserId, userId!);
-                tryAddTag(Tags.AppSec.EventsUsers.InternalUserId, userId!);
 
                 if (foundUserId)
                 {
-                    var processedUserId = processPii(userId!);
+                    var processedUserId = processPii?.Invoke(userId!) ?? userId!;
                     tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.UserId, processedUserId);
                     tryAddTag(Tags.AppSec.EventsUsers.InternalUserId, processedUserId);
                 }
 
                 if (foundLogin)
                 {
-                    var processedUserLogin = processPii(userLogin!);
+                    var processedUserLogin = processPii?.Invoke(userLogin!) ?? userLogin!;
                     tryAddTag(Tags.AppSec.EventsUsers.SignUpEvent.Login, processedUserLogin);
                     tryAddTag(Tags.AppSec.EventsUsers.InternalLogin, processedUserLogin);
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
@@ -72,7 +72,7 @@ public static class UserManagerCreateIntegration
             var userLogin = UserEventsCommon.GetLogin(user);
             var foundUserId = !string.IsNullOrEmpty(userId);
             var foundLogin = !string.IsNullOrEmpty(userLogin);
-            UserEventsCommon.RecordMetricsIfNotFound(foundUserId, foundLogin);
+            UserEventsCommon.RecordMetricsSignupIfNotFound(foundUserId, foundLogin);
             if (returnValue.Succeeded)
             {
                 Func<string, string> processPii;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 43;
+    public const int Length = 44;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -61,6 +61,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -107,6 +108,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -85,7 +85,9 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1);
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 572;
+    private const int CountLength = 578;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -585,9 +585,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:exec" }),
             // instrum.user_auth.missing_user_id, index = 527
-            new(new[] { "framework:aspnetcore_identity" }),
-            new(new[] { "framework:unknown" }),
-            // executed.source, index = 529
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // instrum.user_auth.missing_user_login, index = 531
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // executed.source, index = 535
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -602,9 +609,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 543
+            // executed.propagation, index = 549
             new(null),
-            // executed.sink, index = 544
+            // executed.sink, index = 550
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -632,7 +639,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 571
+            // request.tainted, index = 577
             new(null),
         };
 
@@ -642,7 +649,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 4, 4, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -862,31 +869,37 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
         var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 531 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 529 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[543], increment);
+        Interlocked.Add(ref _buffer.Count[549], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 544 + (int)tag;
+        var index = 550 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[571], increment);
+        Interlocked.Add(ref _buffer.Count[577], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 43;
+    public const int Length = 44;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -61,6 +61,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -107,6 +108,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -85,7 +85,9 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1);
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 572;
+    private const int CountLength = 578;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -585,9 +585,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:exec" }),
             // instrum.user_auth.missing_user_id, index = 527
-            new(new[] { "framework:aspnetcore_identity" }),
-            new(new[] { "framework:unknown" }),
-            // executed.source, index = 529
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // instrum.user_auth.missing_user_login, index = 531
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // executed.source, index = 535
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -602,9 +609,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 543
+            // executed.propagation, index = 549
             new(null),
-            // executed.sink, index = 544
+            // executed.sink, index = 550
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -632,7 +639,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 571
+            // request.tainted, index = 577
             new(null),
         };
 
@@ -642,7 +649,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 4, 4, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -862,31 +869,37 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
         var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 531 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 529 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[543], increment);
+        Interlocked.Add(ref _buffer.Count[549], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 544 + (int)tag;
+        var index = 550 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[571], increment);
+        Interlocked.Add(ref _buffer.Count[577], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 43;
+    public const int Length = 44;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -61,6 +61,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -107,6 +108,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -85,7 +85,9 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1);
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 572;
+    private const int CountLength = 578;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -585,9 +585,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:exec" }),
             // instrum.user_auth.missing_user_id, index = 527
-            new(new[] { "framework:aspnetcore_identity" }),
-            new(new[] { "framework:unknown" }),
-            // executed.source, index = 529
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // instrum.user_auth.missing_user_login, index = 531
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // executed.source, index = 535
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -602,9 +609,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 543
+            // executed.propagation, index = 549
             new(null),
-            // executed.sink, index = 544
+            // executed.sink, index = 550
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -632,7 +639,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 571
+            // request.tainted, index = 577
             new(null),
         };
 
@@ -642,7 +649,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 4, 4, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -862,31 +869,37 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
         var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 531 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 529 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[543], increment);
+        Interlocked.Add(ref _buffer.Count[549], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 544 + (int)tag;
+        var index = 550 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[571], increment);
+        Interlocked.Add(ref _buffer.Count[577], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 43;
+    public const int Length = 44;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -61,6 +61,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -107,6 +108,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -85,7 +85,9 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1);
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 572;
+    private const int CountLength = 578;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -585,9 +585,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "rule_type:command_injection", "rule_variant:exec" }),
             // instrum.user_auth.missing_user_id, index = 527
-            new(new[] { "framework:aspnetcore_identity" }),
-            new(new[] { "framework:unknown" }),
-            // executed.source, index = 529
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // instrum.user_auth.missing_user_login, index = 531
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
+            new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
+            new(new[] { "framework:unknown", "event_type:signup" }),
+            // executed.source, index = 535
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -602,9 +609,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 543
+            // executed.propagation, index = 549
             new(null),
-            // executed.sink, index = 544
+            // executed.sink, index = 550
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -632,7 +639,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 571
+            // request.tainted, index = 577
             new(null),
         };
 
@@ -642,7 +649,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 77, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 5, 5, 2, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 77, 1, 22, 3, 1, 1, 5, 3, 5, 5, 5, 4, 4, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -862,31 +869,37 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
         var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 531 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 529 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[543], increment);
+        Interlocked.Add(ref _buffer.Count[549], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 544 + (int)tag;
+        var index = 550 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[571], increment);
+        Interlocked.Add(ref _buffer.Count[577], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -164,7 +164,11 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Tags.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Tags.AppSec.cs
@@ -18,9 +18,12 @@ public static partial class Tags
 
         internal static class EventsUsers
         {
+            private const string EventsUsersRoot = Events + "users";
+            private const string PropagatedPrefix = "_dd.appsec.usr";
+            internal const string InternalUserId = $"{PropagatedPrefix}.id";
+            internal const string InternalLogin = $"{PropagatedPrefix}.login";
             internal const string True = "true";
             internal const string False = "false";
-            internal const string EventsUsersRoot = Events + "users";
 
             internal static class LoginEvent
             {
@@ -29,12 +32,12 @@ public static partial class Tags
                 internal const string SuccessSdkSource = $"_dd.{Success}.sdk";
                 internal const string SuccessAutoMode = $"_dd.{Success}.auto.mode";
                 internal const string SuccessTrack = Success + ".track";
+                internal const string SuccessLogin = Success + ".usr.login";
 
                 internal const string Failure = Root + ".failure";
                 internal const string FailureUserId = Failure + ".usr.id";
+                internal const string FailureUserLogin = Failure + ".usr.login";
                 internal const string FailureUserExists = Failure + ".usr.exists";
-                internal const string FailureEmail = Failure + ".email";
-                internal const string FailureUserName = Failure + ".username";
                 internal const string FailureAutoMode = $"_dd.{Failure}.auto.mode";
                 internal const string FailureSdkSource = $"_dd.{Failure}.sdk";
                 internal const string FailureTrack = Failure + ".track";
@@ -43,20 +46,15 @@ public static partial class Tags
             internal static class SignUpEvent
             {
                 private const string Root = EventsUsersRoot + ".signup";
-                private const string Success = Root + ".success";
-                internal const string SuccessUserId = Root + ".usr.id";
-                internal const string SuccessEmail = Root + ".usr.email";
-                internal const string SuccessUserName = Root + ".usr.username";
+                internal const string UserId = Root + ".usr.id";
 
-                internal const string SuccessAutoMode = $"_dd.{Success}.auto.mode";
-                internal const string SuccessTrack = Success + ".track";
+                /// <summary>
+                /// In the case of aspnet core it will come down to username which is supposed to be unique (unless custom db is provided)
+                /// </summary>
+                internal const string Login = Root + ".usr.login";
 
-                private const string RootFailure = Root + ".failure";
-                internal const string FailureUserId = RootFailure + ".usr.id";
-                internal const string FailureEmail = RootFailure + ".usr.email";
-                internal const string FailureUserName = RootFailure + ".usr.username";
-                internal const string FailureAutoMode = $"_dd.{RootFailure}.auto.mode";
-                internal const string FailureTrack = RootFailure + ".track";
+                internal const string AutoMode = $"_dd.{Root}.auto.mode";
+                internal const string Track = Root + ".track";
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -219,9 +219,14 @@ internal enum Count
     [TelemetryMetric<RaspRuleType>("rasp.timeout", isCommon: true, NS.ASM)] RaspTimeout,
 
     /// <summary>
-    /// Counts the number of times a timeout was hit when evaluating a specific rule type.
+    /// Counts the number of times a user id hasn't been found  as part of the login success, login failure or signup event
     /// </summary>
-    [TelemetryMetric<AuthenticationFramework>("instrum.user_auth.missing_user_id", isCommon: true, NS.ASM)] MissingUserId,
+    [TelemetryMetric<AuthenticationFrameworkWithEventType>("instrum.user_auth.missing_user_id", isCommon: true, NS.ASM)] MissingUserId,
+
+    /// <summary>
+    /// Counts the number of times a user login (username or email in our case) hasn't been found as part of the login success, login failure or signup event
+    /// </summary>
+    [TelemetryMetric<AuthenticationFrameworkWithEventType>("instrum.user_auth.missing_user_login", isCommon: true, NS.ASM)] MissingUserLogin,
 
 #endregion
 #region Iast Namespace

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -354,10 +354,12 @@ internal static class MetricTags
         [Description("vulnerability_type:email_html_injection")] EmailHtmlInjection = 26,
     }
 
-    public enum AuthenticationFramework
+    public enum AuthenticationFrameworkWithEventType
     {
-        [Description("framework:aspnetcore_identity")] AspNetCoreIdentity,
-        [Description("framework:unknown")] Unknown,
+        [Description("framework:aspnetcore_identity;event_type:login_success")] AspNetCoreIdentityLoginSuccess,
+        [Description("framework:aspnetcore_identity;event_type:login_failure")] AspNetCoreIdentityLoginFailure,
+        [Description("framework:aspnetcore_identity;event_type:signup")] AspNetCoreIdentitySignup,
+        [Description("framework:unknown;event_type:signup")] Unknown,
     }
 
     public enum CIVisibilityTestFramework

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AutoUserEvents.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AutoUserEvents.cs
@@ -115,12 +115,9 @@ namespace Datadog.Trace.Security.IntegrationTests
         }
     }
 
-    public class AspNetCore5AutoUserEventsExtendedModeSecurityDisabled : AspNetCore5AutoUserEvents
+    public class AspNetCore5AutoUserEventsExtendedModeSecurityDisabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+        : AspNetCore5AutoUserEvents(fixture, outputHelper, false, "extended")
     {
-        public AspNetCore5AutoUserEventsExtendedModeSecurityDisabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base(fixture, outputHelper, false, "extended")
-        {
-        }
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/UserEventsCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/UserEventsCommonTests.cs
@@ -26,28 +26,28 @@ public class UserEventsCommonTests
     }
 
     [Fact]
-    public void GetId_EmailIsSecondChoice()
+    public void GetLogin_UserNameIsFirstChoice()
     {
-        var user = new User()
+        var user = new User
         {
             Email = "my@email.com",
-            UserName = "my-username",
+            UserName = "my-username"
         };
-        var id = UserEventsCommon.GetId(user);
+        var login = UserEventsCommon.GetLogin(user);
 
-        id.Should().Be("my@email.com");
+        login.Should().Be("my-username");
     }
 
     [Fact]
-    public void GetId_UserNameIsThirdChoice()
+    public void GetLogin_EmailIsSecondChoice()
     {
-        var user = new User()
+        var user = new User
         {
-            UserName = "my-username",
+            Email = "my@email.com"
         };
-        var id = UserEventsCommon.GetId(user);
+        var login = UserEventsCommon.GetLogin(user);
 
-        id.Should().Be("my-username");
+        login.Should().Be("my@email.com");
     }
 
     [Theory]
@@ -56,7 +56,7 @@ public class UserEventsCommonTests
     [InlineData("bc98f685-9464-463d-ae66-e84b1ef7963e", "anon_7bcd1c9fc4f6e4c2460e0ad38d6ad0d9")]
     public void GetAnonIdTests(string id, string expected)
     {
-        var anonId = UserEventsCommon.GetAnonId(id);
+        var anonId = UserEventsCommon.Anonymize(id);
 
         anonId.Should().Be(expected);
     }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -763,11 +763,23 @@
     },
     "instrum.user_auth.missing_user_id": {
       "tags": [
-        "framework"
+        "framework",
+        "event_type"
       ],
       "metric_type": "count",
       "data_type": "events",
-      "description": "Number of user events skipped due to not having a user id",
+      "description": "The library was unable to obtain a user ID as part of the login success or failure event. This should only be sent if the user login was also unavailable.",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "instrum.user_auth.missing_user_login": {
+      "tags": [
+        "framework",
+        "event_type"
+      ],
+      "metric_type": "count",
+      "data_type": "events",
+      "description": "The library was unable to obtain a user login as part of the login success, login failure or signup event.",
       "send_to_user": false,
       "user_tags": []
     }

--- a/tracer/test/snapshots/Security.AspNetCore5AsmFeatureUserIdSecurityEnabled._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AsmFeatureUserIdSecurityEnabled._.verified.txt
@@ -8,6 +8,7 @@
     Type: web,
     Tags: {
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -29,6 +30,8 @@
       span.kind: server,
       usr.id: Guid_2,
       _dd.appsec.events.users.login.success.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_2,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AsmFeatureUserIdSecurityRemoteActivated._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AsmFeatureUserIdSecurityRemoteActivated._.verified.txt
@@ -8,6 +8,7 @@
     Type: web,
     Tags: {
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -29,6 +30,8 @@
       span.kind: server,
       usr.id: Guid_2,
       _dd.appsec.events.users.login.success.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_2,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-login.auto.failure1.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-login.auto.failure1.verified.txt
@@ -10,6 +10,7 @@
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: true,
       appsec.events.users.login.failure.usr.id: anon_7bcd1c9fc4f6e4c2460e0ad38d6ad0d9,
+      appsec.events.users.login.failure.usr.login: anon_eb97d409396a3e5392936dad92b909da,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +31,8 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: anonymization,
+      _dd.appsec.usr.id: anon_7bcd1c9fc4f6e4c2460e0ad38d6ad0d9,
+      _dd.appsec.usr.login: anon_eb97d409396a3e5392936dad92b909da,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-login.auto.failure2.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-login.auto.failure2.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: false,
-      appsec.events.users.login.failure.usr.id: anon_c34de12d00b78a9977da847b7e55202e,
+      appsec.events.users.login.failure.usr.login: anon_c34de12d00b78a9977da847b7e55202e,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +30,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: anonymization,
+      _dd.appsec.usr.login: anon_c34de12d00b78a9977da847b7e55202e,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-login.auto.success.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-login.auto.success.verified.txt
@@ -8,6 +8,7 @@
     Type: web,
     Tags: {
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: anon_eb97d409396a3e5392936dad92b909da,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -29,6 +30,8 @@
       span.kind: server,
       usr.id: anon_7bcd1c9fc4f6e4c2460e0ad38d6ad0d9,
       _dd.appsec.events.users.login.success.auto.mode: anonymization,
+      _dd.appsec.usr.id: anon_7bcd1c9fc4f6e4c2460e0ad38d6ad0d9,
+      _dd.appsec.usr.login: anon_eb97d409396a3e5392936dad92b909da,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-login.auto.failure1.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-login.auto.failure1.verified.txt
@@ -10,6 +10,7 @@
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: true,
       appsec.events.users.login.failure.usr.id: Guid_1,
+      appsec.events.users.login.failure.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +31,8 @@
       runtime-id: Guid_2,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_1,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-login.auto.failure2.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-login.auto.failure2.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: false,
-      appsec.events.users.login.failure.usr.id: NoSuchUser,
+      appsec.events.users.login.failure.usr.login: NoSuchUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +30,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: identification,
+      _dd.appsec.usr.login: NoSuchUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-login.auto.success.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-login.auto.success.verified.txt
@@ -8,6 +8,7 @@
     Type: web,
     Tags: {
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -29,6 +30,8 @@
       span.kind: server,
       usr.id: Guid_2,
       _dd.appsec.events.users.login.success.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_2,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-login.auto.failure1.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-login.auto.failure1.verified.txt
@@ -10,6 +10,7 @@
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: true,
       appsec.events.users.login.failure.usr.id: Guid_1,
+      appsec.events.users.login.failure.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +31,8 @@
       runtime-id: Guid_2,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_1,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-login.auto.failure2.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-login.auto.failure2.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: false,
-      appsec.events.users.login.failure.usr.id: NoSuchUser,
+      appsec.events.users.login.failure.usr.login: NoSuchUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +30,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: identification,
+      _dd.appsec.usr.login: NoSuchUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-login.auto.success.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-login.auto.success.verified.txt
@@ -8,6 +8,7 @@
     Type: web,
     Tags: {
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -29,6 +30,8 @@
       span.kind: server,
       usr.id: Guid_2,
       _dd.appsec.events.users.login.success.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_2,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-login.auto.failure1.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-login.auto.failure1.verified.txt
@@ -10,6 +10,7 @@
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: true,
       appsec.events.users.login.failure.usr.id: Guid_1,
+      appsec.events.users.login.failure.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +31,8 @@
       runtime-id: Guid_2,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_1,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-login.auto.failure2.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-login.auto.failure2.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: false,
-      appsec.events.users.login.failure.usr.id: NoSuchUser,
+      appsec.events.users.login.failure.usr.login: NoSuchUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -30,6 +30,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.events.users.login.failure.auto.mode: identification,
+      _dd.appsec.usr.login: NoSuchUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-login.auto.success.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-login.auto.success.verified.txt
@@ -8,6 +8,7 @@
     Type: web,
     Tags: {
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: TestUser,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,
@@ -29,6 +30,8 @@
       span.kind: server,
       usr.id: Guid_2,
       _dd.appsec.events.users.login.success.auto.mode: identification,
+      _dd.appsec.usr.id: Guid_2,
+      _dd.appsec.usr.login: TestUser,
       _dd.runtime_family: dotnet
     },
     Metrics: {


### PR DESCRIPTION
## Summary of changes

Fix signup tags that weren't correct.
Add login tags on failure and other internal tagss as per [RFC](https://docs.google.com/document/d/1RT38U6dTTcB-8muiYV4-aVDCsT_XrliyakjtAPyjUpw/edit?tab=t.0#heading=h.dy0zssue7nq2)


## Reason for change

## Implementation details


## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
