### PR TITLE
[IAST] Fix compilation of Samples.Security.AspNetCore2

### DIFF
--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Data/IastControllerHelper.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Data/IastControllerHelper.cs
@@ -2,8 +2,6 @@ using System;
 using System.Data.SQLite;
 using System.Text;
 #if NETCOREAPP
-using Npgsql;
-using Oracle.ManagedDataAccess.Client;
 using Microsoft.Data.Sqlite;
 #endif
 


### PR DESCRIPTION
## Summary of changes

Compilation of Samples.Security.AspNetCore2 because of a bunch of `using` statement referencing nuget packages that are not added to this project.

It looks like the `using` are not actually used, so hopefully just removing them should be enough.
