### PR TITLE
Make more integration settings case insensitive

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -47,24 +47,27 @@ namespace Datadog.Trace.Configuration
 
             // We don't record these in telemetry, because they're blocked anyway
             var config = new ConfigurationBuilder(source, NullConfigurationTelemetry.Instance);
+            var upperName = integrationName.ToUpperInvariant();
             EnabledInternal = config
                      .WithKeys(
-                          string.Format(ConfigurationKeys.Integrations.Enabled, integrationName.ToUpperInvariant()),
+                          string.Format(ConfigurationKeys.Integrations.Enabled, upperName),
                           string.Format(ConfigurationKeys.Integrations.Enabled, integrationName),
-                          string.Format("DD_{0}_ENABLED", integrationName))
+                          $"DD_{integrationName}_ENABLED")
                      .AsBool();
 
 #pragma warning disable 618 // App analytics is deprecated, but still used
             AnalyticsEnabledInternal = config
                               .WithKeys(
+                                   string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, upperName),
                                    string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName),
-                                   string.Format("DD_{0}_ANALYTICS_ENABLED", integrationName))
+                                   $"DD_{integrationName}_ANALYTICS_ENABLED")
                               .AsBool();
 
             AnalyticsSampleRateInternal = config
                                  .WithKeys(
+                                      string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, upperName),
                                       string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName),
-                                      string.Format("DD_{0}_ANALYTICS_SAMPLE_RATE", integrationName))
+                                      $"DD_{integrationName}_ANALYTICS_SAMPLE_RATE")
                                  .AsDouble(1.0);
 #pragma warning restore 618
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
@@ -52,12 +52,17 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("DD_TRACE_FOO_ANALYTICS_ENABLED", "false", false)]
         [InlineData("DD_FOO_ANALYTICS_ENABLED", "true", true)]
         [InlineData("DD_FOO_ANALYTICS_ENABLED", "false", false)]
+        [InlineData("DD_TRACE_Foo_ANALYTICS_ENABLED", "true", true)]
+        [InlineData("DD_TRACE_Foo_ANALYTICS_ENABLED", "false", false)]
+        [InlineData("DD_Foo_ANALYTICS_ENABLED", "true", true)]
+        [InlineData("DD_Foo_ANALYTICS_ENABLED", "false", false)]
         public void IntegrationAnalyticsEnabled(string settingName, string settingValue, bool expected)
         {
-            var source = new NameValueConfigurationSource(new NameValueCollection
-                                                          {
-                                                              { settingName, settingValue }
-                                                          });
+            var dict = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { settingName, settingValue },
+            };
+            var source = new DictionaryConfigurationSource(dict);
 
             var settings = new IntegrationSettings("FOO", source);
             Assert.Equal(expected, settings.AnalyticsEnabled);
@@ -66,12 +71,15 @@ namespace Datadog.Trace.Tests.Configuration
         [Theory]
         [InlineData("DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE", "0.2", 0.2)]
         [InlineData("DD_FOO_ANALYTICS_SAMPLE_RATE", "0.6", 0.6)]
+        [InlineData("DD_TRACE_Foo_ANALYTICS_SAMPLE_RATE", "0.2", 0.2)]
+        [InlineData("DD_Foo_ANALYTICS_SAMPLE_RATE", "0.6", 0.6)]
         public void IntegrationAnalyticsSampleRate(string settingName, string settingValue, double expected)
         {
-            var source = new NameValueConfigurationSource(new NameValueCollection
-                                                          {
-                                                              { settingName, settingValue }
-                                                          });
+            var dict = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { settingName, settingValue },
+            };
+            var source = new DictionaryConfigurationSource(dict);
 
             var settings = new IntegrationSettings("FOO", source);
             Assert.Equal(expected, settings.AnalyticsSampleRate);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
@@ -50,12 +50,10 @@ namespace Datadog.Trace.Tests.Configuration
         [Theory]
         [InlineData("DD_TRACE_FOO_ANALYTICS_ENABLED", "true", true)]
         [InlineData("DD_TRACE_FOO_ANALYTICS_ENABLED", "false", false)]
-        [InlineData("DD_FOO_ANALYTICS_ENABLED", "true", true)]
-        [InlineData("DD_FOO_ANALYTICS_ENABLED", "false", false)]
-        [InlineData("DD_TRACE_Foo_ANALYTICS_ENABLED", "true", true)]
-        [InlineData("DD_TRACE_Foo_ANALYTICS_ENABLED", "false", false)]
         [InlineData("DD_Foo_ANALYTICS_ENABLED", "true", true)]
         [InlineData("DD_Foo_ANALYTICS_ENABLED", "false", false)]
+        [InlineData("DD_TRACE_Foo_ANALYTICS_ENABLED", "true", true)]
+        [InlineData("DD_TRACE_Foo_ANALYTICS_ENABLED", "false", false)]
         public void IntegrationAnalyticsEnabled(string settingName, string settingValue, bool expected)
         {
             var dict = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -64,15 +62,14 @@ namespace Datadog.Trace.Tests.Configuration
             };
             var source = new DictionaryConfigurationSource(dict);
 
-            var settings = new IntegrationSettings("FOO", source);
+            var settings = new IntegrationSettings("Foo", source);
             Assert.Equal(expected, settings.AnalyticsEnabled);
         }
 
         [Theory]
         [InlineData("DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE", "0.2", 0.2)]
-        [InlineData("DD_FOO_ANALYTICS_SAMPLE_RATE", "0.6", 0.6)]
-        [InlineData("DD_TRACE_Foo_ANALYTICS_SAMPLE_RATE", "0.2", 0.2)]
         [InlineData("DD_Foo_ANALYTICS_SAMPLE_RATE", "0.6", 0.6)]
+        [InlineData("DD_TRACE_Foo_ANALYTICS_SAMPLE_RATE", "0.2", 0.2)]
         public void IntegrationAnalyticsSampleRate(string settingName, string settingValue, double expected)
         {
             var dict = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -81,7 +78,7 @@ namespace Datadog.Trace.Tests.Configuration
             };
             var source = new DictionaryConfigurationSource(dict);
 
-            var settings = new IntegrationSettings("FOO", source);
+            var settings = new IntegrationSettings("Foo", source);
             Assert.Equal(expected, settings.AnalyticsSampleRate);
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
@@ -79,7 +79,7 @@ public class ConfigurationTests
         var allPotentialConfigKeys = assemblyStrings
                                     .Where(x => (x.StartsWith("DD_") || x.StartsWith("_DD") || x.StartsWith("DATADOG_") || x.StartsWith("OTEL_")) && !x.Contains(" "))
                                     .Concat(configKeyStrings)
-                                    .Where(x => !x.Contains("{0}")) // exclude the format string ones
+                                    .Where(x => !x.Contains("{0}") && x != "DD_") // exclude the format string ones + the interpolated string ones
                                     .Distinct()
                                     .Where(x => !ExcludedKeys.Contains(x))
                                     .ToList();


### PR DESCRIPTION
## Summary of changes

Make the other settings in `IntegrationSettings` case-insensitive for the `IntegrationId`

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/6175 we made the `DD_TRACE_{0}_ENABLED` configurations case-insensitive for the `IntegrationId`. This PR it makes the other related settings behave similarly

## Implementation details

Add additional fallbacks, the same as for the Enabled case

## Test coverage

Added unit test for it

## Other details

Switched the string.Format to interpolated because, you know, it's 2024

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
