### PR TITLE
Ignore multiple instances of the same version of the tracer

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -88,7 +88,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
             var tracerVersions = FindTracerModules(process)
                 .Select(FileVersionInfo.GetVersionInfo)
-                .Distinct()
+                .DistinctBy(v => v.FileVersion)
                 .ToArray();
 
             if (tracerVersions.Length == 0)


### PR DESCRIPTION
## Summary of changes

In dd-dotnet, when the tracer is found multiple times with the same version, consider them as one.

## Reason for change

We have random failures in the CI because we find the same version of the tracer loaded multiple times, and I haven't been able to figure out why. We've never seen this happening in the wild so it's probably safe to ignore.

## Test coverage

If the tests stop randomly failing then we're good.