### PR TITLE
Add more info when GenerateDumpIfDbgRequested fails (take 4)

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -94,7 +94,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             using var processHelper = runner.LaunchProcess();
 
-            var success = runner.WaitForExitOrCaptureDump(processHelper.Process, milliseconds: 30_000);
+            var success = processHelper.Process.WaitForExit(30_000);
             if (!success)
             {
                 var logger = runner.XUnitLogger;
@@ -102,6 +102,9 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
                 // Note: we don't drain because the process hasn't exited, but it means the output may be incomplete
                 logger.WriteLine("Standard output:");
                 logger.WriteLine(processHelper.StandardOutput);
+
+                logger.WriteLine("Error output:");
+                logger.WriteLine(processHelper.ErrorOutput);
 
                 var pid = processHelper.Process.Id;
 
@@ -138,13 +141,6 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
                 foreach (var process in processes)
                 {
                     logger.WriteLine($"Process: {process.ProcessName} ({process.Id})");
-
-                    if (process.ProcessName == "createdump")
-                    {
-                        var testBaseOutputDir = runner.Environment.GetTestOutputPath();
-                        process.GetAllThreadsStack(testBaseOutputDir, logger);
-                        process.TakeMemoryDump(testBaseOutputDir, logger);
-                    }
                 }
             }
 


### PR DESCRIPTION
## Summary of changes

Add more info to GenerateDumpIfDbgRequested, remove some.

## Reason for change

At this point we know that:
 - all the threads in the crashing process are suspended
 - createdump has exited and become a zombie process

We still don't know why createdump exited without resuming the threads in the crashing process.
At this point it's unlikely we'll able to get any further without enabling strace (createdump does not log an error when resuming threads failed), but I realized that we don't display the content of stderr (even though createdump puts error messages in stderr), so it's worth a try.

## Implementation details

To reduce noise, I removed some previous diagnostic actions that are not useful anymore:
 - we don't need the callstacks or dump of the crashing process anymore because we know the issue is that the threads aren't resumed
 - capturing a dump of createdump will always fail because the process is a zombie at that point