### PR TITLE
Enable RuntimeMetricsShutdownSmokeTest only for .NET 9+

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/RuntimeMetricsShutdownSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/RuntimeMetricsShutdownSmokeTest.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET9_0_OR_GREATER
 
 using System.Threading.Tasks;
 using Xunit;


### PR DESCRIPTION
## Summary of changes

Disable RuntimeMetricsShutdownSmokeTest in runtimes prior to .NET 9.

## Reason for change

We get a ton of non-actionable failures because of https://github.com/dotnet/runtime/issues/103480, which defeats the purpose of the test.
