### PR TITLE
Attempt to fix flakiness in Azure Functions multi-sample build

### DIFF
--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Directory.Build.props
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Azure functions build a separate worker project as part of the build -->
+    <!-- Attempt to clobber the path, because otherwise it overwrites and causes issue -->
+    <ExtensionsCsProjDirectory>$(ArtifactsPath)/WorkerExtensions/Samples.AzureFunctions.V4/bin/$(ArtifactsPivots)</ExtensionsCsProjDirectory>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary of changes

Attempt to fix flakiness in Azure Functions multi-sample build

## Reason for change

https://github.com/DataDog/dd-trace-dotnet/pull/6472 added multi-version building for Azure Functions samples. Unfortunately, this caused the build stage to be flaky, because Azure Functions apparently generates and builds a [completely separate _.csproj_](https://github.com/Azure/azure-functions-dotnet-worker/issues/1252). Unfortunately, it also ignores all the artifact output stuff, which means when we restore/build multiple versions of the app (with different api versions, it stomps over itself. 

e.g. we can see the sample app build itself doing the right thing:
```
08:59:05 [DBG]   Samples.AzureFunctions.V4Isolated -> /project/artifacts/bin/Samples.AzureFunctions.V4Isolated/release_net6.0_1.6.0/Samples.AzureFunctions.V4Isolated.dll
08:59:06 [DBG]   Samples.AzureFunctions.V4Isolated -> /project/artifacts/publish/Samples.AzureFunctions.V4Isolated/release_net6.0_1.6.0/
```

But there's also the "WorkerExtensions" thing which is going completely off the rails, ignores all of the Directory.Build.props etc and just does its own thing

```
08:59:07 [DBG]   WorkerExtensions -> /tmp/oh4iajvh.kcj/publishout/
08:59:07 [DBG]   WorkerExtensions -> /tmp/zv30zzl2.cxz/publishout/Microsoft.Azure.Functions.Worker.Extensions.dll
08:59:08 [DBG]   WorkerExtensions -> /tmp/zv30zzl2.cxz/publishout/
```

Unfortunately, this shows it's trying to build two separate versions to the same location, and things break.

## Implementation details

Went spelunking through the [Azure Functions package](https://nuget.info/packages/Microsoft.Azure.Functions.Worker.Sdk/2.0.0) code and found `Microsoft.Azure.Functions.Worker.Sdk.targets` which is doing the actual build. Tried tweaking some of the msbuild variables to convince it to use different locations:

```xml
<!-- Setting up some paths we will use for later targets. Broken out into its own as we want to pull it in not just for build (ie: Clean also). -->
  <Target Name="_FunctionsGetPaths">
    <PropertyGroup>
      <_FunctionsMetadataPath>$(IntermediateOutputPath)functions.metadata</_FunctionsMetadataPath>
      <_FunctionsWorkerConfigPath>$(IntermediateOutputPath)worker.config.json</_FunctionsWorkerConfigPath>
      <ExtensionsCsProjDirectory Condition="'$(ExtensionsCsProjDirectory)' == ''">$(IntermediateOutputPath)WorkerExtensions</ExtensionsCsProjDirectory>
      <ExtensionsCsProjDirectory>$([System.IO.Path]::GetFullPath($(ExtensionsCsProjDirectory)))</ExtensionsCsProjDirectory> <!-- Ensure ExtensionsCsProjDirectory is a full path. -->
      <ExtensionsCsProj>$([System.IO.Path]::Combine($(ExtensionsCsProjDirectory), WorkerExtensions.csproj))</ExtensionsCsProj>
      <_FunctionsIntermediateExtensionJsonPath>$(ExtensionsCsProjDirectory)\buildout\bin\$(_FunctionsExtensionsJsonName)</_FunctionsIntermediateExtensionJsonPath>
      <_FunctionsIntermediateExtensionUpdatedJsonPath>$(IntermediateOutputPath)$(_FunctionsExtensionsJsonName)</_FunctionsIntermediateExtensionUpdatedJsonPath>
    </PropertyGroup>
  </Target>
```

## Test coverage

Checked the build logs to make sure it's doing what we expect now
