### PR TITLE
Fix compilation of Samples.Security.AspNetCore5

### DIFF
--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -79,6 +79,7 @@ namespace Samples.Security.AspNetCore5.Controllers
     {
         private static SQLiteConnection _dbConnectionSystemData = null;
         private static SqliteConnection _dbConnectionSystemDataMicrosoftData = null;
+        private static SqlConnection _dbConnectionSystemDataSqlClient = null;
         private static IMongoDatabase _mongoDb = null;
 #if NETCOREAPP3_0_OR_GREATER
         private static NpgsqlConnection _dbConnectionNpgsql = null;


### PR DESCRIPTION
## Summary of changes

Make Samples.Security.AspNetCore5 compile again.

## Implementation details

A field that was inadvertently removed was actually used.
