### PR TITLE
[ASM] Update WAF version to 1.22.0

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -63,7 +63,7 @@ partial class Build
 
     AbsolutePath NativeBuildDirectory => RootDirectory / "obj";
 
-    const string LibDdwafVersion = "1.21.0";
+    const string LibDdwafVersion = "1.22.0";
 
     string[] OlderLibDdwafVersions = { "1.3.0", "1.10.0", "1.14.0", "1.16.0" };
 

--- a/tracer/build/smoke_test_snapshots/smoke_test_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_snapshots.json
@@ -39,7 +39,7 @@
       "type": "web",
       "meta": {
         "_dd.appsec.event_rules.version": "1.13.3",
-        "_dd.appsec.waf.version": "1.21.0",
+        "_dd.appsec.waf.version": "1.22.0",
         "_dd.runtime_family": "dotnet",
         "_dd.appsec.s.req.params": "H4sIAAAAAAAAA4uuVkrOzyspys/JSS1Ssoq2iNVRSkwuyczPA3NqYwH+CR9jIQAAAA==",
         "_dd.appsec.s.res.body": "H4sIAAAAAAAAA4u2iAUA8YntnQMAAAA=",

--- a/tracer/build/smoke_test_snapshots/smoke_test_snapshots_2_1.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_snapshots_2_1.json
@@ -39,7 +39,7 @@
       "type": "web",
       "meta": {
 		"_dd.appsec.event_rules.version": "1.13.3",
-        "_dd.appsec.waf.version": "1.21.0",
+        "_dd.appsec.waf.version": "1.22.0",
         "_dd.runtime_family": "dotnet",
         "_dd.appsec.s.res.body": "H4sIAAAAAAAAA4u2iAUA8YntnQMAAAA=",
         "_dd.appsec.s.req.headers": "H4sIAAAAAAAAA4WOMQrAIBDA/uKsQ7fiVw6Ho4oVrIp3Q4v491JcLc4JJNAEVzwcMbITGgB2Y2QT0SWht27kwAWrSzzlt7LIaLNXjJ4WCuFVYkhelRpyDfws/NFVwa7S3+SfdmaarXfzAg6PMlH9AAAA",

--- a/tracer/test/snapshots/Security.AspNetCore5AsmInitializationSecurityEnabled.TestSecurityInitialization.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AsmInitializationSecurityEnabled.TestSecurityInitialization.verified.txt
@@ -34,7 +34,7 @@
       _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"category":"attack_attempt","type":"nosql_injection"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[?\\$(?:(?:s(?:lic|iz)|wher)e|e(?:lemMatch|xists|q)|n(?:o[rt]|in?|e)|l(?:ike|te?)|t(?:ext|ype)|a(?:ll|nd)|jsonSchema|between|regex|x?or|div|mod)\\]?)\\b)","parameters":[{"address":"server.request.query","highlight":["[$slice"],"key_path":["[$slice]"],"value":"[$slice]"}]}]}]},
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetCore5AsmInitializationSecurityEnabledWithBadRuleset.TestSecurityInitialization.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AsmInitializationSecurityEnabledWithBadRuleset.TestSecurityInitialization.verified.txt
@@ -32,7 +32,7 @@
       _dd.appsec.event_rules.errors: {"missing key 'name'":["crs-913-110","crs-913-120","crs-920-260"],"missing key 'tags'":["crs-921-110","crs-921-140"]},
       _dd.appsec.event_rules.version: 1.3.1,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"category":"attack_attempt","type":"nosql_injection"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["[$slice]"],"value":"[$slice]"}]}]}]},
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
@@ -44,7 +44,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.event_rules.version: 1.13.3,
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
@@ -44,7 +44,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.event_rules.version: 1.13.3,
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetWebApiAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_api_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApiAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_api_user.verified.txt
@@ -42,7 +42,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetWebApiAsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_api_health.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApiAsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_api_health.verified.txt
@@ -41,7 +41,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.event_rules.version: 1.13.3,
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
@@ -20,7 +20,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
     Metrics: {

--- a/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_default.aspx.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_default.aspx.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       span.kind: server,
       _dd.appsec.event_rules.version: 1.13.3,
-      _dd.appsec.waf.version: 1.21.0,
+      _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
     Metrics: {


### PR DESCRIPTION
## Summary of changes

This PR updated the WAF to [version 1.22.0](https://github.com/DataDog/libddwaf/releases/tag/1.22.0)

No breaking changes are expected from this version change.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
