### PR TITLE
Add support for more combinations of tags on telemetry metrics

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.Attributes.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.Attributes.cs
@@ -122,7 +122,7 @@ internal partial class Sources
         /// which has a single tag
         /// </summary>
         [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-        internal class TelemetryMetricAttribute<TTag> : System.Attribute
+        internal class TelemetryMetricAttribute<TTag> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
             where TTag : System.Enum
         {
             /// <summary>
@@ -132,10 +132,8 @@ internal partial class Sources
             /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
             /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
             public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+                : base(metricName, isCommon, nameSpace)
             {
-                MetricName = metricName;
-                IsCommon = isCommon;
-                NameSpace = nameSpace;
             }
 
             /// <summary>
@@ -145,34 +143,19 @@ internal partial class Sources
             /// <param name="metricName">The name of the metric, as reported to Datadog</param>
             /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
             public TelemetryMetricAttribute(string metricName, bool isCommon)
-                : this(metricName, isCommon, null!)
+                : base(metricName, isCommon, null!)
             {
             }
 
             /// <summary>
             /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-            /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+            /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
             /// </summary>
             /// <param name="metricName">The name of the metric, as reported to Datadog</param>
             public TelemetryMetricAttribute(string metricName)
-                : this(metricName, isCommon: true, null!)
+                : base(metricName, isCommon: true, null!)
             {
             }
-
-            /// <summary>
-            /// Gets the name of the metric, as reported to Datadog
-            /// </summary>
-            public string MetricName { get; }
-
-            /// <summary>
-            /// Gets a value indicating whether the metric a "common" metric, shared across languages?
-            /// </summary>
-            public bool IsCommon { get; }
-
-            /// <summary>
-            /// Gets the namespace of the metric, if not the default (Tracer)
-            /// </summary>
-            public string? NameSpace { get; }
         }
 
         /// <summary>
@@ -181,7 +164,7 @@ internal partial class Sources
         /// which has two tags
         /// </summary>
         [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-        internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
+        internal class TelemetryMetricAttribute<TTag1, TTag2> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
             where TTag1 : System.Enum
             where TTag2 : System.Enum
         {
@@ -192,10 +175,8 @@ internal partial class Sources
             /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
             /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
             public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+                : base(metricName, isCommon, nameSpace)
             {
-                MetricName = metricName;
-                IsCommon = isCommon;
-                NameSpace = nameSpace;
             }
 
             /// <summary>
@@ -205,34 +186,201 @@ internal partial class Sources
             /// <param name="metricName">The name of the metric, as reported to Datadog</param>
             /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
             public TelemetryMetricAttribute(string metricName, bool isCommon)
-                : this(metricName, isCommon, null!)
+                : base(metricName, isCommon, null!)
             {
             }
 
             /// <summary>
             /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-            /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+            /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
             /// </summary>
             /// <param name="metricName">The name of the metric, as reported to Datadog</param>
             public TelemetryMetricAttribute(string metricName)
-                : this(metricName, isCommon: true, null!)
+                : base(metricName, isCommon: true, null!)
+            {
+            }
+        }
+        
+        /// <summary>
+        /// Used to describe a specific metric defined as a field
+        /// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+        /// which has two tags
+        /// </summary>
+        [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+        internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+            where TTag1 : System.Enum
+            where TTag2 : System.Enum
+            where TTag3 : System.Enum
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+                : base(metricName, isCommon, nameSpace)
             {
             }
 
             /// <summary>
-            /// Gets the name of the metric, as reported to Datadog
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace
             /// </summary>
-            public string MetricName { get; }
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon)
+                : base(metricName, isCommon, null!)
+            {
+            }
 
             /// <summary>
-            /// Gets a value indicating whether the metric a "common" metric, shared across languages?
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
             /// </summary>
-            public bool IsCommon { get; }
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            public TelemetryMetricAttribute(string metricName)
+                : base(metricName, isCommon: true, null!)
+            {
+            }
+        }
+        
+        /// <summary>
+        /// Used to describe a specific metric defined as a field
+        /// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+        /// which has two tags
+        /// </summary>
+        [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+        internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+            where TTag1 : System.Enum
+            where TTag2 : System.Enum
+            where TTag3 : System.Enum
+            where TTag4 : System.Enum
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+                : base(metricName, isCommon, nameSpace)
+            {
+            }
 
             /// <summary>
-            /// Gets the namespace of the metric, if not the default (Tracer)
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace
             /// </summary>
-            public string? NameSpace { get; }
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon)
+                : base(metricName, isCommon, null!)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            public TelemetryMetricAttribute(string metricName)
+                : base(metricName, isCommon: true, null!)
+            {
+            }
+        }
+        
+        /// <summary>
+        /// Used to describe a specific metric defined as a field
+        /// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+        /// which has two tags
+        /// </summary>
+        [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+        internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+            where TTag1 : System.Enum
+            where TTag2 : System.Enum
+            where TTag3 : System.Enum
+            where TTag4 : System.Enum
+            where TTag5 : System.Enum
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+                : base(metricName, isCommon, nameSpace)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon)
+                : base(metricName, isCommon, null!)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            public TelemetryMetricAttribute(string metricName)
+                : base(metricName, isCommon: true, null!)
+            {
+            }
+        }
+        
+        /// <summary>
+        /// Used to describe a specific metric defined as a field
+        /// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+        /// which has two tags
+        /// </summary>
+        [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+        internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5, TTag6> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+            where TTag1 : System.Enum
+            where TTag2 : System.Enum
+            where TTag3 : System.Enum
+            where TTag4 : System.Enum
+            where TTag5 : System.Enum
+            where TTag6 : System.Enum
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+                : base(metricName, isCommon, nameSpace)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+            public TelemetryMetricAttribute(string metricName, bool isCommon)
+                : base(metricName, isCommon, null!)
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+            /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+            /// </summary>
+            /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+            public TelemetryMetricAttribute(string metricName)
+                : base(metricName, isCommon: true, null!)
+            {
+            }
         }
         """;
 }

--- a/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.cs
@@ -97,28 +97,15 @@ internal partial class Sources
                 sb.AppendLine();
                 var (property, metric) = names[i];
 
-                if (metric.Tag2FullyQualifiedName is { } tagName2)
-                {
-                    var tagName1 = metric.Tag1FullyQualifiedName!;
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int increment = 1);
-                        """);
-                }
-                else if (metric.Tag1FullyQualifiedName is { } tagName)
-                {
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int increment = 1);
-                        """);
-                }
-                else
-                {
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}(int increment = 1);
-                        """);
-                }
+                sb.Append(
+                    $$"""
+                          public void Record{{details.ShortName}}{{property}}(
+                      """);
+
+                var array = metric.TagFullyQualifiedNames.AsArray() ?? [];
+                WriteTagArgList(sb, array);
+
+                sb.AppendLine("int increment = 1);");
             }
         }
 
