### PR TITLE
Trim whitespace in DBM_PROPAGATION_MODE

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -487,7 +487,7 @@ namespace Datadog.Trace.Configuration
                                 .WithKeys(ConfigurationKeys.DbmPropagationMode)
                                 .GetAs(
                                      () => new DefaultResult<DbmPropagationLevel>(DbmPropagationLevel.Disabled, nameof(DbmPropagationLevel.Disabled)),
-                                     converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
+                                     converter: x => ToDbmPropagationInput(x.Trim()) ?? ParsingResult<DbmPropagationLevel>.Failure(),
                                      validator: null);
 
             TraceId128BitGenerationEnabled = config

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -487,7 +487,7 @@ namespace Datadog.Trace.Configuration
                                 .WithKeys(ConfigurationKeys.DbmPropagationMode)
                                 .GetAs(
                                      () => new DefaultResult<DbmPropagationLevel>(DbmPropagationLevel.Disabled, nameof(DbmPropagationLevel.Disabled)),
-                                     converter: x => ToDbmPropagationInput(x.Trim()) ?? ParsingResult<DbmPropagationLevel>.Failure(),
+                                     converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
                                      validator: null);
 
             TraceId128BitGenerationEnabled = config
@@ -1303,6 +1303,7 @@ namespace Datadog.Trace.Configuration
 
         internal static DbmPropagationLevel? ToDbmPropagationInput(string inputValue)
         {
+            inputValue = inputValue.Trim(); // we know inputValue isn't null (and have tests for it)
             if (inputValue.Equals("disabled", StringComparison.OrdinalIgnoreCase))
             {
                 return DbmPropagationLevel.Disabled;

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1052,12 +1052,21 @@ namespace Datadog.Trace.Tests.Configuration
         // See TracerSettingsServerlessTests for tests which rely on environment variables
 
         [Theory]
-        [InlineData("", DbmPropagationLevel.Disabled)]
-        [InlineData(null, DbmPropagationLevel.Disabled)]
-        [InlineData("invalid", DbmPropagationLevel.Disabled)]
-        [InlineData("Disabled", DbmPropagationLevel.Disabled)]
-        [InlineData("full", DbmPropagationLevel.Full)]
-        [InlineData("SERVICE", DbmPropagationLevel.Service)]
+        [InlineData("", DbmPropagationLevel.Disabled)]              // empty string defaults to disabled
+        [InlineData(null, DbmPropagationLevel.Disabled)]            // null defaults to disabled
+        [InlineData("      ", DbmPropagationLevel.Disabled)]        // whitespace defaults to disabled
+        [InlineData("invalid", DbmPropagationLevel.Disabled)]       // invalid input
+        [InlineData("full", DbmPropagationLevel.Full)]              // exact match
+        [InlineData("service", DbmPropagationLevel.Service)]        // exact match
+        [InlineData("disabled", DbmPropagationLevel.Disabled)]      // exact match
+        [InlineData("Disabled", DbmPropagationLevel.Disabled)]      // case insenstive
+        [InlineData("SERVICE", DbmPropagationLevel.Service)]        // case insensitive
+        [InlineData("FuLl", DbmPropagationLevel.Full)]              // case insensitive
+        [InlineData(" service", DbmPropagationLevel.Service)]       // trim whitespace
+        [InlineData("service ", DbmPropagationLevel.Service)]       // trim whitespace
+        [InlineData("full   ", DbmPropagationLevel.Full)]           // trim whitespace
+        [InlineData("     disabled", DbmPropagationLevel.Disabled)] // trim whitespace
+        [InlineData("s e r v i c e", DbmPropagationLevel.Disabled)] // invalid input
         public void DbmPropagationMode(string value, object expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DbmPropagationMode, value));


### PR DESCRIPTION
## Summary of changes

Trims whitespace in `DBM_PROPAGATION_MODE`

## Reason for change

Saw usages of `DBM_PROPAGATION_MODE` : `service ` <- note the space at the end, which caused DBM to be disabled.

## Implementation details

Added `.Trim()`

## Test coverage

Added tests

## Other details
<!-- Fixes #{issue} -->

https://datadoghq.atlassian.net/browse/AIDM-493

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
