### PR TITLE
[CI Visibility] Fix MSTest integrarion bug

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -278,17 +278,16 @@ internal static class MsTestIntegration
                     {
                         if (File.Exists(assemblyName))
                         {
-                            assemblyName = AssemblyName.GetAssemblyName(assemblyName).Name ?? string.Empty;
+                            assemblyName = AssemblyName.GetAssemblyName(assemblyName).Name;
                         }
                         else
                         {
-                            assemblyName = new AssemblyName(assemblyName).Name ?? string.Empty;
+                            assemblyName = new AssemblyName(assemblyName).Name;
                         }
                     }
                     catch (Exception ex)
                     {
                         Common.Log.Warning(ex, "Error getting assembly name from {AssemblyName}", assemblyName);
-                        assemblyName = string.Empty;
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -14,6 +15,7 @@ using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.dnlib.DotNet;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2;
 
@@ -266,15 +268,31 @@ internal static class MsTestIntegration
             objTestAssemblyInfo,
             key =>
             {
+                // assemblyName??? MsTest lies about this, if we check the usage it always use the Assembly.Location or similar...
+                // eg:
+                // https://github.com/microsoft/testfx/blob/5c829c1633fdca211c4a96a52a200f61ec85bd5c/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs#L379
+                // https://github.com/microsoft/testfx/blob/5c829c1633fdca211c4a96a52a200f61ec85bd5c/src/Adapter/MSTest.TestAdapter/Discovery/TypeEnumerator.cs#L145
                 if (assemblyName is not null)
                 {
-                    assemblyName = AssemblyName.GetAssemblyName(assemblyName).Name ?? string.Empty;
-                }
-                else
-                {
-                    assemblyName = string.Empty;
+                    try
+                    {
+                        if (File.Exists(assemblyName))
+                        {
+                            assemblyName = AssemblyName.GetAssemblyName(assemblyName).Name ?? string.Empty;
+                        }
+                        else
+                        {
+                            assemblyName = new AssemblyName(assemblyName).Name ?? string.Empty;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Common.Log.Warning(ex, "Error getting assembly name from {AssemblyName}", assemblyName);
+                        assemblyName = string.Empty;
+                    }
                 }
 
+                assemblyName ??= string.Empty;
                 var testAssembly = testAssemblyInfo.Type.Assembly;
                 var frameworkVersion = testAssembly.GetName().Version?.ToString() ?? string.Empty;
                 foreach (var module in testAssembly.Modules)


### PR DESCRIPTION
## Summary of changes

This PR fixes a bug found in the MsTest integration where the assemblyName is empty or an invalid filepath.

## Reason for change

We found an issue in error tracking about receiving an invalid assemblyName that couldn't be resolved because the file didn't exist.

## Implementation details

Now the code validates if the file exist to load it, if not it will try to parse the assembly name, catching all possible exceptions.

## Test coverage

This is a hard to test scenario.