@@ -153,28 +140,15 @@ internal partial class Sources
                 sb.AppendLine();
                 var (property, metric) = names[i];
 
-                if (metric.Tag2FullyQualifiedName is { } tagName2)
-                {
-                    var tagName1 = metric.Tag1FullyQualifiedName!;
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value);
-                        """);
-                }
-                else if (metric.Tag1FullyQualifiedName is { } tagName)
-                {
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int value);
-                        """);
-                }
-                else
-                {
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}(int value);
-                        """);
-                }
+                sb.Append(
+                    $$"""
+                          public void Record{{details.ShortName}}{{property}}(
+                      """);
+
+                var array = metric.TagFullyQualifiedNames.AsArray() ?? [];
+                WriteTagArgList(sb, array);
+
+                sb.AppendLine("int value);");
             }
         }
 
@@ -209,28 +183,15 @@ internal partial class Sources
                 sb.AppendLine();
                 var (property, metric) = names[i];
 
-                if (metric.Tag2FullyQualifiedName is { } tagName2)
-                {
-                    var tagName1 = metric.Tag1FullyQualifiedName!;
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, double value);
-                        """);
-                }
-                else if (metric.Tag1FullyQualifiedName is { } tagName)
-                {
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}({{tagName}} tag, double value);
-                        """);
-                }
-                else
-                {
-                    sb.AppendLine(
-                        $$"""
-                            public void Record{{details.ShortName}}{{property}}(double value);
-                        """);
-                }
+                sb.Append(
+                    $$"""
+                          public void Record{{details.ShortName}}{{property}}(
+                      """);
+
+                var array = metric.TagFullyQualifiedNames.AsArray() ?? [];
+                WriteTagArgList(sb, array);
+
+                sb.AppendLine("double value);");
             }
         }
 
@@ -760,38 +721,13 @@ internal partial class Sources
                 var (property, metric) = names[i];
                 var index = metricsToLocation[i];
 
-                if (metric.Tag2FullyQualifiedName is { } tagName2)
+                if (doRecord)
                 {
-                    if (doRecord)
-                    {
-                        WriteRecordCount(sb, in details, property, index, metric.Tag1FullyQualifiedName!, tagName2, enumDictionary[tagName2].Count);
-                    }
-                    else
-                    {
-                        WriteNoopCount(sb, in details, property, metric.Tag1FullyQualifiedName!, tagName2);
-                    }
-                }
-                else if (metric.Tag1FullyQualifiedName is { } tagName)
-                {
-                    if (doRecord)
-                    {
-                        WriteRecordCount(sb, in details, property, index, tagName);
-                    }
-                    else
-                    {
-                        WriteNoopCount(sb, in details, property, tagName);
-                    }
+                    WriteRecordCount(sb, in details, property, index, metric.TagFullyQualifiedNames, enumDictionary);
                 }
                 else
                 {
-                    if (doRecord)
-                    {
-                        WriteRecordCount(sb, details, property, index);
-                    }
-                    else
-                    {
-                        WriteNoopCount(sb, in details, property);
-                    }
+                    WriteNoopCount(sb, in details, property, metric.TagFullyQualifiedNames, enumDictionary);
                 }
             }
         }
@@ -860,38 +796,13 @@ internal partial class Sources
                 var (property, metric) = names[i];
                 var index = metricsToLocation[i];
 
-                if (metric.Tag2FullyQualifiedName is { } tagName2)
+                if (doRecord)
                 {
-                    if (doRecord)
-                    {
-                        WriteRecordGauge(sb, in details, property, index, metric.Tag1FullyQualifiedName!, tagName2, enumDictionary[tagName2].Count);
-                    }
-                    else
-                    {
-                        WriteNoopGauge(sb, in details, property, metric.Tag1FullyQualifiedName!, tagName2);
-                    }
-                }
-                else if (metric.Tag1FullyQualifiedName is { } tagName)
-                {
-                    if (doRecord)
-                    {
-                        WriteRecordGauge(sb, in details, property, index, tagName);
-                    }
-                    else
-                    {
-                        WriteNoopGauge(sb, in details, property, tagName);
-                    }
+                    WriteRecordGauge(sb, in details, property, index, metric.TagFullyQualifiedNames, enumDictionary);
                 }
                 else
                 {
-                    if (doRecord)
-                    {
-                        WriteRecordGauge(sb, details, property, index);
-                    }
-                    else
-                    {
-                        WriteNoopGauge(sb, in details, property);
-                    }
+                    WriteNoopGauge(sb, in details, property, metric.TagFullyQualifiedNames, enumDictionary);
                 }
             }
         }
@@ -959,38 +870,13 @@ internal partial class Sources
                 var (property, metric) = names[i];
                 var index = metricsToLocation[i];
 
-                if (metric.Tag2FullyQualifiedName is { } tagName2)
+                if (doRecord)
                 {
-                    if (doRecord)
-                    {
-                        WriteRecordDistribution(sb, in details, property, index, metric.Tag1FullyQualifiedName!, tagName2, enumDictionary[tagName2].Count);
-                    }
-                    else
-                    {
-                        WriteNoopDistribution(sb, in details, property, metric.Tag1FullyQualifiedName!, tagName2);
-                    }
-                }
-                else if (metric.Tag1FullyQualifiedName is { } tagName)
-                {
-                    if (doRecord)
-                    {
-                        WriteRecordDistribution(sb, in details, property, index, tagName);
-                    }
-                    else
-                    {
-                        WriteNoopDistribution(sb, in details, property, tagName);
-                    }
+                    WriteRecordDistribution(sb, in details, property, index, metric.TagFullyQualifiedNames, enumDictionary);
                 }
                 else
                 {
-                    if (doRecord)
-                    {
-                        WriteRecordDistribution(sb, details, property, index);
-                    }
-                    else
-                    {
-                        WriteNoopDistribution(sb, in details, property);
-                    }
+                    WriteNoopDistribution(sb, in details, property, metric.TagFullyQualifiedNames, enumDictionary);
                 }
             }
         }
@@ -1027,69 +913,96 @@ internal partial class Sources
             return;
         }
 
-        var i = 0;
+        var index = 0;
         foreach (var (_, metric) in names)
         {
             sb.AppendLine(
                 $$"""
-                            // {{metric.MetricName}}, index = {{i}}
+                            // {{metric.MetricName}}, index = {{index}}
                 """);
             const string prefix =
                 """
                             new(
                 """;
-            if (metric.Tag1FullyQualifiedName is { } tag1Type && enumDictionary[tag1Type].AsArray() is { } tag1Values)
+
+            // Write the cartesian product of all the arrays
+            var tags = metric.TagFullyQualifiedNames.AsArray() ?? [];
+            List<string[]> tagValues = new(tags.Length);
+            bool haveTags = false;
+
+            foreach (var tag in tags)
             {
-                foreach (var tag1Value in tag1Values)
+                var values = enumDictionary[tag].AsArray() ?? [];
+                tagValues.Add([..values]);
+                haveTags |= values.Length > 0;
+            }
+
+            if (haveTags)
+            {
+                // Could reduce allocations here, e.g. use stackalloc, but in a loop so meh
+                var indices = new int[tagValues.Count];
+                while (true)
                 {
-                    if (metric.Tag2FullyQualifiedName is { } tag2Type && enumDictionary[tag2Type].AsArray() is { } tag2Values)
+                    index++;
+                    // Build the current combination
+                    // if every entry is empty, we write null instead of an array
+                    // so need to check first
+                    bool haveNonNullValues = false;
+                    for (var i = 0; i < tagValues.Count; i++)
                     {
-                        foreach (var tag2Value in tag2Values)
+                        if (!string.IsNullOrEmpty(tagValues[i][indices[i]]))
                         {
-                            i++;
-                            sb.Append(prefix);
-
-                            if (string.IsNullOrEmpty(tag1Value) && string.IsNullOrEmpty(tag2Value))
-                            {
-                                sb.AppendLine("null),");
-                                continue;
-                            }
-
-                            sb.Append("new[] { ");
-
-                            WriteAllValues(sb, tag1Value);
-                            WriteAllValues(sb, tag2Value);
-
-                            sb.Remove(sb.Length - 2, 2); // remove the final ', '
-                            sb.AppendLine(" }),");
+                            haveNonNullValues = true;
+                            break;
                         }
                     }
-                    else
+
+                    if (haveNonNullValues)
                     {
-                        i++;
-                        sb.Append(prefix);
-
-                        if (string.IsNullOrEmpty(tag1Value))
+                        // write the full set
+                        sb.Append($$"""{{prefix}}new[] { """);
+                        for (var i = 0; i < tagValues.Count; i++)
                         {
-                            sb.AppendLine("null),");
-                            continue;
+                            WriteAllValues(sb, tagValues[i][indices[i]]);
                         }
-
-                        sb.Append("new[] { ");
-
-                        WriteAllValues(sb, tag1Value);
 
                         sb.Remove(sb.Length - 2, 2); // remove the final ', '
                         sb.AppendLine(" }),");
+                    }
+                    else
+                    {
+                        // no non-empty tags
+                        sb.AppendLine($$"""{{prefix}}null),""");
+                    }
+
+                    // Advance to the next combination
+                    var incrementIndex = tagValues.Count - 1;
+                    while (incrementIndex >= 0)
+                    {
+                        indices[incrementIndex]++;
+                        if (indices[incrementIndex] < tagValues[incrementIndex].Length)
+                        {
+                            // We've successfully incremented this index, so we're ready to write the next combo
+                            break;
+                        }
+
+                        // we went off the end, so reset, and increment the first tag
+                        indices[incrementIndex] = 0;
+                        incrementIndex--;
+                    }
+
+                    // If we've wrapped around at the first index, we're done
+                    if (incrementIndex < 0)
+                    {
+                        break;
                     }
                 }
             }
             else
             {
-                i++;
-                sb
-                   .Append(prefix)
-                   .AppendLine("null),");
+                // no tags
+                index++;
+                sb.AppendLine($$"""{{prefix}}null),""");
             }
         }
 
@@ -1160,196 +1073,311 @@ internal partial class Sources
         return sb.ToString();
     }
 
-    private static void WriteRecordCount(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index)
+    private static void WriteRecordCount(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, int index, EquatableArray<string> tagNames, Dictionary<string, EquatableArray<string>> enumDictionary)
     {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}(int increment = 1)
-                  {
-                      Interlocked.Add(ref _buffer.{{details.ShortName}}[{{index}}], increment);
-                  }
-              """);
-    }
+        var tagArray = tagNames.AsArray() ?? [];
+        if (tagArray.Length == 0)
+        {
+            // we don't need to keep this separate technically, could easily inline it, but it would change the generated code
+            // very slightly (though the IL will remain the same)
 
-    private static void WriteRecordCount(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index, string tagName)
-    {
+            sb.AppendLine(
+                $$"""
+                      public void Record{{details.ShortName}}{{property}}(int increment = 1)
+                      {
+                          Interlocked.Add(ref _buffer.{{details.ShortName}}[{{index}}], increment);
+                      }
+                  """);
+            return;
+        }
+
+        // Produces something similar to this:
+        // public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int increment = 1)
+        // {
+        //     var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
+        //     Interlocked.Add(ref _buffer.{{details.ShortName}}[index], increment);
+        // }
+
+        sb.Append(
+            $$"""
+                  public void Record{{details.ShortName}}{{property}}(
+              """);
+
+        WriteTagArgList(sb, tagArray);
+
+        sb.Append(
+            $$"""
+              int increment = 1)
+                  {
+                      var index = {{index}}
+              """);
+
+        WriteTagIndices(sb, enumDictionary, tagArray);
+
         sb.AppendLine(
             $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int increment = 1)
-                  {
-                      var index = {{index}} + (int)tag;
+              ;
                       Interlocked.Add(ref _buffer.{{details.ShortName}}[index], increment);
                   }
               """);
     }
 
-    private static void WriteRecordCount(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, int index, string tagName1, string tagName2, int tag2EntryCount)
+    private static void WriteRecordGauge(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, int index, EquatableArray<string> tagNames, Dictionary<string, EquatableArray<string>> enumDictionary)
     {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int increment = 1)
-                  {
-                      var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
-                      Interlocked.Add(ref _buffer.{{details.ShortName}}[index], increment);
-                  }
-              """);
-    }
+        var tagArray = tagNames.AsArray() ?? [];
+        if (tagArray.Length == 0)
+        {
+            // we don't need to keep this separate technically, could easily inline it, but it would change the generated code
+            // very slightly (though the IL will remain the same)
 
-    private static void WriteRecordGauge(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index)
-    {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}(int value)
-                  {
-                      Interlocked.Exchange(ref _buffer.{{details.ShortName}}[{{index}}], value);
-                  }
-              """);
-    }
+            sb.AppendLine(
+                $$"""
+                      public void Record{{details.ShortName}}{{property}}(int value)
+                      {
+                          Interlocked.Exchange(ref _buffer.{{details.ShortName}}[{{index}}], value);
+                      }
+                  """);
+            return;
+        }
 
-    private static void WriteRecordGauge(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index, string tagName)
-    {
+        // Produces something similar to this:
+        // public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value)
+        // {
+        //     var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
+        //     Interlocked.Exchange(ref _buffer.{{details.ShortName}}[index], value);
+        // }
+
+        sb.Append(
+            $$"""
+                  public void Record{{details.ShortName}}{{property}}(
+              """);
+
+        WriteTagArgList(sb, tagArray);
+
+        sb.Append(
+            $$"""
+              int value)
+                  {
+                      var index = {{index}}
+              """);
+
+        WriteTagIndices(sb, enumDictionary, tagArray);
+
         sb.AppendLine(
             $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int value)
-                  {
-                      var index = {{index}} + (int)tag;
+              ;
                       Interlocked.Exchange(ref _buffer.{{details.ShortName}}[index], value);
                   }
               """);
     }
 
