### PR TITLE
Parallelize unit tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1339,7 +1339,7 @@ stages:
 
 - stage: unit_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_windows_tracer, merge_commit_id]
+  dependsOn: [build_windows_tracer, merge_commit_id, generate_variables]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -1353,6 +1353,8 @@ stages:
 
     - job: managed
       timeoutInMinutes: 60 #default value
+      strategy:
+        matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_windows_matrix'] ]
       steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1361,7 +1363,7 @@ stages:
       - template: steps/install-dotnet.yml
       - template: steps/restore-working-directory.yml
 
-      - script: tracer\build.cmd BuildAndRunManagedUnitTests --code-coverage-enabled $(CodeCoverageEnabled)
+      - script: tracer\build.cmd BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build and Test
         env:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1380,7 +1382,7 @@ stages:
 
 - stage: unit_tests_macos
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_macos, merge_commit_id]
+  dependsOn: [build_macos, merge_commit_id, generate_variables]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -1390,6 +1392,9 @@ stages:
       jobs: [managed]
 
   - job: managed
+    strategy:
+      matrix:
+        $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_macos_matrix'] ]
     timeoutInMinutes: 90
     pool:
       vmImage: macos-13
@@ -1410,7 +1415,7 @@ stages:
           artifact: build-macos-native_tracer
           path: $(monitoringHome)
 
-      - script: ./tracer/build.sh BuildAndRunManagedUnitTests --code-coverage-enabled $(CodeCoverageEnabled)
+      - script: ./tracer/build.sh BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build and Test
         retryCountOnTaskFailure: 1
         env:
@@ -1430,7 +1435,7 @@ stages:
 
 - stage: unit_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_linux_tracer, build_linux_profiler, merge_commit_id]
+  dependsOn: [build_linux_tracer, build_linux_profiler, merge_commit_id, generate_variables]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -1443,12 +1448,7 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix:
-        x64:
-          baseImage: debian
-          artifactSuffix: linux-x64
-        alpine:
-          baseImage: alpine
-          artifactSuffix: linux-musl-x64
+        $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_x64_matrix'] ]
     pool:
       name: azure-linux-scale-set
 
@@ -1466,7 +1466,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildAndRunManagedUnitTests --code-coverage-enabled $(CodeCoverageEnabled)"
+        command: "BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - publish: artifacts/build_data
@@ -1483,7 +1483,7 @@ stages:
 
 - stage: unit_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_arm64_tracer, merge_commit_id]
+  dependsOn: [build_arm64_tracer, merge_commit_id, generate_variables]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -1494,14 +1494,10 @@ stages:
 
     - job: test
       timeoutInMinutes: 60 #default value
+
       strategy:
         matrix:
-          arm64:
-            baseImage: debian
-            artifactSuffix: linux-arm64
-          alpine:
-            baseImage: alpine
-            artifactSuffix: linux-musl-arm64
+          $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_arm64_matrix'] ]
       pool:
         name: aws-arm64-auto-scaling
       workspace:
@@ -1519,7 +1515,7 @@ stages:
           parameters:
             build: true
             baseImage: $(baseImage)
