### PR TITLE
Exclude common failure in smoke tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -138,8 +138,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
 #if !NET5_0_OR_GREATER
             if (result.StandardOutput.Contains("App completed successfully")
-                && (Regex.IsMatch(result.StandardError, @"open\(/proc/\d+/mem\) FAILED 2 \(No such file or directory\)")
-                || Regex.IsMatch(result.StandardError, @"ptrace\(ATTACH, \d+\) FAILED Operation not permitted")))
+                && Regex.IsMatch(result.StandardError, @"open\(/proc/\d+/mem\) FAILED 2 \(No such file or directory\)"))
             {
                 // The above message is the last thing set before we exit.
                 // We can still get flake on shutdown (which we can't isolate), but for some reason

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -138,7 +138,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
 #if !NET5_0_OR_GREATER
             if (result.StandardOutput.Contains("App completed successfully")
-                && Regex.IsMatch(result.StandardError, @"open\(/proc/\d+/mem\) FAILED 2 \(No such file or directory\)"))
+                && (Regex.IsMatch(result.StandardError, @"open\(/proc/\d+/mem\) FAILED 2 \(No such file or directory\)")
+                || Regex.IsMatch(result.StandardError, @"ptrace\(ATTACH, \d+\) FAILED Operation not permitted")))
             {
                 // The above message is the last thing set before we exit.
                 // We can still get flake on shutdown (which we can't isolate), but for some reason


### PR DESCRIPTION
## Summary of changes

Retries a common error flake that we can't get to the bottom of.

## Reason for change

The runtime _sometimes_ crashes after the app completes and we've shut down, causing flake. We haven't managed to get to the bottom of it yet.

## Implementation details

Retry the smoke tests _once_ if we spot an error that looks like this:

```
ptrace(ATTACH, 14822) FAILED Operation not permitted
```

## Test coverage

Hard to test - as long as it passes for now that's good enough I think
