### PR TITLE
[Tracing] Add configuration to change the trace context propagation extract behavior (APMAPI-1009)

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -737,6 +737,17 @@ namespace Datadog.Trace.Configuration
             /// when an obfuscation mechanism will be implemented in the agent.
             /// </summary>
             internal const string CommandsCollectionEnabled = "DD_TRACE_COMMANDS_COLLECTION_ENABLED";
+
+            /// <summary>
+            /// Configuration key for setting the header extraction propagation behavior. Accepted values are:
+            /// <ul>
+            ///   <li>continue: Extracted span context becomes the parent and baggage is propagated</li>
+            ///   <li>restart: Extracted span context becomes a span link (a new trace is started) and baggage is propagated</li>
+            ///   <li>ignore: We disregard the incoming trace context headers and we also disregard baggage</li>
+            /// </ul>
+            /// Default value is continue.
+            /// </summary>
+            public const string PropagationBehaviorExtract = "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT";
         }
 
         internal static class Telemetry

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -387,6 +387,17 @@ namespace Datadog.Trace.Configuration
         public const string PropagationStyle = "DD_TRACE_PROPAGATION_STYLE";
 
         /// <summary>
+        /// Configuration key for setting the header extraction propagation behavior. Accepted values are:
+        /// <ul>
+        ///   <li>continue: Extracted span context becomes the parent and baggage is propagated</li>
+        ///   <li>restart: Extracted span context becomes a span link (a new trace is started) and baggage is propagated</li>
+        ///   <li>ignore: We disregard the incoming trace context headers and we also disregard baggage</li>
+        /// </ul>
+        /// Default value is continue.
+        /// </summary>
+        public const string PropagationBehaviorExtract = "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT";
+
+        /// <summary>
         /// Configuration key to configure if propagation should only extract the first header once a configure
         /// propagator extracts a valid trace context.
         /// </summary>
@@ -737,17 +748,6 @@ namespace Datadog.Trace.Configuration
             /// when an obfuscation mechanism will be implemented in the agent.
             /// </summary>
             internal const string CommandsCollectionEnabled = "DD_TRACE_COMMANDS_COLLECTION_ENABLED";
-
-            /// <summary>
-            /// Configuration key for setting the header extraction propagation behavior. Accepted values are:
-            /// <ul>
-            ///   <li>continue: Extracted span context becomes the parent and baggage is propagated</li>
-            ///   <li>restart: Extracted span context becomes a span link (a new trace is started) and baggage is propagated</li>
-            ///   <li>ignore: We disregard the incoming trace context headers and we also disregard baggage</li>
-            /// </ul>
-            /// Default value is continue.
-            /// </summary>
-            public const string PropagationBehaviorExtract = "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT";
         }
 
         internal static class Telemetry

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -484,7 +484,7 @@ namespace Datadog.Trace.Configuration
                                          .AsBool(false);
 
             PropagationBehaviorExtract = config
-                                         .WithKeys(ConfigurationKeys.FeatureFlags.PropagationBehaviorExtract)
+                                         .WithKeys(ConfigurationKeys.PropagationBehaviorExtract)
                                          .GetAs(
                                              () => new DefaultResult<ExtractBehavior>(ExtractBehavior.Continue, "continue"),
                                              converter: x => x.ToLowerInvariant() switch

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -483,6 +483,19 @@ namespace Datadog.Trace.Configuration
                                          .WithKeys(ConfigurationKeys.PropagationExtractFirstOnly)
                                          .AsBool(false);
 
+            PropagationBehaviorExtract = config
+                                         .WithKeys(ConfigurationKeys.FeatureFlags.PropagationBehaviorExtract)
+                                         .GetAs(
+                                             () => new DefaultResult<ExtractBehavior>(ExtractBehavior.Continue, "continue"),
+                                             converter: x => x.ToLowerInvariant() switch
+                                             {
+                                                 "continue" => ExtractBehavior.Continue,
+                                                 "restart" => ExtractBehavior.Restart,
+                                                 "ignore" => ExtractBehavior.Ignore,
+                                                 _ => ParsingResult<ExtractBehavior>.Failure(),
+                                             },
+                                             validator: null);
+
             BaggageMaximumItems = config
                                  .WithKeys(ConfigurationKeys.BaggageMaximumItems)
                                  .AsInt32(defaultValue: W3CBaggagePropagator.DefaultMaximumBaggageItems);
@@ -896,6 +909,11 @@ namespace Datadog.Trace.Configuration
         /// extract the first header.
         /// </summary>
         internal bool PropagationExtractFirstOnly { get; }
+
+        /// <summary>
+        /// Gets a value indicating the behavior when extracting propagation headers.
+        /// </summary>
+        internal ExtractBehavior PropagationBehaviorExtract { get; }
 
         /// <summary>
         /// Gets the maximum number of items that can be

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -116,6 +116,12 @@ namespace Datadog.Trace.PlatformHelpers
             scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, userAgent, tags);
             AddHeaderTagsToSpan(scope.Span, request, tracer);
 
