### PR TITLE
Expand number of files that require thorough testing

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -199,7 +199,7 @@ partial class Build
         var baseBranch = string.IsNullOrEmpty(TargetBranch) ? ReleaseBranchForCurrentVersion() : $"origin/{TargetBranch}";
         if (IsGitBaseBranch(baseBranch))
         {
-            // do a full run on the main branch
+         // do a full run on the main branch
             return true;
         }
 
@@ -207,8 +207,14 @@ partial class Build
         var integrationChangedFiles = TargetFrameworks
             .SelectMany(tfm => new[]
             {
+                // Changes to the definitions (new integrations etc)
                 $"tracer/src/Datadog.Trace/Generated/{tfm}/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator",
                 $"tracer/src/Datadog.Trace/Generated/{tfm}/Datadog.Trace.SourceGenerators/AspectsDefinitionsGenerator",
+            })
+            .Concat(new [] {
+                // Changes to the integrations themselves, e.g. change in behaviour
+                "tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation",
+                "tracer/src/Datadog.Trace/Iast/Aspects"
             })
             .ToList();
 

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -129,6 +129,7 @@ partial class Build : NukeBuild
                             Logger.Information($"IsAlpine: {IsAlpine}");
                             Logger.Information($"Version: {Version}");
                             Logger.Information($"RuntimeIdentifier: {RuntimeIdentifier}");
+                            Logger.Information($"TestFrameworks: {string.Join(",", TestingFrameworks.Select(x => x.ToString()))}");
                         });
 
     Target Clean => _ => _


### PR DESCRIPTION
## Summary of changes

Try to catch more integration issues in PRs

## Reason for change

We don't run all TFMs on all PRs, because it increases the load on CI, and doesn't add a huge amount of value. Unfortunately, that means we also occasionally merge PRs that break an untested-in-PR TFM which then fails on master. We attempt to mitigate that, but running all TFMs for "high risk of breakage" PRs. This increases the scope of what constitutes "high risk"

## Implementation details

Previously, we were only counting PRs which change the calltarget or callsite integration points. This PR updates that to include the _implementations_ too

## Test coverage

Tested locally to confirm it works as expected
