### PR TITLE
[ASM] Normalise aspects exception logging

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
@@ -106,7 +106,7 @@ public class BeforeAfterAspectCodeFixProvider : CodeFixProvider
         // create the trystatementsyntax with the internals of the method declaration
         var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
         var logExpression = SyntaxFactory.ExpressionStatement(
-            SyntaxFactory.ParseExpression($$"""IastModule.LogAspectException(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+            SyntaxFactory.ParseExpression($$"""IastModule.LogAspectException(ex, $"{nameof({{typeName}})}.{nameof({{methodName}})}")"""));
         var returnStatement = paramName is not null
                                   ? SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(paramName))
                                   : SyntaxFactory.ReturnStatement();

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
@@ -106,7 +106,7 @@ public class BeforeAfterAspectCodeFixProvider : CodeFixProvider
         // create the trystatementsyntax with the internals of the method declaration
         var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
         var logExpression = SyntaxFactory.ExpressionStatement(
-            SyntaxFactory.ParseExpression($$"""IastModule.Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+            SyntaxFactory.ParseExpression($$"""IastModule.LogAspectException(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
         var returnStatement = paramName is not null
                                   ? SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(paramName))
                                   : SyntaxFactory.ReturnStatement();

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectCodeFixProvider.cs
@@ -106,7 +106,7 @@ public class ReplaceAspectCodeFixProvider : CodeFixProvider
 
         var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
         var logExpression = SyntaxFactory.ExpressionStatement(
-            SyntaxFactory.ParseExpression($$"""IastModule.Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+            SyntaxFactory.ParseExpression($$"""IastModule.LogAspectException(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
 
         var catchSyntax = SyntaxFactory.CatchClause()
                                        .WithDeclaration(catchDeclaration)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectCodeFixProvider.cs
@@ -106,7 +106,7 @@ public class ReplaceAspectCodeFixProvider : CodeFixProvider
 
         var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
         var logExpression = SyntaxFactory.ExpressionStatement(
-            SyntaxFactory.ParseExpression($$"""IastModule.LogAspectException(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+            SyntaxFactory.ParseExpression($$"""IastModule.LogAspectException(ex, $"{nameof({{typeName}})}.{nameof({{methodName}})}")"""));
 
         var catchSyntax = SyntaxFactory.CatchClause()
                                        .WithDeclaration(catchDeclaration)

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
@@ -31,7 +31,7 @@ public class HttpResponseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
@@ -31,7 +31,7 @@ public class HttpResponseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpResponseAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
@@ -37,7 +37,7 @@ public class ControllerBaseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(ControllerBaseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(ControllerBaseAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
@@ -37,7 +37,7 @@ public class ControllerBaseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(ControllerBaseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"{nameof(ControllerBaseAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -42,7 +42,7 @@ public class EntityCommandAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(EntityCommandAspect)}.{nameof(ReviewSqlCommand)}");
+            IastModule.LogAspectException(ex, $"{nameof(EntityCommandAspect)}.{nameof(ReviewSqlCommand)}");
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -42,7 +42,7 @@ public class EntityCommandAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(EntityCommandAspect)}.{nameof(ReviewSqlCommand)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(EntityCommandAspect)}.{nameof(ReviewSqlCommand)}");
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -40,7 +40,7 @@ public class EntityFrameworkCoreAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(EntityFrameworkCoreAspect)}.{nameof(ReviewSqlString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(EntityFrameworkCoreAspect)}.{nameof(ReviewSqlString)}");
             return sqlAsString;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -40,7 +40,7 @@ public class EntityFrameworkCoreAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(EntityFrameworkCoreAspect)}.{nameof(ReviewSqlString)}");
+            IastModule.LogAspectException(ex, $"{nameof(EntityFrameworkCoreAspect)}.{nameof(ReviewSqlString)}");
             return sqlAsString;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
@@ -35,7 +35,7 @@ public class BsonAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(BsonAspect)}.{nameof(AnalyzeJsonString)}");
+            IastModule.LogAspectException(ex, $"{nameof(BsonAspect)}.{nameof(AnalyzeJsonString)}");
             return json;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
@@ -35,7 +35,7 @@ public class BsonAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(BsonAspect)}.{nameof(AnalyzeJsonString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(BsonAspect)}.{nameof(AnalyzeJsonString)}");
             return json;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
@@ -53,7 +53,7 @@ public class MongoDatabaseAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
+            IastModule.LogAspectException(ex, $"{nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
@@ -51,9 +51,9 @@ public class MongoDatabaseAspect
 
             return command;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -35,7 +35,7 @@ public class ISessionAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
             return query;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -35,7 +35,7 @@ public class ISessionAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
+            IastModule.LogAspectException(ex, $"{nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
             return query;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
@@ -63,7 +63,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error while initializing NewtonsoftJsonAspects");
+            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.Ctor");
         }
     }
 
@@ -85,7 +85,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error while tainting the JObject");
+            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.{nameof(ParseObject)}");
         }
 
         return result;
@@ -113,7 +113,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error while tainting the JArray");
+            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.{nameof(ParseArray)}");
         }
 
         return result;
@@ -136,7 +136,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error while tainting the JToken");
+            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.{nameof(ParseToken)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
@@ -63,7 +63,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error while initializing NewtonsoftJsonAspects");
+            IastModule.LogAspectException(ex, "Error while initializing NewtonsoftJsonAspects");
         }
     }
 
