### PR TITLE
Try enabling debug in `EnumerateAssemblyReferencesTest`

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         public EnumerateAssemblyReferencesTest(ITestOutputHelper output)
             : base(output, "EnumerateAssemblyReferences")
         {
+            SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
         }
 
         [SkippableFact]


### PR DESCRIPTION
## Summary of changes

Enable debug mode

## Reason for change

This test crashes on shutdown when _apparently_ everything has exited gracefully. Enabling debug on the off-chance it reveals something

## Implementation details

`DD_TRACE_DEBUG=1`
