### PR TITLE
Include extra tags in error logs

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.Ci
             IDynamicConfigurationManager dynamicConfigurationManager,
             ITracerFlareManager tracerFlareManager)
         {
+            telemetry.RecordCiVisibilitySettings(_settings);
             if (_useLockedManager)
             {
                 return new CITracerManager.LockedManager(settings, agentWriter, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, traceSampler, spanSampler, remoteConfigurationManager, dynamicConfigurationManager, tracerFlareManager);

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
@@ -32,7 +32,7 @@ internal class RedactedErrorLogCollector
     private ConcurrentDictionary<uint, int> _logCounts = new();
     private ConcurrentDictionary<uint, int> _logCountsReserve = new();
 
-    public List<List<LogMessageData>>? GetLogs()
+    public List<List<LogMessageData>>? GetLogs(string? tags = null)
     {
         // This method should only be called in a single-threaded loop
         List<List<LogMessageData>>? batches = null;
@@ -42,6 +42,7 @@ internal class RedactedErrorLogCollector
 
         while (_queue.TryDequeue(out var log))
         {
+            log.Tags = tags;
             var logSize = log.GetApproximateSerializationSize();
             // modify the message to add the final log count
             var eventId = EventIdHash.Compute(log.Message, log.StackTrace);

--- a/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
+using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.Iast.Settings;
@@ -39,6 +40,11 @@ namespace Datadog.Trace.Telemetry
         /// Called to record profiler-related telemetry
         /// </summary>
         public void RecordProfilerSettings(Profiler profiler);
+
+        /// <summary>
+        /// Called to record ci-vis-related telemetry
+        /// </summary>
+        public void RecordCiVisibilitySettings(CIVisibilitySettings settings);
 
         /// <summary>
         /// Dispose resources for sending telemetry

--- a/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Threading.Tasks;
+using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
 
@@ -30,6 +31,10 @@ namespace Datadog.Trace.Telemetry
         }
 
         public void RecordProfilerSettings(Profiler profiler)
+        {
+        }
+
+        public void RecordCiVisibilitySettings(CIVisibilitySettings settings)
         {
         }
 

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -373,7 +373,7 @@ internal class TelemetryController : ITelemetryController
         private bool _isUpdateRequired;
         private string? _tags;
 
-        public void Update(ImmutableTracerSettings settings)
+        public void Update(TracerSettings settings)
         {
             _cloudEnv = settings switch
             {

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -11,6 +11,8 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Ci;
+using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ContinuousProfiler;
@@ -117,6 +119,11 @@ internal class TelemetryController : ITelemetryController
     {
         _configuration.Record(ConfigTelemetryData.ProfilerLoaded, profiler.Status.IsProfilerReady, ConfigurationOrigins.Default);
         _configuration.Record(ConfigTelemetryData.CodeHotspotsEnabled, profiler.ContextTracker.IsEnabled, ConfigurationOrigins.Default);
+    }
+
+    public void RecordCiVisibilitySettings(CIVisibilitySettings settings)
+    {
+        // CI Vis records the settings _directly_ in the global config so don't need to record them again here
     }
 
     public void IntegrationRunning(IntegrationId integrationId)

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -129,7 +129,7 @@ internal class TelemetryController : ITelemetryController
     public void RecordCiVisibilitySettings(CIVisibilitySettings settings)
     {
         // CI Vis records the settings _directly_ in the global config so don't need to record them again here
-        _logTagBuilder.Update(settings);
+        _logTagBuilder.Update(settings, CIVisibility.Enabled);
     }
 
     public void IntegrationRunning(IntegrationId integrationId)
@@ -386,12 +386,12 @@ internal class TelemetryController : ITelemetryController
             _isUpdateRequired = true;
         }
 
-        public void Update(CIVisibilitySettings settings)
+        public void Update(CIVisibilitySettings settings, bool enabled)
         {
             // We don't actually need to record these, because they're added to the global config
             // This isn't nice, as it calls the static property,
             // but we don't have a better way of getting this info right now
-            _isCiVisEnabled = CIVisibility.Enabled;
+            _isCiVisEnabled = enabled;
             _isUpdateRequired = true;
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.AppSec;
+using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.HttpClientHandler;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
@@ -126,6 +127,10 @@ namespace Datadog.Trace.Tests.Telemetry
             }
 
             public void RecordProfilerSettings(Profiler profiler)
+            {
+            }
+
+            public void RecordCiVisibilitySettings(CIVisibilitySettings settings)
             {
             }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/RedactedErrorLogCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/RedactedErrorLogCollectorTests.cs
@@ -378,6 +378,23 @@ public class RedactedErrorLogCollectorTests
             .OnlyContain(x => x.Count == null);
     }
 
+    [Fact]
+    public void AddsTagsToLogDuringSerialization()
+    {
+        var tagBuilder = new TelemetryController.TagBuilder();
+        var collector = new RedactedErrorLogCollector();
+        collector.EnqueueLog(new($"Some log", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
+
+        var logTags = tagBuilder.GetLogTags();
+        var logs = collector.GetLogs(logTags);
+        logs.Should()
+            .ContainSingle()
+            .Which.Should()
+            .ContainSingle()
+            .Which.Tags.Should()
+            .Be(logTags);
+    }
+
     private static string RandomString(int length)
     {
         const string options = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ,!\"£$%^&*()[]{}<>`¬";

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerLogTagBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerLogTagBuilderTests.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="TelemetryControllerLogTagBuilderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Ci.Configuration;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Telemetry;
+
+public class TelemetryControllerLogTagBuilderTests
+{
+    [Fact]
+    public void TagBuilder_ReturnsExpectedDefaults()
+    {
+        var builder = new TelemetryController.TagBuilder();
+        builder.GetLogTags().Should().Be("ci:0,asm:0,prof:0,dyn:0");
+    }
+
+    [Fact]
+    public void TagBuilder_UpdateCiVisTag()
+    {
+        var builder = new TelemetryController.TagBuilder();
+        builder.Update(new CIVisibilitySettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance), enabled: true);
+        builder.GetLogTags().Should().Be("ci:1,asm:0,prof:0,dyn:0");
+    }
+
+    [Theory]
+    [InlineData((int)TelemetryProductType.AppSec, "ci:0,asm:1,prof:0,dyn:0")]
+    [InlineData((int)TelemetryProductType.Profiler, "ci:0,asm:0,prof:1,dyn:0")]
+    [InlineData((int)TelemetryProductType.DynamicInstrumentation, "ci:0,asm:0,prof:0,dyn:1")]
+    public void TagBuilder_UpdateProductTag(int product, string expected)
+    {
+        var builder = new TelemetryController.TagBuilder();
+        builder.Update((TelemetryProductType)product, enabled: true);
+        builder.GetLogTags().Should().Be(expected);
+    }
+
+    [Fact]
+    public void TagBuilder_UpdateCloudTag()
+    {
+        var builder = new TelemetryController.TagBuilder();
+        builder.Update(TracerSettings.Create(new() { { "DD_AZURE_APP_SERVICES", "true" } }).Build());
+        builder.GetLogTags().Should().Be("ci:0,asm:0,prof:0,dyn:0,aas");
+    }
+
+    [Fact]
+    public void TagBuilder_AddsEverything()
+    {
+        var builder = new TelemetryController.TagBuilder();
+        builder.Update(TracerSettings.Create(new() { { "FUNCTIONS_EXTENSION_VERSION", "true" } }).Build());
+        builder.Update(TelemetryProductType.Profiler, enabled: true);
+        builder.Update(TelemetryProductType.DynamicInstrumentation, enabled: true);
+        builder.Update(TelemetryProductType.AppSec, enabled: true);
+        builder.Update(new CIVisibilitySettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance), enabled: true);
+        builder.GetLogTags().Should().Be("ci:1,asm:1,prof:1,dyn:1,azf");
+    }
+
+    [Fact]
+    public void TagBuilder_WhenAdded()
+    {
+        var builder = new TelemetryController.TagBuilder();
+        builder.Update(TracerSettings.Create(new() { { "FUNCTIONS_EXTENSION_VERSION", "true" } }).Build());
+        builder.Update(TelemetryProductType.Profiler, enabled: true);
+        builder.Update(TelemetryProductType.DynamicInstrumentation, enabled: true);
+        builder.Update(TelemetryProductType.AppSec, enabled: true);
+        builder.Update(new CIVisibilitySettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance), enabled: true);
+        builder.GetLogTags().Should().Be("ci:1,asm:1,prof:1,dyn:1,azf");
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerLogTagBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerLogTagBuilderTests.cs
@@ -44,7 +44,7 @@ public class TelemetryControllerLogTagBuilderTests
     public void TagBuilder_UpdateCloudTag()
     {
         var builder = new TelemetryController.TagBuilder();
-        builder.Update(TracerSettings.Create(new() { { "DD_AZURE_APP_SERVICES", "true" } }).Build());
+        builder.Update(TracerSettings.Create(new() { { "DD_AZURE_APP_SERVICES", "true" } }));
         builder.GetLogTags().Should().Be("ci:0,asm:0,prof:0,dyn:0,aas");
     }
 
@@ -52,7 +52,7 @@ public class TelemetryControllerLogTagBuilderTests
     public void TagBuilder_AddsEverything()
     {
         var builder = new TelemetryController.TagBuilder();
-        builder.Update(TracerSettings.Create(new() { { "FUNCTIONS_EXTENSION_VERSION", "true" } }).Build());
+        builder.Update(TracerSettings.Create(new() { { "FUNCTIONS_EXTENSION_VERSION", "true" } }));
         builder.Update(TelemetryProductType.Profiler, enabled: true);
         builder.Update(TelemetryProductType.DynamicInstrumentation, enabled: true);
         builder.Update(TelemetryProductType.AppSec, enabled: true);
@@ -64,7 +64,7 @@ public class TelemetryControllerLogTagBuilderTests
     public void TagBuilder_WhenAdded()
     {
         var builder = new TelemetryController.TagBuilder();
-        builder.Update(TracerSettings.Create(new() { { "FUNCTIONS_EXTENSION_VERSION", "true" } }).Build());
+        builder.Update(TracerSettings.Create(new() { { "FUNCTIONS_EXTENSION_VERSION", "true" } }));
         builder.Update(TelemetryProductType.Profiler, enabled: true);
         builder.Update(TelemetryProductType.DynamicInstrumentation, enabled: true);
         builder.Update(TelemetryProductType.AppSec, enabled: true);


### PR DESCRIPTION
## Summary of changes

Includes details about products enabled in the telemetry error logs

## Reason for change

Should make it easier to categorize errors knowing e.g. whether the error came from a ci-vis app etc.

## Implementation details

The tags are written to _every_ log message, so we need to keep the tags small as possible. I limited it to just 5 tags for now:

- `ci` - is CI Visibility enabled
- `asm` - is ASM enabled
- `prof` - is profiling enabled
- `dyn` - is dynamic instrumentation enabled
- `gcp`/`aws`/`aas`/azf` - are we running in GCP/lambda/AAS/Azure functions (with mini agent)

I _think_ those cover the broadest categories for now. I opted for adding the enabled tag with a `1`/`0`  so we could explicitly see whether it was set or not (apart from the cloud functions which are only added when they apply).

Alternatively, we could _only_ add the tag if it's enabled (like I do for the "cloud" tag). That saves bytes, at the expense of some ambiguity: if the tags aren't there does that mean they definitely were none enabled, or the tagging didn't happen? Happy to switch though if people have a preference.

## Test coverage

Unit tests. Will do a manual test to make sure there's no issues with the intake accepting them.

## Other details

We currently weren't explicitly recording whether CI Vis was enabled, so I added a method to call to "record" the settings. This isn't _really_ required given we can only get the enabled flag via a static property, but it _potentially_ sets us up a bit more cleanly for refactoring later, and is closer to how other products work. I'm happy to be persuaded to remove that commit though

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
