### PR TITLE
Report failures to update GitHub as build errors in Azure Devops

### DIFF
--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -15,13 +15,14 @@ steps:
     allChecks="${{ parameters.checkName }}"
     for stageToSkip in $allChecks; do
       TARGET_URL="https://dev.azure.com/datadoghq/$(AZURE_PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
-      curl -X POST \
+      curl -X POST --fail-with-body --silent --show-error \
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: Bearer $(GITHUB_TOKEN)" \
       https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
       -d '{"state":"${{ parameters.status }}","context":"'"$stageToSkip"'","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'    
     done
   displayName: Set GitHub Status ${{ parameters.status }}
+  failOnStderr: true
   condition: and(succeededOrFailed(), ne(variables['Build.BuildId'], ''))
   continueOnError: true
   env:

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -15,9 +15,9 @@ steps:
     allChecks="${{ parameters.checkName }}"
     for stageToSkip in $allChecks; do
       TARGET_URL="https://dev.azure.com/datadoghq/$(AZURE_PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
-      curl -X POST --fail-with-body --silent --show-error \
+      curl -X POST --fail --silent --show-error \
       -H "Accept: application/vnd.github.v3+json" \
-      -H "Authorization: Bearer $(GITHUB_TOKEN)" \
+      -H "Authorization: Bearer $(GITHUB_TOKEN)X" \
       https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
       -d '{"state":"${{ parameters.status }}","context":"'"$stageToSkip"'","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'    
     done

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -23,7 +23,7 @@ steps:
       TARGET_URL="https://dev.azure.com/datadoghq/$(AZURE_PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
       curl_fail_with_body -X POST --silent --show-error \
         -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: Bearer $(GITHUB_TOKEN)X" \
+        -H "Authorization: Bearer $(GITHUB_TOKEN)" \
         https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
         -d '{"state":"${{ parameters.status }}","context":"'"$stageToSkip"'","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'    
     done

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -11,15 +11,21 @@
 steps:
   # Use semicolon delimited list of checks, and update each of them
 - script: |
-    export IFS=";"
+    # curl is too old so doesn't support --fail-with-body
+    curl_fail_with_body() {
+      curl -o - -w "\n%{http_code}\n" "$@" \
+        | awk '{l[NR] = $0} END {for (i=1; i<=NR-1; i++) print l[i]}; END{ if ($0<200||$0>299) {print "The requested URL returned error: " $0; exit 1}}'
+    }
+
+    # example usage
     allChecks="${{ parameters.checkName }}"
     for stageToSkip in $allChecks; do
       TARGET_URL="https://dev.azure.com/datadoghq/$(AZURE_PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
-      curl -X POST --fail --silent --show-error \
-      -H "Accept: application/vnd.github.v3+json" \
-      -H "Authorization: Bearer $(GITHUB_TOKEN)X" \
-      https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
-      -d '{"state":"${{ parameters.status }}","context":"'"$stageToSkip"'","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'    
+      curl_fail_with_body -X POST --silent --show-error \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: Bearer $(GITHUB_TOKEN)X" \
+        https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
+        -d '{"state":"${{ parameters.status }}","context":"'"$stageToSkip"'","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'    
     done
   displayName: Set GitHub Status ${{ parameters.status }}
   failOnStderr: true


### PR DESCRIPTION
## Summary of changes

Try to make the github status updater show when it has failed to update GitHub

## Reason for change

Currently you have to read the logs to even notice that it failed. With this change the error is flagged, but it doesn't actually stop the stage executing. But at least it's more obvious why Github didn't update if that happens

![image](https://github.com/user-attachments/assets/e246dc1e-ebc0-473d-a344-f0fc194209c0)


## Implementation details

Curl twiddling. Added a `--fail-with-body` equivalent (not available in old curl)

## Test coverage

[Did a manual test](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=169554&view=logs&j=566fcd0b-f504-55d6-728b-d26f0accf189&t=69bb809e-fbe8-5455-a3da-5a168e4e5c11) to make sure it handles failures. This is the test for success