@@ -85,7 +85,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error while tainting the JObject");
+            IastModule.LogAspectException(ex, "Error while tainting the JObject");
         }
 
         return result;
@@ -113,7 +113,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error while tainting the JArray");
+            IastModule.LogAspectException(ex, "Error while tainting the JArray");
         }
 
         return result;
@@ -136,7 +136,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error while tainting the JToken");
+            IastModule.LogAspectException(ex, "Error while tainting the JToken");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -41,7 +41,7 @@ public class DbCommandAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DbCommandAspect)}.{nameof(ReviewExecuteNonQuery)}");
+            IastModule.LogAspectException(ex, $"{nameof(DbCommandAspect)}.{nameof(ReviewExecuteNonQuery)}");
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -41,7 +41,7 @@ public class DbCommandAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DbCommandAspect)}.{nameof(ReviewExecuteNonQuery)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DbCommandAspect)}.{nameof(ReviewExecuteNonQuery)}");
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
@@ -37,7 +37,7 @@ public partial class DirectoryEntryAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectoryEntryAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(DirectoryEntryAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
@@ -37,7 +37,7 @@ public partial class DirectoryEntryAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryEntryAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectoryEntryAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
@@ -37,7 +37,7 @@ public partial class DirectorySearcherAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectorySearcherAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectorySearcherAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
@@ -37,7 +37,7 @@ public partial class DirectorySearcherAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectorySearcherAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(DirectorySearcherAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
@@ -35,7 +35,7 @@ public partial class PrincipalContextAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(PrincipalContextAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(PrincipalContextAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
@@ -35,7 +35,7 @@ public partial class PrincipalContextAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(PrincipalContextAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(PrincipalContextAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
@@ -34,7 +34,7 @@ public partial class SearchRequestAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SearchRequestAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SearchRequestAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
@@ -34,7 +34,7 @@ public partial class SearchRequestAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SearchRequestAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(SearchRequestAspect)}.{nameof(Init)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -83,7 +83,7 @@ public class DirectoryAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -83,7 +83,7 @@ public class DirectoryAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -68,7 +68,7 @@ public class DirectoryInfoAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -68,7 +68,7 @@ public class DirectoryInfoAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -101,7 +101,7 @@ public class FileAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(FileAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }
@@ -152,7 +152,7 @@ public class FileAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPathRead)}");
+            IastModule.LogAspectException(ex, $"{nameof(FileAspect)}.{nameof(ReviewPathRead)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -101,7 +101,7 @@ public class FileAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }
@@ -152,7 +152,7 @@ public class FileAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPathRead)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPathRead)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -41,7 +41,7 @@ public class FileInfoAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -41,7 +41,7 @@ public class FileInfoAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -45,7 +45,7 @@ public class FileStreamAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -45,7 +45,7 @@ public class FileStreamAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -41,7 +41,7 @@ public class StreamReaderAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -41,7 +41,7 @@ public class StreamReaderAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
@@ -40,7 +40,7 @@ public class StreamWriterAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StreamWriterAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StreamWriterAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
@@ -40,7 +40,7 @@ public class StreamWriterAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StreamWriterAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(StreamWriterAspect)}.{nameof(ReviewPath)}");
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net.Mail/SmtpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net.Mail/SmtpClientAspect.cs
@@ -38,7 +38,7 @@ public class SmtpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SmtpClientAspect)}.{nameof(Send)}");
+            IastModule.LogAspectException(ex, $"{nameof(SmtpClientAspect)}.{nameof(Send)}");
             return message;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net.Mail/SmtpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net.Mail/SmtpClientAspect.cs
@@ -38,7 +38,7 @@ public class SmtpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SmtpClientAspect)}.{nameof(Send)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SmtpClientAspect)}.{nameof(Send)}");
             return message;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -62,7 +62,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(Review)}");
             return parameter;
         }
     }
@@ -108,7 +108,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
             return parameter;
         }
     }
@@ -143,7 +143,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
             return parameter;
         }
     }
@@ -166,7 +166,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -62,7 +62,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(Review)}");
             return parameter;
         }
     }
@@ -108,7 +108,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
             return parameter;
         }
     }
@@ -143,7 +143,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
             return parameter;
         }
     }
@@ -166,7 +166,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -65,7 +65,7 @@ public class WebClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(Review)}");
             return parameter;
         }
     }
@@ -139,7 +139,7 @@ public class WebClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(ReviewUri)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(ReviewUri)}");
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -65,7 +65,7 @@ public class WebClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"{nameof(WebClientAspect)}.{nameof(Review)}");
             return parameter;
         }
     }
@@ -139,7 +139,7 @@ public class WebClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(ReviewUri)}");
+            IastModule.LogAspectException(ex, $"{nameof(WebClientAspect)}.{nameof(ReviewUri)}");
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -34,7 +34,7 @@ public class WebRequestAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"{nameof(WebRequestAspect)}.{nameof(Review)}");
             return parameter;
         }
     }
@@ -56,7 +56,7 @@ public class WebRequestAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"{nameof(WebRequestAspect)}.{nameof(Review)}");
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -34,7 +34,7 @@ public class WebRequestAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
             return parameter;
         }
     }
