### PR TITLE
K8s Lib Injection tests: run on a matrix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,8 +124,9 @@ onboarding_tests_installer:
         SCENARIO: [ SIMPLE_INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING ]
 
 onboarding_tests_k8s_injection:
-  variables:
-    WEBLOG_VARIANT: dd-lib-dotnet-init-test-app
+  parallel:
+    matrix:
+      - WEBLOG_VARIANT: dd-lib-dotnet-init-test-app
 
 deploy_to_reliability_env:
   rules:


### PR DESCRIPTION
## Summary of changes
This PR run the K8s Lib injection tests on a matrix.
## Reason for change
This change is necessary because we are going to change the "one pipeline" and these changes could break dd-trace-js pipeline. We need to merge this PR before merging the "one pipeline".
it is the first PR to do this adaptation step by step.
## Implementation details

## Test coverage

## Other details
Coming PRs to apply the change:

system-tests PR changing the K8s lib injection tests: https://github.com/DataDog/system-tests/pull/3689
one pipeline PR: https://github.com/DataDog/libdatadog-build/pull/59/files
Final PR on dd-trace-dotnet: https://github.com/DataDog/dd-trace-dotnet/pull/6451/files
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
