### PR TITLE
[ASM] Restore SqlConnection _dbConnectionSystemDataSqlClient

### DIFF
--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -79,6 +79,7 @@ namespace Samples.Security.AspNetCore5.Controllers
     {
         private static SQLiteConnection _dbConnectionSystemData = null;
         private static SqliteConnection _dbConnectionSystemDataMicrosoftData = null;
+        private static SqlConnection _dbConnectionSystemDataSqlClient = null;
         private static IMongoDatabase _mongoDb = null;
 #if NETCOREAPP3_0_OR_GREATER
         private static NpgsqlConnection _dbConnectionNpgsql = null;


### PR DESCRIPTION
## Summary of changes

It seems that there has been some PR conflict between [this PR](https://github.com/DataDog/dd-trace-dotnet/pull/6482) and [this one](https://github.com/DataDog/dd-trace-dotnet/pull/6491) that have caused a compilation error in Samples.Security.AspNetCore5. Just restoring the missing line will fix it.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
