### PR TITLE
Call `HttpRequest.BuildUrl` to avoid URL caching

### DIFF
--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -151,9 +151,7 @@ namespace Datadog.Trace.AspNet
                 string host = requestHeaders.Get("Host");
                 var userAgent = requestHeaders.Get(HttpHeaderNames.UserAgent);
                 string httpMethod = httpRequest.HttpMethod.ToUpperInvariant();
-                var url = tracer.Settings.BypassHttpRequestUrlCachingEnabled
-                    ? httpContext.Request.BuildUrlForSpan(tracer.TracerManager.QueryStringManager)
-                    : httpContext.Request.GetUrlForSpan(tracer.TracerManager.QueryStringManager);
+                var url = httpContext.Request.GetUrlForSpan(tracer.TracerManager.QueryStringManager, tracer.Settings.BypassHttpRequestUrlCachingEnabled);
                 var tags = new WebTags();
                 scope = tracer.StartActiveInternal(_requestOperationName, extractedContext.SpanContext, tags: tags);
                 // Leave resourceName blank for now - we'll update it in OnEndRequest

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -742,6 +742,8 @@ namespace Datadog.Trace.Configuration
             /// when an obfuscation mechanism will be implemented in the agent.
             /// </summary>
             internal const string CommandsCollectionEnabled = "DD_TRACE_COMMANDS_COLLECTION_ENABLED";
+
+            public const string BypassHttpRequestUrlCachingEnabled = "DD_TRACE_BYPASS_HTTP_REQUEST_URL_CACHING_ENABLED";
         }
 
         internal static class Telemetry

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -575,6 +575,9 @@ namespace Datadog.Trace.Configuration
                                        .WithKeys(ConfigurationKeys.FeatureFlags.CommandsCollectionEnabled)
                                        .AsBool(false);
 
+            BypassHttpRequestUrlCachingEnabled = config.WithKeys(ConfigurationKeys.FeatureFlags.BypassHttpRequestUrlCachingEnabled)
+                                                       .AsBool(false);
+
             var defaultDisabledAdoNetCommandTypes = new string[] { "InterceptableDbCommand", "ProfiledDbCommand" };
             var userDisabledAdoNetCommandTypes = config.WithKeys(ConfigurationKeys.DisabledAdoNetCommandTypes).AsString();
 
@@ -1043,6 +1046,12 @@ namespace Datadog.Trace.Configuration
         /// the "command_execution" integration to the agent.
         /// </summary>
         internal bool CommandsCollectionEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the tracer will bypass .NET Framework's
+        /// HttpRequestUrl caching when HttpRequest.Url is accessed.
+        /// </summary>
+        internal bool BypassHttpRequestUrlCachingEnabled { get; }
 
         /// <summary>
         /// Gets the AAS settings

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -530,6 +530,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("wcf_obfuscation_enabled");
                     writer.WriteValue(instanceSettings.WcfObfuscationEnabled);
 
+                    writer.WritePropertyName("bypass_http_request_url_caching_enabled");
+                    writer.WriteValue(instanceSettings.BypassHttpRequestUrlCachingEnabled);
+
                     writer.WritePropertyName("data_streams_enabled");
                     writer.WriteValue(instanceSettings.IsDataStreamsMonitoringEnabled);
 

--- a/tracer/src/Datadog.Trace/Util/DuckTypes/IHttpRequest.cs
+++ b/tracer/src/Datadog.Trace/Util/DuckTypes/IHttpRequest.cs
@@ -18,7 +18,6 @@ namespace Datadog.Trace.Util.DuckTypes
         [DuckField(Name = "_wr")]
         object? WorkerRequest { get; }
 
-        [Duck(Name = "BuildUrl")]
         Uri BuildUrl(Func<string> pathAccessor);
     }
 }

