### PR TITLE
Change `CopyToOutputDirectory="Always"` to  `CopyToOutputDirectory="PreserveNewest"`

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -28,24 +28,24 @@
     <None Remove="GarbageCollections\3x3GCs-64.bevents" />
     <None Remove="xunit.runner.json" />
     <Content Include="Allocations\allocations-32.bevents">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Allocations\allocations-64.bevents">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Contention\lockContention-32.bevents">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Contention\lockContention-64.bevents">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="GarbageCollections\3x3GCs-32.bevents">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="GarbageCollections\3x3GCs-64.bevents">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/samples/ServiceFabricRemoting/WeatherService.NetCore31/WeatherService.NetCore31.csproj
+++ b/tracer/samples/ServiceFabricRemoting/WeatherService.NetCore31/WeatherService.NetCore31.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <None Include="..\DatadogInstall.bat" Link="DatadogInstall.bat">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\DatadogInstall.ps1" Link="DatadogInstall.ps1">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/samples/ServiceFabricRemoting/WeatherService.NetFx461/WeatherService.NetFx461.csproj
+++ b/tracer/samples/ServiceFabricRemoting/WeatherService.NetFx461/WeatherService.NetFx461.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <None Include="..\DatadogInstall.bat" Link="DatadogInstall.bat">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\DatadogInstall.ps1" Link="DatadogInstall.ps1">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/samples/ServiceFabricRemoting/WebApp/WebApp.csproj
+++ b/tracer/samples/ServiceFabricRemoting/WebApp/WebApp.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <None Include="..\DatadogInstall.bat" Link="DatadogInstall.bat">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\DatadogInstall.ps1" Link="DatadogInstall.ps1">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -61,8 +61,8 @@
       </ItemGroup>
       <ItemGroup>
         <Content Include="..\Datadog.Trace.Bundle\home\**\*.*" LinkBase="home">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-          <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         </Content>
 
         <Content Update="..\Datadog.Trace.Bundle\home\**\readme.txt">

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -11,10 +11,10 @@
     <None Remove="xunit.runner.json" />
     <Compile Include="..\Datadog.Trace.TestHelpers.SharedSource\VerifyHelper.cs" Link="Helpers\VerifyHelper.cs" />
     <Content Include="applicationHost.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <None Remove="xunit.runner.json" />
-    <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Datadog.Trace.Debugger.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Datadog.Trace.Debugger.IntegrationTests.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <None Remove="xunit.runner.json" />
     <Content Include="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
     <Compile Include="..\Datadog.Trace.TestHelpers.SharedSource\VerifyHelper.cs" Link="Helpers\VerifyHelper.cs" />

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <None Remove="xunit.runner.json" />
-    <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
@@ -12,10 +12,10 @@
     <None Remove="xunit.runner.json" />
     <Compile Include="..\Datadog.Trace.TestHelpers.SharedSource\VerifyHelper.cs" Link="VerifyHelper.cs" />
     <Content Include="applicationHost.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers.AutoInstrumentation\Datadog.Trace.TestHelpers.AutoInstrumentation.csproj" />
@@ -75,10 +75,10 @@
 
   <ItemGroup>
     <None Update="CI\Data\*.*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="CI\Data\**\*.*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Content Include="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
@@ -23,13 +23,13 @@
 
   <ItemGroup>
     <None Update="coverage.cobertura.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="coverage.opencover.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="DummyLibrary.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj
@@ -9,15 +9,15 @@
   <ItemGroup>
     <None Remove="xunit.runner.json" />
     <Content Include="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Remove="CoverageRewriterAssembly.dll" />
     <Content Include="CoverageRewriterAssembly.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Remove="CoverageRewriterAssembly.pdb" />
     <Content Include="CoverageRewriterAssembly.pdb">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -35,7 +35,7 @@
   
   <ItemGroup>
     <None Update="datadogConfig.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 </Project>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
@@ -17,10 +17,10 @@
 
   <ItemGroup>
     <Content Include="applicationHost.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Datadog.Trace.Tools.dd_dotnet.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Datadog.Trace.Tools.dd_dotnet.IntegrationTests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <Content Include="applicationHost.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.Tests/Datadog.Trace.Tools.dd_dotnet.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.Tests/Datadog.Trace.Tools.dd_dotnet.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <None Remove="xunit.runner.json" />
     <Content Include="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -33,19 +33,19 @@
   
   <ItemGroup>
     <None Update="CallDatadogConfigJson.exe.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="datadog.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="datadogConfig.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="DoNotCallDatadogConfigJson.exe.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="maps.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Samples.AspNet472.LoaderOptimizationRegKey.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Samples.AspNet472.LoaderOptimizationRegKey.csproj
@@ -140,7 +140,7 @@
     <Content Include="Default.aspx" />
     <Content Include="Global.asax" />
     <Content Include="log4net.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="Properties\PublishProfiles\FolderProfile.pubxml" />
     <Content Include="Site.Master" />

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/LogsInjection.Log4Net.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/LogsInjection.Log4Net.VersionConflict.2x.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <None Update="log4net.205.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
@@ -32,10 +32,10 @@
   <ItemGroup>
     <!-- It appears that this works fine for V3 as well - re-using -->
     <None Update="log4net.205.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="log4net.Pre205.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/LogsInjection.NLog.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/LogsInjection.NLog.VersionConflict.2x.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <None Update="NLog.46.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <None Update="Configurations\*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/LogsInjection.NLog10.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/LogsInjection.NLog10.VersionConflict.2x.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <None Update="NLog.Pre40.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/LogsInjection.NLog20.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/LogsInjection.NLog20.VersionConflict.2x.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <None Update="NLog.Pre40.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Samples.AspNetCoreMinimalApis.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Samples.AspNetCoreMinimalApis.csproj
@@ -13,6 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="Always" />
+    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc30/Samples.AspNetCoreMvc30.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc30/Samples.AspNetCoreMvc30.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="Always" />
+    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="Always" />
+    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.CIVisibilityVersionMismatch/Samples.CIVisibilityVersionMismatch.csproj
+++ b/tracer/test/test-applications/integrations/Samples.CIVisibilityVersionMismatch/Samples.CIVisibilityVersionMismatch.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
@@ -56,7 +56,7 @@
 
   <ItemGroup>
     <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.Selenium/Samples.Selenium.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Selenium/Samples.Selenium.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="ci.runsettings">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.XUnitTests/Samples.XUnitTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.XUnitTests/Samples.XUnitTests.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.XUnitTestsRetries/Samples.XUnitTestsRetries.csproj
+++ b/tracer/test/test-applications/integrations/Samples.XUnitTestsRetries/Samples.XUnitTestsRetries.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of changes
Change `CopyToOutputDirectory="Always"` to  `CopyToOutputDirectory="PreserveNewest"`

## Reason for change
You shouldn't use Always unless you _really_ need to, as it slows things down, by forcing MSBuild to redo a bunch of work

## Implementation details

Find and replace

## Test coverage

If CI works, I'm happy enough. There's a slim chance some of these _do_ need to be Always, but I doubt it...