@@ -56,7 +56,7 @@ public class WebRequestAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebUtilityAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebUtilityAspect.cs
@@ -36,7 +36,7 @@ public class WebUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(WebUtilityAspect)}.{nameof(XssEscape)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebUtilityAspect)}.{nameof(XssEscape)}");
         }
 
         return result;
@@ -60,7 +60,7 @@ public class WebUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(WebUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebUtilityAspect)}.{nameof(SsrfEscape)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebUtilityAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebUtilityAspect.cs
@@ -36,7 +36,7 @@ public class WebUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebUtilityAspect)}.{nameof(XssEscape)}");
+            IastModule.LogAspectException(ex, $"{nameof(WebUtilityAspect)}.{nameof(XssEscape)}");
         }
 
         return result;
@@ -60,7 +60,7 @@ public class WebUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(WebUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex, $"{nameof(WebUtilityAspect)}.{nameof(SsrfEscape)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
@@ -45,7 +45,7 @@ public class ActivatorAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(ActivatorAspect)}.{nameof(ReflectionInjectionParam)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(ActivatorAspect)}.{nameof(ReflectionInjectionParam)}");
             return param;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
@@ -45,7 +45,7 @@ public class ActivatorAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(ActivatorAspect)}.{nameof(ReflectionInjectionParam)}");
+            IastModule.LogAspectException(ex, $"{nameof(ActivatorAspect)}.{nameof(ReflectionInjectionParam)}");
             return param;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
@@ -37,7 +37,7 @@ public class AssemblyAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(AssemblyAspect)}.{nameof(ReflectionAssemblyInjection)}");
+            IastModule.LogAspectException(ex, $"{nameof(AssemblyAspect)}.{nameof(ReflectionAssemblyInjection)}");
             return assemblyString;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
@@ -37,7 +37,7 @@ public class AssemblyAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(AssemblyAspect)}.{nameof(ReflectionAssemblyInjection)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(AssemblyAspect)}.{nameof(ReflectionAssemblyInjection)}");
             return assemblyString;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
@@ -51,7 +51,7 @@ public class TypeAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(TypeAspect)}.{nameof(ReflectionInjectionParam)}");
+            IastModule.LogAspectException(ex, $"{nameof(TypeAspect)}.{nameof(ReflectionInjectionParam)}");
             return param;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
@@ -51,7 +51,7 @@ public class TypeAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(TypeAspect)}.{nameof(ReflectionInjectionParam)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(TypeAspect)}.{nameof(ReflectionInjectionParam)}");
             return param;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
@@ -38,7 +38,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted1)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted1)}");
         }
     }
 
@@ -59,7 +59,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted2)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted2)}");
         }
     }
 
@@ -83,7 +83,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted3)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted3)}");
         }
     }
 
@@ -106,7 +106,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted4)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted4)}");
         }
     }
 
@@ -130,7 +130,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted5)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted5)}");
         }
     }
 
@@ -154,7 +154,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted6)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted6)}");
         }
     }
 
@@ -179,7 +179,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted7)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted7)}");
         }
     }
 
@@ -198,7 +198,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendLiteral)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendLiteral)}");
         }
     }
 
@@ -217,7 +217,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(ToStringAndClear)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(ToStringAndClear)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
@@ -83,7 +83,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted3)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted3)}");
         }
     }
 
@@ -106,7 +106,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted4)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted4)}");
         }
     }
 
@@ -130,7 +130,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted5)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted5)}");
         }
     }
 
@@ -154,7 +154,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted6)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted6)}");
         }
     }
 
@@ -179,7 +179,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted7)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted7)}");
         }
     }
 
@@ -198,7 +198,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendLiteral)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendLiteral)}");
         }
     }
 
@@ -217,7 +217,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(ToStringAndClear)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(ToStringAndClear)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
@@ -38,7 +38,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted1)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted1)}");
         }
     }
 
@@ -59,7 +59,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted2)}");
+            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted2)}");
         }
     }
 

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
@@ -40,7 +40,7 @@ public class HashAlgorithmAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HashAlgorithmAspect)}.{nameof(ComputeHash)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HashAlgorithmAspect)}.{nameof(ComputeHash)}");
             return target;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
@@ -40,7 +40,7 @@ public class HashAlgorithmAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HashAlgorithmAspect)}.{nameof(ComputeHash)}");
+            IastModule.LogAspectException(ex, $"{nameof(HashAlgorithmAspect)}.{nameof(ComputeHash)}");
             return target;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
@@ -29,7 +29,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error in SymmetricAlgorithmAspect.");
+            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(ProcessCipherClassCreation)}");
         }
     }
 

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
@@ -47,7 +47,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitDES)}");
+            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitDES)}");
         }
 
         return target;
@@ -67,7 +67,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitRC2)}");
+            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitRC2)}");
         }
 
         return target;
@@ -87,7 +87,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitTripleDES)}");
+            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitTripleDES)}");
         }
 
         return target;
@@ -107,7 +107,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitRijndaelManaged)}");
+            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitRijndaelManaged)}");
         }
 
         return target;
