### PR TITLE
Parallelise appsec system tests in CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5068,6 +5068,7 @@ stages:
           
         - task: DownloadPipelineArtifact@2
           displayName: Download linux-packages
+          condition: eq( variables['System.JobAttempt'], 1 )
           inputs:
             artifact: linux-packages-linux-x64
             patterns: '**/*tar.gz'
@@ -5078,7 +5079,8 @@ stages:
             echo Moving $PACKAGE_NAME to system-tests/binaries
             mv $(Build.ArtifactStagingDirectory)/$PACKAGE_NAME system-tests/binaries/
           displayName: Move dotnet binary to system test folder
-          
+          condition: eq( variables['System.JobAttempt'], 1 )
+        
         - script: |
             set -e
             cd system-tests
@@ -5099,9 +5101,11 @@ stages:
             docker save system_tests/agent:latest -o ../docker-images/agent.tar
 
           displayName: Build weblogs and agent & save Docker images
-            
+          condition: eq( variables['System.JobAttempt'], 1 )
+        
         - task: PublishPipelineArtifact@1
           displayName: Publish Docker images artifact
+          condition: eq( variables['System.JobAttempt'], 1 )
           inputs:
             path: 'docker-images'
             artifactName: 'docker-images'

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5019,10 +5019,36 @@ stages:
         - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
           displayName: Get system tests repo
           
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux-packages
+          inputs:
+            artifact: linux-packages-linux-x64
+            patterns: '**/*tar.gz'
+            path: $(Build.ArtifactStagingDirectory)
+
         - script: |
-            ./build.sh -i runner
-          displayName: Install runner
+            PACKAGE_NAME=$(basename $(Build.ArtifactStagingDirectory)/datadog-dotnet-apm-*.tar.gz)
+            echo Moving $PACKAGE_NAME to system-tests/binaries
+            mv $(Build.ArtifactStagingDirectory)/$PACKAGE_NAME system-tests/binaries/
+          displayName: Move dotnet binary to system test folder
+          
+        - script: |
+            ./build.sh dotnet
+          displayName: Install runner + Build weblog and agent images
           workingDirectory: system-tests
+          
+        - script: |
+            docker save \
+              system_tests/weblog:latest \
+              system_tests/agent:latest \
+              -o system-tests-images.tar
+          displayName: Save Docker images to tar
+          
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Docker images artifact
+          inputs:
+            targetPath: 'system-tests-images.tar'
+            artifactName: 'docker-images'
           
         - script: |
             set -e
@@ -5083,23 +5109,18 @@ stages:
 
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo
-
+        
       - task: DownloadPipelineArtifact@2
-        displayName: Download linux-packages
+        displayName: Download Docker images
         inputs:
-          artifact: linux-packages-linux-x64
-          patterns: '**/*tar.gz'
-          path: $(Build.ArtifactStagingDirectory)
-
+          artifact: docker-images
+          path: $(Build.SourcesDirectory)
+  
       - script: |
-          PACKAGE_NAME=$(basename $(Build.ArtifactStagingDirectory)/datadog-dotnet-apm-*.tar.gz)
-          echo Moving $PACKAGE_NAME to system-tests/binaries
-          mv $(Build.ArtifactStagingDirectory)/$PACKAGE_NAME system-tests/binaries/
-        displayName: Move dotnet binary to system test folder
-
-      - script: ./build.sh dotnet
-        workingDirectory: system-tests
-        displayName: Build images
+          docker load -i $(Build.SourcesDirectory)/system-tests-images.tar
+          echo "Docker images after loading:"
+          docker images
+        displayName: Load Docker images
 
       - script: ./run.sh $(SCENARIO)
         workingDirectory: system-tests

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5028,7 +5028,7 @@ stages:
             set -e
             
             source venv/bin/activate
-            PYTHONPATH=. python utils/scripts/compute-workflow-parameters.py dotnet -g appsec > out.txt
+            PYTHONPATH=. python utils/scripts/compute-workflow-parameters.py dotnet -g $(scenarioGroups) > out.txt
 
             endtoend_scenarios=$(grep 'endtoend_scenarios' out.txt | sed 's/.*=//g')
             graphql_scenarios=$(grep 'graphql_scenarios' out.txt | sed 's/.*=//g')
