### PR TITLE
Add support for `[DuckPropertyOrField]`

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckAttribute.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckAttribute.cs
@@ -15,14 +15,21 @@ namespace Datadog.Trace.DuckTyping
     internal enum DuckKind
     {
         /// <summary>
-        /// Property
+        /// The target member is a Property
         /// </summary>
         Property,
 
         /// <summary>
-        /// Field
+        /// The target member is a Field
         /// </summary>
-        Field
+        Field,
+
+        /// <summary>
+        /// The target member could be a Property or a Field.
+        /// Both members will be checked for, the first matching member will be used.
+        /// Property members are checked for first.
+        /// </summary>
+        PropertyOrField
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckPropertyOrFieldAttribute.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckPropertyOrFieldAttribute.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="DuckPropertyOrFieldAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DuckTyping;
+
+/// <summary>
+/// Duck attribute where the underlying member could be a field or a property
+/// </summary>
+internal class DuckPropertyOrFieldAttribute : DuckAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuckPropertyOrFieldAttribute"/> class.
+    /// </summary>
+    public DuckPropertyOrFieldAttribute()
+    {
+        Kind = DuckKind.PropertyOrField;
+    }
+}

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -661,9 +661,15 @@ namespace Datadog.Trace.DuckTyping
                 switch (duckAttribute.Kind)
                 {
                     case DuckKind.Property:
+                    case DuckKind.PropertyOrField:
                         PropertyInfo? targetProperty = GetTargetPropertyOrIndex(targetType, duckAttribute.Name, duckAttribute.BindingFlags, proxyProperty);
                         if (targetProperty is null)
                         {
+                            if (duckAttribute.Kind == DuckKind.PropertyOrField)
+                            {
+                                goto case DuckKind.Field;
+                            }
+
                             if (proxyProperty.CanRead && proxyProperty.GetMethod is not null)
                             {
                                 var getMethod = proxyProperty.GetMethod;
@@ -940,9 +946,15 @@ namespace Datadog.Trace.DuckTyping
                 switch (duckAttribute.Kind)
                 {
                     case DuckKind.Property:
+                    case DuckKind.PropertyOrField:
                         PropertyInfo? targetProperty = GetTargetProperty(targetType, duckAttribute.Name, duckAttribute.BindingFlags);
                         if (targetProperty is null)
                         {
+                            if (duckAttribute.Kind == DuckKind.PropertyOrField)
+                            {
+                                goto case DuckKind.Field;
+                            }
+
                             DuckTypePropertyOrFieldNotFoundException.Throw(proxyFieldInfo.Name, duckAttribute.Name, targetType);
                             continue;
                         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/PropertyOrFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/PropertyOrFieldTests.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="PropertyOrFieldTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests;
+
+public class PropertyOrFieldTests
+{
+    [Fact]
+    public void PropertyOrFieldTestUsesPropertyIfAvailable()
+    {
+        var target = new TargetWithProperty();
+        var proxy = target.DuckCast<Proxy>();
+
+        proxy.Value.Should().Be(target.Value);
+    }
+
+    [Fact]
+    public void PropertyOrFieldTestUsesFieldIfAvailable()
+    {
+        var target = new TargetWithField();
+        var proxy = target.DuckCast<Proxy>();
+
+        proxy.Value.Should().Be(target.Value);
+    }
+
+    [Fact]
+    public void PropertyOrFieldTestUsesNameFromDuckAttribute()
+    {
+        var target = new TargetWithFieldAndProperty();
+        var proxy = target.DuckCast<ProxyWithName>();
+
+        proxy.Value.Should().Be(target.GetValue());
+    }
+
+    [DuckCopy]
+    public struct Proxy
+    {
+        [DuckPropertyOrField]
+        public int Value;
+    }
+
+    [DuckCopy]
+    public struct ProxyWithName
+    {
+        [DuckPropertyOrField(Name = "value")]
+        public int Value;
+    }
+
+    public class TargetWithProperty
+    {
+        public int Value { get; } = 1;
+    }
+
+    public class TargetWithField
+    {
+#pragma warning disable SA1401 // should be private
+        public int Value = 1;
+#pragma warning restore SA1401
+    }
+
+    public class TargetWithFieldAndProperty
+    {
+        private int value = 3;
+
+        public int Value { get; } = 4;
+
+        public int GetValue() => value;
+    }
+}


### PR DESCRIPTION
## Summary of changes

Allows you to specify that a duck type member can match a property _or_ a field - whatever's available.

## Reason for change

In the recent version of RabbitMQ, they changed some properties into identically-named fields. Without this change, we'd have to duplicate the whole duck chain hierarchy.

## Implementation details

If the `DuckKind` is `PropertyOrField`, and we fail to find a property, then try to look for a matching field instead.

## Test coverage

Added some simple tests, that it works as expected, but I don't think we need to go as far as duplicating the extensive suite we have for Property or Field matching.

## Other details

Required for RabbitMQ v7 support