### PR TITLE
[Tracer] Fix git metadata retrieval

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -211,7 +211,7 @@ namespace Datadog.Trace.Configuration
                               .AsString();
 
             // DD_GIT_REPOSITORY_URL has precedence over DD_TAGS
-            GitRepositoryUrl = GetExplicitSettingOrTag(GitRepositoryUrl, globalTags, Ci.Tags.CommonTags.GitCommit, ConfigurationKeys.GitRepositoryUrl);
+            GitRepositoryUrl = GetExplicitSettingOrTag(GitRepositoryUrl, globalTags, Ci.Tags.CommonTags.GitRepository, ConfigurationKeys.GitRepositoryUrl);
 
             GitMetadataEnabled = config
                                 .WithKeys(ConfigurationKeys.GitMetadataEnabled)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1275,7 +1275,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             var source = new NameValueConfigurationSource(new()
             {
-                { "DD_TAGS", "env:datadog_env,service:datadog_service,version:datadog_version" },
+                { "DD_TAGS", "env:datadog_env,service:datadog_service,version:datadog_version,git.repository_url:https://Myrepository,git.commit.sha:42" },
             });
 
             var tracerSettings = new TracerSettings(source);
@@ -1283,6 +1283,8 @@ namespace Datadog.Trace.Tests.Configuration
             tracerSettings.Environment.Should().Be("datadog_env");
             tracerSettings.ServiceVersion.Should().Be("datadog_version");
             tracerSettings.ServiceName.Should().Be("datadog_service");
+            tracerSettings.GitRepositoryUrl.Should().Be("https://Myrepository");
+            tracerSettings.GitCommitSha.Should().Be("42");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Fix bug introduced in https://github.com/DataDog/dd-trace-dotnet/pull/6415

## Reason for change

Due to a change in https://github.com/DataDog/dd-trace-dotnet/pull/6415, the git repository url from not fetch using the correct tag.

## Implementation details

Use the git repository url tag to fetch the value from the configuration.

## Test coverage

Add a check in unit tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