@@ -5052,7 +5052,7 @@ stages:
             echo 'matrix_items = {}' >> cross.py
             echo 'for s in combined_scenarios:' >> cross.py
             echo '    for w in script_weblogs:' >> cross.py
-            echo '        matrix_items[s] = {"SCENARIO": s, "WEBLOG_VARIANT": w}' >> cross.py
+            echo '        matrix_items[s + " (" + w + ")"] = {"SCENARIO": s, "WEBLOG_VARIANT": w}' >> cross.py
             echo 'print(json.dumps(matrix_items))' >> cross.py
             
             python cross.py > matrix.json
@@ -5064,8 +5064,8 @@ stages:
           workingDirectory: system-tests
             
     - job: tests
+      displayName: ""
       timeoutInMinutes: 60
-      displayName: Run system-tests scenarios
       pool:
           vmImage: ubuntu-latest
       dependsOn: compute_scenarios

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4995,86 +4995,88 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    scenarioGroups: "essentials,parametric,appsec,remote-config,telemetry,integrations,debugger,profiling"
+    additionalScenarios: '["TRACE_PROPAGATION_STYLE_W3C","LIBRARY_CONF_CUSTOM_HEADER_TAGS"]'
   jobs:
-  - template: steps/update-github-status-jobs.yml
-    parameters:
-      jobs: [test]
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [compute_scenarios, tests]
+        
+    - job: compute_scenarios
+      timeoutInMinutes: 60
+      displayName: Compute system-tests scenarios
+      pool:
+          vmImage: ubuntu-latest
+          
+      steps:
+        - checkout: none
+          
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.12'
+          displayName: Install python 3.12
 
-  - job: test
-    timeoutInMinutes: 60
-    pool:
-      vmImage: ubuntu-latest
+        - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
+          displayName: Get system tests repo
+          
+        - script: |
+            ./build.sh -i runner
+          displayName: Install runner
+          workingDirectory: system-tests
+          
+        - script: |
+            set -e
+            PYTHONPATH=. python utils/scripts/compute-workflow-parameters.py dotnet -g appsec > out.txt
 
-    strategy:
-      matrix:
-        parametric_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: PARAMETRIC
-        parametric_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: PARAMETRIC
-        appsec_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: APPSEC_SCENARIOS
-        appsec_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: APPSEC_SCENARIOS
-        rcm_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: REMOTE_CONFIG_SCENARIOS
-        rcm_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: REMOTE_CONFIG_SCENARIOS
-        telemetry_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: TELEMETRY_SCENARIOS
-        telemetry_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: TELEMETRY_SCENARIOS
-        default_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: DEFAULT
-        default_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: DEFAULT
-        integrations_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: INTEGRATIONS
-        integrations_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: INTEGRATIONS
-        integrations_aws_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: INTEGRATIONS_AWS
-        integrations_aws_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: INTEGRATIONS_AWS
-        crossed_tracing_libraries_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: CROSSED_TRACING_LIBRARIES
-        crossed_tracing_libraries_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: CROSSED_TRACING_LIBRARIES
-        # All the other scenarios that aren't in a secenario group
-        remainder_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: "+S TRACE_PROPAGATION_STYLE_W3C +S PROFILING +S LIBRARY_CONF_CUSTOM_HEADERS_SHORT +S LIBRARY_CONF_CUSTOM_HEADERS_LONG"
-        remainder_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: "+S TRACE_PROPAGATION_STYLE_W3C +S PROFILING +S LIBRARY_CONF_CUSTOM_HEADERS_SHORT +S LIBRARY_CONF_CUSTOM_HEADERS_LONG"
-        debugger_poc:
-          WEBLOG_VARIANT: "poc"
-          SCENARIO: DEBUGGER_SCENARIOS
-        debugger_uds:
-          WEBLOG_VARIANT: "uds"
-          SCENARIO: DEBUGGER_SCENARIOS
+            endtoend_scenarios=$(grep 'endtoend_scenarios' out.txt | sed 's/.*=//g')
+            graphql_scenarios=$(grep 'graphql_scenarios' out.txt | sed 's/.*=//g')
+            parametric_scenarios=$(grep 'parametric_scenarios' out.txt | sed 's/.*=//g')
+            endtoend_weblogs=$(grep 'endtoend_weblogs' out.txt | sed 's/.*=//g')
 
