### PR TITLE
Add additional tests for CI Visibility configuration behaviour

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -217,6 +217,8 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test", null, null, "test")]
+        // This is the current behaviour - _should_ it be, or should the result be normalized, is a separate question...
+        [InlineData("My Service Name!", null, null, "My Service Name!")]
         [InlineData("test", null, "ignored_otel", "test")]
         [InlineData("test", "error", "ignored_otel", "test")]
         [InlineData(null, "test", null, "test")]


### PR DESCRIPTION
## Summary of changes

Adds some more tests for CI Visibility configuration

## Reason for change

In #6399 we changed how this all worked. We _thought_ we had a regression, but it seems that we fixed a bug. This adds tests to confirm the CI Vis behaviour is as expected

## Implementation details

Adds some unit tests

## Test coverage

More
