### PR TITLE
[ASM] Log `FormatException` from `get_Uri` as debug

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
@@ -30,6 +30,10 @@ public class UriBuilderAspect
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result.Uri.OriginalString, uriText);
         }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+        }
         catch (Exception ex)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
@@ -50,6 +54,10 @@ public class UriBuilderAspect
         try
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result.Uri.OriginalString, uri.OriginalString);
+        }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
         catch (Exception ex)
         {
@@ -72,6 +80,10 @@ public class UriBuilderAspect
         try
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result.Uri.OriginalString, host);
+        }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
         catch (Exception ex)
         {
@@ -96,6 +108,10 @@ public class UriBuilderAspect
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result.Uri.OriginalString, host);
         }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+        }
         catch (Exception ex)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
@@ -119,6 +135,10 @@ public class UriBuilderAspect
         try
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result.Uri.OriginalString, host, path);
+        }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
         catch (Exception ex)
         {
@@ -145,6 +165,10 @@ public class UriBuilderAspect
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result.Uri.OriginalString, host, path, extra);
         }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+        }
         catch (Exception ex)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
@@ -166,6 +190,10 @@ public class UriBuilderAspect
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(instance.Uri.OriginalString, parameter);
         }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+        }
         catch (Exception ex)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
@@ -184,6 +212,10 @@ public class UriBuilderAspect
         try
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(instance.Uri.OriginalString, parameter);
+        }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
         catch (Exception ex)
         {
@@ -204,6 +236,10 @@ public class UriBuilderAspect
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(instance.Uri.OriginalString, parameter);
         }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+        }
         catch (Exception ex)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetPath)}");
@@ -222,6 +258,10 @@ public class UriBuilderAspect
         try
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result, instance.Uri.OriginalString);
+        }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
         catch (Exception ex)
         {
@@ -244,6 +284,10 @@ public class UriBuilderAspect
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result, instance.Uri.OriginalString);
         }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+        }
         catch (Exception ex)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetQuery)}");
@@ -264,6 +308,10 @@ public class UriBuilderAspect
         try
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result, instance.Uri.OriginalString);
+        }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
         catch (Exception ex)
         {
@@ -286,6 +334,10 @@ public class UriBuilderAspect
         try
         {
             PropagationModuleImpl.PropagateWholeResultWhenInputTainted(result, (instance as UriBuilder)?.Uri?.OriginalString);
+        }
+        catch (FormatException ex)
+        {
+            IastModule.Log.Debug(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary of changes

Add catch blocks for the `FormatException` in all aspect where the `Uri` is get from the instance.

## Reason for change

[Error identified on Error Tracking](https://app.datadoghq.com/error-tracking?query=service%3Ainstrumentation-telemetry-data%20%2Aiast%2A%20%40lib_language%3Adotnet%20-%2ASystem.OutOfMemoryException%2A%20-%2ASystem.Threading.ThreadAbortException%2A&et-side=data&fromUser=true&issueId=0374ce80-0ddb-11ef-bfb2-da7ad0900002&refresh_mode=sliding&source=all&from_ts=1734966392184&to_ts=1735571192184&live=true).

The instrumentation fails because of an invalid string during the creation of the `Uri`. The tainting would not happen because it requires the `OriginalString` from the `Uri` to keep tracks of its usage.

## Implementation details

From the [Microsoft Docs](https://learn.microsoft.com/en-us/dotnet/api/System.UriBuilder.Uri?view=net-6.0):
> [UriFormatException](https://learn.microsoft.com/en-us/dotnet/api/system.uriformatexception?view=net-6.0)
The URI constructed by the [UriBuilder](https://learn.microsoft.com/en-us/dotnet/api/system.uribuilder?view=net-6.0) properties is invalid.

I did choose FormatException because from the [docs](https://learn.microsoft.com/en-us/dotnet/api/System.UriBuilder.Uri?view=net-6.0#exceptions), they say:
Note: In .NET for Windows Store apps or the Portable Class Library, catch the base class exception, [FormatException](https://learn.microsoft.com/en-us/dotnet/api/system.formatexception?view=net-6.0), instead.