### PR TITLE
Adding Delay to CheckForSmoke to Prevent Flakes

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -153,6 +153,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
             {
                 Assert.True(string.IsNullOrEmpty(result.StandardError), $"Expected no errors in smoke test: {result.StandardError}");
             }
+
+            await Task.Delay(5000);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
There are a couple of  `NoException` tests that make use of `CheckForSmoke` failing after app shutdown so adding delay to try testing 

## Reason for change
To try preventing some flake.