### PR TITLE
Actually include child processes when requested during a memory dump in tests

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -191,7 +191,7 @@ namespace Datadog.Trace.TestHelpers
 
             if (!ranToCompletion && !process.HasExited)
             {
-                var tookMemoryDump = MemoryDumpHelper.CaptureMemoryDump(process);
+                var tookMemoryDump = MemoryDumpHelper.CaptureMemoryDump(process, includeChildProcesses: dumpChildProcesses);
                 process.Kill();
                 throw new Exception($"The sample did not exit in {timeoutMs}ms. Memory dump taken: {tookMemoryDump}. Killing process.");
             }


### PR DESCRIPTION
## Summary of changes

Fix "dump child processes" not working

## Reason for change

#6401 added the ability to say "dump the child processes too", except we didn't wire up the parameter.

## Implementation details

Wire up the parameter