-    steps:
+            echo "Found scenarios: $endtoend_scenarios"
+            echo "Found graphql scenarios: $graphql_scenarios"
+            echo "Found parametric scenarios: $parametric_scenarios"
+            echo "Found weblogs: $endtoend_weblogs"
+            echo "Additional manual scenarios: $(additionalScenarios)"
+            
+            # Inline python script to cross the data into a json
+            echo "import json" > cross.py
+            echo "script_scenarios = json.loads('$endtoend_scenarios')" >> cross.py
+            echo "script_graphql_scenarios = json.loads('$graphql_scenarios')" >> cross.py
+            echo "script_parametric_scenarios = json.loads('$parametric_scenarios')" >> cross.py
+            echo "script_weblogs   = json.loads('$endtoend_weblogs')" >> cross.py
+            echo "extra_scenarios  = json.loads('$(additionalScenarios)')" >> cross.py
+            echo 'combined_scenarios = script_scenarios + script_graphql_scenarios + script_parametric_scenarios + extra_scenarios' >> cross.py
+            echo 'matrix_items = []' >> cross.py
+            echo 'for s in combined_scenarios:' >> cross.py
+            echo '    for w in script_weblogs:' >> cross.py
+            echo '        matrix_items.append({"SCENARIO": s, "WEBLOG_VARIANT": w})' >> cross.py
+            echo 'print(json.dumps(matrix_items))' >> cross.py
+            
+            python cross.py > matrix.json
+            
+            echo "##vso[task.setvariable variable=matrixJson;isOutput=true]$(cat matrix.json)"
+            echo "Json: $(cat matrix.json)"
+          displayName: Generate scenarios matrix JSON
+          name: create_matrix
+          workingDirectory: system-tests
+            
+    - job: tests
+      timeoutInMinutes: 60
+      displayName: Run system-tests scenarios
+      pool:
+          vmImage: ubuntu-latest
+      dependsOn: compute_scenarios
+     
+      strategy:
+        matrix: $[ dependencies.compute_scenarios.outputs['create_matrix.matrixJson'] ]
+
+      steps:
       - checkout: none
 
       - task: UsePythonVersion@0
         inputs:
-            versionSpec: '3.12'
+          versionSpec: '3.12'
         displayName: Install python 3.12
 
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5001,7 +5001,7 @@ stages:
       jobs: [test]
 
   - job: test
-    timeoutInMinutes: 75
+    timeoutInMinutes: 60
     pool:
       vmImage: ubuntu-latest
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5019,36 +5019,10 @@ stages:
         - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
           displayName: Get system tests repo
           
-        - task: DownloadPipelineArtifact@2
-          displayName: Download linux-packages
-          inputs:
-            artifact: linux-packages-linux-x64
-            patterns: '**/*tar.gz'
-            path: $(Build.ArtifactStagingDirectory)
-
         - script: |
-            PACKAGE_NAME=$(basename $(Build.ArtifactStagingDirectory)/datadog-dotnet-apm-*.tar.gz)
-            echo Moving $PACKAGE_NAME to system-tests/binaries
-            mv $(Build.ArtifactStagingDirectory)/$PACKAGE_NAME system-tests/binaries/
-          displayName: Move dotnet binary to system test folder
-          
-        - script: |
-            ./build.sh dotnet
-          displayName: Install runner + Build weblog and agent images
+            ./build.sh -i runner
+          displayName: Install runner
           workingDirectory: system-tests
-          
-        - script: |
-            docker save \
-              system_tests/weblog:latest \
-              system_tests/agent:latest \
-              -o system-tests-images.tar
-          displayName: Save Docker images to tar
-          
-        - task: PublishPipelineArtifact@1
-          displayName: Publish Docker images artifact
-          inputs:
-            targetPath: 'system-tests-images.tar'
-            artifactName: 'docker-images'
           
         - script: |
             set -e
@@ -5067,6 +5041,9 @@ stages:
             echo "Found weblogs: $endtoend_weblogs"
             echo "Additional manual scenarios: $(additionalScenarios)"
             
+            # Write the weblogs to a file (for later use to generate the docker images)
+            python -c "import json; variants = json.loads('$endtoend_weblogs'); print('\n'.join(variants))" > /tmp/weblogs_list.txt
+        
             # Inline python script to cross the data into a json
             echo "import json" > cross.py
             echo "script_scenarios = json.loads('$endtoend_scenarios')" >> cross.py
