### PR TITLE
Run .NET Functions on .NET 8 and .NET 9

### DIFF
--- a/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
@@ -34,6 +34,9 @@ steps:
 
         echo "Manually prepending to path"
         echo "##vso[task.prependpath]$path"
+
+        echo "Manually exporting path to DOTNET_ROOT"
+        echo "##vso[task.setvariable variable=DOTNET_ROOT]$path"
       } else {
         $path = "$HOME\AppData\Local\Microsoft\dotnet_32"
         $arch = "x86"

--- a/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
@@ -34,9 +34,6 @@ steps:
 
         echo "Manually prepending to path"
         echo "##vso[task.prependpath]$path"
-
-        echo "Manually exporting path to DOTNET_ROOT"
-        echo "##vso[task.setvariable variable=DOTNET_ROOT]$path"
       } else {
         $path = "$HOME\AppData\Local\Microsoft\dotnet_32"
         $arch = "x86"

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1811,6 +1811,12 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
     - template: steps/install-dotnet-sdks.yml
+    # This is a hack because otherwise Azure Functions _always_ tries to use the one from program files otherwise
+    - script: |
+        cd /D %PROGRAMFILES%/dotnet
+        rename dotnet.exe dotnet.exe.bak
+        where dotnet
+      displayName: 'Rename default dotnet.exe'
     - template: steps/restore-working-directory.yml
         
     - template: steps/install-msi.yml

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -204,6 +204,8 @@ partial class Build : NukeBuild
                     // new {framework = TargetFramework.NETCOREAPP3_1, runtimeInstall = v3Install, runtimeUninstall = v3Uninstall },
                     new {framework = TargetFramework.NET6_0 },
                     new {framework = TargetFramework.NET7_0 },
+                    new {framework = TargetFramework.NET8_0 },
+                    new {framework = TargetFramework.NET9_0 },
                 };
 
                 var matrix = new Dictionary<string, object>();

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.0.0</ApiVersion>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary of changes

Run the azure function integration tests on .NET 8 and .NET 9

## Reason for change

We currently only run them on .NET 6 and .NET 7, we should run them on all supported frameworks

## Implementation details

- Update azure functions to build and run on .NET 8 and .NET 9
- ~set `DOTNET_ROOT` to the latest location of our installed SDKs (not technically necessary for this, but probably still a good idea to head off other issues)~ This seemed to _cause_ other issues 🙄 And isn't necessary AFAICT, so reverted it
- Manually remove the "built-in" dotnet install in the azure functions test stage. Yes this is horrible. [But they have code to explicitly use it if it's there](https://github.com/Azure/azure-functions-host/blob/cb0a62c51dd800ee1919795b4a933b26c74ed8de/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs#L160), and couldn't find an easy way to override it, so here we are.

## Test coverage

More now!

## Other details

I'm not proud of what I've done