### PR TITLE
Consolidate all integration test targets into a single target

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1781,7 +1781,7 @@ stages:
       displayName: 'Initialize LocalDB'
       workingDirectory: $(Build.Repository.LocalPath)
 
-    - script: tracer\build.cmd CompileTrimmingSamples BuildWindowsIntegrationTests BuildWindowsRegressionTests RunWindowsIntegrationTests RunWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+    - script: tracer\build.cmd CompileTrimmingSamples BuildWindowsIntegrationTests BuildWindowsRegressionTests RunIntegrationTests RunWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Run integration tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -394,7 +394,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests
+    command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
     cap_add:
@@ -541,7 +541,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests
+    command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
     cap_add:
@@ -672,7 +672,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests
+    command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
     cap_add:

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1518,20 +1518,21 @@ partial class Build
             );
         });
 
-    Target RunWindowsIntegrationTests => _ => _
+    Target RunIntegrationTests => _ => _
         .Unlisted()
         .After(BuildTracerHome)
         .After(CompileIntegrationTests)
         .After(CompileSamples)
         .After(CompileTrimmingSamples)
         .After(BuildWindowsIntegrationTests)
+        .After(CompileLinuxOrOsxIntegrationTests)
         .DependsOn(CleanTestLogs)
-        .Requires(() => IsWin)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
+            var filter = GetFilter();
 
             try
             {
@@ -1548,6 +1549,7 @@ partial class Build
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
+                    // Don't apply a custom filter to these tests, they should all be able to be run
                     .When(!string.IsNullOrWhiteSpace(Filter), c => c.SetFilter(Filter))
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                     .When(CodeCoverageEnabled, ConfigureCodeCoverage)
@@ -1556,22 +1558,20 @@ partial class Build
                         .WithDatadogLogger()
                         .SetProjectFile(project)), degreeOfParallelism: 4);
 
-
-                // TODO: I think we should change this filter to run on Windows by default
-                // (RunOnWindows!=False|Category=Smoke)&LoadFromGAC!=True&IIS!=True
                 DotNetTest(config => config
                     .SetDotnetPath(TargetPlatform)
                     .SetConfiguration(BuildConfiguration)
                     .SetTargetPlatformAnyCPU()
                     .SetFramework(Framework)
                     //.WithMemoryDumpAfter(timeoutInMinutes: 30)
+                    .EnableCrashDumps()
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)" : Filter)
                     .SetTestTargetPlatform(TargetPlatform)
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
+                    .When(!string.IsNullOrWhiteSpace(filter), c => c.SetFilter(filter))
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                     .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
@@ -1582,6 +1582,29 @@ partial class Build
             finally
             {
                 CopyDumpsToBuildData();
+            }
+
+            string GetFilter()
+            {
+                var dockerFilter = IncludeTestsRequiringDocker switch
+                {
+                    true => "&(RequiresDockerDependency=true)",
+                    false => "&(RequiresDockerDependency!=true)",
+                    null => string.Empty,
+                };
+
+                var armFilter = IsArm64 ? "&(Category!=ArmUnsupported)" : string.Empty;
+
+                var filter = (string.IsNullOrWhiteSpace(Filter), IsWin) switch
+                {
+                    (false, _) => $"({Filter}){dockerFilter}{armFilter}",
+                    (true, false) => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
+                    // TODO: I think we should change this filter to run on Windows by default, e.g.
+                    // (RunOnWindows!=False|Category=Smoke)&LoadFromGAC!=True&IIS!=True
+                    (true, true) => "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
+                };
+
+                return filter;
             }
         });
 
@@ -1844,169 +1867,6 @@ partial class Build
                     .SetProjectFile(Projects.DdTraceIntegrationTests)
                     .EnableTrxLogOutput(project)
                     .WithDatadogLogger());
