### PR TITLE
Minor fixes for build warnings in samples

### DIFF
--- a/tracer/test/test-applications/debugger/Samples.Debugger.AspNetCore5/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/debugger/Samples.Debugger.AspNetCore5/Controllers/HomeController.cs
@@ -29,7 +29,7 @@ namespace Samples.Debugger.AspNetCore5.Controllers
 
         public IActionResult LangHeader()
         {
-            Response.Headers.Add("content-language", "krypton");
+            Response.Headers["content-language"] = "krypton";
             return Content("Setting content-language");
         }
 

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/ExceptionWithNonSupportedFramesTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/ExceptionWithNonSupportedFramesTest.cs
@@ -27,7 +27,9 @@ namespace Samples.Probes.TestRuns.ExceptionReplay
 
         ref struct MeRefStruct
         {
+#pragma warning disable CS0649 // Field 'ExceptionWithNonSupportedFramesTest.MeRefStruct.Field' is never assigned to, and will always have its default value null
             public string Field;
+#pragma warning restore CS0649
         }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/ApiController.cs
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/ApiController.cs
@@ -32,7 +32,7 @@ namespace Samples.AspNetCoreMvc.Controllers
         {
             if (Request.Headers.ContainsKey(CorrelationIdentifierHeaderName))
             {
-                Response.Headers.Add(CorrelationIdentifierHeaderName, Request.Headers[CorrelationIdentifierHeaderName]);
+                Response.Headers[CorrelationIdentifierHeaderName] = Request.Headers[CorrelationIdentifierHeaderName];
             }
         }
     }

--- a/tracer/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Samples.Microsoft.Data.Sqlite.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Samples.Microsoft.Data.Sqlite.csproj
@@ -6,6 +6,10 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <!-- Ignore unnecessary warning: Found version-specific or distribution-specific runtime 
+     identifier(s): alpine-x64. Affected libraries: SQLitePCLRaw.lib.e_sqlite3. In .NET 8.0 and higher,
+     assets for version-specific and distribution-specific runtime identifiers will not be found by default.  -->
+    <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
 
   </PropertyGroup>
 

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -74,7 +74,6 @@ namespace Samples.Security.AspNetCore5.Controllers
     {
         private static SQLiteConnection _dbConnectionSystemData = null;
         private static SqliteConnection _dbConnectionSystemDataMicrosoftData = null;
-        private static SqlConnection _dbConnectionSystemDataSqlClient = null;
         private static IMongoDatabase _mongoDb = null;
 
         public IActionResult Index()


### PR DESCRIPTION
## Summary of changes

Fixes some build warnings coming from the samples

## Reason for change

Warnings are annoying

## Implementation details

Tries to fix the following warnings:

`##[warning]D:\a\1\s\tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\ApiController.cs(35,17): warning ASP0019: Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key. (https://aka.ms/aspnet/analyzers)`

`##[warning]D:\a\_tool\dotnet\sdk\9.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(322,5): warning NETSDK1206: Found version-specific or distribution-specific runtime identifier(s): alpine-x64. Affected libraries: SQLitePCLRaw.lib.e_sqlite3. In .NET 8.0 and higher, assets for version-specific and distribution-specific runtime identifiers will not be found by default. See https://aka.ms/dotnet/rid-usage for details. [D:\a\1\s\tracer\test\test-applications\integrations\Samples.Microsoft.Data.Sqlite\Samples.Microsoft.Data.Sqlite.csproj::TargetFramework=net8.0]`

`##[warning]D:\a\1\s\tracer\test\test-applications\debugger\dependency-libs\Samples.Probes.TestRuns\ExceptionReplay\ExceptionWithNonSupportedFramesTest.cs(30,27): warning CS0649: Field 'ExceptionWithNonSupportedFramesTest.MeRefStruct.Field' is never assigned to, and will always have its default value null`

`##[warning]D:\a\1\s\tracer\test\test-applications\security\Samples.Security.AspNetCore5\Controllers\IastController.cs(77,38): warning CS0414: The field 'IastController._dbConnectionSystemDataSqlClient' is assigned but its value is never used`

`##[warning]D:\a\1\s\tracer\test\test-applications\debugger\Samples.Debugger.AspNetCore5\Controllers\HomeController.cs(32,13): warning ASP0019: Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key. (https://aka.ms/aspnet/analyzers)`

## Test coverage

This PR is the test
