### PR TITLE
Exclude InetMgr.exe from instrumentation

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -30,6 +30,7 @@ const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace.exe"),
     WStr("devenv.exe"),
     WStr("iisexpresstray.exe"),
+    WStr("InetMgr.exe"),
     WStr("Microsoft.ServiceHub.Controller.exe"),
     WStr("MSBuild.exe"),
     WStr("MsDtsSrvr.exe"),

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -72,6 +72,7 @@ const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace.exe"),
     WStr("devenv.exe"),
     WStr("iisexpresstray.exe"),
+    WStr("InetMgr.exe"),
     WStr("Microsoft.ServiceHub.Controller.exe"),
     WStr("MSBuild.exe"),
     WStr("MsDtsSrvr.exe"),


### PR DESCRIPTION
## Summary of changes

Excludes `InetMgr.exe` from traced processes

## Reason for change

There's no reason to trace this process

## Implementation details

Add to the exclude list

## Other details

Didn't bother adding it to the SSI list seeing as it's Windows only