@@ -127,7 +127,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitAesCryptoServiceProvider)}");
+            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitAesCryptoServiceProvider)}");
         }
 
         return target;
@@ -157,7 +157,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(Create)}");
+            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(Create)}");
             return target;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
@@ -29,7 +29,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error in SymmetricAlgorithmAspect.");
+            IastModule.LogAspectException(ex, "Error in SymmetricAlgorithmAspect.");
         }
     }
 
@@ -47,7 +47,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitDES)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitDES)}");
         }
 
         return target;
@@ -67,7 +67,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitRC2)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitRC2)}");
         }
 
         return target;
@@ -87,7 +87,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitTripleDES)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitTripleDES)}");
         }
 
         return target;
@@ -107,7 +107,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitRijndaelManaged)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitRijndaelManaged)}");
         }
 
         return target;
@@ -127,7 +127,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitAesCryptoServiceProvider)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(InitAesCryptoServiceProvider)}");
         }
 
         return target;
@@ -157,7 +157,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(Create)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(Create)}");
             return target;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
@@ -37,7 +37,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error tainting JsonDocument.Parse result");
+            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(Parse)}");
         }
 
         return doc;
@@ -60,7 +60,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error casting to IJsonElement");
+            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetString)} (DuckCast)");
             return null;
         }
 
@@ -77,7 +77,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error tainting JsonElement.GetString result");
+            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetString)}");
         }
 
         return str;
@@ -101,7 +101,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error casting to IJsonElement");
+            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetRawText)} (DuckCast)");
             return null;
         }
 
@@ -118,7 +118,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error tainting JsonElement.GetRawText result");
+            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetRawText)}");
         }
 
         return str;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
@@ -37,7 +37,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error tainting JsonDocument.Parse result");
+            IastModule.LogAspectException(ex, "Error tainting JsonDocument.Parse result");
         }
 
         return doc;
@@ -60,7 +60,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error casting to IJsonElement");
+            IastModule.LogAspectException(ex, "Error casting to IJsonElement");
             return null;
         }
 
@@ -77,7 +77,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error tainting JsonElement.GetString result");
+            IastModule.LogAspectException(ex, "Error tainting JsonElement.GetString result");
         }
 
         return str;
@@ -101,7 +101,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error casting to IJsonElement");
+            IastModule.LogAspectException(ex, "Error casting to IJsonElement");
             return null;
         }
 
@@ -118,7 +118,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error tainting JsonElement.GetRawText result");
+            IastModule.LogAspectException(ex, "Error tainting JsonElement.GetRawText result");
         }
 
         return str;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -99,7 +99,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(ToString)}");
         }
 
         return result;
@@ -121,7 +121,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(ToString)}");
         }
 
         return result;
@@ -146,7 +146,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -172,7 +172,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -199,7 +199,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -226,7 +226,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -253,7 +253,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -290,7 +290,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -315,7 +315,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -341,7 +341,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendLine)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendLine)}");
         }
 
         return result;
@@ -362,7 +362,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -384,7 +384,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -407,7 +407,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -428,7 +428,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -450,7 +450,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -473,7 +473,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -497,7 +497,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -519,7 +519,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -541,7 +541,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(CopyTo)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(CopyTo)}");
         }
     }
 
@@ -564,7 +564,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -590,7 +590,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -615,7 +615,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -640,7 +640,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -667,7 +667,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -693,7 +693,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -719,7 +719,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -745,7 +745,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -771,7 +771,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -797,7 +797,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -823,7 +823,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -849,7 +849,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -875,7 +875,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -901,7 +901,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -927,7 +927,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -953,7 +953,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -979,7 +979,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -1005,7 +1005,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -1026,7 +1026,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Remove)}");
         }
 
         return result;
@@ -1047,7 +1047,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1070,7 +1070,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1091,7 +1091,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1114,7 +1114,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1133,7 +1133,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(SetLength)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(SetLength)}");
         }
     }
 
@@ -1153,7 +1153,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -34,7 +34,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Init)}");
         }
 
         return result;
@@ -54,7 +54,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Init)}");
         }
 
         return result;
@@ -76,7 +76,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Init)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -34,7 +34,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
         }
 
         return result;
@@ -54,7 +54,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
         }
 
         return result;
@@ -76,7 +76,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Init)}");
         }
 
         return result;
@@ -99,7 +99,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(ToString)}");
         }
 
         return result;
@@ -121,7 +121,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(ToString)}");
         }
 
         return result;
@@ -146,7 +146,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -172,7 +172,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -199,7 +199,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -226,7 +226,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -253,7 +253,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -290,7 +290,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -315,7 +315,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Append)}");
         }
 
         return result;
@@ -341,7 +341,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendLine)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendLine)}");
         }
 
         return result;
@@ -362,7 +362,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -384,7 +384,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -407,7 +407,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -428,7 +428,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -450,7 +450,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -473,7 +473,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -497,7 +497,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -519,7 +519,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
         }
 
         return result;
@@ -541,7 +541,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(CopyTo)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(CopyTo)}");
         }
     }
 
@@ -564,7 +564,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -590,7 +590,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -615,7 +615,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -640,7 +640,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -667,7 +667,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -693,7 +693,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -719,7 +719,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -745,7 +745,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -771,7 +771,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -797,7 +797,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -823,7 +823,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -849,7 +849,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -875,7 +875,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -901,7 +901,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -927,7 +927,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -953,7 +953,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -979,7 +979,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -1005,7 +1005,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -1026,7 +1026,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Remove)}");
         }
 
         return result;