-    private static void WriteRecordGauge(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index, string tagName1, string tagName2, int tag2EntryCount)
+    private static void WriteRecordDistribution(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, int index, EquatableArray<string> tagNames, Dictionary<string, EquatableArray<string>> enumDictionary)
     {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value)
-                  {
-                      var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
-                      Interlocked.Exchange(ref _buffer.{{details.ShortName}}[index], value);
-                  }
-              """);
-    }
+        var tagArray = tagNames.AsArray() ?? [];
+        if (tagArray.Length == 0)
+        {
+            // we don't need to keep this separate technically, could easily inline it, but it would change the generated code
+            // very slightly (though the IL will remain the same)
+            sb.AppendLine(
+                $$"""
+                      public void Record{{details.ShortName}}{{property}}(double value)
+                      {
+                          _buffer.{{details.ShortName}}[{{index}}].TryEnqueue(value);
+                      }
+                  """);
+            return;
+        }
 
-    private static void WriteRecordDistribution(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index)
-    {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}(double value)
-                  {
-                      _buffer.{{details.ShortName}}[{{index}}].TryEnqueue(value);
-                  }
-              """);
-    }
+        // Produces something similar to this:
+        // public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value)
+        // {
+        //     var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
+        //     Interlocked.Exchange(ref _buffer.{{details.ShortName}}[index], value);
+        // }
 
