### PR TITLE
[Shared] Fix bug in logger

### DIFF
--- a/shared/src/native-src/logger.h
+++ b/shared/src/native-src/logger.h
@@ -196,18 +196,7 @@ concept IsWstring = same_as<T, ::shared::WSTRING> ||
 template <IsWstring T>
 void WriteToStream(std::ostringstream& oss, T const& x)
 {
-    if constexpr (std::is_same_v<T, ::shared::WSTRING>)
-    {
-        oss << ::shared::ToString(x);
-    }
-    else if constexpr (std::is_array_v<T>)
-    {
-        oss << ::shared::ToString(x, std::extent_v<T>);
-    }
-    else
-    {
-        oss << ::shared::ToString(x);
-    }
+    oss << ::shared::ToString(x);
 }
 
 template <class Period>


### PR DESCRIPTION
## Summary of changes

Fix a bug in the logger for `WCHAR[n]` string.

## Reason for change

When get a string from the Windows API (for ex:) like
```
WCHAR s[250];
auto nbChars = SuperOldApi(..., s, 250);
...
Log::Info(s);
```

The logger will write all the 250 characters even if the string is smaller.
Example `My Log Line^@Garbage^@^@^@^@^@`
Instead of `My Log Line`

## Implementation details

- Remove the template optimization and use `shared::ToString` instead

## Test coverage
- Add a test in the profiler unit tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