@@ -1047,7 +1047,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1070,7 +1070,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1091,7 +1091,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1114,7 +1114,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1133,7 +1133,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(SetLength)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(SetLength)}");
         }
     }
 
@@ -1153,7 +1153,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
         }
 
         return result;
@@ -1174,7 +1174,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
         }
 
         return result;
@@ -1195,7 +1195,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
         }
 
         return result;
@@ -1216,7 +1216,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
         }
 
         return result;
@@ -1238,7 +1238,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
         }
 
         return result;
@@ -1260,7 +1260,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
@@ -38,7 +38,7 @@ public class JavaScriptSerializerAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error while casting JavaScriptSerializer");
+            IastModule.LogAspectException(ex, "Error while casting JavaScriptSerializer");
             return null;
         }
 
@@ -57,7 +57,7 @@ public class JavaScriptSerializerAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, "Error while tainting json in DeserializeObject");
+            IastModule.LogAspectException(ex, "Error while tainting json in DeserializeObject");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
@@ -38,7 +38,7 @@ public class JavaScriptSerializerAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error while casting JavaScriptSerializer");
+            IastModule.LogAspectException(ex, $"{nameof(JavaScriptSerializerAspects)}.{nameof(DeserializeObject)} (DuckCast)");
             return null;
         }
 
@@ -57,7 +57,7 @@ public class JavaScriptSerializerAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, "Error while tainting json in DeserializeObject");
+            IastModule.LogAspectException(ex, $"{nameof(JavaScriptSerializerAspects)}.{nameof(DeserializeObject)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
@@ -31,7 +31,7 @@ public class HttpControllerAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpControllerAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpControllerAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
@@ -31,7 +31,7 @@ public class HttpControllerAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpControllerAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpControllerAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
@@ -40,7 +40,7 @@ public class HttpSessionStateBaseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpSessionStateBaseAspect)}.{nameof(Add)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpSessionStateBaseAspect)}.{nameof(Add)}");
             return value;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
@@ -40,7 +40,7 @@ public class HttpSessionStateBaseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpSessionStateBaseAspect)}.{nameof(Add)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpSessionStateBaseAspect)}.{nameof(Add)}");
             return value;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
@@ -43,7 +43,7 @@ public class SessionExtensionsAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SessionExtensionsAspect)}.{nameof(ReviewTbv)}");
+            IastModule.LogAspectException(ex, $"{nameof(SessionExtensionsAspect)}.{nameof(ReviewTbv)}");
             return value;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
@@ -43,7 +43,7 @@ public class SessionExtensionsAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SessionExtensionsAspect)}.{nameof(ReviewTbv)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SessionExtensionsAspect)}.{nameof(ReviewTbv)}");
             return value;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpCookieAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpCookieAspect.cs
@@ -39,7 +39,7 @@ public class HttpCookieAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpCookieAspect)}.{nameof(GetValue)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpCookieAspect)}.{nameof(GetValue)}");
         }
 
         return value;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpCookieAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpCookieAspect.cs
@@ -39,7 +39,7 @@ public class HttpCookieAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpCookieAspect)}.{nameof(GetValue)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpCookieAspect)}.{nameof(GetValue)}");
         }
 
         return value;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
@@ -32,7 +32,7 @@ public class HttpResponseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpResponseAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
@@ -32,7 +32,7 @@ public class HttpResponseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpUtilityAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpUtilityAspect.cs
@@ -34,7 +34,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(XssEscape)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(XssEscape)}");
         }
 
         return result;
@@ -58,7 +58,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
         }
 
         return result;
@@ -83,7 +83,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpUtilityAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpUtilityAspect.cs
@@ -34,7 +34,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(XssEscape)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpUtilityAspect)}.{nameof(XssEscape)}");
         }
 
         return result;
@@ -58,7 +58,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
         }
 
         return result;
@@ -83,7 +83,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex, $"{nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
@@ -40,7 +40,7 @@ public class SystemXmlAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(SystemXmlAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(SystemXmlAspect)}.{nameof(ReviewPath)}");
             return xpath;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
@@ -40,7 +40,7 @@ public class SystemXmlAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(SystemXmlAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(SystemXmlAspect)}.{nameof(ReviewPath)}");
             return xpath;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
@@ -35,7 +35,7 @@ public class XPathExtensionAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(XPathExtensionAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(XPathExtensionAspect)}.{nameof(ReviewPath)}");
             return xpath;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
@@ -35,7 +35,7 @@ public class XPathExtensionAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(XPathExtensionAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(XPathExtensionAspect)}.{nameof(ReviewPath)}");
             return xpath;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
@@ -30,7 +30,7 @@ public class RandomAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(RandomAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(RandomAspect)}.{nameof(Init)}");
             return;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
@@ -30,7 +30,7 @@ public class RandomAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(RandomAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(RandomAspect)}.{nameof(Init)}");
             return;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -36,7 +36,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Trim)}");
         }
 
         return result;
@@ -65,7 +65,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Trim)}");
         }
 
         return result;