-    private static void WriteRecordDistribution(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index, string tagName)
-    {
+        sb.Append(
+            $$"""
+                  public void Record{{details.ShortName}}{{property}}(
+              """);
+
+        WriteTagArgList(sb, tagArray);
+
+        sb.Append(
+            $$"""
+              double value)
+                  {
+                      var index = {{index}}
+              """);
+
+        WriteTagIndices(sb, enumDictionary, tagArray);
+
         sb.AppendLine(
             $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName}} tag, double value)
-                  {
-                      var index = {{index}} + (int)tag;
+              ;
                       _buffer.{{details.ShortName}}[index].TryEnqueue(value);
                   }
               """);
     }
 
-    private static void WriteRecordDistribution(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, int index, string tagName1, string tagName2, int tag2EntryCount)
+    private static void WriteTagArgList(StringBuilder sb, string[] tagArray)
     {
-        sb.AppendLine(
+        for (var i = 0; i < tagArray.Length; i++)
+        {
+            sb.Append(tagArray[i])
+              .Append(" tag");
+
+            if (tagArray.Length > 1)
+            {
+                sb.Append(i + 1);
+            }
+
+            sb.Append(", ");
+        }
+    }
+
+    private static void WriteTagIndices(StringBuilder sb, Dictionary<string, EquatableArray<string>> enumDictionary, string[] tagArray)
+    {
+        if (tagArray.Length == 0)
+        {
+            return;
+        }
+
+        Span<int> multipliers = stackalloc int[tagArray.Length];
+        var indexer = 1;
+
+        // set the multipliers for each tag
+        for (var i = tagArray.Length - 1; i >= 0; i--)
+        {
+            multipliers[i] = indexer;
+            indexer *= enumDictionary.TryGetValue(tagArray[i], out var entries) ? entries.Count : 1;
+        }
+
+        for (var i = 0; i < tagArray.Length; i++)
+        {
+            var multiplier = multipliers[i];
+            if (multiplier == 1)
+            {
+                sb.Append(" + (int)tag");
+
+                if (tagArray.Length > 1)
+                {
+                    sb.Append(i + 1);
+                }
+            }
+            else
+            {
+                sb.Append(" + ((int)tag")
+                  .Append(i + 1)
+                  .Append(" * ")
+                  .Append(multiplier)
+                  .Append(')');
+            }
+        }
+    }
+
+    private static void WriteNoopCount(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, EquatableArray<string> tagNames, Dictionary<string, EquatableArray<string>> enumDictionary)
+    {
+        var tagArray = tagNames.AsArray() ?? [];
+        if (tagArray.Length == 0)
+        {
+            // we don't need to keep this separate technically, could easily inline it, but it would change the generated code
+            // very slightly (though the IL will remain the same)
+            sb.AppendLine(
+                $$"""
+                      public void Record{{details.ShortName}}{{property}}(int increment = 1)
+                      {
+                      }
+                  """);
+            return;
+        }
+
+        // Produces something similar to this:
+        // public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int increment = 1)
+        // {
+        // }
+
+        sb.Append(
             $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, double value)
+                  public void Record{{details.ShortName}}{{property}}(
+              """);
+
+        WriteTagArgList(sb, tagArray);
+
+        sb.AppendLine(
+              """
+              int increment = 1)
                   {
-                      var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
-                      _buffer.{{details.ShortName}}[index].TryEnqueue(value);
                   }
               """);
     }
 
