### PR TITLE
[ASM] Fix database tests (netcoreapp3.0)

### DIFF
--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5.DatabaseIntegration/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5.DatabaseIntegration/Controllers/IastController.cs
@@ -77,7 +77,7 @@ namespace Samples.Security.AspNetCore5.Controllers.DatabaseIntegration
             get { return _dbConnectionSystemData ??= IastControllerHelper.CreateSystemDataDatabase(); }
         }
         
-        private static SqliteConnection DbConnectionSystemDataMicrosoftData
+        private static SqliteConnection DbConnectionMicrosoftData
         {
             get { return _dbConnectionSystemDataMicrosoftData ??= IastControllerHelper.CreateMicrosoftDataDatabase(); }
         }
@@ -164,9 +164,9 @@ namespace Samples.Security.AspNetCore5.Controllers.DatabaseIntegration
             IDbConnection db =
                 database switch
                 {
-                    "System.Data.SQLite" => DbConnectionSystemDataMicrosoftData,
+                    "System.Data.SQLite" => DbConnectionSystemData,
                     "System.Data.SqlClient" => DbConnectionSystemDataSqlClient,
-                    "Microsoft.Data.Sqlite" => DbConnectionSystemData,
+                    "Microsoft.Data.Sqlite" => DbConnectionMicrosoftData,
                     "Npgsql" => DbConnectionNpgsql,
                     "MySql.Data" => DbConnectionMySql,
                     "Oracle" => DbConnectionOracle,


### PR DESCRIPTION
## Summary of changes

The databases `System.Data.SQLite` and `Microsoft.Data.Sqlite` were swapped out in the tests.

## Reason for change

Tests were failling on master with `netcoreapp3.0`:
There was a specific check to skip the test with Microsoft.Data.Sqlite on Alpine for `netcoreapp3.0`, this was failing on master.