### PR TITLE
[Profiler] Force waiting for the `LibrariesInfoCache` service to be fully started

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.h
@@ -21,6 +21,14 @@ public:
     ~AutoResetEvent();
 
     void Set();
+
+    // Wait will block the execution of the thread until a call to Set is made
+    // or until it times out.
+    // [parameter] timeout : time to wait before returning.
+    //   if timeout == InfiniteTimeout, it will wait until Set is called.
+    //   if timeout != InfiniteTimeout, it will wait either for a call to Set either for the timeout.
+    // [Return]
+    //   true if Set was called, false is the call timed out.
     bool Wait(std::chrono::milliseconds timeout = InfiniteTimeout);
 
 private:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -33,8 +33,12 @@ bool LibrariesInfoCache::StartImpl()
     _librariesInfo.reserve(100);
     s_instance = this;
     unw_set_iterate_phdr_function(unw_local_addr_space, LibrariesInfoCache::DlIteratePhdr);
-    _worker = std::thread(&LibrariesInfoCache::Work, this);
-    return true;
+    AutoResetEvent startEvent(false);
+    _worker = std::thread(&LibrariesInfoCache::Work, this, std::ref(startEvent));
+    // We must wait for the thread to be fully started and the cache populated
+    // before reporting the service start status.
+    // 2s for CI
+    return startEvent.Wait(2s);
 }
 
 bool LibrariesInfoCache::StopImpl()
@@ -51,7 +55,7 @@ bool LibrariesInfoCache::StopImpl()
     return true;
 }
 
-void LibrariesInfoCache::Work()
+void LibrariesInfoCache::Work(AutoResetEvent& startEvent)
 {
     OpSysTools::SetNativeThreadName(WStr("DD_LibsCache"));
 
@@ -68,6 +72,7 @@ void LibrariesInfoCache::Work()
         timeout = defaultTimeout;
     }
 
+    bool firstCall = true;
     while (!_stopRequested)
     {
         // in the default case, notification mechanism in place, we will block until notification
@@ -80,6 +85,11 @@ void LibrariesInfoCache::Work()
         }
 
         UpdateCache();
+        if (firstCall)
+        {
+            firstCall = false;
+            startEvent.Set();
+        }
     }
 
     Log::Debug("Stopping worker: stop request received.");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -48,7 +48,7 @@ public:
 #ifdef DD_TEST
 private:
 #endif
-    void Work();
+    void Work(AutoResetEvent& startEvent);
 
     static LibrariesInfoCache* s_instance;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <libunwind.h>
 #include <link.h>
+#include <memory>
 #include <shared_mutex>
 #include <thread>
 #include <vector>
@@ -48,7 +49,7 @@ public:
 #ifdef DD_TEST
 private:
 #endif
-    void Work(AutoResetEvent& startEvent);
+    void Work(std::shared_ptr<AutoResetEvent> startEvent);
 
     static LibrariesInfoCache* s_instance;
 


### PR DESCRIPTION
## Summary of changes

`LibrariesInfoCache` service must be fully started before starting other services.

## Reason for change

`LibrariesInfoCache` builds a cache of libraries info and provides a custom implementation of `dl_iterate_phdr` to libunwind.  This prevent the profiler ending in deadlock situation (mainly lock inversion).

If the service is not fully started (callback not set for libunwind, cache not populated...), we can have issue to unwind but also be back in deadlock situation.

So we must make sure this service is fully started before starting the other services.

## Implementation details

- In `StartImpl`, pass an `AutoResetEvent` to the worker thread and wait for 2s for the call to `Set`
- In `Work`, call once the `startEvent` once the cache is populated.

## Test coverage

