### PR TITLE
[Profiler] Fix static analysis job

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -236,6 +236,7 @@ std::vector<int32_t> GetProcessThreads(int32_t pid)
     else
     {
         auto errorNumber = errno;
+        //NOLINTNEXTLINE
         LogOnce(Error, "Failed at opendir ", dirname, " error: ", strerror(errorNumber));
     }
 
@@ -268,6 +269,7 @@ std::vector<std::shared_ptr<IThreadInfo>> GetProcessThreads()
     else
     {
         auto errorNumber = errno;
+        //NOLINTNEXTLINE
         LogOnce(Error, "Failed at opendir ", dirname, " error: ", strerror(errorNumber));
     }
 


### PR DESCRIPTION
## Summary of changes
Fix static analysis job.

## Reason for change
The static analysis job searches in the logs files for ` error:`  string. But if the analyzer reports a programming issues, it will report the whole statement. If that statement contains ` error:` 💥 

## Implementation details

In that specific case, we prevent the analyzer to report those 2 specific statements.

## Test coverage

Static job analysis must be green now.
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
