### PR TITLE
Bail out if we're in a no-dynamic-code scenario

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -41,6 +41,20 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             try
             {
+#if NETCOREAPP
+                // Check if we're in some sort of AOT scenario
+                // Equivalent to checking RuntimeFeature.IsDynamicCodeSupported (added in .NET 8)
+                // https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.NonNativeAot.cs
+                var dynamicCodeSupported = AppContext.TryGetSwitch("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", out bool isDynamicCodeSupported) ? isDynamicCodeSupported : true;
+                if (!dynamicCodeSupported)
+                {
+                    // we require dynamic code so we should just bail out ASAP.
+                    // This doesn't tell us for sure (the switch is only available on .NET 8+) but it's a minimum requirement
+                    StartupLogger.Log("Dynamic code is not supported (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported context switch is false). Automatic instrumentation will be disabled");
+                    return;
+                }
+#endif
+
                 ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
                 if (ManagedProfilerDirectory is null)
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -158,7 +158,7 @@ namespace Datadog.Trace.TestHelpers
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
-        public async Task<Process> StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false)
+        public async Task<Process> StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false, string dotnetRuntimeArgs = null)
         {
             // get path to sample app that the profiler will attach to
             var sampleAppPath = EnvironmentHelper.GetSampleApplicationPath(packageVersion, framework, usePublishWithRID);
@@ -167,9 +167,20 @@ namespace Datadog.Trace.TestHelpers
                 throw new Exception($"application not found: {sampleAppPath}");
             }
 
+            var runtimeArgs = string.Empty;
+            if (!string.IsNullOrEmpty(dotnetRuntimeArgs))
+            {
+                if (!EnvironmentHelper.IsCoreClr() || usePublishWithRID)
+                {
+                    throw new Exception($"Cannot use {nameof(dotnetRuntimeArgs)} with .NET Framework or when publishing with RID");
+                }
+
+                runtimeArgs = $"{dotnetRuntimeArgs} ";
+            }
+
             Output.WriteLine($"Starting Application: {sampleAppPath}");
             var executable = EnvironmentHelper.IsCoreClr() && !usePublishWithRID ? EnvironmentHelper.GetSampleExecutionSource() : sampleAppPath;
-            var args = EnvironmentHelper.IsCoreClr() && !usePublishWithRID ? $"{sampleAppPath} {arguments ?? string.Empty}" : arguments;
+            var args = EnvironmentHelper.IsCoreClr() && !usePublishWithRID ? $"{runtimeArgs}{sampleAppPath} {arguments ?? string.Empty}" : arguments;
 
             var process = await ProfilerHelper.StartProcessWithProfiler(
                 executable,
@@ -187,9 +198,9 @@ namespace Datadog.Trace.TestHelpers
             return process;
         }
 
-        public async Task<ProcessResult> RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool usePublishWithRID = false)
+        public async Task<ProcessResult> RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool usePublishWithRID = false, string dotnetRuntimeArgs = null)
         {
-            var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID);
+            var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID, dotnetRuntimeArgs: dotnetRuntimeArgs);
             using var helper = new ProcessHelper(process);
 
             return WaitForProcessResult(helper);


### PR DESCRIPTION
## Summary of changes

Bail out in the managed loader if we're in a no-dynamic code scenario

## Reason for change

Our automatic instrumentation is currently inherently tied to emitting dynamic code (Duck typing). In no-dynamic-code scenarios we will likely end up crashing (or giving a very degraded experience, with a performance hit at the very least). It's better to bail out early than do that

## Implementation details

Check for the `System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported` app context switch in the managed loader. This controls the `RuntimeFeature.IsDynamicCodeSupported` flag, which in turn determines whether the app auto-bails out in .NET 8+.

Note that this flag is set when you add `<PublishAot>` to your project _even if you don't publish with AOT_. I imagine there are some other environments (pre .NET 8) in which dynamic code is not available, but I don't know if we need to worry about them

## Test coverage

Added an integration tests that sets the flag and confirms we don't get traces when the flag is set to `false`

## Other details

I had to add a helper to the `TestHelper` to pass runtime arguments to `dotnet`