### PR TITLE
[tracing] add null checks when iterating headers in propagators

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
@@ -67,9 +67,15 @@ namespace Datadog.Trace.Propagators
             return null;
 
             // IEnumerable version (different method to avoid try/finally in the caller)
-            static bool TryParse(IEnumerable<string?> headerValues, ref bool hasValue, out ulong result)
+            static bool TryParse(IEnumerable<string?>? headerValues, ref bool hasValue, out ulong result)
             {
                 result = 0;
+
+                if (headerValues is null)
+                {
+                    return false;
+                }
+
                 foreach (string? headerValue in headerValues)
                 {
                     if (ulong.TryParse(headerValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
@@ -133,9 +139,15 @@ namespace Datadog.Trace.Propagators
             return null;
 
             // IEnumerable version (different method to avoid try/finally in the caller)
-            static bool TryParse(IEnumerable<string?> headerValues, ref bool hasValue, out int result)
+            static bool TryParse(IEnumerable<string?>? headerValues, ref bool hasValue, out int result)
             {
                 result = 0;
+
+                if (headerValues is null)
+                {
+                    return false;
+                }
+
                 foreach (string? headerValue in headerValues)
                 {
                     if (int.TryParse(headerValue, out result))
@@ -175,8 +187,13 @@ namespace Datadog.Trace.Propagators
             return ParseStringIEnumerable(headerValues);
 
             // IEnumerable version (different method to avoid try/finally in the caller)
-            static string? ParseStringIEnumerable(IEnumerable<string?> headerValues)
+            static string? ParseStringIEnumerable(IEnumerable<string?>? headerValues)
             {
+                if (headerValues is null)
+                {
+                    return null;
+                }
+
                 foreach (string? headerValue in headerValues)
                 {
                     if (!string.IsNullOrEmpty(headerValue))
@@ -211,8 +228,13 @@ namespace Datadog.Trace.Propagators
             return ParseStringIEnumerable(headerValues);
 
             // IEnumerable version (different method to avoid try/finally in the caller)
-            static string? ParseStringIEnumerable(IEnumerable<string?> headerValues)
+            static string? ParseStringIEnumerable(IEnumerable<string?>? headerValues)
             {
+                if (headerValues is null)
+                {
+                    return null;
+                }
+
                 foreach (string? headerValue in headerValues)
                 {
                     if (!string.IsNullOrEmpty(headerValue))

--- a/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
@@ -5,13 +5,10 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Propagators
 {


### PR DESCRIPTION
 ## Summary of changes

Add null checks in `ParseUtility` to avoid a `NullReferenceException`.

## Reason for change

If a user passes a delegate to `SpanContextExtractor` which returns `null` enumerables, the methods in `ParseUtility` will throw a `NullReferenceException` when they try to iterate over the values with `foreach`.

For example, `Dictionary<TKey, TValue>.GetValueOrDefault(TKey)` can return null if `TValue` is nullable:
```csharp
var dict = new Dictionary<string, List<string>>();
SpanContextExtractor.Extract(headers, (dict, key) => dict.GetValueOrDefault(key))
```

I noticed this while using manual instrumentation for system tests. The workaround I used at the time was to add a null-coalescing operator:
```csharp
SpanContextExtractor.Extract(headers, (dict, key) => dict.GetValueOrDefault(key) ?? [])
```

## Implementation details

Add nullability annotations and the missing check for `null`.

## Test coverage

Expanded existing tests:
- add test with null enumerable (confirmed that test failed before the fix and passed after)
- unrelated to this change: add test with multiple values, ensure we use the first valid value

## Other details
n/a
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
