### PR TITLE
Change `ICorProfilerMethodEnum` to use the `COMPtr`

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -671,6 +671,43 @@ HRESULT IsTypeByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMetadat
 
 HRESULT IsTypeTokenByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMetadataBase& module_metadata, mdToken typeDefOrRefOrSpecToken,
                              bool& isTypeIsByRefLike);
+
+template<class MetaInterface>
+class COMPtrHolder {
+public:
+    COMPtrHolder() {
+        m_ptr = NULL;
+    }
+
+    COMPtrHolder(MetaInterface *ptr) {
+        if (ptr != NULL) {
+            ptr->AddRef();
+        }
+        m_ptr = ptr;
+    }
+
+    ~COMPtrHolder() {
+        if (m_ptr != NULL) {
+            m_ptr->Release();
+            m_ptr = NULL;
+        }
+    }
+
+    MetaInterface *operator->() {
+        return m_ptr;
+    }
+
+    MetaInterface **operator&() {
+        return &m_ptr;
+    }
+
+    operator MetaInterface *() {
+        return m_ptr;
+    }
+
+private:
+    MetaInterface *m_ptr;
+};
 } // namespace trace
 
 #endif // DD_CLR_PROFILER_CLR_HELPERS_H_

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -671,40 +671,6 @@ HRESULT IsTypeByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMetadat
 
 HRESULT IsTypeTokenByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMetadataBase& module_metadata, mdToken typeDefOrRefOrSpecToken,
                              bool& isTypeIsByRefLike);
-
-template<class MetaInterface>
-class COMPtrHolder {
-public:
-    COMPtrHolder() {
-        m_ptr = NULL;
-    }
-
-    COMPtrHolder(MetaInterface *ptr) {
-        m_ptr = ptr;
-    }
-
-    ~COMPtrHolder() {
-        if (m_ptr != NULL) {
-            m_ptr->Release();
-            m_ptr = NULL;
-        }
-    }
-
-    MetaInterface *operator->() {
-        return m_ptr;
-    }
-
-    MetaInterface **operator&() {
-        return &m_ptr;
-    }
-
-    operator MetaInterface *() {
-        return m_ptr;
-    }
-
-private:
-    MetaInterface *m_ptr;
-};
 } // namespace trace
 
 #endif // DD_CLR_PROFILER_CLR_HELPERS_H_

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -680,9 +680,6 @@ public:
     }
 
     COMPtrHolder(MetaInterface *ptr) {
-        if (ptr != NULL) {
-            ptr->AddRef();
-        }
         m_ptr = ptr;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -62,7 +62,7 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
     {
         // Now we enumerate all methods that inline the current methodDef
         BOOL incompleteData = false;
-        ICorProfilerMethodEnum* methodEnum;
+        COMPtrHolder<ICorProfilerMethodEnum> methodEnum = NULL;
 
         HRESULT hr = pInfo->EnumNgenModuleMethodsInliningThisMethod(moduleId, currentModuleId, currentMethodDef,
                                                                     &incompleteData, &methodEnum);
@@ -82,8 +82,7 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
                 methods.push_back(method.methodId);
                 total++;
             }
-            methodEnum->Release();
-            methodEnum = nullptr;
+
             if (total > 0)
             {
                 handler->EnqueueForRejit(modules, methods);

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -62,10 +62,10 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
     {
         // Now we enumerate all methods that inline the current methodDef
         BOOL incompleteData = false;
-        COMPtrHolder<ICorProfilerMethodEnum> methodEnum = NULL;
+        ComPtr<ICorProfilerMethodEnum> methodEnum;
 
         HRESULT hr = pInfo->EnumNgenModuleMethodsInliningThisMethod(moduleId, currentModuleId, currentMethodDef,
-                                                                    &incompleteData, &methodEnum);
+                                                                    &incompleteData, methodEnum.GetAddressOf());
         std::ostringstream hexValue;
         hexValue << std::hex << hr;
         if (SUCCEEDED(hr))


### PR DESCRIPTION
## Summary of changes

This PR changes the way we handle `ICorProfilerMethodEnum` to use the `COMPtr` to release it when it's out of scope.

## Reason for change

Match the rejitprofiler test in the dotnet runtime repo: https://github.com/dotnet/runtime/blob/98049e56a415d9bcf2d002fba71f399ba08cf39c/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp#L280-L281

and instead of manually calling `Release` use the `COMPtrHolder` to automatically release it.
