### PR TITLE
[Crashtracking] Zero the stackframe upon creation

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.cpp
@@ -191,7 +191,7 @@ std::vector<StackFrame> CrashReportingLinux::GetThreadFrames(int32_t tid, Resolv
         unw_get_reg(&cursor, UNW_REG_IP, &ip);
         unw_get_reg(&cursor, UNW_REG_SP, &sp);
 
-        StackFrame stackFrame;
+        StackFrame stackFrame{};
         stackFrame.ip = ip;
         stackFrame.sp = sp;
         stackFrame.isSuspicious = false;


### PR DESCRIPTION
## Summary of changes

Zero the stackframes on Linux on creation.

## Reason for change

Because they were not zero'd, we ended up with garbage in the pdb info fields.

## Implementation details

`{}`