-    private static void WriteNoopCount(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property)
+    private static void WriteNoopGauge(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, EquatableArray<string> tagNames, Dictionary<string, EquatableArray<string>> enumDictionary)
     {
-        sb.AppendLine(
+        var tagArray = tagNames.AsArray() ?? [];
+        if (tagArray.Length == 0)
+        {
+            // we don't need to keep this separate technically, could easily inline it, but it would change the generated code
+            // very slightly (though the IL will remain the same)
+            sb.AppendLine(
+                $$"""
+                      public void Record{{details.ShortName}}{{property}}(int value)
+                      {
+                      }
+                  """);
+            return;
+        }
+
+        // Produces something similar to this:
+        // public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value)
+        // {
+        // }
+
+        sb.Append(
             $$"""
-                  public void Record{{details.ShortName}}{{property}}(int increment = 1)
+                  public void Record{{details.ShortName}}{{property}}(
+              """);
+
+        WriteTagArgList(sb, tagArray);
+
+        sb.AppendLine(
+              """
+              int value)
                   {
                   }
               """);
     }
 
-    private static void WriteNoopCount(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, string tagName)
+    private static void WriteNoopDistribution(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, EquatableArray<string> tagNames, Dictionary<string, EquatableArray<string>> enumDictionary)
     {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int increment = 1)
-                  {
-                  }
-              """);
-    }
+        var tagArray = tagNames.AsArray() ?? [];
+        if (tagArray.Length == 0)
+        {
+            // we don't need to keep this separate technically, could easily inline it, but it would change the generated code
+            // very slightly (though the IL will remain the same)
+            sb.AppendLine(
+                $$"""
+                      public void Record{{details.ShortName}}{{property}}(double value)
+                      {
+                      }
+                  """);
+            return;
+        }
 
-    private static void WriteNoopCount(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, string tagName1, string tagName2)
-    {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int increment = 1)
-                  {
-                  }
-              """);
-    }
+        // Produces something similar to this:
+        // public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value)
+        // {
+        // }
 