@@ -88,7 +88,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Trim)}");
         }
 
         return result;
@@ -118,7 +118,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimStart)}");
         }
 
         return result;
@@ -141,7 +141,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimStart)}");
         }
 
         return result;
@@ -162,7 +162,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimStart)}");
         }
 
         return result;
@@ -192,7 +192,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimEnd)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -36,7 +36,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
         }
 
         return result;
@@ -65,7 +65,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
         }
 
         return result;
@@ -88,7 +88,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Trim)}");
         }
 
         return result;
@@ -118,7 +118,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
         }
 
         return result;
@@ -141,7 +141,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
         }
 
         return result;
@@ -162,7 +162,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimStart)}");
         }
 
         return result;
@@ -192,7 +192,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
         }
 
         return result;
@@ -215,7 +215,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
         }
 
         return result;
@@ -236,7 +236,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
         }
 
         return result;
@@ -259,7 +259,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -281,7 +281,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat_0)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat_0)}");
         }
 
         return result;
@@ -303,7 +303,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat_1)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat_1)}");
         }
 
         return result;
@@ -325,7 +325,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -348,7 +348,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -371,7 +371,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -395,7 +395,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -420,7 +420,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -442,7 +442,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -463,7 +463,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -484,7 +484,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -506,7 +506,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -528,7 +528,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Substring)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Substring)}");
         }
 
         return result;
@@ -551,7 +551,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Substring)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Substring)}");
         }
 
         return result;
@@ -572,7 +572,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToCharArray)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToCharArray)}");
         }
 
         return result;
@@ -595,7 +595,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToCharArray)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToCharArray)}");
         }
 
         return result;
@@ -619,7 +619,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -642,7 +642,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -664,7 +664,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -688,7 +688,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -711,7 +711,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -735,7 +735,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -757,7 +757,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -779,7 +779,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -801,7 +801,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -822,7 +822,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpper)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpper)}");
         }
 
         return result;
@@ -844,7 +844,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpper)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpper)}");
         }
 
         return result;
@@ -865,7 +865,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpperInvariant)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpperInvariant)}");
         }
 
         return result;
@@ -886,7 +886,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLower)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLower)}");
         }
 
         return result;
@@ -908,7 +908,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLower)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLower)}");
         }
 
         return result;
@@ -929,7 +929,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLowerInvariant)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLowerInvariant)}");
         }
 
         return result;
@@ -951,7 +951,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Remove)}");
         }
 
         return result;
@@ -974,7 +974,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Remove)}");
         }
 
         return result;
@@ -997,7 +997,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -1019,7 +1019,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadLeft)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadLeft)}");
         }
 
         return result;
@@ -1042,7 +1042,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadLeft)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadLeft)}");
         }
 
         return result;
@@ -1064,7 +1064,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadRight)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadRight)}");
         }
 
         return result;
@@ -1087,7 +1087,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadRight)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadRight)}");
         }
 
         return result;
@@ -1109,7 +1109,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1132,7 +1132,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1156,7 +1156,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1178,7 +1178,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1201,7 +1201,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1225,7 +1225,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1250,7 +1250,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1273,7 +1273,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1299,7 +1299,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1323,7 +1323,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1347,7 +1347,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1370,7 +1370,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1392,7 +1392,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1415,7 +1415,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1438,7 +1438,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1462,7 +1462,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1485,7 +1485,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1509,7 +1509,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1535,7 +1535,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1558,7 +1558,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1581,7 +1581,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1605,7 +1605,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1628,7 +1628,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Copy)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Copy)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -215,7 +215,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimEnd)}");
         }
 
         return result;
@@ -236,7 +236,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimEnd)}");
         }
 
         return result;
@@ -259,7 +259,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -281,7 +281,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat_0)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat_0)}");
         }
 
         return result;
@@ -303,7 +303,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat_1)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat_1)}");
         }
 
         return result;
@@ -325,7 +325,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -348,7 +348,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -371,7 +371,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -395,7 +395,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -420,7 +420,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -442,7 +442,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -463,7 +463,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -484,7 +484,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -506,7 +506,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
         }
 
         return result;
@@ -528,7 +528,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Substring)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Substring)}");
         }
 
         return result;
@@ -551,7 +551,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Substring)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Substring)}");
         }
 
         return result;
@@ -572,7 +572,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToCharArray)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToCharArray)}");
         }
 
         return result;
@@ -595,7 +595,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToCharArray)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToCharArray)}");
         }
 
         return result;
@@ -619,7 +619,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -642,7 +642,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -664,7 +664,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -688,7 +688,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -711,7 +711,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -735,7 +735,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -757,7 +757,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -779,7 +779,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -801,7 +801,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
         }
 
         return result;
@@ -822,7 +822,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpper)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToUpper)}");
         }
 
         return result;
@@ -844,7 +844,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpper)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToUpper)}");
         }
 
         return result;
@@ -865,7 +865,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToUpperInvariant)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToUpperInvariant)}");
         }
 
         return result;
@@ -886,7 +886,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLower)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToLower)}");
         }
 
         return result;
@@ -908,7 +908,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLower)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToLower)}");
         }
 
         return result;
@@ -929,7 +929,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(ToLowerInvariant)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToLowerInvariant)}");
         }
 
         return result;
