### PR TITLE
Update config-in-code manual instrumentation to use an `IConfigurationSource`

### DIFF
--- a/tracer/src/Datadog.Trace.Manual/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace.Manual/Configuration/IntegrationSettings.cs
@@ -75,4 +75,22 @@ public sealed class IntegrationSettings
             _analyticsEnabled.IsOverridden ? _analyticsEnabled.Value : null,
             _analyticsSampleRate.IsOverridden,
             _analyticsSampleRate.IsOverridden ? _analyticsSampleRate.Value : null);
+
+    internal void RecordChangedKeys(Dictionary<string, object?> results)
+    {
+        if (_enabled.IsOverridden)
+        {
+            results[$"DD_TRACE_{IntegrationName.ToUpperInvariant()}_ENABLED"] = _enabled.Value;
+        }
+
+        if (_analyticsEnabled.IsOverridden)
+        {
+            results[$"DD_TRACE_{IntegrationName.ToUpperInvariant()}_ANALYTICS_ENABLED"] = _analyticsEnabled.Value;
+        }
+
+        if (_analyticsSampleRate.IsOverridden)
+        {
+            results[$"DD_TRACE_{IntegrationName.ToUpperInvariant()}_ANALYTICS_SAMPLE_RATE"] = _analyticsSampleRate.Value;
+        }
+    }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/ConfigureIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/ConfigureIntegration.cs
@@ -4,17 +4,13 @@
 // </copyright>
 
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
-using Datadog.Trace.Logging;
-using Datadog.Trace.Telemetry;
-using Datadog.Trace.Telemetry.Metrics;
-using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer;
 
@@ -26,316 +22,35 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tr
     TypeName = "Datadog.Trace.Tracer",
     MethodName = "Configure",
     ReturnTypeName = ClrNames.Void,
-    ParameterTypeNames = new[] { "System.Collections.Generic.Dictionary`2[System.String,System.Object]" },
-    MinimumVersion = ManualInstrumentationConstants.MinVersion,
+    ParameterTypeNames = ["System.Collections.Generic.Dictionary`2[System.String,System.Object]"],
+    MinimumVersion = "3.7.0",
     MaximumVersion = ManualInstrumentationConstants.MaxVersion,
     IntegrationName = ManualInstrumentationConstants.IntegrationName)]
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class ConfigureIntegration
 {
-    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ConfigureIntegration>();
-
     internal static CallTargetState OnMethodBegin<TTarget>(Dictionary<string, object?> values)
     {
-        // Is this from calling new TracerSettings() or TracerSettings.Global?
-        var isFromDefaults = values.TryGetValue(TracerSettingKeyConstants.IsFromDefaultSourcesKey, out var value) && value is true;
-
-        // Get the starting point
-        var settings = isFromDefaults
-                           ? TracerSettings.FromDefaultSourcesInternal()
-                           : new TracerSettings(null, new ConfigurationTelemetry(), new OverrideErrorLog());
-
-        // Update the settings based on the values they set
-        UpdateSettings(values, settings);
-
-        // Update the global instance
-        Trace.Tracer.ConfigureInternal(new ImmutableTracerSettings(settings, true));
+        ConfigureSettingsWithManualOverrides(values, useLegacySettings: false);
 
         return CallTargetState.GetDefault();
     }
 
-    // Internal for testing
-    internal static void UpdateSettings(Dictionary<string, object?> dictionary, TracerSettings tracerSettings)
+    internal static void ConfigureSettingsWithManualOverrides(Dictionary<string, object?> values, bool useLegacySettings)
     {
-        foreach (var setting in dictionary)
-        {
-            switch (setting.Key)
-            {
-                case TracerSettingKeyConstants.AgentUriKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.ExporterSettings_AgentUri_Set);
-                    tracerSettings.Exporter.AgentUriInternal = (setting.Value as Uri)!;
-                    break;
+        // Is this from calling new TracerSettings() or TracerSettings.Global?
+        var isFromDefaults = values.TryGetValue(TracerSettingKeyConstants.IsFromDefaultSourcesKey, out var value) && value is true;
 
-                case TracerSettingKeyConstants.AnalyticsEnabledKey:
-#pragma warning disable CS0618 // Type or member is obsolete
-                    var boolValue = (bool)setting.Value!;
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_AnalyticsEnabled_Set);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.GlobalAnalyticsEnabled, boolValue, ConfigurationOrigins.Code);
-                    tracerSettings.AnalyticsEnabled = boolValue;
-#pragma warning restore CS0618 // Type or member is obsolete
-                    break;
+        // Build the configuration sources, including our manual instrumentation values
+        var manualConfigSource = new ManualInstrumentationConfigurationSource(values);
+        IConfigurationSource source = isFromDefaults
+                                          ? new CompositeConfigurationSource([manualConfigSource, GlobalConfigurationSource.Instance])
+                                          : manualConfigSource;
 
-                case TracerSettingKeyConstants.CustomSamplingRules:
-                    var rulesAsString = setting.Value as string;
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_CustomSamplingRules_Set);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.CustomSamplingRules, rulesAsString, recordValue: true, ConfigurationOrigins.Code);
-                    tracerSettings.CustomSamplingRules = rulesAsString;
-                    break;
+        var settings = new TracerSettings(source, new ConfigurationTelemetry(), new OverrideErrorLog());
 
