### PR TITLE
[Dynamic Instrumentation] Hotfix SymDB and ER

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -124,7 +124,8 @@ namespace Datadog.Trace.Debugger
                                          .AsInt32(DefaultCodeOriginExitSpanFrames, frames => frames > 0)
                                          .Value;
 
-            SymbolDatabaseCompressionEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseCompressionEnabled).AsBool(false);
+            // Force it to false to disable SymDB compression, will be re-enabled in the next PR
+            SymbolDatabaseCompressionEnabled = false;
         }
 
         public bool Enabled { get; }

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -124,7 +124,7 @@ namespace Datadog.Trace.Debugger
                                          .AsInt32(DefaultCodeOriginExitSpanFrames, frames => frames > 0)
                                          .Value;
 
-            SymbolDatabaseCompressionEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseCompressionEnabled).AsBool(true);
+            SymbolDatabaseCompressionEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseCompressionEnabled).AsBool(false);
         }
 
         public bool Enabled { get; }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/FrameFilter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/FrameFilter.cs
@@ -7,6 +7,7 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 using Datadog.Trace.Debugger.Symbols;
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
@@ -64,7 +65,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 return true;
             }
 
-            return AssemblyFilter.ShouldSkipAssembly(method.Module.Assembly, LiveDebugger.Instance.Settings.ThirdPartyDetectionExcludes, LiveDebugger.Instance.Settings.ThirdPartyDetectionIncludes);
+            return AssemblyFilter.ShouldSkipAssembly(method.Module.Assembly, ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty);
         }
 
         internal static bool ShouldSkipNamespaceIfOnTopOfStack(MethodBase method)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Debugger.Upload
         {
             _apiRequestFactory = apiRequestFactory;
             _eventMetadata = eventMetadata;
-            _enableCompression = enableCompression;
+            _enableCompression = false;
             discoveryService.SubscribeToChanges(c => Endpoint = c.SymbolDbEndpoint);
         }
 
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Debugger.Upload
                 using var gzipStream = new GZipStream(memoryStream, CompressionMode.Compress);
                 await gzipStream.WriteAsync(symbols.Array, 0, symbols.Array.Length).ConfigureAwait(false);
 #endif
-                symbolsItem = new MultipartFormItem("file", "gzip", "file.gz", new ArraySegment<byte>(memoryStream.ToArray()));
+                symbolsItem = new MultipartFormItem("file", "application/gzip", "file.gz", new ArraySegment<byte>(memoryStream.ToArray()));
             }
             else
             {

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Debugger.Upload
         {
             _apiRequestFactory = apiRequestFactory;
             _eventMetadata = eventMetadata;
-            _enableCompression = false;
+            _enableCompression = enableCompression;
             discoveryService.SubscribeToChanges(c => Endpoint = c.SymbolDbEndpoint);
         }
 

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.Dnlib.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.Dnlib.cs
@@ -212,7 +212,7 @@ namespace Datadog.Trace.Pdb
                 {
                     cdiAsyncAndClosure.EncLambdaAndClosureMap = true;
                 }
-                else if (methodCustomDebugInfo.Kind is PdbCustomDebugInfoKind.StateMachineHoistedLocalScopes)
+                else if (methodCustomDebugInfo.Kind is PdbCustomDebugInfoKind.AsyncMethod)
                 {
                     cdiAsyncAndClosure.StateMachineHoistedLocal = true;
                     cdiAsyncAndClosure.StateMachineKickoffMethodRid = (int)((PdbAsyncMethodCustomDebugInfo)methodCustomDebugInfo).KickoffMethod.MDToken.Rid;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Tests.Debugger
                 NullConfigurationTelemetry.Instance);
 
             settings.Enabled.Should().BeTrue();
-            settings.SymbolDatabaseCompressionEnabled.Should().BeTrue();
+            settings.SymbolDatabaseCompressionEnabled.Should().BeFalse();
             settings.SymbolDatabaseUploadEnabled.Should().BeTrue();
             settings.MaximumDepthOfMembersToCopy.Should().Be(100);
             settings.MaxSerializationTimeInMilliseconds.Should().Be(1000);


### PR DESCRIPTION
- Disable compresison in SymDB and fix out of range exception while collecting arguments of some methods
- Exception Replay should work even Live Debugger has not initialized