-    private static void WriteNoopGauge(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property)
-    {
-        sb.AppendLine(
+        sb.Append(
             $$"""
-                  public void Record{{details.ShortName}}{{property}}(int value)
-                  {
-                  }
+                  public void Record{{details.ShortName}}{{property}}(
               """);
-    }
 
-    private static void WriteNoopGauge(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, string tagName)
-    {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int value)
-                  {
-                  }
-              """);
-    }
+        WriteTagArgList(sb, tagArray);
 
-    private static void WriteNoopGauge(StringBuilder sb,  in TelemetryMetricGenerator.EnumDetails details, string property, string tagName1, string tagName2)
-    {
         sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value)
-                  {
-                  }
-              """);
-    }
-
-    private static void WriteNoopDistribution(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property)
-    {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}(double value)
-                  {
-                  }
-              """);
-    }
-
-    private static void WriteNoopDistribution(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, string tagName)
-    {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName}} tag, double value)
-                  {
-                  }
-              """);
-    }
-
-    private static void WriteNoopDistribution(StringBuilder sb, in TelemetryMetricGenerator.EnumDetails details, string property, string tagName1, string tagName2)
-    {
-        sb.AppendLine(
-            $$"""
-                  public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, double value)
+              """
+              double value)
                   {
                   }
               """);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
@@ -118,7 +118,7 @@ internal class TelemetryMetricAttribute : System.Attribute
 /// which has a single tag
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag> : System.Attribute
+internal class TelemetryMetricAttribute<TTag> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag : System.Enum
 {
     /// <summary>
@@ -128,10 +128,8 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -141,34 +139,19 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
     {
     }
-
-    /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
-    /// </summary>
-    public string MetricName { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
-    /// </summary>
-    public bool IsCommon { get; }
-
-    /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
-    /// </summary>
-    public string? NameSpace { get; }
 }
 
 /// <summary>
@@ -177,7 +160,7 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
 /// which has two tags
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
+internal class TelemetryMetricAttribute<TTag1, TTag2> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag1 : System.Enum
     where TTag2 : System.Enum
 {
@@ -188,10 +171,8 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -201,32 +182,199 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
     }
 
     /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string MetricName { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
 
     /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
-    public bool IsCommon { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
 
     /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string? NameSpace { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5, TTag6> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+    where TTag6 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
@@ -118,7 +118,7 @@ internal class TelemetryMetricAttribute : System.Attribute
 /// which has a single tag
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag> : System.Attribute
+internal class TelemetryMetricAttribute<TTag> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag : System.Enum
 {
     /// <summary>
@@ -128,10 +128,8 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -141,34 +139,19 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
     {
     }
-
-    /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
-    /// </summary>
-    public string MetricName { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
-    /// </summary>
-    public bool IsCommon { get; }
-
-    /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
-    /// </summary>
-    public string? NameSpace { get; }
 }
 
 /// <summary>
@@ -177,7 +160,7 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
 /// which has two tags
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
+internal class TelemetryMetricAttribute<TTag1, TTag2> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag1 : System.Enum
     where TTag2 : System.Enum
 {
@@ -188,10 +171,8 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -201,32 +182,199 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
     }
 
     /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string MetricName { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
 
     /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
-    public bool IsCommon { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
 
     /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string? NameSpace { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5, TTag6> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+    where TTag6 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
@@ -118,7 +118,7 @@ internal class TelemetryMetricAttribute : System.Attribute
 /// which has a single tag
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag> : System.Attribute
+internal class TelemetryMetricAttribute<TTag> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag : System.Enum
 {
     /// <summary>
@@ -128,10 +128,8 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -141,34 +139,19 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
     {
     }
-
-    /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
-    /// </summary>
-    public string MetricName { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
-    /// </summary>
-    public bool IsCommon { get; }
-
-    /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
-    /// </summary>
-    public string? NameSpace { get; }
 }
 
 /// <summary>
@@ -177,7 +160,7 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
 /// which has two tags
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
+internal class TelemetryMetricAttribute<TTag1, TTag2> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag1 : System.Enum
     where TTag2 : System.Enum
 {
@@ -188,10 +171,8 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -201,32 +182,199 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
     }
 
     /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string MetricName { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
 
     /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
-    public bool IsCommon { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
 
     /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string? NameSpace { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5, TTag6> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+    where TTag6 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/TelemetryMetricAttribute.g.cs
@@ -118,7 +118,7 @@ internal class TelemetryMetricAttribute : System.Attribute
 /// which has a single tag
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag> : System.Attribute
+internal class TelemetryMetricAttribute<TTag> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag : System.Enum
 {
     /// <summary>
@@ -128,10 +128,8 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -141,34 +139,19 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
     {
     }
-
-    /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
-    /// </summary>
-    public string MetricName { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
-    /// </summary>
-    public bool IsCommon { get; }
-
-    /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
-    /// </summary>
-    public string? NameSpace { get; }
 }
 
 /// <summary>
@@ -177,7 +160,7 @@ internal class TelemetryMetricAttribute<TTag> : System.Attribute
 /// which has two tags
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
-internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
+internal class TelemetryMetricAttribute<TTag1, TTag2> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
     where TTag1 : System.Enum
     where TTag2 : System.Enum
 {
@@ -188,10 +171,8 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
-        MetricName = metricName;
-        IsCommon = isCommon;
-        NameSpace = nameSpace;
     }
 
     /// <summary>
@@ -201,32 +182,199 @@ internal class TelemetryMetricAttribute<TTag1, TTag2> : System.Attribute
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
     public TelemetryMetricAttribute(string metricName, bool isCommon)
-        : this(metricName, isCommon, null!)
+        : base(metricName, isCommon, null!)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
-    /// Uses the default namespace and sets <see cref="IsCommon"/> to <c>true</c>
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
     /// <param name="metricName">The name of the metric, as reported to Datadog</param>
     public TelemetryMetricAttribute(string metricName)
-        : this(metricName, isCommon: true, null!)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
     {
     }
 
     /// <summary>
-    /// Gets the name of the metric, as reported to Datadog
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string MetricName { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
 
     /// <summary>
-    /// Gets a value indicating whether the metric a "common" metric, shared across languages?
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
     /// </summary>
-    public bool IsCommon { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
 
     /// <summary>
-    /// Gets the namespace of the metric, if not the default (Tracer)
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
     /// </summary>
-    public string? NameSpace { get; }
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Used to describe a specific metric defined as a field
+/// inside an enum decorated with <see cref="TelemetryMetricTypeAttribute"/>
+/// which has two tags
+/// </summary>
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false)]
+internal class TelemetryMetricAttribute<TTag1, TTag2, TTag3, TTag4, TTag5, TTag6> : Datadog.Trace.SourceGenerators.TelemetryMetricAttribute
+    where TTag1 : System.Enum
+    where TTag2 : System.Enum
+    where TTag3 : System.Enum
+    where TTag4 : System.Enum
+    where TTag5 : System.Enum
+    where TTag6 : System.Enum
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    /// <param name="nameSpace">The namespace of the metric, if not the default (Tracer)</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon, string nameSpace)
+        : base(metricName, isCommon, nameSpace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    /// <param name="isCommon">Is the metric a "common" metric, shared across languages?</param>
+    public TelemetryMetricAttribute(string metricName, bool isCommon)
+        : base(metricName, isCommon, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryMetricAttribute"/> class.
+    /// Uses the default namespace and sets <see cref="TelemetryMetricAttribute.IsCommon"/> to <c>true</c>
+    /// </summary>
+    /// <param name="metricName">The name of the metric, as reported to Datadog</param>
+    public TelemetryMetricAttribute(string metricName)
+        : base(metricName, isCommon: true, null!)
+    {
+    }
 }

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/TelemetryMetricGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/TelemetryMetricGeneratorTests.cs
@@ -451,10 +451,16 @@ public class TelemetryMetricGeneratorTests
                     var index = 5 + ((int)tag1 * 3) + (int)tag2;
                     Interlocked.Add(ref _buffer.TestMetric[index], increment);
                 }
+            
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int increment = 1)
+                {
+                    var index = 17 + ((int)tag1 * 9) + ((int)tag2 * 3) + (int)tag3;
+                    Interlocked.Add(ref _buffer.TestMetric[index], increment);
+                }
 
                 public void RecordTestMetricZeroAgainTagMetric(int increment = 1)
                 {
-                    Interlocked.Add(ref _buffer.TestMetric[17], increment);
+                    Interlocked.Add(ref _buffer.TestMetric[53], increment);
                 }
             }
             """;
@@ -477,6 +483,10 @@ public class TelemetryMetricGeneratorTests
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, int increment = 1)
                 {
                 }