+            foreach (var link in extractedContext.Links)
+            {
+                // TODO: We should probably just add this as another argument in StartActiveInternal
+                scope.Span.AddLink(link);
+            }
+
             var originalPath = request.PathBase.HasValue ? request.PathBase.Add(request.Path) : request.Path;
             httpContext.Features.Set(new RequestTrackingFeature(originalPath, scope));
 

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -112,15 +112,9 @@ namespace Datadog.Trace.PlatformHelpers
             var routeTemplateResourceNames = tracer.Settings.RouteTemplateResourceNamesEnabled;
             var tags = routeTemplateResourceNames ? new AspNetCoreEndpointTags() : new AspNetCoreTags();
 
-            var scope = tracer.StartActiveInternal(_requestInOperationName, extractedContext.SpanContext, tags: tags);
+            var scope = tracer.StartActiveInternal(_requestInOperationName, extractedContext.SpanContext, tags: tags, links: extractedContext.Links);
             scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, userAgent, tags);
             AddHeaderTagsToSpan(scope.Span, request, tracer);
-
-            foreach (var link in extractedContext.Links)
-            {
-                // TODO: We should probably just add this as another argument in StartActiveInternal
-                scope.Span.AddLink(link);
-            }
 
             var originalPath = request.PathBase.HasValue ? request.PathBase.Add(request.Path) : request.Path;
             httpContext.Features.Set(new RequestTrackingFeature(originalPath, scope));

--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -37,6 +37,8 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
+        public string DisplayName => "b3multi";
+
         public void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -27,6 +27,8 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
+        public string DisplayName => "b3";
+
         public void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -23,6 +23,8 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
+        public string DisplayName => "datadog";
+
         public void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/ExtractBehavior.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ExtractBehavior.cs
@@ -1,0 +1,15 @@
+// <copyright file="ExtractBehavior.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Propagators;
+
+internal enum ExtractBehavior
+{
+    Continue = 0,
+    Ignore = 1,
+    Restart = 2,
+}

--- a/tracer/src/Datadog.Trace/Propagators/IContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/IContextExtractor.cs
@@ -13,6 +13,8 @@ internal interface IContextExtractor
 {
     PropagatorType PropagatorType { get; }
 
+    string DisplayName { get; }
+
     bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out PropagationContext context)
         where TCarrierGetter : struct, ICarrierGetter<TCarrier>;
 }

--- a/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
+++ b/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
@@ -6,7 +6,6 @@
 #nullable enable
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Datadog.Trace.Propagators;
 
@@ -22,14 +21,14 @@ internal readonly struct PropagationContext
     {
         SpanContext = spanContext;
         Baggage = baggage;
-        Links = Enumerable.Empty<SpanLink>();
+        Links = null;
     }
 
     public PropagationContext(SpanContext? spanContext, Baggage? baggage, IEnumerable<SpanLink>? extractionSpanLinks)
     {
         SpanContext = spanContext;
         Baggage = baggage;
-        Links = extractionSpanLinks ?? Enumerable.Empty<SpanLink>();
+        Links = extractionSpanLinks;
     }
 
     public bool IsEmpty => SpanContext is null && Baggage is null;

--- a/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
+++ b/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
@@ -1,9 +1,12 @@
-﻿// <copyright file="PropagationContext.cs" company="Datadog">
+// <copyright file="PropagationContext.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 #nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Datadog.Trace.Propagators;
 
