### PR TITLE
[CI Visibility] Specify if the user is setting the DD_SERVICE

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -16,6 +16,7 @@ using Datadog.Trace.Agent.StreamFactories;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Ci.CiEnvironment;
 using Datadog.Trace.Ci.Configuration;
+using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
@@ -134,6 +135,11 @@ namespace Datadog.Trace.Ci
             {
                 // Extract repository name from the git url and use it as a default service name.
                 tracerSettings.ServiceNameInternal = GetServiceNameFromRepository(CIEnvironmentValues.Instance.Repository);
+                tracerSettings.GlobalTagsInternal[CommonTags.UserProvidedTestServiceTag] = "false";
+            }
+            else
+            {
+                tracerSettings.GlobalTagsInternal[CommonTags.UserProvidedTestServiceTag] = "true";
             }
 
             // Normalize the service name
@@ -203,6 +209,11 @@ namespace Datadog.Trace.Ci
             {
                 // Extract repository name from the git url and use it as a default service name.
                 tracerSettings.ServiceNameInternal = GetServiceNameFromRepository(CIEnvironmentValues.Instance.Repository);
+                tracerSettings.GlobalTagsInternal[CommonTags.UserProvidedTestServiceTag] = "false";
+            }
+            else
+            {
+                tracerSettings.GlobalTagsInternal[CommonTags.UserProvidedTestServiceTag] = "true";
             }
 
             // Normalize the service name

--- a/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
@@ -204,4 +204,9 @@ internal static class CommonTags
     /// GIT PR Base branch name
     /// </summary>
     public const string GitPrBaseBranch = "git.pull_request.base_branch";
+
+    /// <summary>
+    /// Defines if the service is a user provided test service
+    /// </summary>
+    public const string UserProvidedTestServiceTag = "_dd.test.is_user_provided_service";
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -198,6 +198,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             targetTest.Meta.Remove(EarlyFlakeDetectionTags.TestIsNew);
                             targetTest.Meta.Remove(EarlyFlakeDetectionTags.TestIsRetry);
 
+                            // Remove user provided service tag
+                            targetTest.Meta.Remove(CommonTags.UserProvidedTestServiceTag);
+
                             // check the name
                             Assert.Equal("mstestv2.test", targetTest.Name);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -104,6 +104,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             targetSpan.Tags.Remove(EarlyFlakeDetectionTags.TestIsNew);
                             targetSpan.Tags.Remove(EarlyFlakeDetectionTags.TestIsRetry);
 
+                            // Remove user provided service tag
+                            targetSpan.Tags.Remove(CommonTags.UserProvidedTestServiceTag);
+
                             // check the name
                             Assert.Equal("mstestv2.test", targetSpan.Name);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -229,6 +229,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             targetTest.Meta.Remove(EarlyFlakeDetectionTags.TestIsNew);
                             targetTest.Meta.Remove(EarlyFlakeDetectionTags.TestIsRetry);
 
+                            // Remove user provided service tag
+                            targetTest.Meta.Remove(CommonTags.UserProvidedTestServiceTag);
+
                             // check the name
                             Assert.Equal("nunit.test", targetTest.Name);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -98,6 +98,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             targetSpan.Tags.Remove(EarlyFlakeDetectionTags.TestIsNew);
                             targetSpan.Tags.Remove(EarlyFlakeDetectionTags.TestIsRetry);
 
+                            // Remove user provided service tag
+                            targetSpan.Tags.Remove(CommonTags.UserProvidedTestServiceTag);
+
                             // check the name
                             targetSpan.Name.Should().Be("nunit.test");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -203,6 +203,9 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
                 targetTest.Meta.Remove(EarlyFlakeDetectionTags.TestIsNew);
                 targetTest.Meta.Remove(EarlyFlakeDetectionTags.TestIsRetry);
 
+                // Remove user provided service tag
+                targetTest.Meta.Remove(CommonTags.UserProvidedTestServiceTag);
+
                 // check the name
                 Assert.Equal("xunit.test", targetTest.Name);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -72,6 +72,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     targetSpan.Tags.Remove(EarlyFlakeDetectionTags.TestIsNew);
                     targetSpan.Tags.Remove(EarlyFlakeDetectionTags.TestIsRetry);
 
+                    // Remove user provided service tag
+                    targetSpan.Tags.Remove(CommonTags.UserProvidedTestServiceTag);
+
                     // check the name
                     Assert.Equal("xunit.test", targetSpan.Name);
 

