### PR TITLE
Update `dotnet test` tests to take memory dump on hang

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         }
                     };
 
-                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1))
                     {
                         var settings = VerifyHelper.GetCIVisibilitySpanVerifierSettings();
                         settings.UseTextForParameters("packageVersion=" + (expectedTestCount == 20 ? "pre_2_2_4" : "post_2_2_4"));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -437,7 +437,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     }
                 };
 
-                using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion);
+                using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1);
 
                 var packageVersionDescription = expectedTestCount == expectedSpansForPre224 ? "pre_2_2_4" : "post_2_2_4";
                 var settings = VerifyHelper.GetCIVisibilitySpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
                     agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
-                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1))
                     {
                         spans = agent.WaitForSpans(expectedSpanCount)
                                      .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -497,7 +497,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     }
                 };
 
-                using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion);
+                using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1);
 
                 var settings = VerifyHelper.GetCIVisibilitySpanVerifierSettings();
                 settings.UseTextForParameters(friendlyName);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -170,7 +170,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         }
                     };
 
-                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1))
                     {
                         var settings = VerifyHelper.GetCIVisibilitySpanVerifierSettings();
                         settings.UseTextForParameters("packageVersion=all");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
                     agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
-                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1))
                     {
                         spans = agent.WaitForSpans(ExpectedSpanCount)
                                      .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkRetriesTests.cs
@@ -94,7 +94,8 @@ public abstract class TestingFrameworkRetriesTests : TestingFrameworkEvpTest
 
             using var processResult = await RunDotnetTestSampleAndWaitForExit(
                                           agent,
-                                          packageVersion: packageVersion);
+                                          packageVersion: packageVersion,
+                                          expectedExitCode: 1);
 
             // 1 Module
             testModules.Should().HaveCount(1);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -453,7 +453,7 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
                 }
             };
 
-            using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1);
 
             // Check the tests, suites and modules count
             Assert.Equal(expectedSpans, tests.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -158,7 +158,8 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         using var processResult = await RunDotnetTestSampleAndWaitForExit(
                                       agent,
                                       arguments: "--collect:\"XPlat Code Coverage\"",
-                                      packageVersion: packageVersion);
+                                      packageVersion: packageVersion,
+                                      expectedExitCode: 1);
 
         // Check the tests, suites and modules count
         Assert.Equal(ExpectedTestCount, tests.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
             // We remove the evp_proxy endpoint to force the APM protocol compatibility
             agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
-            using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1);
             var spans = agent.WaitForSpans(ExpectedSpanCount)
                          .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))
                          .ToList();

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -115,47 +115,7 @@ namespace Datadog.Trace.TestHelpers
             var process = await StartDotnetTestSample(agent, arguments, packageVersion, aspNetCorePort: 5000, framework: framework, forceVsTestParam: forceVsTestParam);
 
             using var helper = new ProcessHelper(process);
-
-            process.WaitForExit();
-            helper.Drain();
-            var exitCode = process.ExitCode;
-
-            Output.WriteLine($"Exit Code: " + exitCode);
-
-            if (helper.EnvironmentVariables is { } environmentVariables)
-            {
-                var strEnvironmentVariables = new StringBuilder();
-                foreach (var envVar in environmentVariables)
-                {
-                    strEnvironmentVariables.AppendLine($"\t{envVar.Key}={envVar.Value}");
-                }
-
-                Output.WriteLine($"Environment Variables:{Environment.NewLine}{strEnvironmentVariables}");
-            }
-
-            var standardOutput = helper.StandardOutput;
-
-            if (!string.IsNullOrWhiteSpace(standardOutput))
-            {
-                Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
-            }
-            else
-            {
-                Output.WriteLine($"StandardOutput: (empty)");
-            }
-
-            var standardError = helper.ErrorOutput;
-
-            if (!string.IsNullOrWhiteSpace(standardError))
-            {
-                Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
-            }
-            else
-            {
-                Output.WriteLine($"StandardError: (empty)");
-            }
-
-            return new ProcessResult(process, standardOutput, standardError, exitCode);
+            return WaitForProcessResult(helper);
         }
 
         public async Task<Process> StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false)

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -110,12 +110,12 @@ namespace Datadog.Trace.TestHelpers
             return process;
         }
 
-        public async Task<ProcessResult> RunDotnetTestSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", bool forceVsTestParam = false)
+        public async Task<ProcessResult> RunDotnetTestSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", bool forceVsTestParam = false, int expectedExitCode = 0)
         {
             var process = await StartDotnetTestSample(agent, arguments, packageVersion, aspNetCorePort: 5000, framework: framework, forceVsTestParam: forceVsTestParam);
 
             using var helper = new ProcessHelper(process);
-            return WaitForProcessResult(helper, expectedExitCode: 1);
+            return WaitForProcessResult(helper, expectedExitCode);
         }
 
         public async Task<Process> StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false)

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.TestHelpers
             var process = await StartDotnetTestSample(agent, arguments, packageVersion, aspNetCorePort: 5000, framework: framework, forceVsTestParam: forceVsTestParam);
 
             using var helper = new ProcessHelper(process);
-            return WaitForProcessResult(helper);
+            return WaitForProcessResult(helper, expectedExitCode: 1);
         }
 
         public async Task<Process> StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false)


### PR DESCRIPTION
## Summary of changes

Updates `StartDotnetTestSample` to use the existing `WaitForProcessResult` that takes a memory dump

## Reason for change

We've seen some of the CI Vis tests failing recently with hangs. Hopefully this well help diagnose the issue

## Implementation details

Use the existing `WaitForProcessResult` - it's mostly the same code anyway and takes a memory dump if the process hasn't exited, and kills it, instead of waiting forever.

## Test coverage

If the tests pass, that's good enough for now