@@ -13,10 +16,20 @@ internal readonly struct PropagationContext
 
     public readonly Baggage? Baggage;
 
+    public readonly IEnumerable<SpanLink>? Links;
+
     public PropagationContext(SpanContext? spanContext, Baggage? baggage)
     {
         SpanContext = spanContext;
         Baggage = baggage;
+        Links = Enumerable.Empty<SpanLink>();
+    }
+
+    public PropagationContext(SpanContext? spanContext, Baggage? baggage, IEnumerable<SpanLink>? extractionSpanLinks)
+    {
+        SpanContext = spanContext;
+        Baggage = baggage;
+        Links = extractionSpanLinks ?? Enumerable.Empty<SpanLink>();
     }
 
     public bool IsEmpty => SpanContext is null && Baggage is null;

--- a/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
+++ b/tracer/src/Datadog.Trace/Propagators/PropagationContext.cs
@@ -30,6 +30,4 @@ internal readonly struct PropagationContext
         Baggage = baggage;
         Links = extractionSpanLinks;
     }
-
-    public bool IsEmpty => SpanContext is null && Baggage is null;
 }

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -191,7 +191,7 @@ namespace Datadog.Trace.Propagators
 
             return _extractBehavior switch
             {
-                ExtractBehavior.Restart when cumulativeSpanContext is not null => new PropagationContext(default, cumulativeBaggage, [new SpanLink(cumulativeSpanContext, attributes: [new("reason", "propagation_behavior_extract=restart"), new("context_headers", initialExtractorDisplayName!)])]),
+                ExtractBehavior.Restart when cumulativeSpanContext is not null => new PropagationContext(default, cumulativeBaggage, [new SpanLink(cumulativeSpanContext, attributes: [new("reason", "propagation_behavior_extract"), new("context_headers", initialExtractorDisplayName!)])]),
                 ExtractBehavior.Restart => new PropagationContext(default, cumulativeBaggage, []),
                 _ => new PropagationContext(cumulativeSpanContext, cumulativeBaggage, spanLinks),
 

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -138,6 +138,7 @@ namespace Datadog.Trace.Propagators
             SpanContext? cumulativeSpanContext = null;
             Baggage? cumulativeBaggage = null;
             List<SpanLink> spanLinks = new();
+            string? initialExtractorDisplayName = null;
 
             foreach (var extractor in _extractors)
             {
@@ -173,6 +174,7 @@ namespace Datadog.Trace.Propagators
                 if (cumulativeSpanContext == null)
                 {
                     cumulativeSpanContext = currentExtractedContext.SpanContext;
+                    initialExtractorDisplayName = extractor.DisplayName;
                 }
                 else if (currentExtractedContext.SpanContext is { } extractedSpanContext)
                 {
@@ -189,7 +191,7 @@ namespace Datadog.Trace.Propagators
 
             return _extractBehavior switch
             {
-                ExtractBehavior.Restart when cumulativeSpanContext is not null => new PropagationContext(default, cumulativeBaggage, [new SpanLink(cumulativeSpanContext)]),
+                ExtractBehavior.Restart when cumulativeSpanContext is not null => new PropagationContext(default, cumulativeBaggage, [new SpanLink(cumulativeSpanContext, attributes: [new("reason", "propagation_behavior_extract=restart"), new("context_headers", initialExtractorDisplayName!)])]),
                 ExtractBehavior.Restart => new PropagationContext(default, cumulativeBaggage, []),
                 _ => new PropagationContext(cumulativeSpanContext, cumulativeBaggage, spanLinks),
 

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -174,9 +174,16 @@ namespace Datadog.Trace.Propagators
                 {
                     cumulativeSpanContext = currentExtractedContext.SpanContext;
                 }
-                else if (extractor is W3CTraceContextPropagator && currentExtractedContext.SpanContext is { } extractedSpanContext)
+                else if (currentExtractedContext.SpanContext is { } extractedSpanContext)
                 {
-                    MergeExtractedW3CSpanContext(cumulativeSpanContext, extractedSpanContext);
+                    if (cumulativeSpanContext.RawTraceId != extractedSpanContext.RawTraceId)
+                    {
+                        spanLinks.Add(new SpanLink(extractedSpanContext, attributes: [new("reason", "terminated_context"), new("context_headers", extractor.DisplayName)]));
+                    }
+                    else if (extractor is W3CTraceContextPropagator)
+                    {
+                        MergeExtractedW3CSpanContext(cumulativeSpanContext, extractedSpanContext);
+                    }
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Propagators
         {
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
 
-            if (context.IsEmpty)
+            if (context.SpanContext is null && context.Baggage is null)
             {
                 // nothing to inject
                 return;

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagatorFactory.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagatorFactory.cs
@@ -13,12 +13,12 @@ namespace Datadog.Trace.Propagators
 {
     internal static class SpanContextPropagatorFactory
     {
-        public static SpanContextPropagator GetSpanContextPropagator(string[] requestedInjectors, string[] requestedExtractors, bool propagationExtractFirst)
+        public static SpanContextPropagator GetSpanContextPropagator(string[] requestedInjectors, string[] requestedExtractors, bool propagationExtractFirst, ExtractBehavior extractBehavior = default)
         {
             var injectors = GetPropagators<IContextInjector>(requestedInjectors);
             var extractors = GetPropagators<IContextExtractor>(requestedExtractors);
 
-            return new SpanContextPropagator(injectors, extractors, propagationExtractFirst);
+            return new SpanContextPropagator(injectors, extractors, propagationExtractFirst, extractBehavior);
         }
 
         public static IEnumerable<TPropagator> GetPropagators<TPropagator>(string[] headerStyles)

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="W3CBaggagePropagator.cs" company="Datadog">
+// <copyright file="W3CBaggagePropagator.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -39,6 +39,8 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
     }
 
     public PropagatorType PropagatorType => PropagatorType.Baggage;
+
+    public string DisplayName => "baggage";
 
     public void Inject<TCarrier, TCarrierSetter>(
         PropagationContext context,

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -116,6 +116,8 @@ namespace Datadog.Trace.Propagators
 
         public PropagatorType PropagatorType => PropagatorType.TraceContext;
 
+        public string DisplayName => "tracecontext";
+
         public void Inject<TCarrier, TCarrierSetter>(PropagationContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Datadog.Trace.Debugger.ExceptionAutoInstrumentation;
@@ -37,11 +38,16 @@ namespace Datadog.Trace
         {
         }
 
-        internal Span(SpanContext context, DateTimeOffset? start, ITags tags)
+        internal Span(SpanContext context, DateTimeOffset? start, ITags tags, IEnumerable<SpanLink> links = null)
         {
             Tags = tags ?? new CommonTags();
             Context = context;
             StartTime = start ?? Context.TraceContext.Clock.UtcNow;
+
+            foreach (var link in links ?? Enumerable.Empty<SpanLink>())
+            {
+                AddLink(link);
+            }
 
             if (IsLogLevelDebugEnabled)
             {

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -44,9 +44,12 @@ namespace Datadog.Trace
             Context = context;
             StartTime = start ?? Context.TraceContext.Clock.UtcNow;
 
-            foreach (var link in links ?? Enumerable.Empty<SpanLink>())
+            if (links is not null)
             {
-                AddLink(link);
+                foreach (var link in links)
+                {
+                    AddLink(link);
+                }
             }
 
             if (IsLogLevelDebugEnabled)

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -482,9 +482,10 @@ namespace Datadog.Trace
         /// and the span count metric is incremented. Alternatively, if this is not being called from an
         /// automatic integration, call <c>TelemetryFactory.Metrics.RecordCountSpanCreated()</c> directory instead.
         /// </remarks>
-        internal Scope StartActiveInternal(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool finishOnClose = true, ITags tags = null)
+        internal Scope StartActiveInternal(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool finishOnClose = true, ITags tags = null, IEnumerable<SpanLink> links = null)
         {
-            var span = StartSpan(operationName, tags, parent, serviceName, startTime);
+            var span = StartSpan(operationName, tags, parent, serviceName, startTime, links: links);
+
             return TracerManager.ScopeManager.Activate(span, finishOnClose);
         }
 
@@ -494,11 +495,11 @@ namespace Datadog.Trace
         /// and the span count metric is incremented. Alternatively, if this is not being called from an
         /// automatic integration, call <c>TelemetryFactory.Metrics.RecordCountSpanCreated()</c> directly instead.
         /// </remarks>
-        internal Span StartSpan(string operationName, ITags tags = null, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, TraceId traceId = default, ulong spanId = 0, string rawTraceId = null, string rawSpanId = null, bool addToTraceContext = true)
+        internal Span StartSpan(string operationName, ITags tags = null, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, TraceId traceId = default, ulong spanId = 0, string rawTraceId = null, string rawSpanId = null, bool addToTraceContext = true, IEnumerable<SpanLink> links = null)
         {
             var spanContext = CreateSpanContext(parent, serviceName, traceId, spanId, rawTraceId, rawSpanId);
 
-            var span = new Span(spanContext, startTime, tags)
+            var span = new Span(spanContext, startTime, tags, links)
             {
                 OperationName = operationName,
             };

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace
             var schema = new NamingSchema(settings.MetadataSchemaVersion, settings.PeerServiceTagsEnabled, settings.RemoveClientServiceNamesEnabled, defaultServiceName, settings.ServiceNameMappings, settings.PeerServiceNameMappings);
             PerTraceSettings = new(traceSampler, spanSampler, settings.ServiceNameMappings, schema);
 
-            SpanContextPropagator = SpanContextPropagatorFactory.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract, settings.PropagationExtractFirstOnly, ExtractBehavior.Continue);
+            SpanContextPropagator = SpanContextPropagatorFactory.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract, settings.PropagationExtractFirstOnly, settings.PropagationBehaviorExtract);
         }
 
         /// <summary>
@@ -556,6 +556,9 @@ namespace Datadog.Trace
 
                     writer.WritePropertyName("trace_propagation_style_extract_first_only");
                     writer.WriteValue(instanceSettings.PropagationExtractFirstOnly);
+
+                    writer.WritePropertyName("trace_propagation_behavior_extract");
+                    writer.WriteValue(instanceSettings.PropagationBehaviorExtract);
 
                     writer.WritePropertyName("trace_propagation_style_inject");
                     writer.WriteStartArray();

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace
             var schema = new NamingSchema(settings.MetadataSchemaVersion, settings.PeerServiceTagsEnabled, settings.RemoveClientServiceNamesEnabled, defaultServiceName, settings.ServiceNameMappings, settings.PeerServiceNameMappings);
             PerTraceSettings = new(traceSampler, spanSampler, settings.ServiceNameMappings, schema);
 
-            SpanContextPropagator = SpanContextPropagatorFactory.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract, settings.PropagationExtractFirstOnly);
+            SpanContextPropagator = SpanContextPropagatorFactory.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract, settings.PropagationExtractFirstOnly, ExtractBehavior.Continue);
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -457,7 +457,7 @@ namespace Datadog.Trace.Tests.Propagators
                                 },
                                 Attributes =
                                 [
-                                    new("reason", "propagation_behavior_extract=restart"),
+                                    new("reason", "propagation_behavior_extract"),
                                     new("context_headers", "tracecontext")
                                 ],
                             }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -399,7 +399,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = EmptyPropagatedTags,
                           IsRemote = true,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
             result.Links.Should().BeEmpty();
@@ -461,7 +462,8 @@ namespace Datadog.Trace.Tests.Propagators
                                     new("context_headers", "tracecontext")
                                 ],
                             }
-                        });
+                        },
+                        opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -1064,7 +1066,8 @@ namespace Datadog.Trace.Tests.Propagators
                                     new("context_headers", w3CHeaderFirst ? "datadog" : "tracecontext")
                                 ]
                             }