@@ -951,7 +951,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Remove)}");
         }
 
         return result;
@@ -974,7 +974,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Remove)}");
         }
 
         return result;
@@ -997,7 +997,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Insert)}");
         }
 
         return result;
@@ -1019,7 +1019,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadLeft)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadLeft)}");
         }
 
         return result;
@@ -1042,7 +1042,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadLeft)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadLeft)}");
         }
 
         return result;
@@ -1064,7 +1064,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadRight)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadRight)}");
         }
 
         return result;
@@ -1087,7 +1087,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(PadRight)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadRight)}");
         }
 
         return result;
@@ -1109,7 +1109,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1132,7 +1132,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1156,7 +1156,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1178,7 +1178,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1201,7 +1201,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1225,7 +1225,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1250,7 +1250,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1273,7 +1273,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
         }
 
         return result;
@@ -1299,7 +1299,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1323,7 +1323,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1347,7 +1347,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1370,7 +1370,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
         }
 
         return result;
@@ -1392,7 +1392,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;
@@ -1415,7 +1415,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Split)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
@@ -32,7 +32,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -57,7 +57,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -79,7 +79,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -101,7 +101,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -128,7 +128,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -150,7 +150,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -173,7 +173,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -200,7 +200,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -227,7 +227,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -254,7 +254,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -280,7 +280,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -301,7 +301,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(UnescapeDataString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(UnescapeDataString)}");
         }
 
         return result;
@@ -324,7 +324,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(EscapeUriString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(EscapeUriString)}");
         }
 
         return result;
@@ -345,7 +345,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(EscapeDataString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(EscapeDataString)}");
         }
 
         return result;
@@ -366,7 +366,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAbsoluteUri)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAbsoluteUri)}");
         }
 
         return result;
@@ -387,7 +387,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAbsolutePath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAbsolutePath)}");
         }
 
         return result;
@@ -408,7 +408,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetLocalPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetLocalPath)}");
         }
 
         return result;
@@ -435,7 +435,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(MakeRelative)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(MakeRelative)}");
         }
 
         return result;
@@ -460,7 +460,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(MakeRelativeUri)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(MakeRelativeUri)}");
         }
 
         return result;
@@ -481,7 +481,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetHost)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetHost)}");
         }
 
         return result;
@@ -502,7 +502,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetPathAndQuery)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetPathAndQuery)}");
         }
 
         return result;
@@ -523,7 +523,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAuthority)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAuthority)}");
         }
 
         return result;
@@ -544,7 +544,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetQuery)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetQuery)}");
         }
 
         return result;
@@ -566,7 +566,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriAspect)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(ToString)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
@@ -32,7 +32,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -57,7 +57,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -79,7 +79,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -101,7 +101,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -128,7 +128,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -150,7 +150,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -173,7 +173,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -200,7 +200,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -227,7 +227,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -254,7 +254,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -280,7 +280,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
         }
 
         return result;
@@ -301,7 +301,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(UnescapeDataString)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(UnescapeDataString)}");
         }
 
         return result;
@@ -324,7 +324,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(EscapeUriString)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(EscapeUriString)}");
         }
 
         return result;
@@ -345,7 +345,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(EscapeDataString)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(EscapeDataString)}");
         }
 
         return result;
@@ -366,7 +366,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAbsoluteUri)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetAbsoluteUri)}");
         }
 
         return result;
@@ -387,7 +387,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAbsolutePath)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetAbsolutePath)}");
         }
 
         return result;
@@ -408,7 +408,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetLocalPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetLocalPath)}");
         }
 
         return result;
@@ -435,7 +435,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(MakeRelative)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(MakeRelative)}");
         }
 
         return result;
@@ -460,7 +460,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(MakeRelativeUri)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(MakeRelativeUri)}");
         }
 
         return result;
@@ -481,7 +481,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetHost)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetHost)}");
         }
 
         return result;
@@ -502,7 +502,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetPathAndQuery)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetPathAndQuery)}");
         }
 
         return result;
@@ -523,7 +523,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetAuthority)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetAuthority)}");
         }
 
         return result;
@@ -544,7 +544,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(GetQuery)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetQuery)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
@@ -566,7 +566,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriAspect)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(ToString)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
@@ -36,7 +36,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -61,7 +61,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -87,7 +87,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -114,7 +114,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -142,7 +142,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -171,7 +171,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -196,7 +196,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
     }
 
@@ -219,7 +219,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
     }
 
@@ -242,7 +242,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetPath)}");
         }
     }
 
@@ -265,7 +265,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetHost)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetHost)}");
         }
 
         return result;
@@ -290,7 +290,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetQuery)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetQuery)}");
         }
 
         return result;
@@ -315,7 +315,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetPath)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetPath)}");
         }
 
         return result;
@@ -341,7 +341,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.Log.Error(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(ToString)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
@@ -36,7 +36,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -61,7 +61,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -87,7 +87,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -114,7 +114,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -142,7 +142,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -171,7 +171,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
 
         return result;
@@ -196,7 +196,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
         }
     }
 
@@ -219,7 +219,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
         }
     }
 
@@ -242,7 +242,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(SetPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(SetPath)}");
         }
     }
 
@@ -265,7 +265,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetHost)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(GetHost)}");
         }
 
         return result;
