### PR TITLE
Fix name of target creating trimming file + desc

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1006,8 +1006,8 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/install-latest-dotnet-sdk.yml
 
-    # The CreateRootDescriptorsFile tasks expects the native loader but we build that in the other stage
-    - script: ./tracer/build.sh BuildManagedTracerHome BuildNativeLoader --skip CreateRootDescriptorsFile
+    # The CreateTrimmingFile tasks expects the native loader but we build that in the other stage
+    - script: ./tracer/build.sh BuildManagedTracerHome BuildNativeLoader --skip CreateTrimmingFile
       displayName: Build managed tracer + native loader
       retryCountOnTaskFailure: 1
 

--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -25,7 +25,7 @@ jobs:
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" -Recurse -File | Remove-Item
 
       - name: "Regenerating Datadog.Trace.Trimming.xml"
-        run: .\tracer\build.ps1 BuildTracerHome CreateRootDescriptorsFile
+        run: .\tracer\build.ps1 BuildTracerHome CreateTrimmingFile
 
       - name: "Verify no changes in Datadog.Trace.Trimming.xml"
         run: |

--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -23,7 +23,7 @@ partial class Build
        .Description("Sign the dlls produced by building the Tracer, Profiler, and Monitoring home directory, as well as the dd-dotnet exes")
        .Unlisted()
        .Requires(() => IsWin)
-       .After(BuildTracerHome, BuildProfilerHome, BuildNativeLoader,  CreateRootDescriptorsFile, BuildDdDotnet, CopyDdDotnet)
+       .After(BuildTracerHome, BuildProfilerHome, BuildNativeLoader,  CreateTrimmingFile, BuildDdDotnet, CopyDdDotnet)
        .Before(PackNuGet, BuildMsi, ZipMonitoringHome)
        .Executes(() =>
         {

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2437,8 +2437,8 @@ partial class Build
             Logger.Information("File ordered and saved: {File}", csvFilePath);
         });
 
-    Target CreateRootDescriptorsFile => _ => _
-       .Description("Create RootDescriptors.xml file")
+    Target CreateTrimmingFile => _ => _
+       .Description("Create Datadog.Trace.Trimming.xml file")
        .DependsOn(CompileManagedSrc)
        .Executes(() =>
         {

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -205,7 +205,7 @@ partial class Build : NukeBuild
         .DependsOn(DownloadLibDdwaf)
         .DependsOn(CopyLibDdwaf)
         .DependsOn(CreateMissingNullabilityFile)
-        .DependsOn(CreateRootDescriptorsFile);
+        .DependsOn(CreateTrimmingFile);
     
     Target BuildManagedTracerHomeR2R => _ => _
         .Unlisted()
@@ -218,7 +218,7 @@ partial class Build : NukeBuild
         .DependsOn(DownloadLibDdwaf)
         .DependsOn(CopyLibDdwaf)
         .DependsOn(CreateMissingNullabilityFile)
-        .DependsOn(CreateRootDescriptorsFile);
+        .DependsOn(CreateTrimmingFile);
 
     Target BuildTracerHome => _ => _
         .Description("Builds the native and managed src, and publishes the tracer home directory")
@@ -371,7 +371,7 @@ partial class Build : NukeBuild
     Target PackNuGet => _ => _
         .Description("Creates the NuGet packages from the compiled src directory")
         .After(Clean, CompileManagedSrc)
-        .DependsOn(CreateRequiredDirectories, CreateRootDescriptorsFile)
+        .DependsOn(CreateRequiredDirectories, CreateTrimmingFile)
         .Executes(() =>
         {
             DotNetPack(s => s


### PR DESCRIPTION
## Summary of changes

Rename the Nuke target to more closely match the file name

## Reason for change

It's not clear that the trimming.xml file is created by the "RootDescriptors" task

## Implementation details

Rename the target
