### PR TITLE
Pin the lang version in the Nuke build project

### DIFF
--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -14,6 +14,9 @@
     <NukeExcludeDirectoryBuild>True</NukeExcludeDirectoryBuild>
     <NukeTasksEnabled>False</NukeTasksEnabled>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <!-- We need to run with both the .NET 7 and .NET 9 SDKs, because .NET 7 is the -->
+    <!-- latest version we can use in CentOs 7 -->
+    <LangVersion>11</LangVersion>
     <!-- Required, otherwise we can run with .NET 8 -->
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>


### PR DESCRIPTION
## Summary of changes

Pin the language version to C#11 (i.e. .NET 7)

## Reason for change

Without this, Rider/VS prompts you to use C#12/13 constructs, which then cause the build to fail. 

## Implementation details

Just pin the version

## Test coverage

It works
