### PR TITLE
Ensure analyzer tests run against all TFMs

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>


### PR DESCRIPTION
## Summary of changes

Removes the restriction to only running on .NET 5

## Reason for change

There's no good reason for it to be this, it's almost certainly copy pasta

## Implementation details

Remove the restricting target

## Test coverage

The CI should reveal all...

## Other details

Revealed by
- https://github.com/DataDog/dd-trace-dotnet/pull/6500