### PR TITLE
Ducktype instance type check

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -1350,7 +1350,7 @@ namespace Datadog.Trace.DuckTyping
                     return default;
                 }
 
-                return GetProxy(instance.GetType()).CreateInstance<T>(instance);
+                return instance is T tInst ? tInst : GetProxy(instance.GetType()).CreateInstance<T>(instance);
             }
 
             /// <summary>
@@ -1368,7 +1368,7 @@ namespace Datadog.Trace.DuckTyping
                     return default;
                 }
 
-                return GetProxy(typeof(TOriginal)).CreateInstance<T, TOriginal>(instance);
+                return instance is T tInst ? tInst : GetProxy(typeof(TOriginal)).CreateInstance<T, TOriginal>(instance);
             }
 
             /// <summary>
@@ -1384,7 +1384,7 @@ namespace Datadog.Trace.DuckTyping
                     return false;
                 }
 
-                return GetProxy(instance.GetType()).CanCreate();
+                return instance is T || GetProxy(instance.GetType()).CanCreate();
             }
 
             /// <summary>


### PR DESCRIPTION
## Summary of changes

This PR adds a check to avoid creating a proxy if the instance is already of type T or target type.

## Reason for change

This should avoid any misusage of the ducktype library while trying to duckcast something that doesn't need casting.
