### PR TITLE
Fix alpine .NET Core 3.1 telemetry failures

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -25,9 +25,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             helper.SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true");
             helper.SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_AGENTLESS_ENABLED", "true");
             helper.SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_AGENT_PROXY_ENABLED", "false");
-            helper.SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_URL", $"http://localhost:{telemetry.Port}");
+            var telemetryUrl = $"http://127.0.0.1:{telemetry.Port}";
+            helper.SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_URL", telemetryUrl);
             // removed, but necessary for some version conflict tests (e.g. TraceAnnotationsVersionMismatchNewerNuGetTests)
-            helper.SetEnvironmentVariable("DD_TRACE_TELEMETRY_URL", $"http://localhost:{telemetry.Port}");
+            helper.SetEnvironmentVariable("DD_TRACE_TELEMETRY_URL", telemetryUrl);
             // API key is required when using the custom url
             helper.SetEnvironmentVariable("DD_API_KEY", "INVALID_KEY_FOR_TESTS");
             // For legacy versions that don't use V2 by default


### PR DESCRIPTION
## Summary of changes

Fix the telemetry issues we saw after updating the VMs recently

## Reason for change

We updated the VMs and suddenly .NET Core <=3.1 started failing on alpine when we used the "standalone telemetry agent", only when using the "curl" handler (not the socket handler). 

We eventually traced it down to the fact we were setting the url to `localhost`, not `127.0.0.1` as we do elsewhere. Presumably an update to the underlying libcurl caused it to choose the IPv6 address, which the listener is not bound to, causing telemetry to fail

## Implementation details

- Reverted the change in https://github.com/DataDog/dd-trace-dotnet/pull/6324
- `localhost` -> `127.0.0.1` in the `TelemetryHelper`

## Test coverage

The same

## Other details

Reverting the change isn't necessary obviously, but it shows that we fixed it.