### PR TITLE
Disable continuous profiler in GenerateDumpIfDbgRequested

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -85,7 +85,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         [TestAppFact("Samples.ExceptionGenerator")]
         public void GenerateDumpIfDbgRequested(string appName, string framework, string appAssembly)
         {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
+            // The continuous profiler is disabled for this test because it's not needed and it *might* be causing some failures
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, enableProfiler: false, commandLine: "--scenario 7");
 
             runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
             runner.Environment.SetVariable("COMPlus_DbgMiniDumpName", "/dev/null");


### PR DESCRIPTION
## Summary of changes

Disable the continuous profiler in `GenerateDumpIfDbgRequested`

## Reason for change

`GenerateDumpIfDbgRequested` has been flaky for a while now and I've been unable to find the root cause. I suspect the failure might be caused by some weird interaction with the continuous profiler, and the CP isn't actually needed for this test, so I'm disabling it to see if the failure disappears.

