### PR TITLE
Fix the debug symbol publish step in release process

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -110,7 +110,7 @@ jobs:
         shell: bash
         run: |
           mkdir debug_symbols
-          tar -zxvf linux-native-symbols.tar.gz -C debug_symbols
+          tar -zxvf ${{steps.assets.outputs.artifacts_path}}/linux-native-symbols.tar.gz -C debug_symbols
 
       - name: 'Push debug symbols to datadog'
         uses: ./.github/actions/publish-debug-symbols


### PR DESCRIPTION
## Summary of changes

Fixes the debug symbol publish step in release process.

## Reason for change

It's still broken.

## Implementation details

Use the correct path

## Test coverage

Nope

## Other details

If at first you don't succeed, fail, and fail again...