--- a/tracer/src/Datadog.Trace/Util/DuckTypes/IHttpRequest.cs
+++ b/tracer/src/Datadog.Trace/Util/DuckTypes/IHttpRequest.cs
@@ -1,0 +1,24 @@
+// <copyright file="IHttpRequest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.Util.DuckTypes
+{
+    /// <summary>
+    /// Ducktype for System.Web.HttpRequest https://referencesource.microsoft.com/#System.Web/HttpRequest.cs,1931
+    /// </summary>
+    internal interface IHttpRequest
+    {
+        [DuckField(Name = "_wr")]
+        object? WorkerRequest { get; }
+
+        [Duck(Name = "BuildUrl")]
+        Uri BuildUrl(Func<string> pathAccessor);
+    }
+}

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -25,27 +25,26 @@ namespace Datadog.Trace.Util.Http
         /// for all future callers (example the customer's application) if we are the first to call <see cref="HttpRequest.Url"/>.
         /// </para>
         /// <para>
-        /// To avoid this, use <see cref="BuildUrlForSpan(HttpRequest, QueryStringManager)"/> instead.
+        /// To bypass this set <paramref name="bypassHttpRequestUrl"/> to <c>true</c> which is controlled by
+        /// <see cref="Configuration.ConfigurationKeys.FeatureFlags.BypassHttpRequestUrlCachingEnabled"/>.
         /// </para>
         /// </summary>
         /// <param name="request">The <see cref="HttpRequest"/> to get the Uri of.</param>
         /// <param name="queryStringManager">The <see cref="QueryStringManager"/> for obfuscation/quantization.</param>
+        /// <param name="bypassHttpRequestUrl">Whether or not to call access HttpRequest.Url (which caches the URL in HttpRequest).</param>
         /// <returns>The retrieved Url.</returns>
-        internal static string GetUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager)
-            => HttpRequestUtils.GetUrl(RequestDataHelper.GetUrl(request), queryStringManager);
-
-        /// <summary>
-        /// Builds the Url from the <paramref name="request"/>.
-        /// <para>
-        /// Note that this will <em>bypass</em> the caching behavior of the <see cref="HttpRequest.Url"/> property.
-        /// </para>
-        /// </summary>
-        /// <param name="request">The <see cref="HttpRequest"/> to build the <c>Uri</c> from.</param>
-        /// <param name="queryStringManager">The <see cref="QueryStringManager"/> for obfuscation/quantization.</param>
-        /// <returns>The built Url.</returns>
-        /// <remarks>While not <em>required</em> to be set this is controlled by <see cref="Configuration.ConfigurationKeys.FeatureFlags.BypassHttpRequestUrlCachingEnabled"/>.</remarks>
-        internal static string BuildUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager)
-            => HttpRequestUtils.GetUrl(RequestDataHelper.BuildUrl(request), queryStringManager);
+        /// <seealso cref="Configuration.ConfigurationKeys.FeatureFlags.BypassHttpRequestUrlCachingEnabled"/>
+        internal static string GetUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager, bool bypassHttpRequestUrl)
+        {
+            if (bypassHttpRequestUrl)
+            {
+                return HttpRequestUtils.GetUrl(RequestDataHelper.BuildUrl(request), queryStringManager);
+            }
+            else
+            {
+                return HttpRequestUtils.GetUrl(RequestDataHelper.GetUrl(request), queryStringManager);
+            }
+        }
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -18,8 +18,34 @@ namespace Datadog.Trace.Util.Http
         internal static string GetUrlForSpan(this HttpRequestBase request, QueryStringManager queryStringManager)
             => HttpRequestUtils.GetUrl(request.Url, queryStringManager);
 
+        /// <summary>
+        /// Gets the Url from the <paramref name="request"/>.
+        /// <para>
+        /// Note that this will <em>CACHE</em> the <c>Uri</c> of the <paramref name="request"/>
+        /// for all future callers (example the customer's application) if we are the first to call <see cref="HttpRequest.Url"/>.
+        /// </para>
+        /// <para>
+        /// To avoid this, use <see cref="BuildUrlForSpan(HttpRequest, QueryStringManager)"/> instead.
+        /// </para>
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequest"/> to get the Uri of.</param>
+        /// <param name="queryStringManager">The <see cref="QueryStringManager"/> for obfuscation/quantization.</param>
+        /// <returns>The retrieved Url.</returns>
         internal static string GetUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager)
             => HttpRequestUtils.GetUrl(RequestDataHelper.GetUrl(request), queryStringManager);