-            command: "BuildAndRunManagedUnitTests"
+            command: "BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
         - publish: artifacts/build_data

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -23,6 +23,7 @@ partial class Build : NukeBuild
                   .Executes(() =>
                    {
                        GenerateConditionVariables();
+                       GenerateUnitTestFrameworkMatrices();
 
                        GenerateIntegrationTestsWindowsMatrices();
                        GenerateIntegrationTestsLinuxMatrices();
@@ -97,6 +98,36 @@ partial class Build : NukeBuild
                     var variableValue = isChanged.ToString();
                     EnvironmentInfo.SetVariable(variableName, variableValue);
                     AzurePipelines.Instance.SetOutputVariable(variableName, variableValue);
+                }
+            }
+
+            void GenerateUnitTestFrameworkMatrices()
+            {
+                GenerateTfmsMatrix("unit_tests_windows_matrix");
+                GenerateTfmsMatrix("unit_tests_macos_matrix");
+                GenerateLinuxMatrix("x64");
+                GenerateLinuxMatrix("arm64");
+
+                void GenerateTfmsMatrix(string name)
+                {
+                    var matrix = TestingFrameworks
+                       .ToDictionary(t => t.ToString(), t => new { framework = t, });
+
+                    Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetOutputVariable(name, JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateLinuxMatrix(string platform)
+                {
+                    var matrix = new Dictionary<string, object>();
+                    foreach (var framework in TestingFrameworks)
+                    {
+                        matrix.Add($"glibc_{framework}", new { framework = framework, baseImage = "debian", artifactSuffix = $"linux-{platform}"});
+                        matrix.Add($"musl_{framework}", new { framework = framework, baseImage = "alpine", artifactSuffix = $"linux-musl-{platform}"});
+                    }
+
+                    Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetOutputVariable($"unit_tests_linux_{platform}_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
             }
 
@@ -205,7 +236,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsWindowsMsiMatrix(params TargetFramework[] targetFrameworks)
             {
-                var targetPlatforms = new[] { 
+                var targetPlatforms = new[] {
                     (targetPlaform: "x64", enable32Bit: false),
                     (targetPlaform: "x64", enable32Bit: true),
                 };
@@ -235,8 +266,8 @@ partial class Build : NukeBuild
             {
                 var baseImages = new []
                 {
-                    (baseImage: "debian", artifactSuffix: "linux-x64"), 
-                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"), 
+                    (baseImage: "debian", artifactSuffix: "linux-x64"),
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"),
                 };
 
                 var targetFrameworks = TestingFrameworks.Except(new[] { TargetFramework.NET461, TargetFramework.NET462, TargetFramework.NETSTANDARD2_0 });
@@ -285,8 +316,8 @@ partial class Build : NukeBuild
                 var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462 });
                 var baseImages = new []
                 {
-                    (baseImage: "debian", artifactSuffix: "linux-x64"), 
-                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"), 
+                    (baseImage: "debian", artifactSuffix: "linux-x64"),
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"),
                 };
                 var optimizations = new[] { "true", "false" };
 
@@ -365,8 +396,8 @@ partial class Build : NukeBuild
 
                 var baseImages = new []
                 {
-                    (baseImage: "debian", artifactSuffix: "linux-x64"), 
-                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"), 
+                    (baseImage: "debian", artifactSuffix: "linux-x64"),
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"),
                 };
 
                 var matrix = new Dictionary<string, object>();
@@ -420,7 +451,7 @@ partial class Build : NukeBuild
 
                 // tracer home smoke tests
                 GenerateWindowsTracerHomeSmokeTestsMatrix();
-                
+
                 // macos smoke tests
                 GenerateMacosDotnetToolNugetSmokeTestsMatrix();
 
@@ -1089,7 +1120,7 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            // We can't install prerelease versions of the dotnet-tool nuget in .NET Core 3.1, because the --prerelease flag isn't available 
+                            // We can't install prerelease versions of the dotnet-tool nuget in .NET Core 3.1, because the --prerelease flag isn't available
                             new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye"),
                         }.Where(x=> !IsPrerelease || x.PublishFramework != TargetFramework.NETCOREAPP3_1).ToArray(),
                         platformSuffix: "linux-x64",
@@ -1106,7 +1137,7 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
                             new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.15"),
-                            // We can't install prerelease versions of the dotnet-tool nuget in .NET Core 3.1, because the --prerelease flag isn't available 
+                            // We can't install prerelease versions of the dotnet-tool nuget in .NET Core 3.1, because the --prerelease flag isn't available
                         }.Where(x=> !IsPrerelease || x.PublishFramework != TargetFramework.NETCOREAPP3_1).ToArray(),
                         platformSuffix: "linux-musl-x64",
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
@@ -1410,14 +1441,14 @@ partial class Build : NukeBuild
         {
             branch = Environment.GetEnvironmentVariable(AzureBuildSourceBranchName);
         }
-        
+
         Console.WriteLine("Base Branch: {0}", baseBranch);
         Console.WriteLine("Current Branch: {0}", branch);
 
         var cleanBranch = CleanBranchName(branch);
         var cleanBaseBranch = CleanBranchName(baseBranch);
         Console.Write("  {0} == {1}? ", cleanBranch, cleanBaseBranch);
-        
+
         if (string.Equals(cleanBranch, cleanBaseBranch, StringComparison.OrdinalIgnoreCase))
         {
             Console.WriteLine("true");


### PR DESCRIPTION
## Summary of changes

Parallelize the unit test runs in CI

## Reason for change

As we test more frameworks, the runs take longer. We can easily parallize by TFM (e.g. we allow running a specific TFM locally), so this overall speeds up the unit test execution. As we (attempt) to improve the speed of other stages, this allows gaining confidence earlier. Additionally, in the case of flake, re-running a stage takes less time when each TFM is parallelized.

## Implementation details

Generate the matricies, use them in CI

## Test coverage

Did a test run, looks OK to me

## Other details

Reduces the wall time from this:

![image](https://github.com/user-attachments/assets/e62b4743-5726-4309-a441-c3f5af144c2e)
![image](https://github.com/user-attachments/assets/75733f99-8aa9-49ca-9ff5-69cb6bf98644)

to this:

![image](https://github.com/user-attachments/assets/2a4fcb56-0c34-416b-8070-9fc9f5bfa9c9)
