### PR TITLE
[Crashtracking] Improve handling of unhandled exceptions on Windows

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -450,7 +450,6 @@ internal class CreatedumpCommand : Command
 
     private unsafe void GenerateCrashReport(int pid, int? signal, int? crashThread)
     {
-        File.AppendAllText(@"C:\temp\log.txt", $"Started\n");
         var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dll" : "so";
         var profilerLibrary = $"Datadog.Profiler.Native.{extension}";
 


### PR DESCRIPTION
## Summary of changes

In crashtracking on windows, go the extra mile to dispose the ClrMD `DataTarget`  when an unhandled exception occurs.

## Reason for change

A lot of the logic is implemented on the native side (Datadog.Profiler.Native and libdatadog). Unfortunately, native exceptions such as access violation can't be caught on the managed side. It means that if the native side crashes, we don't have a chance to clean the ClrMD context, which in turn means that the threads of the crashing process will remain suspended, preventing it from exiting. To prevent that, we bypass .NET exception management and use SetUnhandledExceptionFilter to catch all exceptions.

## Implementation details

Use `SetUnhandledExceptionFilter` to get a chance to run code when an exception is unhandled. After disposing the ClrMD `DataTarget`, we call the old unhandled exception filter if any.

## Test coverage

Added a test to confirm the process doesn't remain frozen when dd-dotnet crashes.