- Difficult to have one for this one :/
## Other details
Example of deadlock we face in CI
```
Thread 30 (LWP 9751):
#0  __syscall_cp_c (nr=202, u=140659226937600, v=128, w=-1, x=0, y=0, z=0) at ./arch/x86_64/syscall_arch.h:61
#1  0x00007fedc73d3ccd in __futex4_cp (to=0x0, val=-1, op=128, addr=0x7fedc7418900 <lock>) at src/thread/__timedwait.c:24
#2  __timedwait_cp (addr=addr@entry=0x7fedc7418900 <lock>, val=val@entry=-1, clk=clk@entry=0, at=at@entry=0x0, priv=priv@entry=128) at src/thread/__timedwait.c:52
#3  0x00007fedc73d3d74 in __timedwait (addr=addr@entry=0x7fedc7418900 <lock>, val=-1, clk=clk@entry=0, at=at@entry=0x0, priv=128) at src/thread/__timedwait.c:68
#4  0x00007fedc73d63e6 in __pthread_rwlock_timedrdlock (at=<optimized out>, rw=<optimized out>) at src/thread/pthread_rwlock_timedrdlock.c:18
#5  __pthread_rwlock_timedrdlock (rw=rw@entry=0x7fedc7418900 <lock>, at=at@entry=0x0) at src/thread/pthread_rwlock_timedrdlock.c:3
#6  0x00007fedc73d636f in __pthread_rwlock_rdlock (rw=rw@entry=0x7fedc7418900 <lock>) at src/thread/pthread_rwlock_rdlock.c:5
#7  0x00007fedc73de832 in dl_iterate_phdr (callback=0x7fedc5456940 <_ULx86_64_dwarf_callback>, data=0x7fedbe62f540) at ldso/dynlink.c:2360
#8  0x00007fedc737e6d4 in dl_iterate_phdr (callback=0x7fedc5456940 <_ULx86_64_dwarf_callback>, data=0x7fedbe62f540) at /project/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c:367
#9  0x00007fedc545703e in _ULx86_64_dwarf_find_proc_info (as=0x7fedc5b97680 <local_addr_space>, ip=ip@entry=140659226543154, pi=pi@entry=0x7fedbe6300a8, need_unwind_info=need_unwind_info@entry=1, arg=0x7fedbe62fba1) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gfind_proc_info-lsb.c:807
#10 0x00007fedc5452770 in fetch_proc_info (c=0x7fedbe62ff50, ip=140659226543154) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gparser.c:473
#11 0x00007fedc545443d in find_reg_state (sr=0x7fedbe62f7e0, c=0x7fedbe62ff50) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gparser.c:1024
#12 _ULx86_64_dwarf_step (c=c@entry=0x7fedbe62ff50) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gparser.c:1069
#13 0x00007fedc54513ca in _ULx86_64_step (cursor=cursor@entry=0x7fedbe62ff50) at /project/obj/libunwind-prefix/src/libunwind/src/x86_64/Gstep.c:75
#14 0x00007fedc5452217 in trace_init_addr (rsp=<optimized out>, rbp=<optimized out>, rip=140659226543154, cfa=<optimized out>, cursor=0x7fedbe62ff50, f=<optimized out>) at /project/obj/libunwind-prefix/src/libunwind/src/x86_64/Gtrace.c:249
#15 trace_lookup (rsp=<optimized out>, rbp=<optimized out>, rip=140659226543154, cfa=<optimized out>, cache=0x7fedc4b9cee0, cursor=0x7fedbe62ff50) at /project/obj/libunwind-prefix/src/libunwind/src/x86_64/Gtrace.c:331
#16 _ULx86_64_tdep_trace (cursor=cursor@entry=0x7fedbe62ff50, buffer=buffer@entry=0x7fedc31d8008, size=size@entry=0x7fedbe62fb8c) at /project/obj/libunwind-prefix/src/libunwind/src/x86_64/Gtrace.c:449
#17 0x00007fedc5450712 in unw_backtrace2 (buffer=0x7fedc31d8008, size=1024, uc2=0x7fedbe630840, flag=1) at /project/obj/libunwind-prefix/src/libunwind/src/mi/backtrace.c:111
#18 0x00007fedc53b194c in LinuxStackFramesCollector::CollectStackWithBacktrace2 (this=0x7fedc4d1bea0, ctx=0x7fedbe630840) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp:283
#19 LinuxStackFramesCollector::CollectCallStackCurrentThread (this=this@entry=0x7fedc4d1bea0, ctx=ctx@entry=0x7fedbe630840) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp:210
#20 0x00007fedc53b0cd3 in LinuxStackFramesCollector::CollectStackSampleSignalHandler (signal=<optimized out>, info=0x7fedbe630970, context=0x7fedbe630840) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp:378
#21 0x00007fedc53b88e1 in ProfilerSignalManager::CallCustomHandler (this=0x7fedc5b89b08 <ProfilerSignalManager::Get(int)::signalManagers+1944>, signal=10, info=0x7fedbe630970, context=0x7fedbe630840) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp:197
#22 ProfilerSignalManager::SignalHandler (signal=10, info=0x7fedbe630970, context=0x7fedbe630840) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp:188
#23 <signal handler called>
```
