### PR TITLE
fix UpdateVendoredCode on mac

### DIFF
--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -61,7 +61,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Honeypot\Datadog.Dependabot.Honeypot.template" />
-    <EmbeddedResource Include="Honeypot\Datadog.Dependabot.Honeypot.template" />
+    <None Remove="Honeypot/Datadog.Dependabot.Honeypot.template"/>
+    <EmbeddedResource Include="Honeypot/Datadog.Dependabot.Honeypot.template">
+      <!-- We have to force this name because somehow on macOS, it's named without the first 'Honeypot.' -->
+      <LogicalName>Honeypot.Datadog.Dependabot.Honeypot.template</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes

force the name of the honeypot template because it's different on mac and on windows

## Reason for change

the command was broken with the following error:
```
System.ArgumentNullException: Value cannot be null. (Parameter 'stream')
   at System.IO.StreamReader..ctor(Stream stream, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean leaveOpen)
   at Honeypot.DependabotFileManager.GetHoneyPotProjTemplate() in /Users/raphael.vandon/go/src/github.com/DataDog/dd-trace-dotnet/tracer/build/_build/Honeypot/DependabotFileManager.cs:line 120
   at Honeypot.DependabotFileManager.UpdateVendors(AbsolutePath honeypotProject) in /Users/raphael.vandon/go/src/github.com/DataDog/dd-trace-dotnet/tracer/build/_build/Honeypot/DependabotFileManager.cs:line 31
```
I discovered almost by chance that the resource had the "wrong" name in the dll when built on my mac. Forcing the name doesn't change anything on windows, and unifies the behavior on mac.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
