### PR TITLE
[Profiler] Make `timer_create`-based CPU profiler default

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -25,6 +25,13 @@ std::string const Configuration::DefaultEmptyString = "";
 std::chrono::seconds const Configuration::DefaultDevUploadInterval = 20s;
 std::chrono::seconds const Configuration::DefaultProdUploadInterval = 60s;
 std::chrono::milliseconds const Configuration::DefaultCpuProfilingInterval = 9ms;
+CpuProfilerType const Configuration::DefaultCpuProfilerType =
+#ifdef _WINDOWS
+    CpuProfilerType::ManualCpuTime;
+#else
+    CpuProfilerType::TimerCreate;
+#endif
+
 
 Configuration::Configuration()
 {
@@ -98,7 +105,7 @@ Configuration::Configuration()
     _ssiLongLivedThreshold = ExtractSsiLongLivedThreshold();
     _isTelemetryToDiskEnabled = GetEnvironmentValue(EnvironmentVariables::TelemetryToDiskEnabled, false);
     _isSsiTelemetryEnabled = GetEnvironmentValue(EnvironmentVariables::SsiTelemetryEnabled, false);
-    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, CpuProfilerType::ManualCpuTime);
+    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
 }
 
 fs::path Configuration::ExtractLogDirectory()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -117,6 +117,7 @@ private:
     static std::chrono::seconds const DefaultDevUploadInterval;
     static std::chrono::seconds const DefaultProdUploadInterval;
     static std::chrono::milliseconds const DefaultCpuProfilingInterval;
+    static CpuProfilerType const DefaultCpuProfilerType;
 
     bool _isProfilingEnabled;
     bool _isCpuProfilingEnabled;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
@@ -47,10 +47,13 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var logFile = Directory.GetFiles(runner.Environment.LogDir)
                 .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
 
-            var nbSignalHandlerInstallation = File.ReadLines(logFile)
-                .Count(l => l.Contains("Successfully setup signal handler for"));
+            File.ReadLines(logFile)
+                .Count(l => l.Contains("Successfully setup signal handler for User defined signal 1 signal"))
+                .Should().Be(1);
 
-            nbSignalHandlerInstallation.Should().Be(1);
+            File.ReadLines(logFile)
+                .Count(l => l.Contains("Successfully setup signal handler for Profiling timer expired signal"))
+                .Should().Be(1);
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1043,20 +1043,38 @@ TEST_F(ConfigurationTest, CheckDefaultCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr(""));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+    auto expected =
+#ifdef _WINDOWS
+        CpuProfilerType::ManualCpuTime;
+#else
+        CpuProfilerType::TimerCreate;
+#endif
+    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
 }
 
 TEST_F(ConfigurationTest, CheckDefaultCpuProfilerTypeWhenEnvVarNotSet)
 {
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+    auto expected =
+#ifdef _WINDOWS
+        CpuProfilerType::ManualCpuTime;
+#else
+        CpuProfilerType::TimerCreate;
+#endif
+    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
 }
 
 TEST_F(ConfigurationTest, CheckUnknownCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("UnknownCpuProfilerType"));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+    auto expected =
+#ifdef _WINDOWS
+        CpuProfilerType::ManualCpuTime;
+#else
+        CpuProfilerType::TimerCreate;
+#endif
+    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
 }
 
 TEST_F(ConfigurationTest, CheckManualCpuProfilerType)


### PR DESCRIPTION
## Summary of changes

GA the `timer_create`-based CPU profiler.

## Reason for change

The new Linux Cpu profiler is based on `timer_create`. It has been under development last quarter. We  enabled it recently by default and let it run in CIs to find remaining issues.
Those issues have been fixed.

## Implementation details

In the configuration set the default CPU profiler (linux) to `timer_create`

## Test coverage
Tests are updated accordingly
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
