### PR TITLE
[IAST] Fix recursive custom attribute crash

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -912,8 +912,12 @@ std::vector<WSTRING> ModuleInfo::GetCustomAttributes(mdToken token)
                                                                  &attributeCtorToken, &attribute_data, &data_size);
             if (SUCCEEDED(hr))
             {
-                auto attrCtor = GetMemberRefInfo(attributeCtorToken);
-                res.push_back(attrCtor->GetTypeName());
+                mdTypeRef typeToken;
+                if (SUCCEEDED(_metadataImport->GetMemberRefProps(attributeCtorToken, &typeToken, nullptr, 0, nullptr, nullptr, nullptr)))
+                {
+                    auto typeInfo = GetTypeInfo(typeToken);
+                    res.push_back(typeInfo->GetName());
+                }
             }
         }
     }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Bugs/GetCustomAttributesCrashTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Bugs/GetCustomAttributesCrashTests.cs
@@ -1,0 +1,45 @@
+// <copyright file="GetCustomAttributesCrashTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Xunit;
+
+namespace Samples.InstrumentedTests.Iast.Bugs;
+
+public class GetCustomAttributesCrashTests : Samples.InstrumentedTests.Iast.Vulnerabilities.InstrumentationTestsBase
+{
+    public GetCustomAttributesCrashTests()
+    {
+    }
+
+    [Fact]
+    public void GivenACustomAttributeSelfTagged_WhenInstrumented_NoCrashHappens()
+    {
+        _ = MyCustomClass.Test(); // This made the process crash before the fix
+    }
+
+    class MyCustomAttribute : Attribute
+    {
+        [MyCustom]
+        public MyCustomAttribute() { }
+
+        [MyCustom]
+        public void TestMethod() { }
+    }
+
+    static class MyCustomClass
+    {
+        [MyCustom]
+        public static string Test()
+        { 
+            return GetString() + GetString();
+        }
+
+        public static string GetString()
+        {
+            return "String";
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
Break recursion when discovering custom attributes of a method and that method was the constructor of an attribute decorated with the same attribute.

## Reason for change
A stack overflow crash would happen if a constructor of an attribute was decorated with the same attribute.

## Implementation details
We only want type name of the method in order to retrieve the attributes applied. Instead of retrieving the MemberRefInfo class, which read the custom attributes on the constructor, we now query the profiling API for the typedef of the method, and get its name directly.

## Test coverage
A unit test has been provided. This test crashed before the fix.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