--- a/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=post_2_2_4_all_efd.verified.txt
+++ b/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=post_2_2_4_all_efd.verified.txt
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -122,7 +123,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -187,7 +189,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -252,7 +255,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -317,7 +321,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -382,7 +387,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -447,7 +453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -512,7 +519,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -577,7 +585,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -642,7 +651,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -706,7 +716,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -770,7 +781,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -835,7 +847,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -900,7 +913,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -965,7 +979,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1030,7 +1045,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1095,7 +1111,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1160,7 +1177,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1225,7 +1243,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1290,7 +1309,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1355,7 +1375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1419,7 +1440,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1484,7 +1506,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1549,7 +1572,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1614,7 +1638,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1679,7 +1704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1744,7 +1770,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1809,7 +1836,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1874,7 +1902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1939,7 +1968,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2004,7 +2034,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2068,7 +2099,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2137,7 +2169,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2207,7 +2240,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2277,7 +2311,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2347,7 +2382,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2417,7 +2453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2487,7 +2524,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2557,7 +2595,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2627,7 +2666,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2697,7 +2737,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2767,7 +2808,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2836,7 +2878,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2906,7 +2949,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2976,7 +3020,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3046,7 +3091,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3116,7 +3162,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3186,7 +3233,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3256,7 +3304,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3326,7 +3375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3396,7 +3446,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3466,7 +3517,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3535,7 +3587,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3605,7 +3658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3675,7 +3729,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3745,7 +3800,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3815,7 +3871,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3885,7 +3942,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3955,7 +4013,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4025,7 +4084,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4095,7 +4155,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4165,7 +4226,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4233,7 +4295,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4302,7 +4365,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4371,7 +4435,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4440,7 +4505,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4509,7 +4575,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4578,7 +4645,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4647,7 +4715,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4716,7 +4785,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4785,7 +4855,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4854,7 +4925,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4919,7 +4991,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4985,7 +5058,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5051,7 +5125,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5117,7 +5192,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5183,7 +5259,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5249,7 +5326,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5315,7 +5393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5381,7 +5460,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5447,7 +5527,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5513,7 +5594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5578,7 +5660,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5644,7 +5727,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5710,7 +5794,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5776,7 +5861,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5842,7 +5928,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5908,7 +5995,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5974,7 +6062,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6040,7 +6129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6106,7 +6196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6172,7 +6263,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6237,7 +6329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6303,7 +6396,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6369,7 +6463,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6435,7 +6530,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6501,7 +6597,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6567,7 +6664,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6633,7 +6731,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6699,7 +6798,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6765,7 +6865,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6831,7 +6932,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6895,7 +6997,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6960,7 +7063,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7025,7 +7129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7090,7 +7195,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7155,7 +7261,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7220,7 +7327,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7285,7 +7393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7350,7 +7459,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7415,7 +7525,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7480,7 +7591,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7546,7 +7658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7613,7 +7726,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7680,7 +7794,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7747,7 +7862,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7813,7 +7929,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7882,7 +7999,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7952,7 +8070,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8022,7 +8141,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8092,7 +8212,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8162,7 +8283,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8232,7 +8354,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8302,7 +8425,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8372,7 +8496,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8442,7 +8567,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8512,7 +8638,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8577,7 +8704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8643,7 +8771,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8709,7 +8838,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8775,7 +8905,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8841,7 +8972,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8907,7 +9039,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8973,7 +9106,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9039,7 +9173,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9105,7 +9240,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9171,7 +9307,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9238,7 +9375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9302,7 +9440,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9367,7 +9506,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9432,7 +9572,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9497,7 +9638,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9562,7 +9704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9627,7 +9770,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9692,7 +9836,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9757,7 +9902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9822,7 +9968,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9887,7 +10034,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=post_2_2_4_efd_with_test_bypass.verified.txt
+++ b/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=post_2_2_4_efd_with_test_bypass.verified.txt
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -122,7 +123,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -187,7 +189,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -252,7 +255,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -317,7 +321,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -382,7 +387,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -447,7 +453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -512,7 +519,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -577,7 +585,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -642,7 +651,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -706,7 +716,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -770,7 +781,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -835,7 +847,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -900,7 +913,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -965,7 +979,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1030,7 +1045,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1095,7 +1111,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1160,7 +1177,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1225,7 +1243,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1290,7 +1309,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1355,7 +1375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1419,7 +1440,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1484,7 +1506,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1549,7 +1572,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1614,7 +1638,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1679,7 +1704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1744,7 +1770,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1809,7 +1836,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1874,7 +1902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1939,7 +1968,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2004,7 +2034,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2068,7 +2099,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2137,7 +2169,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2207,7 +2240,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2277,7 +2311,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2347,7 +2382,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2417,7 +2453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2487,7 +2524,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2557,7 +2595,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2627,7 +2666,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2697,7 +2737,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2767,7 +2808,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2836,7 +2878,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2906,7 +2949,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2976,7 +3020,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3046,7 +3091,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3116,7 +3162,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3186,7 +3233,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3256,7 +3304,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3326,7 +3375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3396,7 +3446,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3466,7 +3517,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3535,7 +3587,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3605,7 +3658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3675,7 +3729,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3745,7 +3800,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3815,7 +3871,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3885,7 +3942,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3955,7 +4013,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4025,7 +4084,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4095,7 +4155,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4165,7 +4226,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4233,7 +4295,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4302,7 +4365,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4371,7 +4435,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4440,7 +4505,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4509,7 +4575,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4578,7 +4645,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4647,7 +4715,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4716,7 +4785,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4785,7 +4855,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4854,7 +4925,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4919,7 +4991,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4985,7 +5058,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5051,7 +5125,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5117,7 +5192,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5183,7 +5259,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5249,7 +5326,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5315,7 +5393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5381,7 +5460,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5447,7 +5527,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5513,7 +5594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5578,7 +5660,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5644,7 +5727,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5710,7 +5794,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5776,7 +5861,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5842,7 +5928,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5908,7 +5995,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5974,7 +6062,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6040,7 +6129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6106,7 +6196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6172,7 +6263,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6237,7 +6329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6303,7 +6396,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6369,7 +6463,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6435,7 +6530,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6501,7 +6597,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6567,7 +6664,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6633,7 +6731,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6699,7 +6798,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6765,7 +6865,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6831,7 +6932,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6895,7 +6997,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6960,7 +7063,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7025,7 +7129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7090,7 +7195,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7155,7 +7261,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7220,7 +7327,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7285,7 +7393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7350,7 +7459,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7415,7 +7525,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7480,7 +7591,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7546,7 +7658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7613,7 +7726,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7680,7 +7794,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7747,7 +7862,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7813,7 +7929,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7882,7 +7999,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7952,7 +8070,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8022,7 +8141,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8092,7 +8212,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8162,7 +8283,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8232,7 +8354,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8302,7 +8425,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8372,7 +8496,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8442,7 +8567,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8512,7 +8638,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8576,7 +8703,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8643,7 +8771,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8707,7 +8836,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8772,7 +8902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8837,7 +8968,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8902,7 +9034,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8967,7 +9100,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9032,7 +9166,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9097,7 +9232,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9162,7 +9298,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9227,7 +9364,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9292,7 +9430,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=pre_2_2_4_all_efd.verified.txt
+++ b/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=pre_2_2_4_all_efd.verified.txt
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -122,7 +123,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -187,7 +189,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -252,7 +255,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -317,7 +321,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -382,7 +387,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -447,7 +453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -512,7 +519,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -577,7 +585,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -642,7 +651,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -706,7 +716,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -770,7 +781,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -835,7 +847,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -900,7 +913,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -965,7 +979,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1030,7 +1045,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1095,7 +1111,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1160,7 +1177,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1225,7 +1243,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1290,7 +1309,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1355,7 +1375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1419,7 +1440,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1484,7 +1506,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1549,7 +1572,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1614,7 +1638,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1679,7 +1704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1744,7 +1770,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1809,7 +1836,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1874,7 +1902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1939,7 +1968,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2004,7 +2034,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2068,7 +2099,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2137,7 +2169,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2207,7 +2240,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2277,7 +2311,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2347,7 +2382,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2417,7 +2453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2487,7 +2524,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2557,7 +2595,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2627,7 +2666,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2697,7 +2737,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2767,7 +2808,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2836,7 +2878,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2906,7 +2949,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2976,7 +3020,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3046,7 +3091,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3116,7 +3162,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3186,7 +3233,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3256,7 +3304,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3326,7 +3375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3396,7 +3446,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3466,7 +3517,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3535,7 +3587,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3605,7 +3658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3675,7 +3729,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3745,7 +3800,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3815,7 +3871,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3885,7 +3942,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3955,7 +4013,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4025,7 +4084,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4095,7 +4155,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4165,7 +4226,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4233,7 +4295,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4302,7 +4365,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4371,7 +4435,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4440,7 +4505,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4509,7 +4575,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4578,7 +4645,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4647,7 +4715,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4716,7 +4785,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4785,7 +4855,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4854,7 +4925,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4919,7 +4991,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4985,7 +5058,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5051,7 +5125,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5117,7 +5192,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5183,7 +5259,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5249,7 +5326,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5315,7 +5393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5381,7 +5460,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5447,7 +5527,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5513,7 +5594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5578,7 +5660,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5644,7 +5727,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5710,7 +5794,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5776,7 +5861,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5842,7 +5928,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5908,7 +5995,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5974,7 +6062,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6040,7 +6129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6106,7 +6196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6172,7 +6263,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6237,7 +6329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6303,7 +6396,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6369,7 +6463,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6435,7 +6530,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6501,7 +6597,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6567,7 +6664,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6633,7 +6731,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6699,7 +6798,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6765,7 +6865,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6831,7 +6932,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6895,7 +6997,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6960,7 +7063,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7025,7 +7129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7090,7 +7195,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7155,7 +7261,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7220,7 +7327,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7285,7 +7393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7350,7 +7459,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7415,7 +7525,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7480,7 +7591,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7546,7 +7658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7613,7 +7726,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7679,7 +7793,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7748,7 +7863,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7818,7 +7934,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7888,7 +8005,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7958,7 +8076,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8028,7 +8147,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8098,7 +8218,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8168,7 +8289,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8238,7 +8360,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8308,7 +8431,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8378,7 +8502,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8443,7 +8568,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8509,7 +8635,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8575,7 +8702,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8641,7 +8769,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8707,7 +8836,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8773,7 +8903,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8839,7 +8970,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8905,7 +9037,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8971,7 +9104,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9037,7 +9171,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9104,7 +9239,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9168,7 +9304,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9233,7 +9370,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9298,7 +9436,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9363,7 +9502,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9428,7 +9568,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9493,7 +9634,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9558,7 +9700,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9623,7 +9766,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9688,7 +9832,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9753,7 +9898,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=pre_2_2_4_efd_with_test_bypass.verified.txt
+++ b/tracer/test/snapshots/MsTestV2EvpTests.EarlyFlakeDetection_packageVersion=pre_2_2_4_efd_with_test_bypass.verified.txt
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -122,7 +123,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -187,7 +189,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -252,7 +255,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -317,7 +321,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -382,7 +387,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -447,7 +453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -512,7 +519,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -577,7 +585,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -642,7 +651,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -706,7 +716,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -770,7 +781,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -835,7 +847,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -900,7 +913,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -965,7 +979,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1030,7 +1045,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1095,7 +1111,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1160,7 +1177,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1225,7 +1243,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1290,7 +1309,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1355,7 +1375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1419,7 +1440,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1484,7 +1506,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1549,7 +1572,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1614,7 +1638,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1679,7 +1704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1744,7 +1770,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1809,7 +1836,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1874,7 +1902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1939,7 +1968,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2004,7 +2034,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2068,7 +2099,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2137,7 +2169,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2207,7 +2240,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2277,7 +2311,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2347,7 +2382,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2417,7 +2453,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2487,7 +2524,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2557,7 +2595,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2627,7 +2666,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2697,7 +2737,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2767,7 +2808,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2836,7 +2878,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2906,7 +2949,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2976,7 +3020,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3046,7 +3091,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3116,7 +3162,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3186,7 +3233,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3256,7 +3304,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3326,7 +3375,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3396,7 +3446,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3466,7 +3517,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3535,7 +3587,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3605,7 +3658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3675,7 +3729,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3745,7 +3800,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3815,7 +3871,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3885,7 +3942,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3955,7 +4013,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4025,7 +4084,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4095,7 +4155,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4165,7 +4226,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4233,7 +4295,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4302,7 +4365,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4371,7 +4435,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4440,7 +4505,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4509,7 +4575,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4578,7 +4645,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4647,7 +4715,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4716,7 +4785,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4785,7 +4855,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4854,7 +4925,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4919,7 +4991,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4985,7 +5058,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5051,7 +5125,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5117,7 +5192,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5183,7 +5259,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5249,7 +5326,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5315,7 +5393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5381,7 +5460,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5447,7 +5527,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5513,7 +5594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5578,7 +5660,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5644,7 +5727,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5710,7 +5794,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5776,7 +5861,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5842,7 +5928,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5908,7 +5995,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5974,7 +6062,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6040,7 +6129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6106,7 +6196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6172,7 +6263,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6237,7 +6329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6303,7 +6396,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6369,7 +6463,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6435,7 +6530,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6501,7 +6597,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6567,7 +6664,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6633,7 +6731,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6699,7 +6798,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6765,7 +6865,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6831,7 +6932,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6895,7 +6997,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6960,7 +7063,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7025,7 +7129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7090,7 +7195,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7155,7 +7261,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7220,7 +7327,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7285,7 +7393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7350,7 +7459,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7415,7 +7525,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7480,7 +7591,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7546,7 +7658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7613,7 +7726,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7679,7 +7793,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7748,7 +7863,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7818,7 +7934,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7888,7 +8005,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7958,7 +8076,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8028,7 +8147,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8098,7 +8218,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8168,7 +8289,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8238,7 +8360,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8308,7 +8431,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8378,7 +8502,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8442,7 +8567,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8509,7 +8635,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8573,7 +8700,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8638,7 +8766,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8703,7 +8832,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8768,7 +8898,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8833,7 +8964,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8898,7 +9030,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8963,7 +9096,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9028,7 +9162,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9093,7 +9228,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9158,7 +9294,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2EvpTests.SubmitTraces_packageVersion=post_2_2_4.verified.txt
+++ b/tracer/test/snapshots/MsTestV2EvpTests.SubmitTraces_packageVersion=post_2_2_4.verified.txt
@@ -56,7 +56,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -119,7 +120,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -182,7 +184,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -245,7 +248,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -308,7 +312,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -376,7 +381,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -444,7 +450,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -512,7 +519,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -579,7 +587,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -643,7 +652,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -707,7 +717,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -771,7 +782,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -834,7 +846,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -899,7 +912,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -965,7 +979,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1031,7 +1046,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1097,7 +1113,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1162,7 +1179,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1230,7 +1248,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1294,7 +1313,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1360,7 +1380,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1423,7 +1444,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2EvpTests.SubmitTraces_packageVersion=pre_2_2_4.verified.txt
+++ b/tracer/test/snapshots/MsTestV2EvpTests.SubmitTraces_packageVersion=pre_2_2_4.verified.txt
@@ -56,7 +56,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -119,7 +120,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -182,7 +184,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -245,7 +248,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -308,7 +312,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -376,7 +381,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -444,7 +450,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -512,7 +519,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -579,7 +587,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -643,7 +652,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -707,7 +717,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -771,7 +782,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -834,7 +846,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -899,7 +912,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -965,7 +979,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1030,7 +1045,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1098,7 +1114,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1162,7 +1179,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1228,7 +1246,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1291,7 +1310,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2Tests.SubmitTraces_packageVersion=post_2_2_4.verified.txt
+++ b/tracer/test/snapshots/MsTestV2Tests.SubmitTraces_packageVersion=post_2_2_4.verified.txt
@@ -53,7 +53,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -115,7 +116,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -177,7 +179,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -239,7 +242,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -301,7 +305,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -368,7 +373,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -435,7 +441,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -502,7 +509,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -568,7 +576,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -631,7 +640,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -694,7 +704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -757,7 +768,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -819,7 +831,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -883,7 +896,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -948,7 +962,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1013,7 +1028,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1078,7 +1094,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1142,7 +1159,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1209,7 +1227,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1272,7 +1291,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1337,7 +1357,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1399,7 +1420,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2Tests.SubmitTraces_packageVersion=pre_2_2_4.verified.txt
+++ b/tracer/test/snapshots/MsTestV2Tests.SubmitTraces_packageVersion=pre_2_2_4.verified.txt
@@ -53,7 +53,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -115,7 +116,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -177,7 +179,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -239,7 +242,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -301,7 +305,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -368,7 +373,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -435,7 +441,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -502,7 +509,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -568,7 +576,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -631,7 +640,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -694,7 +704,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -757,7 +768,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -819,7 +831,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -883,7 +896,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -948,7 +962,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1012,7 +1027,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1079,7 +1095,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1142,7 +1159,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1207,7 +1225,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1269,7 +1288,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2Tests2.SubmitTraces_packageVersion=post_2_2_4.verified.txt
+++ b/tracer/test/snapshots/MsTestV2Tests2.SubmitTraces_packageVersion=post_2_2_4.verified.txt
@@ -49,7 +49,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -111,7 +112,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -173,7 +175,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -235,7 +238,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -302,7 +306,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -369,7 +374,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -436,7 +442,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -502,7 +509,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -565,7 +573,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -628,7 +637,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -691,7 +701,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -753,7 +764,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -817,7 +829,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -882,7 +895,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -947,7 +961,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1012,7 +1027,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1076,7 +1092,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1143,7 +1160,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1206,7 +1224,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1271,7 +1290,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1333,7 +1353,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/MsTestV2Tests2.SubmitTraces_packageVersion=pre_2_2_4.verified.txt
+++ b/tracer/test/snapshots/MsTestV2Tests2.SubmitTraces_packageVersion=pre_2_2_4.verified.txt
@@ -49,7 +49,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -111,7 +112,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -173,7 +175,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -235,7 +238,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -302,7 +306,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -369,7 +374,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -436,7 +442,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -502,7 +509,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -565,7 +573,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -628,7 +637,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -691,7 +701,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -753,7 +764,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -817,7 +829,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -882,7 +895,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -946,7 +960,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1013,7 +1028,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1076,7 +1092,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1141,7 +1158,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1203,7 +1221,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/NUnitEvpTests.EarlyFlakeDetection_all_efd.verified.txt
+++ b/tracer/test/snapshots/NUnitEvpTests.EarlyFlakeDetection_all_efd.verified.txt
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -125,7 +126,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -190,7 +192,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -256,7 +259,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -322,7 +326,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -388,7 +393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -454,7 +460,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -520,7 +527,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -586,7 +594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -652,7 +661,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -718,7 +728,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -784,7 +795,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -849,7 +861,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -915,7 +928,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -981,7 +995,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1047,7 +1062,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1113,7 +1129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1179,7 +1196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1245,7 +1263,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1311,7 +1330,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1377,7 +1397,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1443,7 +1464,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1511,7 +1533,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1580,7 +1603,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1649,7 +1673,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1718,7 +1743,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1787,7 +1813,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1856,7 +1883,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1925,7 +1953,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1994,7 +2023,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2063,7 +2093,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2132,7 +2163,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2200,7 +2232,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2269,7 +2302,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2338,7 +2372,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2407,7 +2442,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2476,7 +2512,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2545,7 +2582,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2614,7 +2652,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2683,7 +2722,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2752,7 +2792,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2821,7 +2862,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2889,7 +2931,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2958,7 +3001,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3027,7 +3071,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3096,7 +3141,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3165,7 +3211,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3234,7 +3281,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3303,7 +3351,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3372,7 +3421,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3441,7 +3491,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3510,7 +3561,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3578,7 +3630,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3647,7 +3700,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3716,7 +3770,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3785,7 +3840,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3854,7 +3910,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3923,7 +3980,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3992,7 +4050,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4061,7 +4120,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4130,7 +4190,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4199,7 +4260,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4267,7 +4329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4336,7 +4399,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4405,7 +4469,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4474,7 +4539,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4543,7 +4609,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4612,7 +4679,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4681,7 +4749,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4750,7 +4819,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4819,7 +4889,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4888,7 +4959,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4956,7 +5028,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5025,7 +5098,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5094,7 +5168,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5163,7 +5238,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5232,7 +5308,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5301,7 +5378,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5370,7 +5448,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5439,7 +5518,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5508,7 +5588,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5577,7 +5658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5641,7 +5723,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5706,7 +5789,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5771,7 +5855,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5836,7 +5921,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5901,7 +5987,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5966,7 +6053,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6031,7 +6119,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6096,7 +6185,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6161,7 +6251,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6226,7 +6317,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6292,7 +6384,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6357,7 +6450,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6423,7 +6517,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6489,7 +6584,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6555,7 +6651,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6621,7 +6718,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6687,7 +6785,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6753,7 +6852,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6819,7 +6919,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6885,7 +6986,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6951,7 +7053,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7020,7 +7123,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7090,7 +7194,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7160,7 +7265,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7230,7 +7336,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7300,7 +7407,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7370,7 +7478,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7440,7 +7549,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7510,7 +7620,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7580,7 +7691,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7650,7 +7762,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7719,7 +7832,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7789,7 +7903,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7859,7 +7974,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7929,7 +8045,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7999,7 +8116,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8069,7 +8187,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8139,7 +8258,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8209,7 +8329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8279,7 +8400,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8349,7 +8471,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8418,7 +8541,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8488,7 +8612,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8558,7 +8683,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8628,7 +8754,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8698,7 +8825,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8768,7 +8896,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8838,7 +8967,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8908,7 +9038,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8978,7 +9109,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9048,7 +9180,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9116,7 +9249,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9185,7 +9319,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9254,7 +9389,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9323,7 +9459,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9392,7 +9529,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9461,7 +9599,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9530,7 +9669,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9599,7 +9739,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9668,7 +9809,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9737,7 +9879,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9803,7 +9946,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9870,7 +10014,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9937,7 +10082,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10004,7 +10150,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10071,7 +10218,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10138,7 +10286,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10205,7 +10354,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10272,7 +10422,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10339,7 +10490,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10406,7 +10558,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10472,7 +10625,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10539,7 +10693,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10606,7 +10761,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10673,7 +10829,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10740,7 +10897,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10807,7 +10965,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10874,7 +11033,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10941,7 +11101,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11008,7 +11169,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11075,7 +11237,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11141,7 +11304,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11208,7 +11372,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11275,7 +11440,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11342,7 +11508,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11409,7 +11576,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11476,7 +11644,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11543,7 +11712,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11610,7 +11780,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11677,7 +11848,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11744,7 +11916,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11808,7 +11981,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11873,7 +12047,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11938,7 +12113,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12003,7 +12179,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12068,7 +12245,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12133,7 +12311,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12198,7 +12377,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12263,7 +12443,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12328,7 +12509,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12393,7 +12575,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12459,7 +12642,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12526,7 +12710,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12593,7 +12778,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12660,7 +12846,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12726,7 +12913,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12795,7 +12983,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12865,7 +13054,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12935,7 +13125,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13005,7 +13196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13075,7 +13267,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13145,7 +13338,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13215,7 +13409,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13285,7 +13480,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13355,7 +13551,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13425,7 +13622,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13490,7 +13688,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13556,7 +13755,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13622,7 +13822,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13688,7 +13889,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13754,7 +13956,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13820,7 +14023,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13886,7 +14090,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13952,7 +14157,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14018,7 +14224,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14084,7 +14291,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14151,7 +14359,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14215,7 +14424,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14280,7 +14490,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14345,7 +14556,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14410,7 +14622,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14475,7 +14688,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14540,7 +14754,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14605,7 +14820,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14670,7 +14886,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14735,7 +14952,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14800,7 +15018,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14864,7 +15083,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14929,7 +15149,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14994,7 +15215,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15059,7 +15281,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15124,7 +15347,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15189,7 +15413,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15254,7 +15479,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15319,7 +15545,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15384,7 +15611,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15449,7 +15677,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15517,7 +15746,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15586,7 +15816,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15655,7 +15886,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15724,7 +15956,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15793,7 +16026,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15862,7 +16096,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15931,7 +16166,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16000,7 +16236,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16069,7 +16306,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16138,7 +16376,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16202,7 +16441,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16267,7 +16507,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16332,7 +16573,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16397,7 +16639,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16462,7 +16705,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16527,7 +16771,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16592,7 +16837,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16657,7 +16903,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16722,7 +16969,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16787,7 +17035,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/NUnitEvpTests.EarlyFlakeDetection_efd_with_test_bypass.verified.txt
+++ b/tracer/test/snapshots/NUnitEvpTests.EarlyFlakeDetection_efd_with_test_bypass.verified.txt
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -125,7 +126,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -190,7 +192,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -256,7 +259,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -322,7 +326,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -388,7 +393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -454,7 +460,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -520,7 +527,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -586,7 +594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -652,7 +661,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -718,7 +728,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -784,7 +795,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -849,7 +861,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -915,7 +928,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -981,7 +995,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1047,7 +1062,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1113,7 +1129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1179,7 +1196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1245,7 +1263,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1311,7 +1330,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1377,7 +1397,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1443,7 +1464,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1511,7 +1533,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1580,7 +1603,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1649,7 +1673,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1718,7 +1743,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1787,7 +1813,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1856,7 +1883,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1925,7 +1953,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1994,7 +2023,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2063,7 +2093,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2132,7 +2163,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2200,7 +2232,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2269,7 +2302,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2338,7 +2372,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2407,7 +2442,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2476,7 +2512,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2545,7 +2582,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2614,7 +2652,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2683,7 +2722,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2752,7 +2792,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2821,7 +2862,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2889,7 +2931,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2958,7 +3001,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3027,7 +3071,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3096,7 +3141,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3165,7 +3211,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3234,7 +3281,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3303,7 +3351,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3372,7 +3421,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3441,7 +3491,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3510,7 +3561,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3578,7 +3630,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3647,7 +3700,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3716,7 +3770,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3785,7 +3840,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3854,7 +3910,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3923,7 +3980,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3992,7 +4050,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4061,7 +4120,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4130,7 +4190,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4199,7 +4260,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4267,7 +4329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4336,7 +4399,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4405,7 +4469,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4474,7 +4539,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4543,7 +4609,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4612,7 +4679,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4681,7 +4749,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4750,7 +4819,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4819,7 +4889,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4888,7 +4959,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4956,7 +5028,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5025,7 +5098,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5094,7 +5168,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5163,7 +5238,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5232,7 +5308,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5301,7 +5378,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5370,7 +5448,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5439,7 +5518,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5508,7 +5588,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5577,7 +5658,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5641,7 +5723,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5706,7 +5789,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5771,7 +5855,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5836,7 +5921,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5901,7 +5987,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5966,7 +6053,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6031,7 +6119,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6096,7 +6185,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6161,7 +6251,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6226,7 +6317,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6292,7 +6384,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6357,7 +6450,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6423,7 +6517,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6489,7 +6584,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6555,7 +6651,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6621,7 +6718,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6687,7 +6785,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6753,7 +6852,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6819,7 +6919,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6885,7 +6986,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6951,7 +7053,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7020,7 +7123,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7090,7 +7194,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7160,7 +7265,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7230,7 +7336,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7300,7 +7407,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7370,7 +7478,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7440,7 +7549,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7510,7 +7620,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7580,7 +7691,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7650,7 +7762,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7719,7 +7832,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7789,7 +7903,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7859,7 +7974,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7929,7 +8045,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7999,7 +8116,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8069,7 +8187,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8139,7 +8258,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8209,7 +8329,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8279,7 +8400,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8349,7 +8471,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8418,7 +8541,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8488,7 +8612,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8558,7 +8683,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8628,7 +8754,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8698,7 +8825,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8768,7 +8896,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8838,7 +8967,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8908,7 +9038,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8978,7 +9109,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9048,7 +9180,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9116,7 +9249,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9185,7 +9319,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9254,7 +9389,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9323,7 +9459,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9392,7 +9529,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9461,7 +9599,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9530,7 +9669,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9599,7 +9739,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9668,7 +9809,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9737,7 +9879,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9803,7 +9946,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9870,7 +10014,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -9937,7 +10082,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10004,7 +10150,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10071,7 +10218,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10138,7 +10286,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10205,7 +10354,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10272,7 +10422,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10339,7 +10490,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10406,7 +10558,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10472,7 +10625,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10539,7 +10693,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10606,7 +10761,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10673,7 +10829,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10740,7 +10897,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10807,7 +10965,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10874,7 +11033,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -10941,7 +11101,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11008,7 +11169,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11075,7 +11237,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11141,7 +11304,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11208,7 +11372,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11275,7 +11440,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11342,7 +11508,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11409,7 +11576,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11476,7 +11644,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11543,7 +11712,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11610,7 +11780,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11677,7 +11848,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11744,7 +11916,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11808,7 +11981,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11873,7 +12047,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -11938,7 +12113,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12003,7 +12179,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12068,7 +12245,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12133,7 +12311,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12198,7 +12377,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12263,7 +12443,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12328,7 +12509,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12393,7 +12575,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12459,7 +12642,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12526,7 +12710,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12593,7 +12778,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12660,7 +12846,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12726,7 +12913,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12795,7 +12983,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12865,7 +13054,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -12935,7 +13125,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13005,7 +13196,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13075,7 +13267,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13145,7 +13338,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13215,7 +13409,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13285,7 +13480,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13355,7 +13551,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13425,7 +13622,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13489,7 +13687,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13556,7 +13755,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13620,7 +13820,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13685,7 +13886,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13750,7 +13952,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13815,7 +14018,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13880,7 +14084,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -13945,7 +14150,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14010,7 +14216,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14075,7 +14282,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14140,7 +14348,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14205,7 +14414,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14269,7 +14479,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14334,7 +14545,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14399,7 +14611,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14464,7 +14677,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14529,7 +14743,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14594,7 +14809,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14659,7 +14875,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14724,7 +14941,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14789,7 +15007,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14854,7 +15073,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14922,7 +15142,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -14991,7 +15212,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15060,7 +15282,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15129,7 +15352,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15198,7 +15422,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15267,7 +15492,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15336,7 +15562,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15405,7 +15632,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15474,7 +15702,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15543,7 +15772,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15607,7 +15837,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15672,7 +15903,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15737,7 +15969,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15802,7 +16035,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15867,7 +16101,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15932,7 +16167,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -15997,7 +16233,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16062,7 +16299,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16127,7 +16365,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -16192,7 +16431,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/NUnitEvpTests.SubmitTraces_packageVersion=all.verified.txt
+++ b/tracer/test/snapshots/NUnitEvpTests.SubmitTraces_packageVersion=all.verified.txt
@@ -56,7 +56,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -123,7 +124,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -187,7 +189,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -251,7 +254,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -318,7 +322,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -385,7 +390,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -452,7 +458,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -519,7 +526,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -586,7 +594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -653,7 +662,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -716,7 +726,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -781,7 +792,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -845,7 +857,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -913,7 +926,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -981,7 +995,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1049,7 +1064,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1116,7 +1132,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1181,7 +1198,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1246,7 +1264,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1311,7 +1330,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1374,7 +1394,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1439,7 +1460,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1505,7 +1527,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1571,7 +1594,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1637,7 +1661,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1702,7 +1727,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1770,7 +1796,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1834,7 +1861,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1900,7 +1928,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1963,7 +1992,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2026,7 +2056,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2093,7 +2124,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2156,7 +2188,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/NUnitTests.SubmitTraces_packageVersion=all.verified.txt
+++ b/tracer/test/snapshots/NUnitTests.SubmitTraces_packageVersion=all.verified.txt
@@ -53,7 +53,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -119,7 +120,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -182,7 +184,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -245,7 +248,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -311,7 +315,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -377,7 +382,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -443,7 +449,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -509,7 +516,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -575,7 +583,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -641,7 +650,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -703,7 +713,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -767,7 +778,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -830,7 +842,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -897,7 +910,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -964,7 +978,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1031,7 +1046,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1097,7 +1113,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1161,7 +1178,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1225,7 +1243,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1289,7 +1308,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1351,7 +1371,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1415,7 +1436,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1480,7 +1502,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1545,7 +1568,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1610,7 +1634,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1674,7 +1699,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1741,7 +1767,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1804,7 +1831,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1869,7 +1897,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1931,7 +1960,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1993,7 +2023,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2059,7 +2090,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2121,7 +2153,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/SeleniumTests.Injection_all_versions.verified.txt
+++ b/tracer/test/snapshots/SeleniumTests.Injection_all_versions.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/XUnitEvpTests.EarlyFlakeDetection_all_efd.verified.txt
+++ b/tracer/test/snapshots/XUnitEvpTests.EarlyFlakeDetection_all_efd.verified.txt
@@ -58,7 +58,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -128,7 +129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -198,7 +200,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -268,7 +271,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -338,7 +342,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -408,7 +413,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -478,7 +484,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -548,7 +555,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -618,7 +626,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -688,7 +697,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -757,7 +767,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -827,7 +838,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -897,7 +909,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -967,7 +980,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1037,7 +1051,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1107,7 +1122,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1177,7 +1193,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1247,7 +1264,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1317,7 +1335,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1387,7 +1406,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1456,7 +1476,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1526,7 +1547,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1596,7 +1618,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1666,7 +1689,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1736,7 +1760,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1806,7 +1831,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1876,7 +1902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1946,7 +1973,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2016,7 +2044,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2086,7 +2115,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2154,7 +2184,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2223,7 +2254,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2292,7 +2324,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2361,7 +2394,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2430,7 +2464,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2499,7 +2534,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2568,7 +2604,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2637,7 +2674,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2706,7 +2744,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2775,7 +2814,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2840,7 +2880,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2906,7 +2947,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2972,7 +3014,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3038,7 +3081,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3104,7 +3148,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3170,7 +3215,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3236,7 +3282,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3302,7 +3349,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3368,7 +3416,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3434,7 +3483,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3499,7 +3549,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3565,7 +3616,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3631,7 +3683,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3697,7 +3750,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3763,7 +3817,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3829,7 +3884,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3895,7 +3951,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3961,7 +4018,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4027,7 +4085,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4093,7 +4152,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4158,7 +4218,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4224,7 +4285,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4290,7 +4352,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4356,7 +4419,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4422,7 +4486,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4488,7 +4553,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4554,7 +4620,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4620,7 +4687,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4686,7 +4754,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4752,7 +4821,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4816,7 +4886,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4881,7 +4952,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4946,7 +5018,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5011,7 +5084,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5076,7 +5150,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5141,7 +5216,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5206,7 +5282,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5271,7 +5348,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5336,7 +5414,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5401,7 +5480,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5467,7 +5547,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5533,7 +5614,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5599,7 +5681,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5668,7 +5751,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5738,7 +5822,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5808,7 +5893,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5878,7 +5964,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5948,7 +6035,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6018,7 +6106,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6088,7 +6177,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6158,7 +6248,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6228,7 +6319,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6298,7 +6390,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6363,7 +6456,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6429,7 +6523,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6495,7 +6590,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6561,7 +6657,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6627,7 +6724,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6693,7 +6791,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6759,7 +6858,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6825,7 +6925,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6891,7 +6992,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6957,7 +7059,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7024,7 +7127,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7088,7 +7192,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7153,7 +7258,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7218,7 +7324,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7283,7 +7390,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7348,7 +7456,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7413,7 +7522,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7478,7 +7588,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7543,7 +7654,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7608,7 +7720,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7673,7 +7786,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7737,7 +7851,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7802,7 +7917,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7867,7 +7983,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7932,7 +8049,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7997,7 +8115,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8062,7 +8181,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8127,7 +8247,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8192,7 +8313,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8257,7 +8379,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -8322,7 +8445,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/XUnitEvpTests.EarlyFlakeDetection_efd_with_test_bypass.verified.txt
+++ b/tracer/test/snapshots/XUnitEvpTests.EarlyFlakeDetection_efd_with_test_bypass.verified.txt
@@ -58,7 +58,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -128,7 +129,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -198,7 +200,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -268,7 +271,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -338,7 +342,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -408,7 +413,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -478,7 +484,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -548,7 +555,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -618,7 +626,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -688,7 +697,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -757,7 +767,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -827,7 +838,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -897,7 +909,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -967,7 +980,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1037,7 +1051,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1107,7 +1122,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1177,7 +1193,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1247,7 +1264,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1317,7 +1335,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1387,7 +1406,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1456,7 +1476,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1526,7 +1547,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1596,7 +1618,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1666,7 +1689,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1736,7 +1760,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1806,7 +1831,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1876,7 +1902,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1946,7 +1973,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2016,7 +2044,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2086,7 +2115,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2154,7 +2184,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2223,7 +2254,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2292,7 +2324,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2361,7 +2394,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2430,7 +2464,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2499,7 +2534,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2568,7 +2604,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2637,7 +2674,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2706,7 +2744,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2775,7 +2814,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2840,7 +2880,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2906,7 +2947,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -2972,7 +3014,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3038,7 +3081,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3104,7 +3148,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3170,7 +3215,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3236,7 +3282,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3302,7 +3349,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3368,7 +3416,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3434,7 +3483,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3499,7 +3549,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3565,7 +3616,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3631,7 +3683,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3697,7 +3750,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3763,7 +3817,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3829,7 +3884,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3895,7 +3951,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -3961,7 +4018,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4027,7 +4085,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4093,7 +4152,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4158,7 +4218,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4224,7 +4285,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4290,7 +4352,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4356,7 +4419,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4422,7 +4486,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4488,7 +4553,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4554,7 +4620,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4620,7 +4687,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4686,7 +4754,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4752,7 +4821,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4816,7 +4886,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4881,7 +4952,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -4946,7 +5018,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5011,7 +5084,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5076,7 +5150,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5141,7 +5216,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5206,7 +5282,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5271,7 +5348,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5336,7 +5414,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5401,7 +5480,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5467,7 +5547,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5533,7 +5614,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5599,7 +5681,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5668,7 +5751,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5738,7 +5822,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5808,7 +5893,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5878,7 +5964,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -5948,7 +6035,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6018,7 +6106,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6088,7 +6177,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6158,7 +6248,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6228,7 +6319,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6298,7 +6390,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6362,7 +6455,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6429,7 +6523,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6493,7 +6588,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6558,7 +6654,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6623,7 +6720,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6688,7 +6786,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6753,7 +6852,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6818,7 +6918,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6883,7 +6984,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -6948,7 +7050,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7013,7 +7116,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7078,7 +7182,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7142,7 +7247,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7207,7 +7313,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7272,7 +7379,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7337,7 +7445,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7402,7 +7511,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7467,7 +7577,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7532,7 +7643,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7597,7 +7709,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7662,7 +7775,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -7727,7 +7841,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/XUnitEvpTests.SubmitTraces_packageVersion=all.verified.txt
+++ b/tracer/test/snapshots/XUnitEvpTests.SubmitTraces_packageVersion=all.verified.txt
@@ -57,7 +57,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -125,7 +126,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -193,7 +195,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -260,7 +263,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -324,7 +328,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -388,7 +393,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -452,7 +458,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -515,7 +522,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -580,7 +588,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -645,7 +654,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -710,7 +720,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -778,7 +789,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -842,7 +854,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -908,7 +921,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -971,7 +985,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1034,7 +1049,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/XUnitTests.SubmitTraces_packageVersion=all.verified.txt
+++ b/tracer/test/snapshots/XUnitTests.SubmitTraces_packageVersion=all.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -54,7 +54,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -121,7 +122,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -188,7 +190,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -254,7 +257,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -317,7 +321,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -380,7 +385,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -443,7 +449,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -505,7 +512,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -569,7 +577,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -633,7 +642,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -697,7 +707,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -764,7 +775,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -827,7 +839,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -892,7 +905,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -954,7 +968,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,
@@ -1016,7 +1031,8 @@
       test.working_directory: CommandWorkingDirectory,
       version: 1.0.0,
       _dd.ci.env_vars: {"SYSTEM_TEAMPROJECTID":"TeamProjectId","BUILD_BUILDID":"BuildId","SYSTEM_JOBID":"JobId"},
-      _dd.origin: ciapp-test
+      _dd.origin: ciapp-test,
+      _dd.test.is_user_provided_service: true
     },
     Metrics: {
       process_id: 0,


### PR DESCRIPTION
## Summary of changes

This PR sets a tag to let the ci visibility backend know if the DD_SERVICE value was provided by the user or auto-generated.

## Reason for change

This required by the backend.

## Test coverage

- Updated snapshots.
- Fixed tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
