### PR TITLE
Log an error message when the profiler is loaded multiple times

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -51,6 +51,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         Logger::EnableDebug(true);
     }
 
+    if (profiler != nullptr)
+    {
+        Logger::Error("The Tracer Profiler is initialized multiple times. This may cause unpredictable failures.",
+            " When running aspnetcore in IIS, make sure to disable managed code in the application pool settings.",
+            " https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/advanced?view=aspnetcore-9.0#create-the-iis-site");
+    }
+
     CorProfilerBase::Initialize(cor_profiler_info_unknown);
 
     // we used to bail-out if tracing was disabled, but we now allow the tracer to be loaded


### PR DESCRIPTION
## Summary of changes

Log an error message when the profiler is loaded multiple times.

## Reason for change

Despite mentioning it in our documentation, we still regularly have escalations caused by the usage of .NET Framework and .NET Core in the same pool. Adding an error log will make diagnostic easier.

We could also entirely bail out when we detect multiple initialization, but I'm afraid we might break existing customers.

## Implementation details

Using the `profiler` field to find out if the profiler was initialized. It means we won't detect double-initialization if the first initialization failed midway through, but I don't think we really care.

## Test coverage

Tested on my machine.