@@ -5088,7 +5065,47 @@ stages:
           displayName: Generate scenarios matrix JSON
           name: create_matrix
           workingDirectory: system-tests
+          
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux-packages
+          inputs:
+            artifact: linux-packages-linux-x64
+            patterns: '**/*tar.gz'
+            path: $(Build.ArtifactStagingDirectory)
+
+        - script: |
+            PACKAGE_NAME=$(basename $(Build.ArtifactStagingDirectory)/datadog-dotnet-apm-*.tar.gz)
+            echo Moving $PACKAGE_NAME to system-tests/binaries
+            mv $(Build.ArtifactStagingDirectory)/$PACKAGE_NAME system-tests/binaries/
+          displayName: Move dotnet binary to system test folder
+          
+        - script: |
+            set -e
+            cd system-tests
+            mkdir -p ../docker-images
+        
+            while read w; do
+              echo "------------------------------------"
+              echo "Building images for variant: $w"
+              echo "------------------------------------"
+              # Build the images. For example:
+              ./build.sh dotnet --weblog-variant $w
             
+              # Save weblog variant image
+              docker save system_tests/weblog:latest -o ../docker-images/$w.tar
+            done < /tmp/weblogs_list.txt
+            
+            # Save agent image
+            docker save system_tests/agent:latest -o ../docker-images/agent.tar
+
+          displayName: Build weblogs and agent & save Docker images
+            
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Docker images artifact
+          inputs:
+            path: 'docker-images'
+            artifactName: 'docker-images'
+
     - job: tests
       displayName: ""
       timeoutInMinutes: 60
@@ -5115,12 +5132,22 @@ stages:
         inputs:
           artifact: docker-images
           path: $(Build.SourcesDirectory)
-  
+
       - script: |
-          docker load -i $(Build.SourcesDirectory)/system-tests-images.tar
-          echo "Docker images after loading:"
+          echo "Loading images for variant: $(WEBLOG_VARIANT)"
+          docker load -i "$(Build.SourcesDirectory)/$(WEBLOG_VARIANT).tar"
+          
+          echo "Loading agent image"
+          docker load -i "$(Build.SourcesDirectory)/agent.tar"
+          
+          echo "Available Docker images after loading:"
           docker images
-        displayName: Load Docker images
+        displayName: Docker load the correct variant
+
+      - script: |
+              ./build.sh -i runner
+        displayName: Install runner
+        workingDirectory: system-tests
 
       - script: ./run.sh $(SCENARIO)
         workingDirectory: system-tests

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5001,7 +5001,7 @@ stages:
       jobs: [test]
 
   - job: test
-    timeoutInMinutes: 60
+    timeoutInMinutes: 75
     pool:
       vmImage: ubuntu-latest
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5108,7 +5108,7 @@ stages:
           condition: eq( variables['System.JobAttempt'], 1 )
           inputs:
             path: 'docker-images'
-            artifactName: 'docker-images'
+            artifactName: 'system-test-docker-images'
 
     - job: tests
       displayName: ""
@@ -5134,7 +5134,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         displayName: Download Docker images
         inputs:
-          artifact: docker-images
+          artifact: system-test-docker-images
           path: $(Build.SourcesDirectory)
 
       - script: |

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4996,7 +4996,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
     scenarioGroups: "essentials,parametric,appsec,remote-config,telemetry,integrations,debugger,profiling"
-    additionalScenarios: '["TRACE_PROPAGATION_STYLE_W3C","LIBRARY_CONF_CUSTOM_HEADER_TAGS"]'
+    additionalScenarios: '[\"TRACE_PROPAGATION_STYLE_W3C\",\"LIBRARY_CONF_CUSTOM_HEADER_TAGS\"]'
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -5026,6 +5026,8 @@ stages:
           
         - script: |
             set -e
+            
+            source venv/bin/activate
             PYTHONPATH=. python utils/scripts/compute-workflow-parameters.py dotnet -g appsec > out.txt
 
             endtoend_scenarios=$(grep 'endtoend_scenarios' out.txt | sed 's/.*=//g')