-                        ]);
+                        ],
+                        opts => opts.ExcludingMissingMembers());
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -454,7 +454,12 @@ namespace Datadog.Trace.Tests.Propagators
                                     PropagatedTags = EmptyPropagatedTags,
                                     IsRemote = true,
                                     LastParentId = ZeroLastParentId,
-                                }
+                                },
+                                Attributes =
+                                [
+                                    new("reason", "propagation_behavior_extract=restart"),
+                                    new("context_headers", "tracecontext")
+                                ],
                             }
                         });
         }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/SpanLinkMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/SpanLinkMock.cs
@@ -1,0 +1,16 @@
+// <copyright file="SpanLinkMock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.Tests.Propagators;
+
+internal class SpanLinkMock
+{
+    public List<KeyValuePair<string, string>> Attributes { get; set; }
+
+    public SpanContextMock Context { get; set; }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -353,6 +353,7 @@
   "DD_TRACE_EXPAND_ROUTE_TEMPLATES_ENABLED": "trace_route_template_expansion_enabled",
   "DD_TRACE_STATS_COMPUTATION_ENABLED": "trace_stats_computation_enabled",
   "_DD_TRACE_STATS_COMPUTATION_INTERVAL": "trace_stats_computation_interval",
+  "DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT": "trace_propagation_behavior_extract",
   "DD_TRACE_PROPAGATION_STYLE_INJECT": "trace_propagation_style_inject",
   "DD_PROPAGATION_STYLE_INJECT": "trace_propagation_style_inject",
   "DD_TRACE_PROPAGATION_STYLE_EXTRACT": "trace_propagation_style_extract",


### PR DESCRIPTION
## Summary of changes
This implements two features within the context extraction logic:
- Adds a new `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT` to update the logic of context extraction independently of the propagator list. The behaviors modify the returned SpanContext and SpanLinks fields to better handle incoming contexts that could cause issues for service owners
- When additional trace contexts are identified and their trace-id does not match the first extracted trace context, create a span link that represents that span context. This is a missing feature that has been standardized and adopted across libraries and it is extremely adjacent to the first feature, so it was done in this effort

## Reason for change
We've seen several cases now where users receive distributed tracing headers from services they do not control, and automatically inheriting the trace-id/sampling decisions leads to a degraded customer experience. While users already have a workaround today of configuring `DD_TRACE_PROPAGATION_STYLE_EXTRACT=none` to ignore incoming headers, that conflates the ideas of propagator formats with trace continuation.

As a result, we're implementing a new `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT` config, which allows service owners to better configure how distributed tracing headers should be extracted. The available values are:
- `continue` (existing behavior): The extracted span context (if present) becomes the parent and any baggage is propagated.
- `restart`: A new trace is started and any baggage is propagated. The extracted span context (if present) is added as a span link on the new span.
- `ignore`: The incoming trace context headers and baggage are ignored entirely.

## Implementation details

### `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT`
- The `PropagationContext` type is augmented with a `Links` property, which represents spans links to add to the span started from that `PropagationContext`.
- The `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT` configuration is added, which is converted into the new `ExtractBehavior` enum with values representing each state and the enum is configured on the `SpanContextPropagator` object instance (which is the entrypoint for the extract/inject operations that are run against all configured propagator formats).
- In the `SpanContextPropagator.Extract` operation, the `ExtractBehavior` field is used to update the extracted span context as described above

### Additional changes
- The `Tracer.StartActiveInternal` API has been updated to accept span links and this is propagated down to the `Span` constructor so we can add span links at span start more easily
- The AspNetCore instrumentation has been updated to add the span links from the extracted context to the new Span. Other HTTP integrations need to be updated as well, but this is the first integration that is tested by system-tests

### Resulting Span Links
If a span link is generated due to its trace-id conflicting with the extracted trace context, the span link will carry the original trace-id, span-id, sampling flag, and tracestate. Additionally, it will have the following attributes:
- Key=`reason`, Value=`terminated_context`
- Key=`context_headers`, Value=`<Name of the propagator>`

If a span link is generated due to the `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT=restart` behavior, the span link will carry the original trace-id, span-id, sampling flag, and tracestate. Additionally, it will have the following attributes:
- Key=`reason`, Value=`propagation_behavior_extract=restart`
- Key=`context_headers`, Value=`<Name of the propagator>`

## Test coverage
- https://github.com/DataDog/dd-trace-dotnet/pull/6471 added further baggage tests
- This PR also adds unit tests to the `MultiSpanContextPropagatorTests` class to test all of the new behaviors
- The system-tests for `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT` and the conflicting trace-ids have been tested against this implementation and the tests pass

## Other details
I wish I could have separated out the two different span links features but I needed both of them to test some of the edge cases of the new `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT` configuration, so here we are.