+
+        /// <summary>
+        /// Builds the Url from the <paramref name="request"/>.
+        /// <para>
+        /// Note that this will <em>bypass</em> the caching behavior of the <see cref="HttpRequest.Url"/> property.
+        /// </para>
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequest"/> to build the <c>Uri</c> from.</param>
+        /// <param name="queryStringManager">The <see cref="QueryStringManager"/> for obfuscation/quantization.</param>
+        /// <returns>The built Url.</returns>
+        /// <remarks>While not <em>required</em> to be set this is controlled by <see cref="Configuration.ConfigurationKeys.FeatureFlags.BypassHttpRequestUrlCachingEnabled"/>.</remarks>
+        internal static string BuildUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager)
+            => HttpRequestUtils.GetUrl(RequestDataHelper.BuildUrl(request), queryStringManager);
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
@@ -6,9 +6,11 @@
 using System;
 #if NETFRAMEWORK
 using System.Collections.Specialized;
+using System.Reflection;
 using System.Web;
 using System.Web.ModelBinding;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog.Events;
 #else
 using Microsoft.AspNetCore.Http;
 #endif
@@ -149,8 +151,7 @@ internal static class RequestDataHelper
 #endif
 
 #if NETFRAMEWORK
-    // Get the url from a HttpRequest
-    internal static Uri? GetUrl(HttpRequest request)
+    private static Uri? TryGetRequestUrl(HttpRequest request, string logMessage)
     {
         try
         {
@@ -158,9 +159,57 @@ internal static class RequestDataHelper
         }
         catch (HttpRequestValidationException)
         {
-            Log.Debug("Error reading request.Url from the request.");
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug("Error reading request.Url from the request. {Message}", logMessage);
+            }
+
             return null;
         }
+    }
+
+    // Get the url from a HttpRequest
+    internal static Uri? GetUrl(HttpRequest request)
+    {
+        // TODO do we need to lock(request) here?
+        var urlField = typeof(HttpRequest).GetField("_url", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        if (urlField is null)
+        {
+            return TryGetRequestUrl(request, "Failed to reflect into _url of HttpRequest, falling back to Url property.");
+        }
+
+        var urlValueBefore = urlField.GetValue(request) as Uri;
+
+        // if the .Url has already been accessed by something else
+        // then the _url field will have already been cached
+        // in this instance we shouldn't reset the field to ensure we
+        // don't introduce some side-effect
+        // however .Url doesn't just check _url, so we should still call the actual property
+        if (urlValueBefore is not null)
+        {
+            return TryGetRequestUrl(request, "_url was already accessed by something else.");
+        }
+
+        // we are first callers of the .Url property
+        // we should cache this value and then reset the _url field
+        // to ensure we don't introduce side-effects
+        // we saw this happen with customers using Owin middleware
+        var url = TryGetRequestUrl(request, "_url was not accessed by anything else.");
+
+        // reset _url
+        try
+        {
+            // will happen regardless whether we got a value or not from .Url
+            urlField?.SetValue(request, null);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Error resetting request.Url.");
+            return url;
+        }
+
+        return url;
     }
 #endif
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -654,5 +654,6 @@
   "crashtracking_debug_url": "crashtracking_debug_url",
   "debug_stack_enabled": "debug_stack_enabled",
   "DD_TRACE_BAGGAGE_MAX_ITEMS": "trace_baggage_max_items",
-  "DD_TRACE_BAGGAGE_MAX_BYTES": "trace_baggage_max_bytes"
+  "DD_TRACE_BAGGAGE_MAX_BYTES": "trace_baggage_max_bytes",
+  "DD_TRACE_BYPASS_HTTP_REQUEST_URL_CACHING_ENABLED": "trace_bypass_http_request_url_caching_enabled"
 }

--- a/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
@@ -130,7 +130,7 @@ public class RequestDataHelperTests
     }
 
     [Fact]
