### PR TITLE
[ASM]Fix appsec waf benchmark for real 

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/EmptyDatadogTracer.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/EmptyDatadogTracer.cs
@@ -19,15 +19,15 @@ namespace Benchmarks.Trace.Asm
     {
         public string DefaultServiceName => "My Service Name";
 
-        public ImmutableTracerSettings Settings => throw new NotImplementedException();
+        public ImmutableTracerSettings Settings => new(new NullConfigurationSource());
 
-        IGitMetadataTagsProvider IDatadogTracer.GitMetadataTagsProvider => throw new NotImplementedException();
+        IGitMetadataTagsProvider IDatadogTracer.GitMetadataTagsProvider => new NullGitMetadataProvider();
 
-        PerTraceSettings IDatadogTracer.PerTraceSettings => throw new NotImplementedException();
+        PerTraceSettings IDatadogTracer.PerTraceSettings => null;
 
         void IDatadogTracer.Write(ArraySegment<Span> span)
         {
-            throw new NotImplementedException();
+           
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Don't throw when creating a trace context and an empty datadog tracer

## Reason for change

It [was throwing](https://datadoghq.atlassian.net/browse/APMAPI-893) when creating the context.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
