### PR TITLE
Use agent telemetry proxy instead of the standalone telemetry

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -47,11 +47,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         public static void AssertIntegrationEnabled(this MockTracerAgent mockAgent, IntegrationId integrationId)
+            => mockAgent.AssertIntegration(integrationId, enabled: true, autoEnabled: true);
+
+        public static void AssertIntegrationDisabled(this MockTracerAgent mockAgent, IntegrationId integrationId)
+            => mockAgent.AssertIntegration(integrationId, enabled: false, autoEnabled: true);
+
+        public static void AssertIntegration(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
         {
             mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
             var allData = mockAgent.Telemetry.Cast<TelemetryData>().ToArray();
-            AssertIntegration(allData, integrationId, true, true);
+            AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
         public static void AssertIntegration(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -103,8 +103,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var isExternalSpan = metadataSchemaVersion == "v0";
                 var clientSpanServiceName = isExternalSpan ? $"{EnvironmentHelper.FullSampleName}-http-client" : EnvironmentHelper.FullSampleName;
 
-                using var telemetry = this.ConfigureTelemetry();
-                using (var agent = EnvironmentHelper.GetMockAgent())
+                using (var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true))
                 using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
                 {
                     agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
@@ -166,11 +165,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     }
 
                     using var scope = new AssertionScope();
-                    telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
+                    agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
                     // ignore for now auto enabled for simplicity
-                    telemetry.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: IsUsingSocketHandler(instrumentation), autoEnabled: null);
-                    telemetry.AssertIntegration(IntegrationId.WinHttpHandler, enabled: IsUsingWinHttpHandler(instrumentation), autoEnabled: null);
-                    telemetry.AssertIntegration(IntegrationId.CurlHandler, enabled: IsUsingCurlHandler(instrumentation), autoEnabled: null);
+                    agent.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: IsUsingSocketHandler(instrumentation), autoEnabled: null);
+                    agent.AssertIntegration(IntegrationId.WinHttpHandler, enabled: IsUsingWinHttpHandler(instrumentation), autoEnabled: null);
+                    agent.AssertIntegration(IntegrationId.CurlHandler, enabled: IsUsingCurlHandler(instrumentation), autoEnabled: null);
                     VerifyInstrumentation(processResult.Process);
                 }
             }
@@ -197,10 +196,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 SetInstrumentationVerification();
                 ConfigureInstrumentation(instrumentation, enableSocketsHandler);
 
-                using var telemetry = this.ConfigureTelemetry();
                 int httpPort = TcpPortProvider.GetOpenPort();
 
-                using (var agent = EnvironmentHelper.GetMockAgent())
+                using (var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true))
                 using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
                 {
                     var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
@@ -216,10 +214,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     using var scope = new AssertionScope();
                     // ignore auto enabled for simplicity
-                    telemetry.AssertIntegrationDisabled(IntegrationId.HttpMessageHandler);
-                    telemetry.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: false, autoEnabled: null);
-                    telemetry.AssertIntegration(IntegrationId.WinHttpHandler, enabled: false, autoEnabled: null);
-                    telemetry.AssertIntegration(IntegrationId.CurlHandler, enabled: false, autoEnabled: null);
+                    agent.AssertIntegrationDisabled(IntegrationId.HttpMessageHandler);
+                    agent.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: false, autoEnabled: null);
+                    agent.AssertIntegration(IntegrationId.WinHttpHandler, enabled: false, autoEnabled: null);
+                    agent.AssertIntegration(IntegrationId.CurlHandler, enabled: false, autoEnabled: null);
                     VerifyInstrumentation(processResult.Process);
                 }
             }


### PR DESCRIPTION
## Summary of changes

Use the agent proxy instead of the standalone telemetry in the HttpMessageHandlerTests

## Reason for change

Currently (after updating the VM images) the non-socket handler tests fail due to a lack of telemetry. I really don't understand how or why - the logs show that we are _successfully_ sending telemetry _somewhere_ 😬 Will investigate that in parallel.

Note also, this _only_ impacts alpine with .NET Core 2.1, 3.0, and 3.1. Debian or .NET 5+ are unaffected 🤷‍♂️ 

## Implementation details

Switched to using the agent proxy for telemetry (and added some missing extension helpers to the helper)

## Test coverage

The same really, there's no reason we need to use the external telemetry proxy for these tests.

## Other details

Will follow up once we have more details. Hopefully this will finally unblock the builds