### PR TITLE
Fix the build and some versions

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8.0)
+cmake_minimum_required (VERSION 3.13.4)
 cmake_policy(SET CMP0015 NEW)
 
 # macOS uses 3.30 which deprecates FetchContent_Populate in favor of FetchContent_MakeAvailable,

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -317,15 +317,10 @@ namespace PrepareRelease
                     // upgrading four part, then three part *seems* safe
                     text => ThreePartVersionReplace(FourPartVersionReplace(text)));
 
-                // Top-level CMakeLists.txt
-                SynchronizeVersion(
-                    "CMakeLists.txt",
-                    text => FullVersionReplace(text, ".", prefix: "VERSION "));
-
                 // Native clr profiler updates
                 SynchronizeVersion(
                     "src/Datadog.Tracer.Native/CMakeLists.txt",
-                    text => FullVersionReplace(text, ".", prefix: "VERSION "));
+                    text => FullVersionReplace(text, ".", prefix: "\"Datadog.Tracer.Native\" VERSION "));
 
                 SynchronizeVersion(
                     "src/Datadog.Tracer.Native/Resource.rc",
@@ -349,11 +344,11 @@ namespace PrepareRelease
 
                 SynchronizeVersion(
                     "../profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt",
-                    text => FullVersionReplace(text, ".", prefix: "VERSION "));
+                    text => FullVersionReplace(text, ".", prefix: "\"Datadog.Profiler.Native.Linux\" VERSION "));
 
                 SynchronizeVersion(
                     "../profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt",
-                    text => FullVersionReplace(text, ".", prefix: "VERSION "));
+                    text => FullVersionReplace(text, ".", prefix: "\"Datadog.Linux.ApiWrapper\" VERSION "));
 
                 SynchronizeVersion(
                     "../profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h",
@@ -372,7 +367,7 @@ namespace PrepareRelease
 
                 SynchronizeVersion(
                     "../shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt",
-                    text => FullVersionReplace(text, ".", prefix: "VERSION "));
+                    text => FullVersionReplace(text, ".", prefix: "\"Datadog.Trace.ClrProfiler.Native\" VERSION "));
 
                 SynchronizeVersion(
                     "../shared/src/native-src/version.h",

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8.0)
+cmake_minimum_required (VERSION 3.13.4)
 cmake_policy(SET CMP0015 NEW)
 
 # macOS uses 3.30 which deprecates FetchContent_Populate in favor of FetchContent_MakeAvailable,

--- a/tracer/src/Datadog.Tracer.Native/Generated/generated_calltargets.g.cpp
+++ b/tracer/src/Datadog.Tracer.Native/Generated/generated_calltargets.g.cpp
@@ -9,7 +9,7 @@ namespace trace
 {
 int GeneratedDefinitions::InitCallTargets(UINT32 enabledCategories, UINT32 platform)
 {
-WCHAR* assemblyName = (WCHAR*)WStr("Datadog.Trace, Version=3.7.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+WCHAR* assemblyName = (WCHAR*)WStr("Datadog.Trace, Version=3.8.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
 WCHAR* sig000[]={(WCHAR*)WStr("!!0"),(WCHAR*)WStr("StackExchange.Redis.Message"),(WCHAR*)WStr("StackExchange.Redis.ResultProcessor`1[!!0]"),(WCHAR*)WStr("StackExchange.Redis.ServerEndPoint"),};
 WCHAR* sig001[]={(WCHAR*)WStr("!!0"),(WCHAR*)WStr("StackExchange.Redis.Message"),(WCHAR*)WStr("StackExchange.Redis.ResultProcessor`1[!!0]"),(WCHAR*)WStr("StackExchange.Redis.ServerEndPoint"),(WCHAR*)WStr("!!0"),};


### PR DESCRIPTION
## Summary of changes

Fix the build and the version-bump action

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/6457, @vandonr spotted that we accidentally, incorrectly, "bumped" the required version of cmake.

![image](https://github.com/user-attachments/assets/5843c1db-2dad-439e-8ed8-eeeb2d05def5)

Additionally, the new calltargets_generated.g.cpp file _also_ now embeds the version, so we need to either update that, or stop embedding the version.

@daniel-romano-DD is looking into the latter approach [here](https://github.com/DataDog/dd-trace-dotnet/pull/6464), so this PR is just a fix to unblock PRs.

## Implementation details

- Revert the broken CMakeLists.txt
- Fix the broken generated file
- Be more discerning in our CMakeLists updates

## Test coverage

Tested the version bump routine locally, and confirmed it works as expected now. 

## Other details

It would be _really_ nice if the version bumping just required bumping one or two values... That _might_  be somewhat feasible in the future, but for now...