+            
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int increment = 1)
+                {
+                }
 
                 public void RecordTestMetricZeroAgainTagMetric(int increment = 1)
                 {
@@ -494,6 +504,8 @@ public class TelemetryMetricGeneratorTests
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, int increment = 1);
 
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int increment = 1);
+            
                 public void RecordTestMetricZeroAgainTagMetric(int increment = 1);
             }
             """;
@@ -514,6 +526,10 @@ public class TelemetryMetricGeneratorTests
                 }
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, int increment = 1)
+                {
+                }
+
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int increment = 1)
                 {
                 }
 
@@ -745,9 +761,15 @@ public class TelemetryMetricGeneratorTests
                     Interlocked.Exchange(ref _buffer.TestMetric[index], value);
                 }
 
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int value)
+                {
+                    var index = 17 + ((int)tag1 * 9) + ((int)tag2 * 3) + (int)tag3;
+                    Interlocked.Exchange(ref _buffer.TestMetric[index], value);
+                }
+
                 public void RecordTestMetricZeroAgainTagMetric(int value)
                 {
-                    Interlocked.Exchange(ref _buffer.TestMetric[17], value);
+                    Interlocked.Exchange(ref _buffer.TestMetric[53], value);
                 }
             }
             """;
@@ -771,6 +793,10 @@ public class TelemetryMetricGeneratorTests
                 {
                 }
 
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int value)
+                {
+                }
+
                 public void RecordTestMetricZeroAgainTagMetric(int value)
                 {
                 }
@@ -786,6 +812,8 @@ public class TelemetryMetricGeneratorTests
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, int value);
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, int value);
+
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int value);
 
                 public void RecordTestMetricZeroAgainTagMetric(int value);
             }
@@ -807,6 +835,10 @@ public class TelemetryMetricGeneratorTests
                 }
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, int value)
+                {
+                }
+
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, int value)
                 {
                 }
 
@@ -1040,9 +1072,15 @@ public class TelemetryMetricGeneratorTests
                     _buffer.TestMetric[index].TryEnqueue(value);
                 }
 
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, double value)
+                {
+                    var index = 17 + ((int)tag1 * 9) + ((int)tag2 * 3) + (int)tag3;
+                    _buffer.TestMetric[index].TryEnqueue(value);
+                }
+
                 public void RecordTestMetricZeroAgainTagMetric(double value)
                 {
-                    _buffer.TestMetric[17].TryEnqueue(value);
+                    _buffer.TestMetric[53].TryEnqueue(value);
                 }
             }
             """;
@@ -1066,6 +1104,10 @@ public class TelemetryMetricGeneratorTests
                 {
                 }
 
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, double value)
+                {
+                }
+
                 public void RecordTestMetricZeroAgainTagMetric(double value)
                 {
                 }
@@ -1081,6 +1123,8 @@ public class TelemetryMetricGeneratorTests
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, double value);
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, double value);
+
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, double value);
 
                 public void RecordTestMetricZeroAgainTagMetric(double value);
             }
@@ -1102,6 +1146,10 @@ public class TelemetryMetricGeneratorTests
                 }
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, double value)
+                {
+                }
+
+                public void RecordTestMetricThreeTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, MyTests.TestMetricNameSpace.OtherTag tag3, double value)
                 {
                 }
 
@@ -1400,7 +1448,7 @@ public class TelemetryMetricGeneratorTests
                 /// <summary>
                 /// The number of separate metrics in the <see cref="MyTests.TestMetricNameSpace.TestMetric" /> metric.
                 /// </summary>
-                public const int Length = 4;
+                public const int Length = 5;
 
                 /// <summary>
                 /// Gets the metric name for the provided metric
@@ -1413,6 +1461,7 @@ public class TelemetryMetricGeneratorTests
                         MyTests.TestMetricNameSpace.TestMetric.ZeroTagMetric => "metric.zero",
                         MyTests.TestMetricNameSpace.TestMetric.OneTagMetric => "metric.one",
                         MyTests.TestMetricNameSpace.TestMetric.TwoTagMetric => "metric.two",
+                        MyTests.TestMetricNameSpace.TestMetric.ThreeTagMetric => "metric.three",
                         MyTests.TestMetricNameSpace.TestMetric.ZeroAgainTagMetric => "metric.zeroagain",
                         _ => null!,
                     };
@@ -2277,7 +2326,7 @@ public class TelemetryMetricGeneratorTests
         {
             var aggregation = isDistribution ? "AggregatedDistribution" : "AggregatedMetric";
             return $$"""
