### PR TITLE
[Crashtracker] Fix missing GetThreadDescription symbol

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/CrashReportingWindows.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/CrashReportingWindows.cpp
@@ -6,6 +6,7 @@
 #include "CrashReportingWindows.h"
 #include "TlHelp32.h"
 #include "DbgHelp.h"
+#include "OpSysTools.h"
 #include "Psapi.h"
 
 #include <shared/src/native-src/string.h>
@@ -75,15 +76,8 @@ std::vector<std::pair<int32_t, std::string>> CrashReportingWindows::GetThreads()
 
                 if (thread.IsValid())
                 {
-                    std::string threadName;
-                    PWSTR description;
-
-                    if (SUCCEEDED(GetThreadDescription(thread, &description)))
-                    {
-                        threadName = shared::ToString(description);
-                    }
-
-                    threads.push_back({ threadEntry.th32ThreadID, std::move(threadName) });
+                    auto wThreadName = OpSysTools::GetNativeThreadName(thread);
+                    threads.push_back({ threadEntry.th32ThreadID, shared::ToString(wThreadName) });
                 }
             }
         } while (Thread32Next(threadSnapshot, &threadEntry));


### PR DESCRIPTION
## Summary of changes

This should fix the [issue](https://github.com/DataDog/dd-trace-dotnet/issues/6353)
 
## Reason for change

Crashtracker uses `GetThreadDescription`  function from `kernel32.dll` (or kernelbase.dll). Which makes this function to be required for loading the `Datadog.Profiler.Native.dll`.

For some reason, the dynamic loader/linker is unable to find this function. To prevent this, we reuse what's in `OpSysTools`.

## Implementation details

- Use `OpSysTools::GetThreadName` and convert the `WSTRING`  to `std::string`.

## Test coverage

## Other details

We need to checks that threads are correctly retrieved in crashtracker.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