-    public void GetUrl_WhenUrlHasNotBeenAccessed_ShouldReturnUrlAndResetUrlField()
+    public void BuildUrl_WhenUrlHasNotBeenAccessed_ShouldReturnUrlAndResetUrlField()
     {
         var request = CreateHttpRequest("GET");
         var urlField = typeof(HttpRequest).GetField("_url", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -139,7 +139,7 @@ public class RequestDataHelperTests
         // this will mean that Url will need to be built
         urlField.GetValue(request).Should().BeNull();
 
-        var url = RequestDataHelper.GetUrl(request);
+        var url = RequestDataHelper.BuildUrl(request);
 
         url.Should().NotBeNull();
         url.ToString().Should().Be("http://127.0.0.1/test/test.aspx");
@@ -150,7 +150,7 @@ public class RequestDataHelperTests
     }
 
     [Fact]
-    public void GetUrl_WhenUrlIsResetAndHttpRequestIsModified_ShouldReturnUpdatedUrl()
+    public void BuildUrl_WhenUrlIsResetAndHttpRequestIsModified_ShouldReturnUpdatedUrl()
     {
         var initialHost = "localhost";
         var newHost = "example.com";
@@ -168,7 +168,7 @@ public class RequestDataHelperTests
 
         // simulate tracer calling HttpRequest.Url
         // Call GetUrl to get the initial URL and reset _url
-        var initialUrl = RequestDataHelper.GetUrl(request);
+        var initialUrl = RequestDataHelper.BuildUrl(request);
 
         // Modify the HttpRequest object by changing the host
         // This is emulating some middleware that is running after us

--- a/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
@@ -194,29 +194,6 @@ public class RequestDataHelperTests
     }
 
     [Fact]
-    public void GetUrl_WhenUrlHasBeenAccessed_ShouldReturnCachedUrlAndNotResetUrlField()
-    {
-        var request = CreateHttpRequest("GET");
-        var urlField = typeof(HttpRequest).GetField("_url", BindingFlags.NonPublic | BindingFlags.Instance);
-
-        // Access request.Url to set _url
-        var initialUrl = request.Url;
-
-        // Verify that _url is set before we call as we'd expect
-        var urlBeforeRequestDataHelper = urlField.GetValue(request) as Uri;
-        urlBeforeRequestDataHelper.Should().NotBeNull();
-
-        var url = RequestDataHelper.GetUrl(request);
-
-        url.Should().NotBeNull();
-        url.Should().BeSameAs(initialUrl);
-
-        // Verify that _url is still set
-        var urlValueAfter = urlField.GetValue(request) as Uri;
-        urlValueAfter.Should().NotBeNull();
-    }
-
-    [Fact]
     public void GivenADangerousQueryString_WhenCallingASMAndIAST_NoExceptionIsThrown()
     {
         var request = new HttpRequest("file", "http://localhost/benchmarks", "data=<script>alert(1)</script>");


### PR DESCRIPTION
## Summary of changes

Manually compute the value of `HttpRequest.Url` for .NET Framework so that that it won't be cached for other callers due to us.

## Reason for change

For .NET Framework we access `HttpRequest.Url` when adding data to Spans.
When called this method will build the URL of the `HttpRequest` if we are the first accessors and then the result will be cached in a private field `_url`.

The issue here is that there seems to be a few edge cases where this causes us to build the HttpRequest _before_ it is desired to be built.
 
## Implementation details

Adds a new feature flag: `BypassHttpRequestUrlCachingEnabled` to allow bypassing of the current behavior where the URL would be cached.

Duck types the `HttpRequest` `BuildUrl` function to manually build the URL to avoid caching it when enabled.

## Test coverage

Added some _unit tests_ for this that rely on reflection and attempted to emulate previous behavior and the behavior we want to fix.

## Other details

I'm not confident that this a smart idea.

We will end up with an incorrect value here, but we did previously as well (only in these rare cases) but we will hopefully get ourselves out of the picture of affecting/altering application behavior.
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->

https://datadoghq.atlassian.net/browse/AIDM-500
