### PR TITLE
[ASM] Update Iast Log Warning to Error

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
@@ -53,7 +53,7 @@ public class MongoDatabaseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
@@ -85,7 +85,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error while tainting the JObject");
+            IastModule.Log.Error(ex, "Error while tainting the JObject");
         }
 
         return result;
@@ -113,7 +113,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error while tainting the JArray");
+            IastModule.Log.Error(ex, "Error while tainting the JArray");
         }
 
         return result;
@@ -136,7 +136,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error while tainting the JToken");
+            IastModule.Log.Error(ex, "Error while tainting the JToken");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
@@ -38,7 +38,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted1)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted1)}");
         }
     }
 
@@ -59,7 +59,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted2)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted2)}");
         }
     }
 
@@ -83,7 +83,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted3)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted3)}");
         }
     }
 
@@ -106,7 +106,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted4)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted4)}");
         }
     }
 
@@ -130,7 +130,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted5)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted5)}");
         }
     }
 
@@ -154,7 +154,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted6)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted6)}");
         }
     }
 
@@ -179,7 +179,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted7)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted7)}");
         }
     }
 
@@ -198,7 +198,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendLiteral)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendLiteral)}");
         }
     }
 
@@ -217,7 +217,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(ToStringAndClear)}");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(ToStringAndClear)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
@@ -37,7 +37,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error tainting JsonDocument.Parse result");
+            IastModule.Log.Error(ex, "Error tainting JsonDocument.Parse result");
         }
 
         return doc;
@@ -60,7 +60,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error casting to IJsonElement");
+            IastModule.Log.Error(ex, "Error casting to IJsonElement");
             return null;
         }
 
@@ -77,7 +77,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error tainting JsonElement.GetString result");
+            IastModule.Log.Error(ex, "Error tainting JsonElement.GetString result");
         }
 
         return str;
@@ -101,7 +101,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error casting to IJsonElement");
+            IastModule.Log.Error(ex, "Error casting to IJsonElement");
             return null;
         }
 
@@ -118,7 +118,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error tainting JsonElement.GetRawText result");
+            IastModule.Log.Error(ex, "Error tainting JsonElement.GetRawText result");
         }
 
         return str;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
@@ -57,7 +57,7 @@ public class JavaScriptSerializerAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Warning(ex, "Error while tainting json in DeserializeObject");
+            IastModule.Log.Error(ex, "Error while tainting json in DeserializeObject");
         }
 
         return result;


### PR DESCRIPTION
## Summary of changes

Change `Iast.Log.Warning(..)` to `.Error(..)` in try catch blocks of Aspects.

## Reason for change

Improve error logging. These errors could be shown in the Error Tracking telemetry.