### PR TITLE
[ASM] iast: Fix for NullReferenceException in Stacktrace Walker

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/StackWalker.cs
+++ b/tracer/src/Datadog.Trace/Iast/StackWalker.cs
@@ -55,7 +55,8 @@ internal static class StackWalker
     public static bool TryGetFrame(StackTrace stackTrace, out StackFrame? targetFrame)
     {
         targetFrame = null;
-        foreach (var frame in stackTrace.GetFrames())
+        var frames = stackTrace.GetFrames() ?? Enumerable.Empty<StackFrame>();
+        foreach (var frame in frames)
         {
             var declaringType = frame?.GetMethod()?.DeclaringType;
 


### PR DESCRIPTION
## Summary of changes

In .NET Framework the `GetFrames()` method can return null.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
