### PR TITLE
[CI Visibility] Catch `UploadRepositoryChanges` exceptions

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
@@ -139,7 +139,19 @@ internal static class CiUtils
             if (ciVisibilitySettings.GitUploadEnabled != false || ciVisibilitySettings.IntelligentTestRunnerEnabled)
             {
                 // If we are in git upload only then we can defer the await until the child command exits.
-                uploadRepositoryChangesTask = Task.Run(() => lazyItrClient.Value.UploadRepositoryChangesAsync());
+                async Task UploadRepositoryChangesAsync()
+                {
+                    try
+                    {
+                        await lazyItrClient.Value.UploadRepositoryChangesAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "RunCiCommand: Error uploading repository git metadata.");
+                    }
+                }
+
+                uploadRepositoryChangesTask = Task.Run(UploadRepositoryChangesAsync);
 
                 // Once the repository has been uploaded we switch off the git upload in children processes
                 profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.GitUploadEnabled] = "0";


### PR DESCRIPTION
## Summary of changes

This PR adds some missing try/catch for the UploadRepositoryChanges calls.

## Reason for change

This method is being used in the `dd-trace` runner, currently if the method fails (backend error) then `dd-trace` will throw an exception.

## Implementation details

We create a function method to wrap the call with a try/catch block so we don't throw and fail the customer CI.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
