### PR TITLE
Support relative path in `DD_DOTNET_TRACER_HOME`

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
             StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
-            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
+            var path = new FileInfo(Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll")).FullName;
             StartupLogger.Debug("Looking for: {0}", path);
 
             if (IsDatadogAssembly(path, out var cachedAssembly))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             }
 
             var tracerHomeDirectory = ReadEnvironmentVariable("DD_DOTNET_TRACER_HOME") ?? string.Empty;
-            var fullPath = Path.Combine(tracerHomeDirectory, tracerFrameworkDirectory);
+            var fullPath = Path.GetFullPath(Path.Combine(tracerHomeDirectory, tracerFrameworkDirectory));
 
             if (!Directory.Exists(fullPath))
             {
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
             StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
-            var path = Path.GetFullPath(Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll"));
+            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
             StartupLogger.Debug("Looking for: {0}", path);
 
             if (IsDatadogAssembly(path, out var cachedAssembly))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             if (!Directory.Exists(fullPath))
             {
-                StartupLogger.Log($"The tracer home directory cannot be found at '{fullPath}', based on the DD_DOTNET_TRACER_HOME value '{tracerHomeDirectory}'");
+                StartupLogger.Log($"The tracer home directory cannot be found at '{fullPath}', based on the DD_DOTNET_TRACER_HOME value '{tracerHomeDirectory}' and current directory {Environment.CurrentDirectory}");
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
             StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
-            var path = new FileInfo(Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll")).FullName;
+            var path = Path.GetFullPath(Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll"));
             StartupLogger.Debug("Looking for: {0}", path);
 
             if (IsDatadogAssembly(path, out var cachedAssembly))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         private static string ResolveManagedProfilerDirectory()
         {
             var tracerHomeDirectory = ReadEnvironmentVariable("DD_DOTNET_TRACER_HOME") ?? string.Empty;
-            var fullPath = Path.Combine(tracerHomeDirectory, "net461");
+            var fullPath = Path.GetFullPath(Path.Combine(tracerHomeDirectory, "net461"));
             if (!Directory.Exists(fullPath))
             {
                 StartupLogger.Log($"The tracer home directory cannot be found at '{fullPath}', based on the DD_DOTNET_TRACER_HOME value '{tracerHomeDirectory}'");
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             }
 
             // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
-            var path = Path.GetFullPath(string.IsNullOrEmpty(ManagedProfilerDirectory) ? $"{assemblyName.Name}.dll" : Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll"));
+            var path = string.IsNullOrEmpty(ManagedProfilerDirectory) ? $"{assemblyName.Name}.dll" : Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
             StartupLogger.Debug("  Looking for: '{0}'", path);
 
             if (File.Exists(path))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             }
 
             // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
-            var path = new FileInfo(string.IsNullOrEmpty(ManagedProfilerDirectory) ? $"{assemblyName.Name}.dll" : Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll")).FullName;
+            var path = Path.GetFullPath(string.IsNullOrEmpty(ManagedProfilerDirectory) ? $"{assemblyName.Name}.dll" : Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll"));
             StartupLogger.Debug("  Looking for: '{0}'", path);
 
             if (File.Exists(path))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             }
 
             // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
-            var path = string.IsNullOrEmpty(ManagedProfilerDirectory) ? $"{assemblyName.Name}.dll" : Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
+            var path = new FileInfo(string.IsNullOrEmpty(ManagedProfilerDirectory) ? $"{assemblyName.Name}.dll" : Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll")).FullName;
             StartupLogger.Debug("  Looking for: '{0}'", path);
 
             if (File.Exists(path))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             var fullPath = Path.GetFullPath(Path.Combine(tracerHomeDirectory, "net461"));
             if (!Directory.Exists(fullPath))
             {
-                StartupLogger.Log($"The tracer home directory cannot be found at '{fullPath}', based on the DD_DOTNET_TRACER_HOME value '{tracerHomeDirectory}'");
+                StartupLogger.Log($"The tracer home directory cannot be found at '{fullPath}', based on the DD_DOTNET_TRACER_HOME value '{tracerHomeDirectory}' and current directory {Environment.CurrentDirectory}");
                 return null;
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/PathUtil.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/PathUtil.cs
@@ -1,0 +1,266 @@
+﻿// <copyright file="PathUtil.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests;
+
+public class PathUtil
+{
+    /// <summary>
+    /// Create a relative path from one path to another. Paths will be resolved before calculating the difference.
+    /// Default path comparison for the active platform will be used (OrdinalIgnoreCase for Windows or Mac, Ordinal for Unix).
+    /// </summary>
+    /// <param name="relativeTo">The source path the output should be relative to. This path is always considered to be a directory.</param>
+    /// <param name="path">The destination path.</param>
+    /// <returns>The relative path or <paramref name="path"/> if the paths don't share the same root.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="relativeTo"/> or <paramref name="path"/> is <c>null</c> or an empty string.</exception>
+    public static string GetRelativePath(string relativeTo, string path)
+#if NETCOREAPP
+        => Path.GetRelativePath(relativeTo, path);
+#else
+    {
+        const char directorySeparatorChar = '\\';
+        const char altDirectorySeparatorChar = '/';
+        const char volumeSeparatorChar = ':';
+
+        const string extendedDevicePathPrefix = @"\\?\";
+        const string uncExtendedPathPrefix = @"\\?\UNC\";
+
+        // based on https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L843
+        var comparisonType = StringComparison.OrdinalIgnoreCase; // Windows only
+        relativeTo = Path.GetFullPath(relativeTo);
+        path = Path.GetFullPath(path);
+
+        // Need to check if the roots are different- if they are we need to return the "to" path.
+        if (!AreRootsEqual(relativeTo, path, comparisonType))
+        {
+            return path;
+        }
+
+        var commonLength = GetCommonPathLength(relativeTo, path, ignoreCase: true);
+
+        // If there is nothing in common they can't share the same root, return the "to" path as is.
+        if (commonLength == 0)
+        {
+            return path;
+        }
+
+        // Trailing separators aren't significant for comparison
+        var relativeToLength = relativeTo.Length;
+        if (EndsInDirectorySeparator(relativeTo))
+        {
+            relativeToLength--;
+        }
+
+        var pathEndsInSeparator = EndsInDirectorySeparator(path);
+        var pathLength = path.Length;
+        if (pathEndsInSeparator)
+        {
+            pathLength--;
+        }
+
+        // If we have effectively the same path, return "."
+        if (relativeToLength == pathLength && commonLength >= relativeToLength)
+        {
+            return ".";
+        }
+
+        // We have the same root, we need to calculate the difference now using the
+        // common Length and Segment count past the length.
+        //
+        // Some examples:
+        //
+        //  C:\Foo C:\Bar L3, S1 -> ..\Bar
+        //  C:\Foo C:\Foo\Bar L6, S0 -> Bar
+        //  C:\Foo\Bar C:\Bar\Bar L3, S2 -> ..\..\Bar\Bar
+        //  C:\Foo\Foo C:\Foo\Bar L7, S1 -> ..\Bar
+
+        var sb = new StringBuilder();
+        sb.EnsureCapacity(Math.Max(relativeTo.Length, path.Length));
+
+        // Add parent segments for segments past the common on the "from" path
+        if (commonLength < relativeToLength)
+        {
+            sb.Append("..");
+
+            for (var i = commonLength + 1; i < relativeToLength; i++)
+            {
+                if (IsDirectorySeparator(relativeTo[i]))
+                {
+                    sb.Append(directorySeparatorChar);
+                    sb.Append("..");
+                }
+            }
+        }
+        else if (IsDirectorySeparator(path[commonLength]))
+        {
+            // No parent segments and we need to eat the initial separator
+            //  (C:\Foo C:\Foo\Bar case)
+            commonLength++;
+        }
+
+        // Now add the rest of the "to" path, adding back the trailing separator
+        var differenceLength = pathLength - commonLength;
+        if (pathEndsInSeparator)
+        {
+            differenceLength++;
+        }
+
+        if (differenceLength > 0)
+        {
+            if (sb.Length > 0)
+            {
+                sb.Append(directorySeparatorChar);
+            }
+
+            sb.Append(path, commonLength, differenceLength);
+        }
+
+        return sb.ToString();
+
+        static int GetCommonPathLength(string first, string second, bool ignoreCase)
+        {
+            var commonChars = EqualStartingCharacterCount(first, second, ignoreCase: ignoreCase);
+
+            // If nothing matches
+            if (commonChars == 0)
+            {
+                return commonChars;
+            }
+
+            // Or we're a full string and equal length or match to a separator
+            if (commonChars == first.Length
+             && (commonChars == second.Length || IsDirectorySeparator(second[commonChars])))
+            {
+                return commonChars;
+            }
+
+            if (commonChars == second.Length && IsDirectorySeparator(first[commonChars]))
+            {
+                return commonChars;
+            }
+
+            // It's possible we matched somewhere in the middle of a segment e.g. C:\Foodie and C:\Foobar.
+            while (commonChars > 0 && !IsDirectorySeparator(first[commonChars - 1]))
+            {
+                commonChars--;
+            }
+
+            return commonChars;
+        }
+
+        static int EqualStartingCharacterCount(string first, string second, bool ignoreCase)
+        {
+            if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second))
+            {
+                return 0;
+            }
+
+            var commonChars = 0;
+            var f = 0;
+            var s = 0;
+
+            var l = first[f];
+            var r = second[s];
+            var leftEnd = first.Length;
+            var rightEnd = second.Length;
+
+            while (l < leftEnd
+                && r < rightEnd
+                && (l == r || (ignoreCase && char.ToUpperInvariant(l) == char.ToUpperInvariant(r))))
+            {
+                commonChars++;
+                l++;
+                r++;
+            }
+
+            return commonChars;
+        }
+
+        static bool AreRootsEqual(string first, string second, StringComparison comparisonType)
+        {
+            var firstRootLength = GetRootLength(first);
+            var secondRootLength = GetRootLength(second);
+
+            return firstRootLength == secondRootLength
+                && string.Compare(
+                       strA: first,
+                       indexA: 0,
+                       strB: second,
+                       indexB: 0,
+                       length: firstRootLength,
+                       comparisonType: comparisonType) == 0;
+        }
+
+        static int GetRootLength(string path)
+        {
+            var i = 0;
+            var volumeSeparatorLength = 2; // Length to the colon "C:"
+            var uncRootLength = 2; // Length to the start of the server name "\\"
+
+            var extendedSyntax = path.StartsWith(extendedDevicePathPrefix);
+            var extendedUncSyntax = path.StartsWith(uncExtendedPathPrefix);
+            if (extendedSyntax)
+            {
+                // Shift the position we look for the root from to account for the extended prefix
+                if (extendedUncSyntax)
+                {
+                    // "\\" -> "\\?\UNC\"
+                    uncRootLength = uncExtendedPathPrefix.Length;
+                }
+                else
+                {
+                    // "C:" -> "\\?\C:"
+                    volumeSeparatorLength += extendedDevicePathPrefix.Length;
+                }
+            }
+
+            if ((!extendedSyntax || extendedUncSyntax) && path.Length > 0 && IsDirectorySeparator(path[0]))
+            {
+                // UNC or simple rooted path (e.g. "\foo", NOT "\\?\C:\foo")
+
+                i = 1; // Drive rooted (\foo) is one character
+                if (extendedUncSyntax || (path.Length > 1 && IsDirectorySeparator(path[1])))
+                {
+                    // UNC (\\?\UNC\ or \\), scan past the next two directory separators at most
+                    // (e.g. to \\?\UNC\Server\Share or \\Server\Share\)
+                    i = uncRootLength;
+                    var n = 2; // Maximum separators to skip
+                    while (i < path.Length && (!IsDirectorySeparator(path[i]) || --n > 0))
+                    {
+                        i++;
+                    }
+                }
+            }
+            else if (path.Length >= volumeSeparatorLength &&
+                     path[volumeSeparatorLength - 1] == volumeSeparatorChar)
+            {
+                // Path is at least longer than where we expect a colon, and has a colon (\\?\A:, A:)
+                // If the colon is followed by a directory separator, move past it
+                i = volumeSeparatorLength;
+                if (path.Length >= volumeSeparatorLength + 1 && IsDirectorySeparator(path[volumeSeparatorLength]))
+                {
+                    i++;
+                }
+            }
+
+            return i;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool IsDirectorySeparator(char c)
+        {
+            return c == directorySeparatorChar || c == altDirectorySeparatorChar;
+        }
+
+        static bool EndsInDirectorySeparator(string path)
+            => path.Length > 0 && IsDirectorySeparator(path[path.Length - 1]);
+    }
+#endif
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -136,7 +136,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task WhenUsingRelativeTracerHome_InstrumentsApp()
         {
-            SetEnvironmentVariable("DD_INTERNAL_WAIT_FOR_DEBUGGER_ATTACH", "1");
             // the working dir when we run the app is the _test_ project, not the app itself, so we need to be relative to that
             // This is a perfect example of why we don't recommend using relative paths for these variables
             var workingDir = Environment.CurrentDirectory;
@@ -155,7 +154,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task WhenUsingPathWithDotsInInTracerHome_InstrumentsApp()
         {
-            SetEnvironmentVariable("DD_INTERNAL_WAIT_FOR_DEBUGGER_ATTACH", "1");
             // not using Path.Combine here because it resolves the .. and we want it in the path
             var path = Path.Combine(EnvironmentHelper.MonitoringHome, "..", Path.GetFileName(EnvironmentHelper.MonitoringHome)!);
             Output.WriteLine("Using DD_DOTNET_TRACER_HOME " + path);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -160,7 +160,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             agent.Spans.Should().NotBeEmpty();
             agent.Telemetry.Should().NotBeEmpty();
         }
-#endif
 
 #if NETCOREAPP && !NETCOREAPP3_1_OR_GREATER
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -154,7 +154,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task WhenUsingPathWithDotsInInTracerHome_InstrumentsApp()
         {
-            // not using Path.Combine here because it resolves the .. and we want it in the path
             var path = Path.Combine(EnvironmentHelper.MonitoringHome, "..", Path.GetFileName(EnvironmentHelper.MonitoringHome)!);
             Output.WriteLine("Using DD_DOTNET_TRACER_HOME " + path);
             SetEnvironmentVariable("DD_DOTNET_TRACER_HOME", path);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -130,6 +130,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
         }
+#endif
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]


### PR DESCRIPTION
## Summary of changes

Resolve the path read from `DD_DOTNET_TRACER_HOME` to an absolute path before trying to load an assembly from there.

## Reason for change

When writing a sample app and adding `Datadog.Trace.Bundle` as a dependency, it can be natural to set those variables to something like this :
`CORECLR_PROFILER_PATH=./datadog/osx/Datadog.Trace.ClrProfiler.Native.dylib`
`DD_DOTNET_TRACER_HOME=./datadog`

In recent versions of .NET, `CORECLR_PROFILER_PATH ` supports a relative path, but `DD_DOTNET_TRACER_HOME` doesn't and never has, and throws an `ArgumentException` [as documented](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext.loadfromassemblypath?view=net-9.0) when you try this with v3 of the packages.

However, in v2 of the library, if you referenced `Datadog.Trace.Bundle` or `Datadog.Trace`, the value of `DD_DOTNET_TRACER_HOME` was _never actually used_. That meant that it _appeared_ as though relative paths worked. 

In actual fact, what was happening is that referencing one of these NuGet packages caused the `Datadog.Trace.dll` file to be copied to the `bin`/`publish` output folder. As this dll was always next to the `.exe`, it was loaded automatically by the runtime, and never invoked the `AssemblyResolve` event code in the managed loader to load from monitoring home.

In v3, we no longer ship `Datadog.Trace.dll` in the NuGet packages, instead shipping `Datadog.Trace.Manual.dll`. That means that the `DD_DOTNET_TRACER_HOME` variable _is_ used with v3, even when you reference the bundle, and gives the _appearance_ that "relative paths are broken". To work around that, this PR adds support for relative paths.

To be clear, we **still don't recommend using relative paths for these variables** in general. The difficulty in understanding what the path is _relative to_, means that it will be often be more hassle than it's worth. That said, it can make sense in the bundle scenario described above, hence this PR.

## Implementation details

Call `GetFullPath()` on the value provided in `DD_DOTNET_TRACER_HOME`. This uses a native call (e.g. `Interop.Sys.GetCwd() on linux, GetFullPathNameW()` on Windows) to determine the full path given a (potentially) relative path.

## Test coverage

- Added a couple of tests to confirm relative paths work.
- Added a shim implementation of `Path.GetRelativePath()` for .NET Framework based on the .NET Core implementation.

## Other details

Interestingly, getting the _correct_ relative path in the integration tests is a massive pain. The problem is that the relative path you need is _not_ the path relative to the executable, it's relative to "the current directory", which could be anywhere, depending on how you run the application. In the integration tests, for example, the current directory is the directory containing the _integration test executable_ 💀