-            }
-            finally
-            {
-                CopyDumpsToBuildData();
-            }
-        });
-
-    Target RunLinuxIntegrationTests => _ => _
-        .After(CompileLinuxOrOsxIntegrationTests)
-        .After(CompileTrimmingSamples)
-        .DependsOn(CleanTestLogs)
-        .Description("Runs the linux integration tests")
-        .Requires(() => Framework)
-        .Requires(() => !IsWin)
-        .Triggers(PrintSnapshotsDiff)
-        .Executes(() =>
-        {
-            var isDebugRun = IsDebugRun();
-
-            var dockerFilter = IncludeTestsRequiringDocker switch
-            {
-                true => "&(RequiresDockerDependency=true)",
-                false => "&(RequiresDockerDependency!=true)",
-                null => string.Empty,
-            };
-
-            var armFilter = IsArm64 ? "&(Category!=ArmUnsupported)" : string.Empty;
-
-            var filter = string.IsNullOrWhiteSpace(Filter) switch
-            {
-                false => $"({Filter}){dockerFilter}{armFilter}",
-                true => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
-            };
-
-            try
-            {
-                // Run these ones in parallel
-                DotNetTest(config => config
-                        .SetConfiguration(BuildConfiguration)
-                        .EnableNoRestore()
-                        .EnableNoBuild()
-                        .SetFramework(Framework)
-                        //.WithMemoryDumpAfter(timeoutInMinutes: 30)
-                        .EnableCrashDumps()
-                        .SetFilter(filter)
-                        .SetIsDebugRun(isDebugRun)
-                        .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
-                        .SetTestTargetPlatform(TargetPlatform)
-                        .SetLogsDirectory(TestLogsDirectory)
-                        .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
-                        .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
-                        .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                        .When(CodeCoverageEnabled, ConfigureCodeCoverage)
-                        .CombineWith(ParallelIntegrationTests, (s, project) => s
-                            .EnableTrxLogOutput(GetResultsDirectory(project))
-                            .WithDatadogLogger()
-                            .SetProjectFile(project)),
-                    degreeOfParallelism: 2);
-
-                // Run this one separately so we can tail output
-                DotNetTest(config => config
-                    .SetConfiguration(BuildConfiguration)
-                    .EnableNoRestore()
-                    .EnableNoBuild()
-                    .SetFramework(Framework)
-                    //.WithMemoryDumpAfter(timeoutInMinutes: 30)
-                    .EnableCrashDumps()
-                    .SetFilter(filter)
-                    .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
-                    .SetTestTargetPlatform(TargetPlatform)
-                    .SetLogsDirectory(TestLogsDirectory)
-                    .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
-                    .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
-                    .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
-                    .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
-                        .EnableTrxLogOutput(GetResultsDirectory(project))
-                        .WithDatadogLogger()
-                        .SetProjectFile(project))
-                );
-            }
-            finally
-            {
-                CopyDumpsToBuildData();
-            }
-        });
-
-    Target RunOsxIntegrationTests => _ => _
-        .After(CompileLinuxOrOsxIntegrationTests)
-        .DependsOn(CleanTestLogs)
-        .Description("Runs the osx integration tests")
-        .Requires(() => Framework)
-        .Requires(() => IsOsx)
-        .Triggers(PrintSnapshotsDiff)
-        .Executes(() =>
-        {
-            var isDebugRun = IsDebugRun();
-
-            var dockerFilter = IncludeTestsRequiringDocker switch
-            {
-                true => "&(RequiresDockerDependency=true)",
-                false => "&(RequiresDockerDependency!=true)",
-                null => string.Empty,
-            };
-
-            var armFilter = IsArm64 ? "&(Category!=ArmUnsupported)" : string.Empty;
-
-            var filter = string.IsNullOrWhiteSpace(Filter) switch
-            {
-                false => Filter,
-                true => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
-            };
-
-            var targetPlatform = IsArm64 ? (MSBuildTargetPlatform)"arm64" : TargetPlatform;
-
-            try
-            {
-                // Run these ones in parallel
-                DotNetTest(config => config
-                        .SetConfiguration(BuildConfiguration)
-                        .EnableNoRestore()
-                        .EnableNoBuild()
-                        .SetFramework(Framework)
-                        //.WithMemoryDumpAfter(timeoutInMinutes: 30)
-                        .EnableCrashDumps()
-                        .SetFilter(filter)
-                        .SetIsDebugRun(isDebugRun)
-                        .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
-                        .SetLocalOsxEnvironmentVariables()
-                        .SetTestTargetPlatform(targetPlatform)
-                        .SetLogsDirectory(TestLogsDirectory)
-                        .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
-                        .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
-                        .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                        .When(CodeCoverageEnabled, ConfigureCodeCoverage)
-                        .CombineWith(ParallelIntegrationTests, (s, project) => s
-                            .EnableTrxLogOutput(GetResultsDirectory(project))
-                            .WithDatadogLogger()
-                            .SetProjectFile(project)),
-                    degreeOfParallelism: 2);
-
-                // Run this one separately so we can tail output
-                DotNetTest(config => config
-                    .SetConfiguration(BuildConfiguration)
-                    .EnableNoRestore()
-                    .EnableNoBuild()
-                    .SetFramework(Framework)
-                    //.WithMemoryDumpAfter(timeoutInMinutes: 30)
-                    .EnableCrashDumps()
-                    .SetFilter(filter)
-                    .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
-                    .SetLocalOsxEnvironmentVariables()
-                    .SetTestTargetPlatform(targetPlatform)
-                    .SetLogsDirectory(TestLogsDirectory)
-                    .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
-                    .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
-                    .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
-                    .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
-                        .EnableTrxLogOutput(GetResultsDirectory(project))
-                        .WithDatadogLogger()
-                        .SetProjectFile(project))
-                );
             }
             finally
             {

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -296,7 +296,7 @@ partial class Build : NukeBuild
         .DependsOn(BuildWindowsIntegrationTests)
         .DependsOn(CompileSamples)
         .DependsOn(CompileTrimmingSamples)
-        .DependsOn(RunWindowsIntegrationTests);
+        .DependsOn(RunIntegrationTests);
 
     Target BuildAndRunWindowsRegressionTests => _ => _
         .Requires(() => IsWin)
@@ -327,7 +327,7 @@ partial class Build : NukeBuild
         .Requires(() => !IsWin)
         .Description("Builds and runs the linux integration tests. Requires docker-compose dependencies")
         .DependsOn(BuildLinuxIntegrationTests)
-        .DependsOn(RunLinuxIntegrationTests)
+        .DependsOn(RunIntegrationTests)
         .DependsOn(RunLinuxDdDotnetIntegrationTests);
 
     Target BuildOsxIntegrationTests => _ => _
@@ -344,7 +344,7 @@ partial class Build : NukeBuild
         .DependsOn(BuildOsxIntegrationTests)
         .DependsOn(CompileSamples)
         .DependsOn(CompileTrimmingSamples)
-        .DependsOn(RunOsxIntegrationTests);
+        .DependsOn(RunIntegrationTests);
 
     Target BuildAndRunToolArtifactTests => _ => _
        .Description("Builds and runs the tool artifacts tests")


### PR DESCRIPTION
## Summary of changes

## Reason for change

We previously had `RunWindowsIntegrationTests`, `RunLinuxIntegrationTests`, `RunOsxIntegrationTests`, each with _subtle_ differences. Overall that adds complexity which isn't really necessary

## Implementation details

Combine everything into a single target, and just specialize the filter instead to reduce the code

## Test coverage

Tested locally on Windows, and ran a CI test, but OSX side is untested currently. 

## Other details

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/6498

https://datadoghq.atlassian.net/browse/LANGPLAT-66