### PR TITLE
[Profiler] Avoid ETW tests flackiness

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Allocations/AllocationsProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Allocations/AllocationsProfilerTest.cs
@@ -18,7 +18,7 @@ namespace Datadog.Profiler.IntegrationTests.Allocations
     {
         private const string ScenarioGenerics = "--scenario 9";
         private const string ScenarioMeasureAllocation = "--scenario 16";
-        private const string ScenarioWithoutGC = "--scenario 25 --threads 2 --param 1000";
+        private const string ScenarioWithoutGC = "--scenario 6 --threads 1";
 
         private readonly ITestOutputHelper _output;
 
@@ -130,6 +130,8 @@ namespace Datadog.Profiler.IntegrationTests.Allocations
         public void ShouldGetAllocationSamplesViaEtw(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioWithoutGC);
+            // allow agent proxy to send the recorded events
+            runner.TestDurationInSeconds = 30;
 
             EnvironmentHelper.DisableDefaultProfilers(runner);
             runner.Environment.SetVariable(EnvironmentVariables.AllocationProfilerEnabled, "1");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -15,7 +15,7 @@ namespace Datadog.Profiler.IntegrationTests.Contention
     public class ContentionProfilerTest
     {
         private const string ScenarioContention = "--scenario 10 --threads 20";
-        private const string ScenarioWithoutContention = "--scenario 25 --threads 2 --param 1000";
+        private const string ScenarioWithoutContention = "--scenario 6 --threads 1";
 
         private readonly ITestOutputHelper _output;
 
@@ -90,6 +90,8 @@ namespace Datadog.Profiler.IntegrationTests.Contention
         public void ShouldGetLockContentionSamplesViaEtw(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioWithoutContention);
+            // allow agent proxy to send the recorded events
+            runner.TestDurationInSeconds = 30;
 
             EnvironmentHelper.DisableDefaultProfilers(runner);
             runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "1");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectionsProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectionsProfilerTest.cs
@@ -14,7 +14,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
     public class GarbageCollectionsProfilerTest
     {
         private const string ScenarioGenerics = "--scenario 12";
-        private const string ScenarioWithoutGC = "--scenario 25 --threads 2 --param 1000";
+        private const string ScenarioWithoutGC = "--scenario 6 --threads 1";
         private const string GcRootFrame = "|lm: |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:";
 
         private readonly ITestOutputHelper _output;
@@ -62,6 +62,8 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
         public void ShouldGetGarbageCollectionSamplesViaEtw(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioWithoutGC);
+            // allow agent proxy to send the recorded events
+            runner.TestDurationInSeconds = 30;
 
             // disable default profilers except GC
             runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");


### PR DESCRIPTION
## Summary of changes
Pick a less CPU intensive scenario and increase test timeout

## Reason for change
The previous version of the tests showed that the agent proxy was not able to asynchronously send the recorded events before the test ends.

## Implementation details
Increase the timeout so the profiled application lives long enough to receive the recorded events

## Test coverage
yes

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
