### PR TITLE
[Test Optimization] Collect more logs on EFD tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -365,6 +365,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [Trait("Category", "EarlyFlakeDetection")]
         public async Task EarlyFlakeDetection(string packageVersion, string evpVersionToRemove, bool expectedGzip, string settingsJson, string testsJson, int expectedSpansForPre224, int expectedSpansForPost224, string friendlyName)
         {
+            SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
             var version = string.IsNullOrEmpty(packageVersion) ? new Version("2.2.8") : new Version(packageVersion);
             var tests = new List<MockCIVisibilityTest>();
             var testSuites = new List<MockCIVisibilityTestSuite>();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -420,6 +420,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 }
             }
 
+            SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
             var tests = new List<MockCIVisibilityTest>();
             var testSuites = new List<MockCIVisibilityTestSuite>();
             var testModules = new List<MockCIVisibilityTestModule>();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -379,6 +379,8 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 
     public virtual async Task EarlyFlakeDetection(string packageVersion, string evpVersionToRemove, bool expectedGzip, string settingsJson, string testsJson, int expectedSpans, string friendlyName)
     {
+        SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+
         var tests = new List<MockCIVisibilityTest>();
         var testSuites = new List<MockCIVisibilityTestSuite>();
         var testModules = new List<MockCIVisibilityTestModule>();


### PR DESCRIPTION
## Summary of changes

Trying to collect more logs to catch the flakiness issue / deadlock in Early Flake Detection tests.

## Reason for change

We need to collect more info

## Implementation details

Just enabling debug logs for these Samples app
