### PR TITLE
allow running exploration tests on mac

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -249,6 +249,7 @@ partial class Build
                 x =>
                 {
                     x = x
+                       .SetDotnetPath(TargetPlatform)
                        .SetProjectFile(testDescription.GetTestTargetPath(ExplorationTestsDirectory, targetFramework, BuildConfiguration))
                        .EnableNoRestore()
                        .EnableNoBuild()


### PR DESCRIPTION
## Summary of changes

platform was not part of the parameters, so it only tried with the default value (x64), which didn't work on mac

## Reason for change

I want to be able to run exploration tests locally

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