-                private const int TestMetricLength = 18;
+                private const int TestMetricLength = 54;
 
                 /// <summary>
                 /// Creates the buffer for the <see cref="MyTests.TestMetricNameSpace.TestMetric" /> values.
@@ -2305,7 +2354,44 @@ public class TelemetryMetricGeneratorTests
                         new(new[] { "error" }),
                         new(new[] { "error", "random" }),
                         new(new[] { "error", "ducktyping", "othertag", "somethingelse" }),
-                        // metric.zeroagain, index = 17
+                        // metric.three, index = 17
+                        new(new[] { "one" }),
+                        new(new[] { "two" }),
+                        new(new[] { "three" }),
+                        new(new[] { "random", "one" }),
+                        new(new[] { "random", "two" }),
+                        new(new[] { "random", "three" }),
+                        new(new[] { "ducktyping", "othertag", "somethingelse", "one" }),
+                        new(new[] { "ducktyping", "othertag", "somethingelse", "two" }),
+                        new(new[] { "ducktyping", "othertag", "somethingelse", "three" }),
+                        new(new[] { "debug", "one" }),
+                        new(new[] { "debug", "two" }),
+                        new(new[] { "debug", "three" }),
+                        new(new[] { "debug", "random", "one" }),
+                        new(new[] { "debug", "random", "two" }),
+                        new(new[] { "debug", "random", "three" }),
+                        new(new[] { "debug", "ducktyping", "othertag", "somethingelse", "one" }),
+                        new(new[] { "debug", "ducktyping", "othertag", "somethingelse", "two" }),
+                        new(new[] { "debug", "ducktyping", "othertag", "somethingelse", "three" }),
+                        new(new[] { "info", "one" }),
+                        new(new[] { "info", "two" }),
+                        new(new[] { "info", "three" }),
+                        new(new[] { "info", "random", "one" }),
+                        new(new[] { "info", "random", "two" }),
+                        new(new[] { "info", "random", "three" }),
+                        new(new[] { "info", "ducktyping", "othertag", "somethingelse", "one" }),
+                        new(new[] { "info", "ducktyping", "othertag", "somethingelse", "two" }),
+                        new(new[] { "info", "ducktyping", "othertag", "somethingelse", "three" }),
+                        new(new[] { "error", "one" }),
+                        new(new[] { "error", "two" }),
+                        new(new[] { "error", "three" }),
+                        new(new[] { "error", "random", "one" }),
+                        new(new[] { "error", "random", "two" }),
+                        new(new[] { "error", "random", "three" }),
+                        new(new[] { "error", "ducktyping", "othertag", "somethingelse", "one" }),
+                        new(new[] { "error", "ducktyping", "othertag", "somethingelse", "two" }),
+                        new(new[] { "error", "ducktyping", "othertag", "somethingelse", "three" }),
+                        // metric.zeroagain, index = 53
                         new(null),
                     };
 
@@ -2315,7 +2401,7 @@ public class TelemetryMetricGeneratorTests
                 /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
                 /// </summary>
                 private static int[] TestMetricEntryCounts { get; }
-                    = new int[]{ 1, 4, 12, 1, };
+                    = new int[]{ 1, 4, 12, 36, 1, };
             """;
         }
 
@@ -2426,6 +2512,9 @@ public class TelemetryMetricGeneratorTests
                 [TelemetryMetric<LogLevel, ErrorType>("metric.two")]
                 TwoTagMetric,
 
+                [TelemetryMetric<LogLevel, ErrorType, OtherTag>("metric.three")]
+                ThreeTagMetric,
+
                 [TelemetryMetric("metric.zeroagain")]
                 ZeroAgainTagMetric,
             }
@@ -2469,6 +2558,13 @@ public class TelemetryMetricGeneratorTests
                 [Description("")] None,
                 [Description("random;;")] Random,
                 [Description("ducktyping;;othertag;somethingelse")] DuckTyping,
+            }
+
+            public enum OtherTag
+            {
+                [Description("one")] One,
+                [Description("two")] Two,
+                [Description("three")] Three,
             }
             """;
     }


### PR DESCRIPTION
## Summary of changes

Allow passing in more tag values to telemetry metrics

## Reason for change

@tonyredondo requested it as it would make some of the combinatorial tag requirements for ci visibility easier.

## Implementation details

Generalised the current behaviour (that limited it to 2 metrics)

> [!WARNING]
> The original 2 metrics limitation was _partly_ there to avoid the combinatorial explosion you can get with more metrics. Be aware that we _always_ generate _all_ combinations of tags, so if only _certain_ combinations of tags should be set together, then you should use the existing capabilities of grouping multiple tags.

During the factoring, I was careful to keep the generated code consistent. We can sweep through and simplify the generator (by allowing trivial renaming of variables etc) later, but didn't want to muddy the waters for review in this PR.

## Test coverage

Added unit tests for the source generator. We should carefully test and review the first _real_ usage of the multiple-generics, to confirm there's no unexpected issues.

