### PR TITLE
[IAST] skip dotnet 2.1 tests that can't work

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
@@ -568,13 +568,11 @@ public abstract class AspNetCore2IastTestsFullSampling : AspNetCore2IastTests
                             .DisableRequireUniquePrefix();
     }
 
-    [SkippableFact]
+    [SkippableFact(Skip = "End point missing due to changes in Samples.Security.AspNetCore2 - refactoring in progess to restore")]
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     public async Task TestIastStoredXssRequest()
     {
-        throw new SkipException("End point missing due to changes in Samples.Security.AspNetCore2 - refactoring in progess to restore");
-
         var filename = "Iast.StoredXss.AspNetCore2." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         if (RedactionEnabled is true) { filename += ".RedactionEnabled"; }
         var url = "/Iast/StoredXss";
@@ -593,13 +591,11 @@ public abstract class AspNetCore2IastTestsFullSampling : AspNetCore2IastTests
                             .DisableRequireUniquePrefix();
     }
 
-    [SkippableFact]
+    [SkippableFact(Skip = "End point missing due to changes in Samples.Security.AspNetCore2 - refactoring in progess to restore")]
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     public async Task TestIastStoredXssEscapedRequest()
     {
-        throw new SkipException("End point missing due to changes in Samples.Security.AspNetCore2 - refactoring in progess to restore");
-
         var filename = "Iast.StoredXssEscaped.AspNetCore2." + (IastEnabled ? "IastEnabled" : "IastDisabled");
         var url = "/Iast/StoredXssEscaped";
         IncludeAllHttpSpans = true;


### PR DESCRIPTION
## Summary of changes

Previous fix didn't work.