### PR TITLE
[WIP] Automatically generate supported integrations

### DIFF
--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -252,6 +252,8 @@ partial class Build
 
            var outputPath = TracerDirectory / "build" / "supported_versions.json";
            await GenerateSupportMatrix.GenerateInstrumentationSupportMatrix(outputPath, distinctIntegrations);
+
+           GenerateIntegrationMarkdownTable.GenerateTable(outputPath, TracerDirectory / "build" / "integrations.md");
            
            Logger.Information("Verifying that updated dependabot file is valid...");
 
@@ -259,7 +261,17 @@ partial class Build
            CopyFile(dependabotProj, tempProjectFile, FileExistsPolicy.Overwrite);
            DotNetRestore(x => x.SetProjectFile(tempProjectFile));
        });
-    
+
+    Target GenerateMarkdownTable => _ => _
+   .Description("Generates the Markdown Table")
+   .Executes(() =>
+   {
+       var outputPath = TracerDirectory / "build" / "supported_versions.json";
+
+       GenerateIntegrationMarkdownTable.GenerateTable(outputPath, TracerDirectory / "build" / "integrations.md");
+
+   });
+
     Target GenerateSpanDocumentation => _ => _
         .Description("Regenerate documentation from our code models")
         .Executes(() =>

--- a/tracer/build/_build/GeneratePackageVersions/GenerateIntegrationMarkdownTable.cs
+++ b/tracer/build/_build/GeneratePackageVersions/GenerateIntegrationMarkdownTable.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GeneratePackageVersions
+{
+    internal class GenerateIntegrationMarkdownTable
+    {
+        private class Package
+        {
+            [JsonPropertyName("name")]
+            public string Name { get; set; }
+
+            [JsonPropertyName("minVersionTestedInclusive")]
+            public string MinVersionTested { get; set; }
+
+            [JsonPropertyName("maxVersionTestedInclusive")]
+            public string MaxVersionTested { get; set; }
+        }
+
+        private class Integration
+        {
+            [JsonPropertyName("integrationName")]
+            public string IntegrationName { get; set; }
+
+            [JsonPropertyName("assemblyName")]
+            public string AssemblyName { get; set; }
+
+            [JsonPropertyName("minAssemblyVersionInclusive")]
+            public string MinAssemblyVersion { get; set; }
+
+            [JsonPropertyName("maxAssemblyVersionInclusive")]
+            public string MaxAssemblyVersion { get; set; }
+
+            [JsonPropertyName("packages")]
+            public List<Package> Packages { get; set; }
+        }
+
+        public static void GenerateTable(string input, string output)
+        {
+            var jsonContent = File.ReadAllText(input);
+            var integrations = JsonSerializer.Deserialize<List<Integration>>(jsonContent);
+
+            var distinctIntegrations = integrations
+                .GroupBy(i => i.IntegrationName)
+                .Select(group =>
+                {
+                    var assemblies = group.Select(i => new
+                    {
+                        Name = i.AssemblyName,
+                        MinVersion = i.MinAssemblyVersion,
+                        MaxVersion = i.MaxAssemblyVersion,
+                        Packages = i.Packages ?? new List<Package>()
+                    }).ToList();
+
+                    return new
+                    {
+                        IntegrationName = group.Key,
+                        Implementations = assemblies.Select(assembly => new
+                        {
+                            Type = "Assembly",
+                            Name = assembly.Name,
+                            MinVersion = assembly.MinVersion,
+                            MaxVersion = assembly.MaxVersion
+                        })
+                        .Concat(
+                            assemblies.SelectMany(a => a.Packages)
+                                .Where(p => p.MinVersionTested != null || p.MaxVersionTested != null)
+                                .Select(p => new
+                                {
+                                    Type = "Package",
+                                    Name = p.Name,
+                                    MinVersion = p.MinVersionTested ?? "-",
+                                    MaxVersion = p.MaxVersionTested ?? "-"
+                                })
+                        )
+                        .OrderBy(x => x.Type)
+                        .ThenBy(x => x.Name)
+                        .ToList()
+                    };
+                })
+                .OrderBy(i => i.IntegrationName);
+
+            using var writer = new StreamWriter(output);
+            writer.WriteLine("| Integration | Type | Name | Minimum Version | Maximum Version |");
+            writer.WriteLine("|------------|------|------|----------------|----------------|");
+
+            foreach (var integration in distinctIntegrations)
+            {
+                if (!integration.Implementations.Any())
+                {
+                    // Write a single row for integrations with no implementations
+                    writer.WriteLine($"| {integration.IntegrationName} | - | - | - | - |");
+                }
+                else
+                {
+                    // Write a row for each implementation (both assemblies and packages)
+                    var isFirst = true;
+                    foreach (var impl in integration.Implementations)
+                    {
+                        var integrationName = isFirst ? integration.IntegrationName : "";
+                        writer.WriteLine($"| {integrationName} | {impl.Type} | {impl.Name} | {impl.MinVersion} | {impl.MaxVersion} |");
+                        isFirst = false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tracer/build/integrations.md
+++ b/tracer/build/integrations.md
@@ -1,0 +1,129 @@
+| Integration | Type | Name | Minimum Version | Maximum Version |
+|------------|------|------|----------------|----------------|
+| AdoNet | Assembly | netstandard | 2.0.0 | 2.65535.65535 |
+|  | Assembly | System.Data | 2.0.0 | 4.65535.65535 |
+|  | Assembly | System.Data.Common | 4.0.0 | 9.65535.65535 |
+|  | Package | System.Data.SqlClient | 4.1.0 | 4.9.0 |
+| Aerospike | Assembly | AerospikeClient | 4.0.0 | 7.65535.65535 |
+|  | Package | Aerospike.Client | 4.0.3 | 7.4.0 |
+| AspNet | Assembly | System.Web | 4.0.0 | 4.65535.65535 |
+| AspNetCore | Assembly | Microsoft.AspNetCore.Authentication.Abstractions | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.AspNetCore.Http | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.AspNetCore.Identity | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.AspNetCore.Mvc.Core | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.AspNetCore.Server.IIS | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.AspNetCore.Server.Kestrel.Core | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.AspNetCore.Session | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.AspNetCore.StaticFiles | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.Extensions.Identity.Core | 2.0.0 | 9.65535.65535 |
+| AspNetMvc | Assembly | System.Web.Mvc | 4.0.0 | 5.65535.65535 |
+| AspNetWebApi2 | Assembly | System.Web.Http | 5.1.0 | 5.65535.65535 |
+| AwsDynamoDb | Assembly | AWSSDK.DynamoDBv2 | 3.0.0 | 3.65535.65535 |
+|  | Package | AWSSDK.DynamoDBv2 | 3.1.5.3 | 3.7.403.3 |
+| AwsEventBridge | Assembly | AWSSDK.EventBridge | 3.3.0 | 3.65535.65535 |
+|  | Package | AWSSDK.EventBridge | 3.3.102.16 | 3.7.401.51 |
+| AwsKinesis | Assembly | AWSSDK.Kinesis | 3.0.0 | 3.65535.65535 |
+|  | Package | AWSSDK.Kinesis | 3.1.3.5 | 3.7.402.30 |
+| AwsLambda | Assembly | Amazon.Lambda.RuntimeSupport | 1.4.0 | 1.65535.65535 |
+|  | Package | Amazon.Lambda.RuntimeSupport | 1.12.0 | 1.12.0 |
+| AwsSdk | Assembly | AWSSDK.Core | 3.0.0 | 3.65535.65535 |
+| AwsSns | Assembly | AWSSDK.SimpleNotificationService | 3.0.0 | 3.65535.65535 |
+|  | Package | AWSSDK.SimpleNotificationService | 3.1.2.1 | 3.7.400.53 |
+| AwsSqs | Assembly | AWSSDK.SQS | 3.0.0 | 3.65535.65535 |
+|  | Package | AWSSDK.SQS | 3.1.0.13 | 3.7.400.53 |
+| AzureFunctions | Assembly | Microsoft.Azure.Functions.Worker.Core | 1.4.0 | 1.65535.65535 |
+|  | Assembly | Microsoft.Azure.WebJobs.Host | 3.0.0 | 3.65535.65535 |
+|  | Assembly | Microsoft.Azure.WebJobs.Script.Grpc | 4.0.0 | 4.65535.65535 |
+|  | Assembly | Microsoft.Azure.WebJobs.Script.WebHost | 3.0.0 | 4.65535.65535 |
+| AzureServiceBus | Assembly | Azure.Messaging.ServiceBus | 7.14.0 | 7.65535.65535 |
+|  | Package | Azure.Messaging.ServiceBus | 7.4.0 | 7.17.5 |
+| CosmosDb | Assembly | Microsoft.Azure.Cosmos.Client | 3.6.0 | 3.65535.65535 |
+|  | Package | Microsoft.Azure.Cosmos | 3.6.0 | 3.46.0 |
+| Couchbase | Assembly | Couchbase.NetClient | 2.2.8 | 3.65535.65535 |
+|  | Package | CouchbaseNetClient | 2.4.8 | 3.6.4 |
+| DatadogTraceManual | Assembly | Datadog.Trace.Manual | 3.0.0 | 3.65535.65535 |
+|  | Assembly | Datadog.Trace.OpenTracing | 3.0.0 | 3.65535.65535 |
+| DotnetTest | Assembly | coverlet.core | 3.0.0 | 6.65535.65535 |
+|  | Assembly | dotnet | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.VisualStudio.TraceDataCollector | 15.0.0 | 15.65535.65535 |
+|  | Assembly | vstest.console | 15.0.0 | 15.65535.65535 |
+|  | Assembly | vstest.console.arm64 | 15.0.0 | 15.65535.65535 |
+| ElasticsearchNet | Assembly | Elasticsearch.Net | 5.0.0 | 7.65535.65535 |
+|  | Package | Elasticsearch.Net | 5.3.1 | 7.17.5 |
+| GraphQL | Assembly | GraphQL | 2.3.0 | 7.65535.65535 |
+|  | Assembly | GraphQL.SystemReactive | 4.0.0 | 4.65535.65535 |
+|  | Package | GraphQL | 4.1.0 | 7.9.0 |
+| Grpc | Assembly | Google.Protobuf | 3.0.0 | 3.65535.65535 |
+|  | Assembly | Grpc.AspNetCore.Server | 2.0.0 | 2.65535.65535 |
+|  | Assembly | Grpc.Core | 2.0.0 | 2.65535.65535 |
+|  | Assembly | Grpc.Net.Client | 2.0.0 | 2.65535.65535 |
+|  | Package | Grpc | 2.29.0 | 2.46.6 |
+|  | Package | Grpc.AspNetCore | 2.29.0 | 2.66.0 |
+|  | Package | Grpc.AspNetCore | 2.29.0 | 2.66.0 |
+| HashAlgorithm | Assembly | System.Security.Cryptography | 7.0.0 | 9.65535.65535 |
+|  | Assembly | System.Security.Cryptography.Primitives | 1.0.0 | 6.65535.65535 |
+| HotChocolate | Assembly | HotChocolate.Execution | 11.0.0 | 13.65535.65535 |
+|  | Package | HotChocolate.AspNetCore | 11.3.8 | 13.9.14 |
+| HttpMessageHandler | Assembly | System.Net.Http | 4.0.0 | 9.65535.65535 |
+|  | Assembly | System.Net.Http.WinHttpHandler | 4.0.0 | 9.65535.65535 |
+|  | Assembly | Yarp.ReverseProxy | 1.1.0 | 2.65535.65535 |
+|  | Package | Yarp.ReverseProxy | 1.0.1 | 2.2.0 |
+| IbmMq | Assembly | amqmdnetstd | 9.0.0 | 9.65535.65535 |
+| ILogger | Assembly | Microsoft.Extensions.Logging | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.Extensions.Logging.Abstractions | 2.0.0 | 9.65535.65535 |
+|  | Assembly | Microsoft.Extensions.Telemetry | 8.0.0 | 9.65535.65535 |
+|  | Package | Microsoft.Extensions.Telemetry | 8.10.0 | 8.10.0 |
+| Kafka | Assembly | Confluent.Kafka | 1.4.0 | 2.65535.65535 |
+|  | Package | Confluent.Kafka | 1.4.4 | 2.6.1 |
+| Log4Net | Assembly | log4net | 1.0.0 | 3.65535.65535 |
+|  | Package | log4net | 1.2.11 | 3.0.3 |
+| MongoDb | Assembly | MongoDB.Driver.Core | 2.1.0 | 2.65535.65535 |
+|  | Package | MongoDB.Driver | 2.0.2 | 2.30.0 |
+| Msmq | Assembly | System.Messaging | 4.0.0 | 4.65535.65535 |
+| MsTestV2 | Assembly | Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter | 14.0.0 | 14.65535.65535 |
+|  | Assembly | Microsoft.VisualStudio.TestPlatform.TestFramework | 14.0.0 | 14.65535.65535 |
+| MySql | Assembly | MySql.Data | 6.7.0 | 9.65535.65535 |
+|  | Assembly | MySqlConnector | 0.61.0 | 2.65535.65535 |
+|  | Package | MySql.Data | 6.7.9 | 9.1.0 |
+|  | Package | MySqlConnector | 0.61.0 | 2.4.0 |
+| NLog | Assembly | NLog | 1.0.0 | 5.65535.65535 |
+|  | Package | NLog | 1.0.0.505 | 5.3.4 |
+| Npgsql | Assembly | Npgsql | 4.0.0 | 8.65535.65535 |
+|  | Package | Npgsql | 4.1.14 | 8.0.6 |
+| NUnit | Assembly | nunit.framework | 3.0.0 | 4.65535.65535 |
+|  | Package | NUnit | 3.6.1 | 4.2.2 |
+| OpenTelemetry | Assembly | OpenTelemetry | 1.0.0 | 1.0.0 |
+|  | Assembly | OpenTelemetry.Api | 1.0.0 | 1.0.0 |
+|  | Package | OpenTelemetry.Api | 1.0.1 | 1.10.0 |
+| Oracle | Assembly | Oracle.DataAccess | 4.122.0 | 4.122.65535 |
+|  | Assembly | Oracle.ManagedDataAccess | 2.0.0 | 23.65535.65535 |
+| Process | Assembly | System | 1.0.0 | 9.65535.65535 |
+|  | Assembly | System.Diagnostics.Process | 1.0.0 | 9.65535.65535 |
+| RabbitMQ | Assembly | RabbitMQ.Client | 3.6.9 | 6.65535.65535 |
+|  | Package | RabbitMQ.Client | 3.6.9 | 6.8.1 |
+| Remoting | Assembly | System.Runtime.Remoting | 4.0.0 | 4.65535.65535 |
+| Selenium | Assembly | WebDriver | 3.0.0 | 4.65535.65535 |
+|  | Package | Selenium.WebDriver | 4.0.1 | 4.26.1 |
+| Serilog | Assembly | Serilog | 1.0.0 | 4.65535.65535 |
+|  | Package | Serilog | 1.4.214 | 4.1.0 |
+| ServiceStackRedis | Assembly | ServiceStack.Redis | 4.0.0 | 8.65535.65535 |
+|  | Package | ServiceStack.Redis | 4.5.14 | 8.4.0 |
+| SqlClient | Assembly | Microsoft.Data.SqlClient | 1.0.0 | 5.65535.65535 |
+|  | Assembly | Microsoft.Data.Sqlite | 2.0.0 | 9.65535.65535 |
+|  | Assembly | System.Data.SqlClient | 4.0.0 | 4.65535.65535 |
+|  | Assembly | System.Data.SQLite | 1.0.0 | 2.65535.65535 |
+|  | Package | Microsoft.Data.SqlClient | 1.1.4 | 5.2.2 |
+|  | Package | Microsoft.Data.Sqlite | 2.2.6 | 8.0.11 |
+|  | Package | System.Data.SqlClient | 4.1.0 | 4.9.0 |
+| Ssrf | Assembly | RestSharp | 104.0.0 | 112.65535.65535 |
+| StackExchangeRedis | Assembly | StackExchange.Redis | 1.0.0 | 2.65535.65535 |
+|  | Assembly | StackExchange.Redis.StrongName | 1.0.0 | 2.65535.65535 |
+|  | Package | StackExchange.Redis | 1.0.488 | 2.8.16 |
+| StackTraceLeak | Assembly | Microsoft.AspNetCore.Diagnostics | 2.0.0 | 9.65535.65535 |
+| TestPlatformAssemblyResolver | Assembly | Microsoft.TestPlatform.PlatformAbstractions | 15.0.0 | 15.65535.65535 |
+| Wcf | Assembly | System.ServiceModel | 4.0.0 | 4.65535.65535 |
+| WebRequest | Assembly | System.Net.Requests | 4.0.0 | 9.65535.65535 |
+| Xss | Assembly | Microsoft.AspNetCore.Html.Abstractions | 1.0.0 | 9.65535.65535 |
+| XUnit | Assembly | xunit.execution.desktop | 2.2.0 | 2.65535.65535 |
+|  | Assembly | xunit.execution.dotnet | 2.2.0 | 2.65535.65535 |
+|  | Package | xunit | 2.2.0 | 2.9.2 |


### PR DESCRIPTION
## Summary of changes

Adds functionality for us to automatically generate a markdown table of what integrations we support and their minimum and maximum versions.

## Reason for change

We'd like to automate this process away.
We'd like to provide more transparency in the versions that we actually _test_ with respect to the minimum version and the maximum version.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
