### PR TITLE
[dd-dotnet] Catch error when failing to read env vars on IIS

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/ApplicationPool.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/ApplicationPool.cs
@@ -3,8 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#pragma warning disable SA1108 // BlockStatementsMustNotContainEmbeddedComments
+
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows.IIS
 {
@@ -55,14 +58,21 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows.IIS
         {
             var result = new Dictionary<string, string>();
 
-            using var environmentVariables = _applicationPool.GetElementByName("environmentVariables");
-            using var collection = environmentVariables.Collection();
-            var count = collection.Count();
-
-            for (int i = 0; i < count; i++)
+            try
             {
-                using var item = collection.GetItem(i);
-                result.Add(item.GetStringProperty("name"), item.GetStringProperty("value"));
+                using var environmentVariables = _applicationPool.GetElementByName("environmentVariables");
+                using var collection = environmentVariables.Collection();
+                var count = collection.Count();
+
+                for (int i = 0; i < count; i++)
+                {
+                    using var item = collection.GetItem(i);
+                    result.Add(item.GetStringProperty("name"), item.GetStringProperty("value"));
+                }
+            }
+            catch (Win32Exception ex) when ((uint)ex.NativeErrorCode == 0x80070585) // Invalid index
+            {
+                Utils.WriteWarning("Could not read IIS environment variables. This is expected if using a version of IIS prior to 10.");
             }
 
             return result;


### PR DESCRIPTION
## Summary of changes

Catch the error and log a warning when the diagnostic tool fails to read custom environment variables on an IIS application pool.

## Reason for change

Versions of IIS prior to 10 didn't have an `<environmentVariables>` node.

## Implementation details

Just catching the exceptions. And disabling rule SA1108 because stylecop doesn't like my comment.

## Test coverage

I tried replacing `environmentVariables` with an attribute that doesn't exist and it works.
