### PR TITLE
[Profiler] Fix UBsan Job

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
@@ -76,4 +76,4 @@ public:
         static std::once_flag UNIQUE_ONCE_FLAG_##__COUNTER__;                                                              \
         std::call_once(                                                                                                    \
             UNIQUE_ONCE_FLAG_##__COUNTER__, [](auto&&... args) { Log::level(std::forward<decltype(args)>(args)...); }, __VA_ARGS__); \
-    } while (0)
+    } while (0) // NOLINT

--- a/profiler/test/Datadog.Profiler.Native.Tests/ClrEventsParserTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ClrEventsParserTest.cpp
@@ -107,8 +107,14 @@ TEST(ClrEventsParserTest, ContentionStartV2)
     parser.ParseEvent(1234ns, 2, KEYWORD_CONTENTION, EVENT_CONTENTION_START, sizeof(ContentionStartV2Payload), reinterpret_cast<LPCBYTE>(&payload));
 }
 
+// The CLR sends events with misalign field.
+// In this case, since we create an event, it's ok to disregard the misalign issue
+// reported by UBSAN
 template <typename T>
 uint64_t Write(std::uint8_t* buffer, std::uint64_t offset, T const& value)
+#ifdef LINUX
+__attribute__((no_sanitize("alignment")))
+#endif
 {
     *reinterpret_cast<T*>(buffer + offset) = value;
     return offset + sizeof(T);


### PR DESCRIPTION
## Summary of changes

Fix the UBSAN job.

## Reason for change

A recent unit test was added. This test builds events by writing the field in raw memory (like the CLR does). But the alignment is not taken care of (like the CLR) and UBSAN shouts about.

## Implementation details

Since it's a test, we just disable UBSAN on the function (in the test) that creates the event.

