### PR TITLE
[Crashtracking] Display a nicer error message when the glibc version is too old

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -426,7 +426,17 @@ internal class CreatedumpCommand : Command
         var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dll" : "so";
         var profilerLibrary = $"Datadog.Profiler.Native.{extension}";
 
-        var lib = NativeLibrary.Load(Path.Combine(AppContext.BaseDirectory, profilerLibrary));
+        IntPtr lib;
+
+        try
+        {
+            lib = NativeLibrary.Load(Path.Combine(AppContext.BaseDirectory, profilerLibrary));
+        }
+        catch (DllNotFoundException ex) when (ex.Message.Contains("GLIBC"))
+        {
+            Errors.Add($"The GLIBC version is too old");
+            return;
+        }
 
         var export = NativeLibrary.GetExport(lib, "CreateCrashReport");
 


### PR DESCRIPTION
## Summary of changes

Change the error message when loading the profiler fails because of the glibc version.

Before:

```
Datadog - Some errors occurred while analyzing the crash:
- Unexpected exception: System.DllNotFoundException: Unable to load shared 
library 
'/opt/datadog-packages/datadog-apm-library-dotnet/3.6.1/linux-arm64/Datadog.Prof
iler.Native.so' or one of its dependencies. In order to help diagnose loading 
problems, consider using a tool like strace. If you're using glibc, consider 
setting the LD_DEBUG environment variable: 
/lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by 
/opt/datadog-packages/datadog-apm-library-dotnet/3.6.1/linux-arm64/Datadog.Profi
ler.Native.so)

   at 
System.Runtime.InteropServices.NativeLibrary.LoadLibErrorTracker.Throw(String) +
0x50
   at System.Runtime.InteropServices.NativeLibrary.LoadFromPath(String, Boolean)
+ 0x4c
   at Datadog.Trace.Tools.dd_dotnet.CreatedumpCommand.GenerateCrashReport(Int32,
Nullable`1, Nullable`1) + 0x110
   at Datadog.Trace.Tools.dd_dotnet.CreatedumpCommand.Execute(InvocationContext 
context) + 0x94
```

After:

```
Datadog - Some errors occurred while analyzing the crash:
- The GLIBC version is too old
```

## Reason for change

The error is "expected" in some environment, so it's better to make the message less scary.