@@ -290,7 +290,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetQuery)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(GetQuery)}");
         }
 
         return result;
@@ -315,7 +315,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(GetPath)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(GetPath)}");
         }
 
         return result;
@@ -341,7 +341,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(UriBuilderAspect)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(ToString)}");
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -868,13 +868,20 @@ internal static partial class IastModule
 
     public static void LogAspectException(Exception ex, string aspectInfo)
     {
-        if (!LoggedAspectExceptionMessages.Add(aspectInfo.GetHashCode()))
+        try
         {
-            Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
+            if (!LoggedAspectExceptionMessages.Add(aspectInfo.GetHashCode()))
+            {
+                Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
+            }
+            else
+            {
+                Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
+            }
         }
-        else
+        catch (Exception e)
         {
-            Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
+            Log.Debug(e, "Error while logging aspect exception.");
         }
     }
 

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -870,14 +870,24 @@ internal static partial class IastModule
     {
         try
         {
-            if (!LoggedAspectExceptionMessages.Add(aspectInfo.GetHashCode()))
+            var hashCode = aspectInfo.GetHashCode();
+            bool alreadyLogged;
+            lock (LoggedAspectExceptionMessages)
             {
-                Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
+                alreadyLogged = !LoggedAspectExceptionMessages.Add(hashCode);
+            }
+
+// intentionally using string interpolation in logging, as the resulting string is actually a constant, and contains the important aspect information
+#pragma warning disable DDLOG004 // Message templates should be constant
+            if (alreadyLogged)
+            {
+                Log.Debug(ex, $"Error invoking {aspectInfo}");
             }
             else
             {
-                Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
+                Log.Error(ex, $"Error invoking {aspectInfo}");
             }
+#pragma warning restore DDLOG004 // Message templates should be constant
         }
         catch (Exception e)
         {

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -61,6 +61,7 @@ internal static partial class IastModule
     private static readonly Func<TaintedObject, bool> Always = (x) => true;
     private static readonly DbRecordManager DbRecords = new DbRecordManager(IastSettings);
     private static readonly SourceType[] _dbSources = [SourceType.SqlRowValue];
+    private static readonly HashSet<int> LoggedAspectExceptionMessages = [];
     private static bool _showTimeoutExceptionError = true;
 
     internal static void LogTimeoutError(RegexMatchTimeoutException err)
@@ -863,6 +864,16 @@ internal static partial class IastModule
 
         // We use the same secure marks as XSS, but excluding db sources
         GetScope(messageDuck.Body, IntegrationId.EmailHtmlInjection, VulnerabilityTypeName.EmailHtmlInjection, OperationNameEmailHtmlInjection, taintValidator: Always, safeSources: _dbSources, exclusionSecureMarks: SecureMarks.Xss);
+    }
+
+    public static void LogAspectException(Exception ex, string message)
+    {
+        if (!LoggedAspectExceptionMessages.Add(message.GetHashCode()))
+        {
+            return;
+        }
+
+        Log.Error(ex, "Aspect Exception: {Message}.", message);
     }
 
     internal static void RegisterDbRecord(object instance)

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -866,14 +866,16 @@ internal static partial class IastModule
         GetScope(messageDuck.Body, IntegrationId.EmailHtmlInjection, VulnerabilityTypeName.EmailHtmlInjection, OperationNameEmailHtmlInjection, taintValidator: Always, safeSources: _dbSources, exclusionSecureMarks: SecureMarks.Xss);
     }
 
-    public static void LogAspectException(Exception ex, string message)
+    public static void LogAspectException(Exception ex, string aspectInfo)
     {
-        if (!LoggedAspectExceptionMessages.Add(message.GetHashCode()))
+        if (!LoggedAspectExceptionMessages.Add(aspectInfo.GetHashCode()))
         {
-            return;
+            Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
         }
-
-        Log.Error(ex, "Aspect Exception: {Message}.", message);
+        else
+        {
+            Log.Debug(ex, "Error invoking {AspectInfo}", aspectInfo);
+        }
     }
 
     internal static void RegisterDbRecord(object instance)

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -126,7 +126,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"{nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -163,7 +163,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"{nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -211,7 +211,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"{nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -259,7 +259,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"{nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -126,7 +126,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -163,7 +163,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -211,7 +211,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -259,7 +259,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.LogAspectException(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Properties/launchSettings.json
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Properties/launchSettings.json
@@ -106,7 +106,8 @@
         "DD_IAST_DEDUPLICATION_ENABLED": "false",
         "DD_IAST_VULNERABILITIES_PER_REQUEST": "100",
         "DD_IAST_REQUEST_SAMPLING": "100",
-        "DD_IAST_MAX_CONCURRENT_REQUESTS": "1"
+        "DD_IAST_MAX_CONCURRENT_REQUESTS": "1",
+        "COMPLUS_ForceEnc": "1"
       },
       "Logging": {
         "LogLevel": {


### PR DESCRIPTION
## Summary of changes

- Update in all aspects catch exception block the exception error logging to `IastModule.LogAspectException`.
- `IastModule.LogAspectException` in the IastModule that will only print out an error one time

## Reason for change

## Implementation details

There is a new hash set of errors printed (based on their HashCode) so an error is only printed out only one time.

## Test coverage

- Updated Analyzer