### PR TITLE
Add more info when GenerateDumpIfDbgRequested fails (take 3)

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -90,6 +90,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
             runner.Environment.SetVariable("COMPlus_DbgMiniDumpName", "/dev/null");
             runner.Environment.SetVariable("COMPlus_DbgMiniDumpType", string.Empty);
+            runner.Environment.SetVariable("COMPlus_CreateDumpDiagnostics", "1");
 
             using var processHelper = runner.LaunchProcess();
 


### PR DESCRIPTION
## Summary of changes

Enable createdump diagnostics during the `GenerateDumpIfDbgRequested` test.

## Reason for change

Thanks to the added information from https://github.com/DataDog/dd-trace-dotnet/pull/6197, I have good confidence that createdump is crashing before resuming the parent process. I hope that enabling diagnostic messages will give more insight as to why/where it crashes.

## Implementation details

Setting `COMPlus_CreateDumpDiagnostics=1`