-                case TracerSettingKeyConstants.DiagnosticSourceEnabledKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_DiagnosticSourceEnabled_Set);
-                    // there is no setter, it doesn't do anything
-                    break;
-
-                case TracerSettingKeyConstants.DisabledIntegrationNamesKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_DisabledIntegrationNames_Set);
-                    var hashset = setting.Value as HashSet<string>;
-                    var stringified = hashset is null ? null : string.Join(",", hashset);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.DisabledIntegrations, stringified, recordValue: true, ConfigurationOrigins.Code);
-                    tracerSettings.DisabledIntegrationNames = hashset ?? [];
-                    break;
-
-                case TracerSettingKeyConstants.EnvironmentKey:
-                    var envAsString = setting.Value as string;
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_Environment_Set);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.Environment, envAsString, recordValue: true, ConfigurationOrigins.Code);
-                    tracerSettings.Environment = envAsString;
-                    break;
-
-                case TracerSettingKeyConstants.GlobalSamplingRateKey:
-                    var rateAsDouble = setting.Value as double?;
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_GlobalSamplingRate_Set);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.GlobalSamplingRate, rateAsDouble, ConfigurationOrigins.Code);
-                    tracerSettings.GlobalSamplingRate = rateAsDouble;
-                    break;
-
-                case TracerSettingKeyConstants.GrpcTags:
-                    if (setting.Value is IDictionary<string, string> { } grpcTags)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_GrpcTags_Set);
-                        var currentTags = tracerSettings.GrpcTags;
-                        // This is a replacement, so make sure to clear
-                        // Could also use a setter
-                        currentTags.Clear();
-                        foreach (var tag in grpcTags)
-                        {
-                            currentTags[tag.Key] = tag.Value;
-                        }
-
-                        tracerSettings.Telemetry.Record(ConfigurationKeys.GrpcTags, Stringify(grpcTags), recordValue: true, ConfigurationOrigins.Code);
-                    }
-
-                    break;
-
-                case TracerSettingKeyConstants.HeaderTags:
-                    if (setting.Value is IDictionary<string, string> { } headerTags)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_HeaderTags_Set);
-                        var currentTags = tracerSettings.HeaderTags;
-                        // This is a replacement, so make sure to clear
-                        // Could also use a setter
-                        currentTags.Clear();
-                        foreach (var tag in headerTags)
-                        {
-                            currentTags[tag.Key] = tag.Value;
-                        }
-
-                        tracerSettings.Telemetry.Record(ConfigurationKeys.HeaderTags, Stringify(headerTags), recordValue: true, ConfigurationOrigins.Code);
-                    }
-
-                    break;
-
-                case TracerSettingKeyConstants.GlobalTagsKey:
-                    if (setting.Value is IDictionary<string, string> { } tags)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_GlobalTags_Set);
-                        var globalTags = tracerSettings.GlobalTags;
-                        // This is a replacement, so make sure to clear
-                        // Could also use a setter
-                        globalTags.Clear();
-                        foreach (var tag in tags)
-                        {
-                            globalTags[tag.Key] = tag.Value;
-                        }
-
-                        tracerSettings.Telemetry.Record(ConfigurationKeys.GlobalTags, Stringify(tags), recordValue: true, ConfigurationOrigins.Code);
-                    }
-
-                    break;
-
-                case TracerSettingKeyConstants.HttpClientErrorCodesKey:
-                    if (setting.Value is IEnumerable<int> clientErrorCodes)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_SetHttpClientErrorStatusCodes);
-                        // this one currently records telemetry in the called method: we can tidy that up later
-                        tracerSettings.SetHttpClientErrorStatusCodesInternal(clientErrorCodes);
-                    }
-
-                    break;
-
-                case TracerSettingKeyConstants.HttpServerErrorCodesKey:
-                    if (setting.Value is IEnumerable<int> serverErrorCodes)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_SetHttpServerErrorStatusCodes);
-                        // this one currently records telemetry in the called method: we can tidy that up later
-                        tracerSettings.SetHttpServerErrorStatusCodesInternal(serverErrorCodes);
-                    }
-
-                    break;
-
-                case TracerSettingKeyConstants.KafkaCreateConsumerScopeEnabledKey:
-                    var kafkaScopeEnabled = (bool)setting.Value!;
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_KafkaCreateConsumerScopeEnabled_Set);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.KafkaCreateConsumerScopeEnabled, kafkaScopeEnabled, ConfigurationOrigins.Code);
-                    tracerSettings.KafkaCreateConsumerScopeEnabled = kafkaScopeEnabled;
-                    break;
-
-                case TracerSettingKeyConstants.LogsInjectionEnabledKey:
-#pragma warning disable DD0002 // This API is only for public usage and should not be called internally (there's no internal version currently)
-                    // this one currently records telemetry in the called method: we can tidy that up later
-                    tracerSettings.LogsInjectionEnabled = (bool)setting.Value!;
-#pragma warning restore DD0002
-                    break;
-
-                case TracerSettingKeyConstants.ServiceNameKey:
-                    var serviceName = setting.Value as string;
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_ServiceName_Set);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.ServiceName, serviceName, recordValue: true, ConfigurationOrigins.Code);
-                    tracerSettings.ServiceName = serviceName;
-                    break;
-
-                case TracerSettingKeyConstants.ServiceNameMappingsKey:
-                    if (setting.Value is Dictionary<string, string> mappings)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_SetServiceNameMappings);
-                        // this one currently records telemetry in the called method: we can tidy that up later
-                        tracerSettings.SetServiceNameMappingsInternal(mappings);
-                    }
-
-                    break;
-
-                case TracerSettingKeyConstants.MaxTracesSubmittedPerSecondKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_MaxTracesSubmittedPerSecond_Set);
-                    var tracesPerSecond = (int)setting.Value!;
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.TraceRateLimit, tracesPerSecond, ConfigurationOrigins.Code);
-                    tracerSettings.MaxTracesSubmittedPerSecond = tracesPerSecond;
-                    break;
-
-                case TracerSettingKeyConstants.ServiceVersionKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_ServiceVersion_Set);
-                    var serviceVersion = setting.Value as string;
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.ServiceVersion, serviceVersion, recordValue: true, ConfigurationOrigins.Code);
-                    tracerSettings.ServiceVersion = serviceVersion;
-                    break;
-
-                case TracerSettingKeyConstants.StartupDiagnosticLogEnabledKey:
-                    var logEnabled = (bool)setting.Value!;
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_StartupDiagnosticLogEnabled_Set);
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.StartupDiagnosticLogEnabled, logEnabled, ConfigurationOrigins.Code);
-                    tracerSettings.StartupDiagnosticLogEnabled = logEnabled;
-                    break;
-
-                case TracerSettingKeyConstants.StatsComputationEnabledKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_StatsComputationEnabled_Set);
-                    var statsComputation = (bool)setting.Value!;
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.StatsComputationEnabled, statsComputation, ConfigurationOrigins.Code);
-                    tracerSettings.StatsComputationEnabled = statsComputation;
-                    break;
-
-                case TracerSettingKeyConstants.TraceEnabledKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_TraceEnabled_Set);
-                    var traceEnabled = (bool)setting.Value!;
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.TraceEnabled, traceEnabled, ConfigurationOrigins.Code);
-                    tracerSettings.TraceEnabled = traceEnabled;
-                    break;
-
-                case TracerSettingKeyConstants.TracerMetricsEnabledKey:
-                    TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_TracerMetricsEnabled_Set);
-                    var metricsEnabled = (bool)setting.Value!;
-                    tracerSettings.Telemetry.Record(ConfigurationKeys.TracerMetricsEnabled, metricsEnabled, ConfigurationOrigins.Code);
-                    tracerSettings.TracerMetricsEnabled = metricsEnabled;
-                    break;
-
-                case TracerSettingKeyConstants.IntegrationSettingsKey:
-                    UpdateIntegrations(tracerSettings, setting.Value as Dictionary<string, object?[]>);
-                    break;
-
-                default:
-                    Log.Warning("Unknown manual instrumentation key '{Key}' provided. Ignoring value '{Value}'", setting.Key, setting.Value);
-                    break;
-            }
-#pragma warning restore DD0002
-        }
-
-        static string Stringify(IDictionary<string, string> from)
-        {
-            var sb = StringBuilderCache.Acquire();
-            foreach (var tag in from)
-            {
-                sb.Append(tag.Key ?? string.Empty)
-                  .Append(':')
-                  .Append(tag.Value ?? string.Empty)
-                  .Append(',');
-            }
-
-            if (sb.Length > 0)
-            {
-                sb.Length--;
-            }
-
-            return StringBuilderCache.GetStringAndRelease(sb);
-        }
-
-        static void UpdateIntegrations(TracerSettings settings, Dictionary<string, object?[]>? updated)
-        {
-            if (updated is null || updated.Count == 0)
-            {
-                return;
-            }
-
-            var integrations = settings.Integrations.Settings;
-
-            foreach (var pair in updated)
-            {
-                if (!IntegrationRegistry.TryGetIntegrationId(pair.Key, out var integrationId))
-                {
-                    Log.Warning("Error updating integration {IntegrationName} from manual instrumentation - unknown integration ID", pair.Key);
-                    continue;
-                }
-
-                var setting = integrations[(int)integrationId];
-
-                if (IntegrationSettingsSerializationHelper.TryDeserializeFromManual(
-                       pair.Value,
-                       out var enabledChanged,
-                       out var enabled,
-                       out var analyticsEnabledChanged,
-                       out var analyticsEnabled,
-                       out var analyticsSampleRateChanged,
-                       out var analyticsSampleRate))
-                {
-                    if (enabledChanged)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettings_Enabled_Set);
-                        setting.Enabled = enabled;
-                    }
-
-#pragma warning disable 618 // App analytics is deprecated, but still used
-                    if (analyticsEnabledChanged)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettings_AnalyticsEnabled_Set);
-                        setting.AnalyticsEnabled = analyticsEnabled;
-                    }
-
-                    if (analyticsSampleRateChanged)
-                    {
-                        TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettings_AnalyticsSampleRate_Set);
-                        setting.AnalyticsSampleRate = analyticsSampleRate;
-                    }
-#pragma warning restore 618
-                }
-            }
-        }
+        // Update the global instance
+        Trace.Tracer.ConfigureInternal(new ImmutableTracerSettings(settings, true));
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/ConfigureIntegration_Pre3_7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/ConfigureIntegration_Pre3_7.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="ConfigureIntegration_Pre3_7.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer;
+
+/// <summary>
+/// System.Void Datadog.Trace.Tracer::Configure(System.Collections.Generic.Dictionary`2[System.String,System.Object]) calltarget instrumentation
+/// </summary>
+[InstrumentMethod(
+    AssemblyName = "Datadog.Trace.Manual",
+    TypeName = "Datadog.Trace.Tracer",
+    MethodName = "Configure",
+    ReturnTypeName = ClrNames.Void,
+    ParameterTypeNames = ["System.Collections.Generic.Dictionary`2[System.String,System.Object]"],
+    MinimumVersion = ManualInstrumentationConstants.MinVersion,
+    MaximumVersion = "3.6.*",
+    IntegrationName = ManualInstrumentationConstants.IntegrationName)]
+[Browsable(false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public class ConfigureIntegration_Pre3_7
+{
+    internal static CallTargetState OnMethodBegin<TTarget>(Dictionary<string, object?> values)
+    {
+        ConfigureIntegration.ConfigureSettingsWithManualOverrides(values, useLegacySettings: true);
+        return CallTargetState.GetDefault();
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
@@ -23,7 +23,17 @@ namespace Datadog.Trace.Configuration
     /// </summary>
     internal class CompositeConfigurationSource : IConfigurationSource, IEnumerable<IConfigurationSource>
     {
-        private readonly List<IConfigurationSource> _sources = new();
+        private readonly List<IConfigurationSource> _sources;
+
+        public CompositeConfigurationSource()
+        {
+            _sources = new();
+        }
+
+        public CompositeConfigurationSource(IEnumerable<IConfigurationSource> sources)
+        {
+            _sources = [..sources];
+        }
 
         /// <summary>
         /// Adds a new configuration source to this instance.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DictionaryObjectConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DictionaryObjectConfigurationSource.cs
@@ -15,7 +15,6 @@ namespace Datadog.Trace.Configuration;
 
 internal class DictionaryObjectConfigurationSource : IConfigurationSource
 {
-    private readonly IReadOnlyDictionary<string, object?> _dictionary;
     private readonly ConfigurationOrigins _origin;
 
     public DictionaryObjectConfigurationSource(IReadOnlyDictionary<string, object?> dictionary)
@@ -25,15 +24,20 @@ internal class DictionaryObjectConfigurationSource : IConfigurationSource
 
     public DictionaryObjectConfigurationSource(IReadOnlyDictionary<string, object?> dictionary, ConfigurationOrigins origin)
     {
-        _dictionary = dictionary;
+        Dictionary = dictionary;
         _origin = origin;
     }
 
-    public bool IsPresent(string key) => _dictionary.ContainsKey(key);
+    protected IReadOnlyDictionary<string, object?> Dictionary { get; }
+
+    protected virtual bool TryGetValue(string key, out object? value)
+        => Dictionary.TryGetValue(key, out value);
+
+    public bool IsPresent(string key) => Dictionary.ContainsKey(key);
 
     public ConfigurationResult<string> GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
     {
-        if (_dictionary.TryGetValue(key, out var objValue) && objValue is not null)
+        if (TryGetValue(key, out var objValue) && objValue is not null)
         {
             if (objValue is not string value)
             {
@@ -56,7 +60,7 @@ internal class DictionaryObjectConfigurationSource : IConfigurationSource
 
     public ConfigurationResult<int> GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
     {
-        if (_dictionary.TryGetValue(key, out var objValue) && objValue is not null)
+        if (TryGetValue(key, out var objValue) && objValue is not null)
         {
             if (objValue is not int value)
             {
@@ -79,7 +83,7 @@ internal class DictionaryObjectConfigurationSource : IConfigurationSource
 
     public ConfigurationResult<double> GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
     {
-        if (_dictionary.TryGetValue(key, out var objValue) && objValue is not null)
+        if (TryGetValue(key, out var objValue) && objValue is not null)
         {
             if (objValue is not double value)
             {
@@ -102,7 +106,7 @@ internal class DictionaryObjectConfigurationSource : IConfigurationSource
 
     public ConfigurationResult<bool> GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
     {
-        if (_dictionary.TryGetValue(key, out var objValue) && objValue is not null)
+        if (TryGetValue(key, out var objValue) && objValue is not null)
         {
             if (objValue is not bool value)
             {
@@ -128,7 +132,7 @@ internal class DictionaryObjectConfigurationSource : IConfigurationSource
 
     public ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
     {
-        if (_dictionary.TryGetValue(key, out var objValue) && objValue is not null)
+        if (TryGetValue(key, out var objValue) && objValue is not null)
         {
             if (objValue is not IDictionary<string, string> value)
             {
@@ -152,7 +156,7 @@ internal class DictionaryObjectConfigurationSource : IConfigurationSource
 
     public ConfigurationResult<T> GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
     {
-        if (_dictionary.TryGetValue(key, out var objValue) && objValue is not null)
+        if (TryGetValue(key, out var objValue) && objValue is not null)
         {
             // Handle conversion
             var valueAsString = objValue.ToString()!;

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationConfigurationSource.cs
@@ -50,7 +50,7 @@ internal class ManualInstrumentationConfigurationSource : DictionaryObjectConfig
         return result;
     }
 
-    private static PublicApiUsage? GetTelemetryKey(string key) => key switch
+    internal static PublicApiUsage? GetTelemetryKey(string key) => key switch
     {
         TracerSettingKeyConstants.AgentUriKey => PublicApiUsage.ExporterSettings_AgentUri_Set,
         TracerSettingKeyConstants.AnalyticsEnabledKey => PublicApiUsage.TracerSettings_AnalyticsEnabled_Set,

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationConfigurationSource.cs
@@ -1,0 +1,97 @@
+﻿// <copyright file="ManualInstrumentationConfigurationSource.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+
+namespace Datadog.Trace.Configuration.ConfigurationSources;
+
+/// <summary>
+/// Wraps the settings passed in from the manual instrumentation API in a configuration source, to make it easier to integrate
+/// </summary>
+internal class ManualInstrumentationConfigurationSource : DictionaryObjectConfigurationSource
+{
+    public ManualInstrumentationConfigurationSource(IReadOnlyDictionary<string, object?> dictionary)
+        : base(dictionary, ConfigurationOrigins.Code)
+    {
+    }
+
+    protected override bool TryGetValue(string key, out object? value)
+    {
+        // Get the value for the given key, but also record telemetry
+        // This is also where any "remapping" should be done, in cases
+        // where either the manual-instrumentation key differs or the
+        // type stored in the dictionary differs
+
+        var result = base.TryGetValue(key, out value);
+        if (result)
+        {
+            if (GetTelemetryKey(key) is { } telemetryKey)
+            {
+                TelemetryFactory.Metrics.Record(telemetryKey);
+            }
+
+            if (value is not null)
+            {
+                value = RemapResult(key, value);
+            }
+        }
+
+        return result;
+    }
+
+    private static PublicApiUsage? GetTelemetryKey(string key) => key switch
+    {
+        TracerSettingKeyConstants.AgentUriKey => PublicApiUsage.ExporterSettings_AgentUri_Set,
+        TracerSettingKeyConstants.AnalyticsEnabledKey => PublicApiUsage.TracerSettings_AnalyticsEnabled_Set,
+        TracerSettingKeyConstants.CustomSamplingRules => PublicApiUsage.TracerSettings_CustomSamplingRules_Set,
+        TracerSettingKeyConstants.DiagnosticSourceEnabledKey => PublicApiUsage.TracerSettings_DiagnosticSourceEnabled_Set,
+        TracerSettingKeyConstants.DisabledIntegrationNamesKey => PublicApiUsage.TracerSettings_DisabledIntegrationNames_Set,
+        TracerSettingKeyConstants.EnvironmentKey => PublicApiUsage.TracerSettings_Environment_Set,
+        TracerSettingKeyConstants.GlobalSamplingRateKey => PublicApiUsage.TracerSettings_GlobalSamplingRate_Set,
+        TracerSettingKeyConstants.GrpcTags => PublicApiUsage.TracerSettings_GrpcTags_Set,
+        TracerSettingKeyConstants.HeaderTags => PublicApiUsage.TracerSettings_HeaderTags_Set,
+        TracerSettingKeyConstants.GlobalTagsKey => PublicApiUsage.TracerSettings_GlobalTags_Set,
+        TracerSettingKeyConstants.HttpClientErrorCodesKey => PublicApiUsage.TracerSettings_SetHttpClientErrorStatusCodes,
+        TracerSettingKeyConstants.HttpServerErrorCodesKey => PublicApiUsage.TracerSettings_SetHttpServerErrorStatusCodes,
+        TracerSettingKeyConstants.KafkaCreateConsumerScopeEnabledKey => PublicApiUsage.TracerSettings_KafkaCreateConsumerScopeEnabled_Set,
+        TracerSettingKeyConstants.LogsInjectionEnabledKey => PublicApiUsage.TracerSettings_LogsInjectionEnabled_Set,
+        TracerSettingKeyConstants.ServiceNameKey => PublicApiUsage.TracerSettings_ServiceName_Set,
+        TracerSettingKeyConstants.ServiceNameMappingsKey => PublicApiUsage.TracerSettings_SetServiceNameMappings,
+        TracerSettingKeyConstants.MaxTracesSubmittedPerSecondKey => PublicApiUsage.TracerSettings_MaxTracesSubmittedPerSecond_Set,
+        TracerSettingKeyConstants.ServiceVersionKey => PublicApiUsage.TracerSettings_ServiceVersion_Set,
+        TracerSettingKeyConstants.StartupDiagnosticLogEnabledKey => PublicApiUsage.TracerSettings_StartupDiagnosticLogEnabled_Set,
+        TracerSettingKeyConstants.StatsComputationEnabledKey => PublicApiUsage.TracerSettings_StatsComputationEnabled_Set,
+        TracerSettingKeyConstants.TraceEnabledKey => PublicApiUsage.TracerSettings_TraceEnabled_Set,
+        TracerSettingKeyConstants.TracerMetricsEnabledKey => PublicApiUsage.TracerSettings_TracerMetricsEnabled_Set,
+        TracerSettingKeyConstants.IntegrationSettingsKey => PublicApiUsage.TracerSettings_TracerMetricsEnabled_Set,
+        // These are pretty hacky but about the best we can do
+        _ when key.EndsWith("_ANALYTICS_ENABLED", StringComparison.Ordinal) => PublicApiUsage.IntegrationSettings_AnalyticsEnabled_Set,
+        _ when key.EndsWith("_ANALYTICS_SAMPLE_RATE", StringComparison.Ordinal) => PublicApiUsage.IntegrationSettings_AnalyticsSampleRate_Set,
+        _ when key.StartsWith("DD_TRACE_", StringComparison.Ordinal) && key.EndsWith("_ANALYTICS_SAMPLE_RATE", StringComparison.Ordinal)
+            => PublicApiUsage.IntegrationSettings_Enabled_Set, // this could definitely be too broad, but about the best we can reasonably do
+        _ => null
+    };
+
+    private static object RemapResult(string key, object value) => key switch
+    {
+        TracerSettingKeyConstants.AgentUriKey => value is Uri uri ? uri.ToString() : value,
+        TracerSettingKeyConstants.HttpServerErrorCodesKey => value is List<int> list
+                                                                 ? string.Join(",", list.Select(i => i.ToString(CultureInfo.InvariantCulture)))
+                                                                 : value,
+        TracerSettingKeyConstants.HttpClientErrorCodesKey => value is List<int> list
+                                                                 ? string.Join(",", list.Select(i => i.ToString(CultureInfo.InvariantCulture)))
+                                                                 : value,
+        _ => value,
+    };
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationLegacyConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationLegacyConfigurationSource.cs
@@ -108,7 +108,9 @@ internal class ManualInstrumentationLegacyConfigurationSource : DictionaryObject
         return false;
     }
 
-    private static IntegrationId? GetIntegrationEnabled(string key) => key switch
+    // This list is fixed in time and doesn't need to be updated
+    // Internal for testing
+    internal static IntegrationId? GetIntegrationEnabled(string key) => key switch
     {
         "DD_TRACE_HTTPMESSAGEHANDLER_ENABLED" => IntegrationId.HttpMessageHandler,
         "DD_TRACE_HTTPSOCKETSHANDLER_ENABLED" => IntegrationId.HttpSocketsHandler,
@@ -185,7 +187,9 @@ internal class ManualInstrumentationLegacyConfigurationSource : DictionaryObject
         _ => null,
     };
 
-    private static IntegrationId? GetIntegrationAnalyticsEnabled(string key) => key switch
+    // This list is fixed in time and doesn't need to be updated
+    // Internal for testing
+    internal static IntegrationId? GetIntegrationAnalyticsEnabled(string key) => key switch
     {
         "DD_TRACE_HTTPMESSAGEHANDLER_ANALYTICS_ENABLED" => IntegrationId.HttpMessageHandler,
         "DD_TRACE_HTTPSOCKETSHANDLER_ANALYTICS_ENABLED" => IntegrationId.HttpSocketsHandler,
@@ -262,7 +266,9 @@ internal class ManualInstrumentationLegacyConfigurationSource : DictionaryObject
         _ => null,
     };
 
-    private static IntegrationId? GetIntegrationAnalyticsSampleRate(string key) => key switch
+    // This list is fixed in time and doesn't need to be updated
+    // Internal for testing
+    internal static IntegrationId? GetIntegrationAnalyticsSampleRate(string key) => key switch
     {
         "DD_TRACE_HTTPMESSAGEHANDLER_ANALYTICS_SAMPLE_RATE" => IntegrationId.HttpMessageHandler,
         "DD_TRACE_HTTPSOCKETSHANDLER_ANALYTICS_SAMPLE_RATE" => IntegrationId.HttpSocketsHandler,
@@ -339,7 +345,9 @@ internal class ManualInstrumentationLegacyConfigurationSource : DictionaryObject
         _ => null,
     };
 
-    private static PublicApiUsage? GetTelemetryKey(string key) => key switch
+    // This list is fixed in time and doesn't need to be updated
+    // Internal for testing
+    internal static PublicApiUsage? GetTelemetryKey(string key) => key switch
     {
         TracerSettingKeyConstants.AgentUriKey => PublicApiUsage.ExporterSettings_AgentUri_Set,
         TracerSettingKeyConstants.AnalyticsEnabledKey => PublicApiUsage.TracerSettings_AnalyticsEnabled_Set,
@@ -363,7 +371,6 @@ internal class ManualInstrumentationLegacyConfigurationSource : DictionaryObject
         TracerSettingKeyConstants.StatsComputationEnabledKey => PublicApiUsage.TracerSettings_StatsComputationEnabled_Set,
         TracerSettingKeyConstants.TraceEnabledKey => PublicApiUsage.TracerSettings_TraceEnabled_Set,
         TracerSettingKeyConstants.TracerMetricsEnabledKey => PublicApiUsage.TracerSettings_TracerMetricsEnabled_Set,
-        TracerSettingKeyConstants.IntegrationSettingsKey => PublicApiUsage.TracerSettings_TracerMetricsEnabled_Set,
         _ => null,
     };
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationLegacyConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationLegacyConfigurationSource.cs
@@ -1,0 +1,381 @@
+﻿// <copyright file="ManualInstrumentationLegacyConfigurationSource.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+
+namespace Datadog.Trace.Configuration.ConfigurationSources;
+
+/// <summary>
+/// Wraps the settings passed in from the manual instrumentation API in a configuration source, to make it easier to integrate.
+/// Only used for legacy manual instrumentation (where the integration settings are serialized as an array)
+/// </summary>
+internal class ManualInstrumentationLegacyConfigurationSource : DictionaryObjectConfigurationSource
+{
+    public ManualInstrumentationLegacyConfigurationSource(IReadOnlyDictionary<string, object?> dictionary)
+        : base(dictionary, ConfigurationOrigins.Code)
+    {
+    }
+
+    protected override bool TryGetValue(string key, out object? value)
+    {
+        // Get the value for the given key, but also record telemetry
+        // This is also where any "remapping" should be done, in cases
+        // where either the manual-instrumentation key differs or the
+        // type stored in the dictionary differs
+
+        var result = TryGetSpecialCase(Dictionary, key, out value) || base.TryGetValue(key, out value);
+        if (result)
+        {
+            if (GetTelemetryKey(key) is { } telemetryKey)
+            {
+                TelemetryFactory.Metrics.Record(telemetryKey);
+            }
+
+            if (value is not null)
+            {
+                value = RemapResult(key, value);
+            }
+        }
+
+        return result;
+    }
+
+    private static bool TryGetSpecialCase(IReadOnlyDictionary<string, object?> dictionary, string key, out object? value)
+    {
+        // we currently only special-case integration related settings, which are stored in a nested dictionary
+
+        // We're looking for:
+        //   DD_TRACE_<Integration>_ENABLED
+        //   DD_TRACE_<Integration>_ANALYTICS_ENABLED
+        //   DD_TRACE_<Integration>_ANALYTICS_SAMPLE_RATE
+
+        // yes, this really sucks right now
+        var enabledIntegration = GetIntegrationEnabled(key);
+        var analyticsIntegration = GetIntegrationAnalyticsEnabled(key);
+        var sampleRateIntegration = GetIntegrationAnalyticsSampleRate(key);
+        if ((enabledIntegration.HasValue || analyticsIntegration.HasValue || sampleRateIntegration.HasValue)
+         && dictionary.TryGetValue(TracerSettingKeyConstants.IntegrationSettingsKey, out var raw)
+         && raw is Dictionary<string, object?[]> integrations)
+        {
+            // ok, we have some integrations, see if we have the _right_ one
+            var integrationId = enabledIntegration ?? analyticsIntegration ?? sampleRateIntegration!.Value;
+            var integrationName = IntegrationRegistry.GetName(integrationId);
+            if (integrations.TryGetValue(integrationName, out var values)
+             && values is not null
+             && IntegrationSettingsSerializationHelper.TryDeserializeFromManual(
+                    values,
+                    out var enabledChanged,
+                    out var enabled,
+                    out var analyticsEnabledChanged,
+                    out var analyticsEnabled,
+                    out var analyticsSampleRateChanged,
+                    out var analyticsSampleRate))
+            {
+                if (enabledIntegration.HasValue && enabledChanged)
+                {
+                    TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettings_Enabled_Set);
+                    value = enabled;
+                    return true;
+                }
+
+                if (analyticsIntegration.HasValue && analyticsEnabledChanged)
+                {
+                    TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettings_AnalyticsEnabled_Set);
+                    value = analyticsEnabled;
+                    return true;
+                }
+
+                if (sampleRateIntegration.HasValue && analyticsSampleRateChanged)
+                {
+                    TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettings_AnalyticsSampleRate_Set);
+                    value = analyticsSampleRate;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static IntegrationId? GetIntegrationEnabled(string key) => key switch
+    {
+        "DD_TRACE_HTTPMESSAGEHANDLER_ENABLED" => IntegrationId.HttpMessageHandler,
+        "DD_TRACE_HTTPSOCKETSHANDLER_ENABLED" => IntegrationId.HttpSocketsHandler,
+        "DD_TRACE_WINHTTPHANDLER_ENABLED" => IntegrationId.WinHttpHandler,
+        "DD_TRACE_CURLHANDLER_ENABLED" => IntegrationId.CurlHandler,
+        "DD_TRACE_ASPNETCORE_ENABLED" => IntegrationId.AspNetCore,
+        "DD_TRACE_ADONET_ENABLED" => IntegrationId.AdoNet,
+        "DD_TRACE_ASPNET_ENABLED" => IntegrationId.AspNet,
+        "DD_TRACE_ASPNETMVC_ENABLED" => IntegrationId.AspNetMvc,
+        "DD_TRACE_ASPNETWEBAPI2_ENABLED" => IntegrationId.AspNetWebApi2,
+        "DD_TRACE_GRAPHQL_ENABLED" => IntegrationId.GraphQL,
+        "DD_TRACE_HOTCHOCOLATE_ENABLED" => IntegrationId.HotChocolate,
+        "DD_TRACE_MONGODB_ENABLED" => IntegrationId.MongoDb,
+        "DD_TRACE_XUNIT_ENABLED" => IntegrationId.XUnit,
+        "DD_TRACE_NUNIT_ENABLED" => IntegrationId.NUnit,
+        "DD_TRACE_MSTESTV2_ENABLED" => IntegrationId.MsTestV2,
+        "DD_TRACE_WCF_ENABLED" => IntegrationId.Wcf,
+        "DD_TRACE_WEBREQUEST_ENABLED" => IntegrationId.WebRequest,
+        "DD_TRACE_ELASTICSEARCHNET_ENABLED" => IntegrationId.ElasticsearchNet,
+        "DD_TRACE_SERVICESTACKREDIS_ENABLED" => IntegrationId.ServiceStackRedis,
+        "DD_TRACE_STACKEXCHANGEREDIS_ENABLED" => IntegrationId.StackExchangeRedis,
+        "DD_TRACE_SERVICEREMOTING_ENABLED" => IntegrationId.ServiceRemoting,
+        "DD_TRACE_RABBITMQ_ENABLED" => IntegrationId.RabbitMQ,
+        "DD_TRACE_MSMQ_ENABLED" => IntegrationId.Msmq,
+        "DD_TRACE_KAFKA_ENABLED" => IntegrationId.Kafka,
+        "DD_TRACE_COSMOSDB_ENABLED" => IntegrationId.CosmosDb,
+        "DD_TRACE_AWSSDK_ENABLED" => IntegrationId.AwsSdk,
+        "DD_TRACE_AWSSQS_ENABLED" => IntegrationId.AwsSqs,
+        "DD_TRACE_AWSSNS_ENABLED" => IntegrationId.AwsSns,
+        "DD_TRACE_AWSEVENTBRIDGE_ENABLED" => IntegrationId.AwsEventBridge,
+        "DD_TRACE_AWSLAMBDA_ENABLED" => IntegrationId.AwsLambda,
+        "DD_TRACE_ILOGGER_ENABLED" => IntegrationId.ILogger,
+        "DD_TRACE_AEROSPIKE_ENABLED" => IntegrationId.Aerospike,
+        "DD_TRACE_AZUREFUNCTIONS_ENABLED" => IntegrationId.AzureFunctions,
+        "DD_TRACE_COUCHBASE_ENABLED" => IntegrationId.Couchbase,
+        "DD_TRACE_MYSQL_ENABLED" => IntegrationId.MySql,
+        "DD_TRACE_NPGSQL_ENABLED" => IntegrationId.Npgsql,
+        "DD_TRACE_ORACLE_ENABLED" => IntegrationId.Oracle,
+        "DD_TRACE_SQLCLIENT_ENABLED" => IntegrationId.SqlClient,
+        "DD_TRACE_SQLITE_ENABLED" => IntegrationId.Sqlite,
+        "DD_TRACE_SERILOG_ENABLED" => IntegrationId.Serilog,
+        "DD_TRACE_LOG4NET_ENABLED" => IntegrationId.Log4Net,
+        "DD_TRACE_NLOG_ENABLED" => IntegrationId.NLog,
+        "DD_TRACE_TRACEANNOTATIONS_ENABLED" => IntegrationId.TraceAnnotations,
+        "DD_TRACE_GRPC_ENABLED" => IntegrationId.Grpc,
+        "DD_TRACE_PROCESS_ENABLED" => IntegrationId.Process,
+        "DD_TRACE_HASHALGORITHM_ENABLED" => IntegrationId.HashAlgorithm,
+        "DD_TRACE_SYMMETRICALGORITHM_ENABLED" => IntegrationId.SymmetricAlgorithm,
+        "DD_TRACE_OPENTELEMETRY_ENABLED" => IntegrationId.OpenTelemetry,
+        "DD_TRACE_PATHTRAVERSAL_ENABLED" => IntegrationId.PathTraversal,
+        "DD_TRACE_LDAP_ENABLED" => IntegrationId.Ldap,
+        "DD_TRACE_SSRF_ENABLED" => IntegrationId.Ssrf,
+        "DD_TRACE_AWSKINESIS_ENABLED" => IntegrationId.AwsKinesis,
+        "DD_TRACE_AZURESERVICEBUS_ENABLED" => IntegrationId.AzureServiceBus,
+        "DD_TRACE_SYSTEMRANDOM_ENABLED" => IntegrationId.SystemRandom,
+        "DD_TRACE_AWSDYNAMODB_ENABLED" => IntegrationId.AwsDynamoDb,
+        "DD_TRACE_HARDCODEDSECRET_ENABLED" => IntegrationId.HardcodedSecret,
+        "DD_TRACE_IBMMQ_ENABLED" => IntegrationId.IbmMq,
+        "DD_TRACE_REMOTING_ENABLED" => IntegrationId.Remoting,
+        "DD_TRACE_TRUSTBOUNDARYVIOLATION_ENABLED" => IntegrationId.TrustBoundaryViolation,
+        "DD_TRACE_UNVALIDATEDREDIRECT_ENABLED" => IntegrationId.UnvalidatedRedirect,
+        "DD_TRACE_TESTPLATFORMASSEMBLYRESOLVER_ENABLED" => IntegrationId.TestPlatformAssemblyResolver,
+        "DD_TRACE_STACKTRACELEAK_ENABLED" => IntegrationId.StackTraceLeak,
+        "DD_TRACE_XPATHINJECTION_ENABLED" => IntegrationId.XpathInjection,
+        "DD_TRACE_REFLECTIONINJECTION_ENABLED" => IntegrationId.ReflectionInjection,
+        "DD_TRACE_XSS_ENABLED" => IntegrationId.Xss,
+        "DD_TRACE_NHIBERNATE_ENABLED" => IntegrationId.NHibernate,
+        "DD_TRACE_DOTNETTEST_ENABLED" => IntegrationId.DotnetTest,
+        "DD_TRACE_SELENIUM_ENABLED" => IntegrationId.Selenium,
+        "DD_TRACE_DIRECTORYLISTINGLEAK_ENABLED" => IntegrationId.DirectoryListingLeak,
+        "DD_TRACE_SESSIONTIMEOUT_ENABLED" => IntegrationId.SessionTimeout,
+        "DD_TRACE_DATADOGTRACEMANUAL_ENABLED" => IntegrationId.DatadogTraceManual,
+        "DD_TRACE_EMAILHTMLINJECTION_ENABLED" => IntegrationId.EmailHtmlInjection,
+        _ => null,
+    };
+
+    private static IntegrationId? GetIntegrationAnalyticsEnabled(string key) => key switch
+    {
+        "DD_TRACE_HTTPMESSAGEHANDLER_ANALYTICS_ENABLED" => IntegrationId.HttpMessageHandler,
+        "DD_TRACE_HTTPSOCKETSHANDLER_ANALYTICS_ENABLED" => IntegrationId.HttpSocketsHandler,
+        "DD_TRACE_WINHTTPHANDLER_ANALYTICS_ENABLED" => IntegrationId.WinHttpHandler,
+        "DD_TRACE_CURLHANDLER_ANALYTICS_ENABLED" => IntegrationId.CurlHandler,
+        "DD_TRACE_ASPNETCORE_ANALYTICS_ENABLED" => IntegrationId.AspNetCore,
+        "DD_TRACE_ADONET_ANALYTICS_ENABLED" => IntegrationId.AdoNet,
+        "DD_TRACE_ASPNET_ANALYTICS_ENABLED" => IntegrationId.AspNet,
+        "DD_TRACE_ASPNETMVC_ANALYTICS_ENABLED" => IntegrationId.AspNetMvc,
+        "DD_TRACE_ASPNETWEBAPI2_ANALYTICS_ENABLED" => IntegrationId.AspNetWebApi2,
+        "DD_TRACE_GRAPHQL_ANALYTICS_ENABLED" => IntegrationId.GraphQL,
+        "DD_TRACE_HOTCHOCOLATE_ANALYTICS_ENABLED" => IntegrationId.HotChocolate,
+        "DD_TRACE_MONGODB_ANALYTICS_ENABLED" => IntegrationId.MongoDb,
+        "DD_TRACE_XUNIT_ANALYTICS_ENABLED" => IntegrationId.XUnit,
+        "DD_TRACE_NUNIT_ANALYTICS_ENABLED" => IntegrationId.NUnit,
+        "DD_TRACE_MSTESTV2_ANALYTICS_ENABLED" => IntegrationId.MsTestV2,
+        "DD_TRACE_WCF_ANALYTICS_ENABLED" => IntegrationId.Wcf,
+        "DD_TRACE_WEBREQUEST_ANALYTICS_ENABLED" => IntegrationId.WebRequest,
+        "DD_TRACE_ELASTICSEARCHNET_ANALYTICS_ENABLED" => IntegrationId.ElasticsearchNet,
+        "DD_TRACE_SERVICESTACKREDIS_ANALYTICS_ENABLED" => IntegrationId.ServiceStackRedis,
+        "DD_TRACE_STACKEXCHANGEREDIS_ANALYTICS_ENABLED" => IntegrationId.StackExchangeRedis,
+        "DD_TRACE_SERVICEREMOTING_ANALYTICS_ENABLED" => IntegrationId.ServiceRemoting,
+        "DD_TRACE_RABBITMQ_ANALYTICS_ENABLED" => IntegrationId.RabbitMQ,
+        "DD_TRACE_MSMQ_ANALYTICS_ENABLED" => IntegrationId.Msmq,
+        "DD_TRACE_KAFKA_ANALYTICS_ENABLED" => IntegrationId.Kafka,
+        "DD_TRACE_COSMOSDB_ANALYTICS_ENABLED" => IntegrationId.CosmosDb,
+        "DD_TRACE_AWSSDK_ANALYTICS_ENABLED" => IntegrationId.AwsSdk,
+        "DD_TRACE_AWSSQS_ANALYTICS_ENABLED" => IntegrationId.AwsSqs,
+        "DD_TRACE_AWSSNS_ANALYTICS_ENABLED" => IntegrationId.AwsSns,
+        "DD_TRACE_AWSEVENTBRIDGE_ANALYTICS_ENABLED" => IntegrationId.AwsEventBridge,
+        "DD_TRACE_AWSLAMBDA_ANALYTICS_ENABLED" => IntegrationId.AwsLambda,
+        "DD_TRACE_ILOGGER_ANALYTICS_ENABLED" => IntegrationId.ILogger,
+        "DD_TRACE_AEROSPIKE_ANALYTICS_ENABLED" => IntegrationId.Aerospike,
+        "DD_TRACE_AZUREFUNCTIONS_ANALYTICS_ENABLED" => IntegrationId.AzureFunctions,
+        "DD_TRACE_COUCHBASE_ANALYTICS_ENABLED" => IntegrationId.Couchbase,
+        "DD_TRACE_MYSQL_ANALYTICS_ENABLED" => IntegrationId.MySql,
+        "DD_TRACE_NPGSQL_ANALYTICS_ENABLED" => IntegrationId.Npgsql,
+        "DD_TRACE_ORACLE_ANALYTICS_ENABLED" => IntegrationId.Oracle,
+        "DD_TRACE_SQLCLIENT_ANALYTICS_ENABLED" => IntegrationId.SqlClient,
+        "DD_TRACE_SQLITE_ANALYTICS_ENABLED" => IntegrationId.Sqlite,
+        "DD_TRACE_SERILOG_ANALYTICS_ENABLED" => IntegrationId.Serilog,
+        "DD_TRACE_LOG4NET_ANALYTICS_ENABLED" => IntegrationId.Log4Net,
+        "DD_TRACE_NLOG_ANALYTICS_ENABLED" => IntegrationId.NLog,
+        "DD_TRACE_TRACEANNOTATIONS_ANALYTICS_ENABLED" => IntegrationId.TraceAnnotations,
+        "DD_TRACE_GRPC_ANALYTICS_ENABLED" => IntegrationId.Grpc,
+        "DD_TRACE_PROCESS_ANALYTICS_ENABLED" => IntegrationId.Process,
+        "DD_TRACE_HASHALGORITHM_ANALYTICS_ENABLED" => IntegrationId.HashAlgorithm,
+        "DD_TRACE_SYMMETRICALGORITHM_ANALYTICS_ENABLED" => IntegrationId.SymmetricAlgorithm,
+        "DD_TRACE_OPENTELEMETRY_ANALYTICS_ENABLED" => IntegrationId.OpenTelemetry,
+        "DD_TRACE_PATHTRAVERSAL_ANALYTICS_ENABLED" => IntegrationId.PathTraversal,
+        "DD_TRACE_LDAP_ANALYTICS_ENABLED" => IntegrationId.Ldap,
+        "DD_TRACE_SSRF_ANALYTICS_ENABLED" => IntegrationId.Ssrf,
+        "DD_TRACE_AWSKINESIS_ANALYTICS_ENABLED" => IntegrationId.AwsKinesis,
+        "DD_TRACE_AZURESERVICEBUS_ANALYTICS_ENABLED" => IntegrationId.AzureServiceBus,
+        "DD_TRACE_SYSTEMRANDOM_ANALYTICS_ENABLED" => IntegrationId.SystemRandom,
+        "DD_TRACE_AWSDYNAMODB_ANALYTICS_ENABLED" => IntegrationId.AwsDynamoDb,
+        "DD_TRACE_HARDCODEDSECRET_ANALYTICS_ENABLED" => IntegrationId.HardcodedSecret,
+        "DD_TRACE_IBMMQ_ANALYTICS_ENABLED" => IntegrationId.IbmMq,
+        "DD_TRACE_REMOTING_ANALYTICS_ENABLED" => IntegrationId.Remoting,
+        "DD_TRACE_TRUSTBOUNDARYVIOLATION_ANALYTICS_ENABLED" => IntegrationId.TrustBoundaryViolation,
+        "DD_TRACE_UNVALIDATEDREDIRECT_ANALYTICS_ENABLED" => IntegrationId.UnvalidatedRedirect,
+        "DD_TRACE_TESTPLATFORMASSEMBLYRESOLVER_ANALYTICS_ENABLED" => IntegrationId.TestPlatformAssemblyResolver,
+        "DD_TRACE_STACKTRACELEAK_ANALYTICS_ENABLED" => IntegrationId.StackTraceLeak,
+        "DD_TRACE_XPATHINJECTION_ANALYTICS_ENABLED" => IntegrationId.XpathInjection,
+        "DD_TRACE_REFLECTIONINJECTION_ANALYTICS_ENABLED" => IntegrationId.ReflectionInjection,
+        "DD_TRACE_XSS_ANALYTICS_ENABLED" => IntegrationId.Xss,
+        "DD_TRACE_NHIBERNATE_ANALYTICS_ENABLED" => IntegrationId.NHibernate,
+        "DD_TRACE_DOTNETTEST_ANALYTICS_ENABLED" => IntegrationId.DotnetTest,
+        "DD_TRACE_SELENIUM_ANALYTICS_ENABLED" => IntegrationId.Selenium,
+        "DD_TRACE_DIRECTORYLISTINGLEAK_ANALYTICS_ENABLED" => IntegrationId.DirectoryListingLeak,
+        "DD_TRACE_SESSIONTIMEOUT_ANALYTICS_ENABLED" => IntegrationId.SessionTimeout,
+        "DD_TRACE_DATADOGTRACEMANUAL_ANALYTICS_ENABLED" => IntegrationId.DatadogTraceManual,
+        "DD_TRACE_EMAILHTMLINJECTION_ANALYTICS_ENABLED" => IntegrationId.EmailHtmlInjection,
+        _ => null,
+    };
+
+    private static IntegrationId? GetIntegrationAnalyticsSampleRate(string key) => key switch
+    {
+        "DD_TRACE_HTTPMESSAGEHANDLER_ANALYTICS_SAMPLE_RATE" => IntegrationId.HttpMessageHandler,
+        "DD_TRACE_HTTPSOCKETSHANDLER_ANALYTICS_SAMPLE_RATE" => IntegrationId.HttpSocketsHandler,
+        "DD_TRACE_WINHTTPHANDLER_ANALYTICS_SAMPLE_RATE" => IntegrationId.WinHttpHandler,
+        "DD_TRACE_CURLHANDLER_ANALYTICS_SAMPLE_RATE" => IntegrationId.CurlHandler,
+        "DD_TRACE_ASPNETCORE_ANALYTICS_SAMPLE_RATE" => IntegrationId.AspNetCore,
+        "DD_TRACE_ADONET_ANALYTICS_SAMPLE_RATE" => IntegrationId.AdoNet,
+        "DD_TRACE_ASPNET_ANALYTICS_SAMPLE_RATE" => IntegrationId.AspNet,
+        "DD_TRACE_ASPNETMVC_ANALYTICS_SAMPLE_RATE" => IntegrationId.AspNetMvc,
+        "DD_TRACE_ASPNETWEBAPI2_ANALYTICS_SAMPLE_RATE" => IntegrationId.AspNetWebApi2,
+        "DD_TRACE_GRAPHQL_ANALYTICS_SAMPLE_RATE" => IntegrationId.GraphQL,
+        "DD_TRACE_HOTCHOCOLATE_ANALYTICS_SAMPLE_RATE" => IntegrationId.HotChocolate,
+        "DD_TRACE_MONGODB_ANALYTICS_SAMPLE_RATE" => IntegrationId.MongoDb,
+        "DD_TRACE_XUNIT_ANALYTICS_SAMPLE_RATE" => IntegrationId.XUnit,
+        "DD_TRACE_NUNIT_ANALYTICS_SAMPLE_RATE" => IntegrationId.NUnit,
+        "DD_TRACE_MSTESTV2_ANALYTICS_SAMPLE_RATE" => IntegrationId.MsTestV2,
+        "DD_TRACE_WCF_ANALYTICS_SAMPLE_RATE" => IntegrationId.Wcf,
+        "DD_TRACE_WEBREQUEST_ANALYTICS_SAMPLE_RATE" => IntegrationId.WebRequest,
+        "DD_TRACE_ELASTICSEARCHNET_ANALYTICS_SAMPLE_RATE" => IntegrationId.ElasticsearchNet,
+        "DD_TRACE_SERVICESTACKREDIS_ANALYTICS_SAMPLE_RATE" => IntegrationId.ServiceStackRedis,
+        "DD_TRACE_STACKEXCHANGEREDIS_ANALYTICS_SAMPLE_RATE" => IntegrationId.StackExchangeRedis,
+        "DD_TRACE_SERVICEREMOTING_ANALYTICS_SAMPLE_RATE" => IntegrationId.ServiceRemoting,
+        "DD_TRACE_RABBITMQ_ANALYTICS_SAMPLE_RATE" => IntegrationId.RabbitMQ,
+        "DD_TRACE_MSMQ_ANALYTICS_SAMPLE_RATE" => IntegrationId.Msmq,
+        "DD_TRACE_KAFKA_ANALYTICS_SAMPLE_RATE" => IntegrationId.Kafka,
+        "DD_TRACE_COSMOSDB_ANALYTICS_SAMPLE_RATE" => IntegrationId.CosmosDb,
+        "DD_TRACE_AWSSDK_ANALYTICS_SAMPLE_RATE" => IntegrationId.AwsSdk,
+        "DD_TRACE_AWSSQS_ANALYTICS_SAMPLE_RATE" => IntegrationId.AwsSqs,
+        "DD_TRACE_AWSSNS_ANALYTICS_SAMPLE_RATE" => IntegrationId.AwsSns,
+        "DD_TRACE_AWSEVENTBRIDGE_ANALYTICS_SAMPLE_RATE" => IntegrationId.AwsEventBridge,
+        "DD_TRACE_AWSLAMBDA_ANALYTICS_SAMPLE_RATE" => IntegrationId.AwsLambda,
+        "DD_TRACE_ILOGGER_ANALYTICS_SAMPLE_RATE" => IntegrationId.ILogger,
+        "DD_TRACE_AEROSPIKE_ANALYTICS_SAMPLE_RATE" => IntegrationId.Aerospike,
+        "DD_TRACE_AZUREFUNCTIONS_ANALYTICS_SAMPLE_RATE" => IntegrationId.AzureFunctions,
+        "DD_TRACE_COUCHBASE_ANALYTICS_SAMPLE_RATE" => IntegrationId.Couchbase,
+        "DD_TRACE_MYSQL_ANALYTICS_SAMPLE_RATE" => IntegrationId.MySql,
+        "DD_TRACE_NPGSQL_ANALYTICS_SAMPLE_RATE" => IntegrationId.Npgsql,
+        "DD_TRACE_ORACLE_ANALYTICS_SAMPLE_RATE" => IntegrationId.Oracle,
+        "DD_TRACE_SQLCLIENT_ANALYTICS_SAMPLE_RATE" => IntegrationId.SqlClient,
+        "DD_TRACE_SQLITE_ANALYTICS_SAMPLE_RATE" => IntegrationId.Sqlite,
+        "DD_TRACE_SERILOG_ANALYTICS_SAMPLE_RATE" => IntegrationId.Serilog,
+        "DD_TRACE_LOG4NET_ANALYTICS_SAMPLE_RATE" => IntegrationId.Log4Net,
+        "DD_TRACE_NLOG_ANALYTICS_SAMPLE_RATE" => IntegrationId.NLog,
+        "DD_TRACE_TRACEANNOTATIONS_ANALYTICS_SAMPLE_RATE" => IntegrationId.TraceAnnotations,
+        "DD_TRACE_GRPC_ANALYTICS_SAMPLE_RATE" => IntegrationId.Grpc,
+        "DD_TRACE_PROCESS_ANALYTICS_SAMPLE_RATE" => IntegrationId.Process,
+        "DD_TRACE_HASHALGORITHM_ANALYTICS_SAMPLE_RATE" => IntegrationId.HashAlgorithm,
+        "DD_TRACE_SYMMETRICALGORITHM_ANALYTICS_SAMPLE_RATE" => IntegrationId.SymmetricAlgorithm,
+        "DD_TRACE_OPENTELEMETRY_ANALYTICS_SAMPLE_RATE" => IntegrationId.OpenTelemetry,
+        "DD_TRACE_PATHTRAVERSAL_ANALYTICS_SAMPLE_RATE" => IntegrationId.PathTraversal,
+        "DD_TRACE_LDAP_ANALYTICS_SAMPLE_RATE" => IntegrationId.Ldap,
+        "DD_TRACE_SSRF_ANALYTICS_SAMPLE_RATE" => IntegrationId.Ssrf,
+        "DD_TRACE_AWSKINESIS_ANALYTICS_SAMPLE_RATE" => IntegrationId.AwsKinesis,
+        "DD_TRACE_AZURESERVICEBUS_ANALYTICS_SAMPLE_RATE" => IntegrationId.AzureServiceBus,
+        "DD_TRACE_SYSTEMRANDOM_ANALYTICS_SAMPLE_RATE" => IntegrationId.SystemRandom,
+        "DD_TRACE_AWSDYNAMODB_ANALYTICS_SAMPLE_RATE" => IntegrationId.AwsDynamoDb,
+        "DD_TRACE_HARDCODEDSECRET_ANALYTICS_SAMPLE_RATE" => IntegrationId.HardcodedSecret,
+        "DD_TRACE_IBMMQ_ANALYTICS_SAMPLE_RATE" => IntegrationId.IbmMq,
+        "DD_TRACE_REMOTING_ANALYTICS_SAMPLE_RATE" => IntegrationId.Remoting,
+        "DD_TRACE_TRUSTBOUNDARYVIOLATION_ANALYTICS_SAMPLE_RATE" => IntegrationId.TrustBoundaryViolation,
+        "DD_TRACE_UNVALIDATEDREDIRECT_ANALYTICS_SAMPLE_RATE" => IntegrationId.UnvalidatedRedirect,
+        "DD_TRACE_TESTPLATFORMASSEMBLYRESOLVER_ANALYTICS_SAMPLE_RATE" => IntegrationId.TestPlatformAssemblyResolver,
+        "DD_TRACE_STACKTRACELEAK_ANALYTICS_SAMPLE_RATE" => IntegrationId.StackTraceLeak,
+        "DD_TRACE_XPATHINJECTION_ANALYTICS_SAMPLE_RATE" => IntegrationId.XpathInjection,
+        "DD_TRACE_REFLECTIONINJECTION_ANALYTICS_SAMPLE_RATE" => IntegrationId.ReflectionInjection,
+        "DD_TRACE_XSS_ANALYTICS_SAMPLE_RATE" => IntegrationId.Xss,
+        "DD_TRACE_NHIBERNATE_ANALYTICS_SAMPLE_RATE" => IntegrationId.NHibernate,
+        "DD_TRACE_DOTNETTEST_ANALYTICS_SAMPLE_RATE" => IntegrationId.DotnetTest,
+        "DD_TRACE_SELENIUM_ANALYTICS_SAMPLE_RATE" => IntegrationId.Selenium,
+        "DD_TRACE_DIRECTORYLISTINGLEAK_ANALYTICS_SAMPLE_RATE" => IntegrationId.DirectoryListingLeak,
+        "DD_TRACE_SESSIONTIMEOUT_ANALYTICS_SAMPLE_RATE" => IntegrationId.SessionTimeout,
+        "DD_TRACE_DATADOGTRACEMANUAL_ANALYTICS_SAMPLE_RATE" => IntegrationId.DatadogTraceManual,
+        "DD_TRACE_EMAILHTMLINJECTION_ANALYTICS_SAMPLE_RATE" => IntegrationId.EmailHtmlInjection,
+        _ => null,
+    };
+
+    private static PublicApiUsage? GetTelemetryKey(string key) => key switch
+    {
+        TracerSettingKeyConstants.AgentUriKey => PublicApiUsage.ExporterSettings_AgentUri_Set,
+        TracerSettingKeyConstants.AnalyticsEnabledKey => PublicApiUsage.TracerSettings_AnalyticsEnabled_Set,
+        TracerSettingKeyConstants.CustomSamplingRules => PublicApiUsage.TracerSettings_CustomSamplingRules_Set,
+        TracerSettingKeyConstants.DiagnosticSourceEnabledKey => PublicApiUsage.TracerSettings_DiagnosticSourceEnabled_Set,
+        TracerSettingKeyConstants.DisabledIntegrationNamesKey => PublicApiUsage.TracerSettings_DisabledIntegrationNames_Set,
+        TracerSettingKeyConstants.EnvironmentKey => PublicApiUsage.TracerSettings_Environment_Set,
+        TracerSettingKeyConstants.GlobalSamplingRateKey => PublicApiUsage.TracerSettings_GlobalSamplingRate_Set,
+        TracerSettingKeyConstants.GrpcTags => PublicApiUsage.TracerSettings_GrpcTags_Set,
+        TracerSettingKeyConstants.HeaderTags => PublicApiUsage.TracerSettings_HeaderTags_Set,
+        TracerSettingKeyConstants.GlobalTagsKey => PublicApiUsage.TracerSettings_GlobalTags_Set,
+        TracerSettingKeyConstants.HttpClientErrorCodesKey => PublicApiUsage.TracerSettings_SetHttpClientErrorStatusCodes,
+        TracerSettingKeyConstants.HttpServerErrorCodesKey => PublicApiUsage.TracerSettings_SetHttpServerErrorStatusCodes,
+        TracerSettingKeyConstants.KafkaCreateConsumerScopeEnabledKey => PublicApiUsage.TracerSettings_KafkaCreateConsumerScopeEnabled_Set,
+        TracerSettingKeyConstants.LogsInjectionEnabledKey => PublicApiUsage.TracerSettings_LogsInjectionEnabled_Set,
+        TracerSettingKeyConstants.ServiceNameKey => PublicApiUsage.TracerSettings_ServiceName_Set,
+        TracerSettingKeyConstants.ServiceNameMappingsKey => PublicApiUsage.TracerSettings_SetServiceNameMappings,
+        TracerSettingKeyConstants.MaxTracesSubmittedPerSecondKey => PublicApiUsage.TracerSettings_MaxTracesSubmittedPerSecond_Set,
+        TracerSettingKeyConstants.ServiceVersionKey => PublicApiUsage.TracerSettings_ServiceVersion_Set,
+        TracerSettingKeyConstants.StartupDiagnosticLogEnabledKey => PublicApiUsage.TracerSettings_StartupDiagnosticLogEnabled_Set,
+        TracerSettingKeyConstants.StatsComputationEnabledKey => PublicApiUsage.TracerSettings_StatsComputationEnabled_Set,
+        TracerSettingKeyConstants.TraceEnabledKey => PublicApiUsage.TracerSettings_TraceEnabled_Set,
+        TracerSettingKeyConstants.TracerMetricsEnabledKey => PublicApiUsage.TracerSettings_TracerMetricsEnabled_Set,
+        TracerSettingKeyConstants.IntegrationSettingsKey => PublicApiUsage.TracerSettings_TracerMetricsEnabled_Set,
+        _ => null,
+    };
+
+    private static object RemapResult(string key, object value) => key switch
+    {
+        TracerSettingKeyConstants.AgentUriKey => value is Uri uri ? uri.ToString() : value,
+        TracerSettingKeyConstants.HttpServerErrorCodesKey => value is List<int> list
+                                                                 ? string.Join(",", list.Select(i => i.ToString(CultureInfo.InvariantCulture)))
+                                                                 : value,
+        TracerSettingKeyConstants.HttpClientErrorCodesKey => value is List<int> list
+                                                                 ? string.Join(",", list.Select(i => i.ToString(CultureInfo.InvariantCulture)))
+                                                                 : value,
+        _ => value,
+    };
+}

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -260,6 +260,7 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Extensions.SpanExtensionsSetUserIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.CtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration_Pre3_7"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.StartSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ForceFlushAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.GetActiveScopeIntegration"

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -273,6 +273,7 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Extensions.SpanExtensionsSetUserIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.CtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration_Pre3_7"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.StartSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ForceFlushAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.GetActiveScopeIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -269,6 +269,7 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Extensions.SpanExtensionsSetUserIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.CtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration_Pre3_7"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.StartSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ForceFlushAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.GetActiveScopeIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -269,6 +269,7 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Extensions.SpanExtensionsSetUserIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.CtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ConfigureIntegration_Pre3_7"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.StartSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.ForceFlushAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Tracer.GetActiveScopeIntegration"

--- a/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/ManualInstrumentationLegacyConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/ManualInstrumentationLegacyConfigurationSourceTests.cs
@@ -1,0 +1,92 @@
+﻿// <copyright file="ManualInstrumentationLegacyConfigurationSourceTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+public class ManualInstrumentationLegacyConfigurationSourceTests
+{
+    public static IEnumerable<object[]> SupportedIds()
+        => IntegrationRegistry.Ids.Values
+                              .Where(x => x <= (int)IntegrationId.EmailHtmlInjection) // legacy source only supports integrations up to EmailHtmlInjection
+                              .Select(x => new object[] { x });
+
+    public static IEnumerable<object[]> UnsupportedIds()
+        => IntegrationRegistry.Ids.Values
+                              .Where(x => x > (int)IntegrationId.EmailHtmlInjection) // legacy source only supports integrations up to EmailHtmlInjection
+                              .Select(x => new object[] { x });
+
+    [Theory]
+    [MemberData(nameof(SupportedIds))]
+    public void GetIntegrationEnabled_SupportedValues_ReturnsExpectedValues(int id)
+    {
+        var integrationId = (IntegrationId)id;
+        var name = IntegrationRegistry.GetName(integrationId).ToUpperInvariant();
+        var enabledKey = string.Format(ConfigurationKeys.Integrations.Enabled, name);
+
+        var actual = ManualInstrumentationLegacyConfigurationSource.GetIntegrationEnabled(enabledKey);
+
+        actual.Should().Be(integrationId);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedIds))]
+    public void GetIntegrationAnalyticsEnabled_SupportedValues_ReturnsExpectedValues(int id)
+    {
+        var integrationId = (IntegrationId)id;
+        var name = IntegrationRegistry.GetName(integrationId).ToUpperInvariant();
+        var enabledKey = string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, name);
+
+        var actual = ManualInstrumentationLegacyConfigurationSource.GetIntegrationAnalyticsEnabled(enabledKey);
+
+        actual.Should().Be(integrationId);
+    }
+
+    [Theory(Skip = "There are no unsupported IDs yet, and xunit doesn't like that")]
+    [MemberData(nameof(UnsupportedIds))]
+    public void GetIntegrationEnabled_ForUnsupportedValues_ReturnsNull(int id)
+    {
+        var integrationId = (IntegrationId)id;
+        var name = IntegrationRegistry.GetName(integrationId).ToUpperInvariant();
+        var enabledKey = string.Format(ConfigurationKeys.Integrations.Enabled, name);
+
+        var actual = ManualInstrumentationLegacyConfigurationSource.GetIntegrationEnabled(enabledKey);
+
+        actual.Should().BeNull();
+    }
+
+    [Theory(Skip = "There are no unsupported IDs yet, and xunit doesn't like that")]
+    [MemberData(nameof(UnsupportedIds))]
+    public void GetIntegrationAnalyticsEnabled_ForUnsupportedValues_ReturnsNull(int id)
+    {
+        var integrationId = (IntegrationId)id;
+        var name = IntegrationRegistry.GetName(integrationId).ToUpperInvariant();
+        var enabledKey = string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, name);
+
+        var actual = ManualInstrumentationLegacyConfigurationSource.GetIntegrationAnalyticsEnabled(enabledKey);
+
+        actual.Should().BeNull();
+    }
+
+    [Theory(Skip = "There are no unsupported IDs yet, and xunit doesn't like that")]
+    [MemberData(nameof(UnsupportedIds))]
+    public void GetIntegrationAnalyticsSampleRate_ForUnsupportedValues_ReturnsNull(int id)
+    {
+        var integrationId = (IntegrationId)id;
+        var name = IntegrationRegistry.GetName(integrationId).ToUpperInvariant();
+        var enabledKey = string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, name);
+
+        var actual = ManualInstrumentationLegacyConfigurationSource.GetIntegrationAnalyticsSampleRate(enabledKey);
+
+        actual.Should().BeNull();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
@@ -54,6 +54,17 @@ public class ConfigurationTests
         "DD_INJECT_FORCE",
     };
 
+    // These are the keys that are used in the integration registry which are _not_ sent to telemetry, so we can ignore them
+    private static readonly string[] IntegrationSettingKeys =
+        IntegrationRegistry.Names
+            .SelectMany(x => new[]
+                            {
+                                $"DD_TRACE_{x.ToUpperInvariant()}_ENABLED",
+                                $"DD_TRACE_{x.ToUpperInvariant()}_ANALYTICS_ENABLED",
+                                $"DD_TRACE_{x.ToUpperInvariant()}_ANALYTICS_SAMPLE_RATE"
+                            })
+            .ToArray();
+
     [Fact]
     public void AllConfigurationValuesAreRegisteredWithIntake()
     {
@@ -79,9 +90,9 @@ public class ConfigurationTests
         var allPotentialConfigKeys = assemblyStrings
                                     .Where(x => (x.StartsWith("DD_") || x.StartsWith("_DD") || x.StartsWith("DATADOG_") || x.StartsWith("OTEL_")) && !x.Contains(" "))
                                     .Concat(configKeyStrings)
-                                    .Where(x => !x.Contains("{0}") && x != "DD_") // exclude the format string ones + the interpolated string ones
+                                    .Where(x => !x.Contains("{0}") && x != "DD_" && x != "DD_TRACE_") // exclude the format string ones + the interpolated string ones
                                     .Distinct()
-                                    .Where(x => !ExcludedKeys.Contains(x))
+                                    .Where(x => !ExcludedKeys.Contains(x) && !IntegrationSettingKeys.Contains(x))
                                     .ToList();
 
         var keysWithoutConfig = new List<string>();


### PR DESCRIPTION
Change how we "apply" settings from manual configuration to the automatic side to use `IConfigurationSource` 

## Reason for change

The previous design of how we "apply" settings made in code using manual instrumentation required mutating a `TracerSettings` object after it was already built. In fact, this is pretty much the _only_ place that we mutate the settings.

By switching to using a "configuration source" approach, so that the settings are built _once_ with the correct values opens up the option to make these immutable (and therefore delete all of the `Immutable*` settings we currently have. This reduces both code duplication and work we do on startup, and opens the path to further refactoring improvements.

Note that the public API does not change, so consumers of Datadog.Trace.Manual are still working with a mutable object initially.

## Implementation details

Currently we pass a `Dictionary<string, object>` between the manual and automatic side. Previously, we then iterated the keys, compared against known values, and modified `TracerSettings` as required.

With the changes, we have a `ManualInstrumentationConfigurationSource` which just "wraps" the `Dictionary<>`, and returns the correct value as required for a given key. Overall, I think this is much cleaner.

Where things get messy is how we handle disabling specific integrations. The existing dictionary is optimised for looping through the provided values, fetching the setting that needs to be modified, and changing all the required properties. Unfortunately, the `IConfigurationSource` approach where we're looking up by a key like `DD_TRACE_NPGSQL_ENABLED` works _horribly_ for this pattern 🙁. So I introduced an additional approach which explicitly _additionally_ transfers the settings using these values, making them just "standard" lookups.

> Note that due to backwards + forwards compatibility requirements
> - We _still_ need to send the "old" version of integration settings from the manual side, in case it's used with an old version of the auto instrumentation
> - We _still_ need to handle the "old" version of integration settings in the auto side, in case it's used with an old version of the manual instrumentation. 
>   - At least in this case we can use the more efficient `IConfigurationSource` reader, so we don't pay the expense of retrieving the settings. The only downside is a couple of extra allocations when they _do_ disable integrations in code.


Minor other changes:
- Add helper ctor to `CompositeConfigurationSource` for creating the internal list from a collection of `IConfigurationSource`
- Tweak `DictionaryObjectConfigurationSource` so we can derive from it
- Create a separate integration for <3.7.0 manual instrumentation that uses the legacy settings, otherwise use the new settings objects

## Test coverage

Mostly covered by existing unit tests (and indirectly by integration tests). Tweaked the test to test both the new and legacy configuration source.

## Other details

Requires https://github.com/DataDog/dd-trace-dotnet/pull/6393 to fix how we read integration settings


Part of stack 
- https://github.com/DataDog/dd-trace-dotnet/pull/6370
- https://github.com/DataDog/dd-trace-dotnet/pull/6376
- https://github.com/DataDog/dd-trace-dotnet/pull/6385
- https://github.com/DataDog/dd-trace-dotnet/pull/6386
- https://github.com/DataDog/dd-trace-dotnet/pull/6397 👈 This PR
- https://github.com/DataDog/dd-trace-dotnet/pull/6399
- https://github.com/DataDog/dd-trace-dotnet/pull/6400
- https://github.com/DataDog/dd-trace-dotnet/pull/6405
- https://github.com/DataDog/dd-trace-dotnet/pull/6408