@@ -5047,10 +5049,10 @@ stages:
             echo "script_weblogs   = json.loads('$endtoend_weblogs')" >> cross.py
             echo "extra_scenarios  = json.loads('$(additionalScenarios)')" >> cross.py
             echo 'combined_scenarios = script_scenarios + script_graphql_scenarios + script_parametric_scenarios + extra_scenarios' >> cross.py
-            echo 'matrix_items = []' >> cross.py
+            echo 'matrix_items = {}' >> cross.py
             echo 'for s in combined_scenarios:' >> cross.py
             echo '    for w in script_weblogs:' >> cross.py
-            echo '        matrix_items.append({"SCENARIO": s, "WEBLOG_VARIANT": w})' >> cross.py
+            echo '        matrix_items[s] = {"SCENARIO": s, "WEBLOG_VARIANT": w}' >> cross.py
             echo 'print(json.dumps(matrix_items))' >> cross.py
             
             python cross.py > matrix.json

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4995,8 +4995,8 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-    scenarioGroups: "essentials,parametric,appsec,remote-config,telemetry,integrations,debugger,profiling"
-    additionalScenarios: '[\"TRACE_PROPAGATION_STYLE_W3C\",\"LIBRARY_CONF_CUSTOM_HEADER_TAGS\"]'
+    scenarioGroups: "appsec"
+    additionalScenarios: '[\"PARAMETRIC\", \"REMOTE_CONFIG_SCENARIOS\", \"TELEMETRY_SCENARIOS\", \"DEFAULT\", \"INTEGRATIONS\", \"INTEGRATIONS_AWS\", \"CROSSED_TRACING_LIBRARIES\", \"DEBUGGER_SCENARIOS\", \"+S PROFILING +S TRACE_PROPAGATION_STYLE_W3C +S LIBRARY_CONF_CUSTOM_HEADER_TAGS\"]'
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:


### PR DESCRIPTION
## Summary of changes

- Parallelise all `appsec` system-tests scenarios in the CI.
`appsec` group scenarios have been broke down to scenarios, and each individual scenario are run in a specific job.

- Remove old scenario `LIBRARY_CONF_CUSTOM_HEADERS_SHORT` and `LIBRARY_CONF_CUSTOM_HEADERS_LONG` from the running list. They are both now linked to the `LIBRARY_CONF_CUSTOM_HEADER_TAGS` scenario (which was added to the `additionalScenarios` list)

- Speed up run of system tests by building the weblogs and agent docker images before the execution of the tests matrix.

The majority of all the scenarios get completed in less than 5 min.
From 1h before the parallelisation:
![image](https://github.com/user-attachments/assets/b26f55b3-eb5a-49a6-b359-ece749626a1c)

To approximately more than 45 min after (depending of the attribution of runners). That's also the parametric tests that are taking now the more time:
![image](https://github.com/user-attachments/assets/05bda4f7-4f7a-49f6-8bb1-7643431e96c6)

# Implementation details

### List all scenarios that are part of groups

This is using the following command to get the scenarios from a scenario group name:
`PYTHONPATH=. python utils/scripts/compute-workflow-parameters.py dotnet -g appsec`

This way we can dynamically get the available weblogs in the system-tests and all scenarios.

### Build the matrix

In order to create the matrix, a python script have been created to merge all scenarios for listed groups and the additional scenario that we want to run that are not part of a group.

We grep the output of the system-test command to fully get all scenarios and construct back a json dictionary with all the scenario name and the weblog variant that need to be used with it.

### Update

For future update, if a new group scenario needs to be broke down into scenarios, it should be added to this variable list:
`scenarioGroups: "appsec"`

If specific scenario or group scenario needs to run directly, they need to be added to that list:
`additionalScenarios: '[\"PARAMETRIC\", \"REMOTE_CONFIG_SCENARIOS\", \"TELEMETRY_SCENARIOS\", \"DEFAULT\", \"INTEGRATIONS\", \"INTEGRATIONS_AWS\", \"CROSSED_TRACING_LIBRARIES\", \"DEBUGGER_SCENARIOS\", \"+S PROFILING +S TRACE_PROPAGATION_STYLE_W3C +S LIBRARY_CONF_CUSTOM_HEADER_TAGS\"]'
`
### Build time

The weblog and agent docker images are build before and given as artefacts for all test jobs to reduce the completion time.

## Reason for change

The system-tests were timing out in a bunch of PRs. Some group scenarios took more than 1h to be run.
