### PR TITLE
[ASM] Skip integration tests using Microsoft.Data.Sqlite on netcoreapp3.0

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -227,8 +227,15 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
     [InlineData("Microsoft.Data.Sqlite")]
     public async Task TestIastStoredXssRequest(string database)
     {
-        var filename = "Iast.StoredXss.AspNetCore5." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         var useMicrosoftDataDb = database == "Microsoft.Data.Sqlite";
+#if NETCOREAPP3_0
+        if (useMicrosoftDataDb && EnvironmentHelper.IsAlpine())
+        {
+            throw new SkipException();
+        }
+#endif
+
+        var filename = "Iast.StoredXss.AspNetCore5." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         if (RedactionEnabled is true) { filename += ".RedactionEnabled"; }
         var url = $"/Iast/StoredXss?param=<b>RawValue</b>&useMicrosoftDataDb={useMicrosoftDataDb}";
         IncludeAllHttpSpans = true;
@@ -255,8 +262,15 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
     [InlineData("Microsoft.Data.Sqlite")]
     public async Task TestIastStoredXssEscapedRequest(string database)
     {
-        var filename = "Iast.StoredXssEscaped.AspNetCore5." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         var useMicrosoftDataDb = database == "Microsoft.Data.Sqlite";
+#if NETCOREAPP3_0
+        if (useMicrosoftDataDb && EnvironmentHelper.IsAlpine())
+        {
+            throw new SkipException();
+        }
+#endif
+
+        var filename = "Iast.StoredXssEscaped.AspNetCore5." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         var url = $"/Iast/StoredXssEscaped?useMicrosoftDataDb={useMicrosoftDataDb}";
         IncludeAllHttpSpans = true;
         await TryStartApp();
@@ -282,8 +296,15 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
     [InlineData("Microsoft.Data.Sqlite")]
     public async Task TestIastStoredSqliRequest(string database)
     {
-        var filename = "Iast.StoredSqli.AspNetCore5." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         var useMicrosoftDataDb = database == "Microsoft.Data.Sqlite";
+#if NETCOREAPP3_0
+        if (useMicrosoftDataDb && EnvironmentHelper.IsAlpine())
+        {
+            throw new SkipException();
+        }
+#endif
+
+        var filename = "Iast.StoredSqli.AspNetCore5." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         var url = $"/Iast/StoredSqli?useMicrosoftDataDb={useMicrosoftDataDb}";
         IncludeAllHttpSpans = true;
         await TryStartApp();


### PR DESCRIPTION
## Summary of changes

Skip integration tests using `Microsoft.Data.Sqlite` on `netcoreapp3.0`.

## Reason for change

On the CI, the tests using the sqlite databse using `Microsoft.Data.Sqlite` on `netcoreapp3.0` were failing.