### PR TITLE
Redact `##vso` in CI

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -210,7 +210,9 @@ namespace Datadog.Trace.TestHelpers
 
                 if (testCase.TestMethodArguments != null)
                 {
-                    parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString() ?? "null"));
+                    // We replace ##vso to avoid sending "commands" via the log output when we're testing CI Visibility stuff
+                    // We should redact other CI's command prefixes as well in the future, but for now this is enough
+                    parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString()?.Replace("##vso", "#####") ?? "null"));
                 }
 
                 var test = $"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}({parameters})";


### PR DESCRIPTION
## Summary of changes

Redact `##vso` from being printed when we write test method arguments

## Reason for change

When printed to the console, this signifies a "command" which confuses azdo:

```
##[warning]'11:09:46 [DBG] [xUnit.net 00:00:02.05] Datadog.Trace.Tools.Runner.IntegrationTests: STARTED: Datadog.Trace.Tools.Runner.IntegrationTests.ConfigureCiCommandTests.ConfigureCi(azp, ##vso\[task.setvariable variable=(?<name>[A-Z1-9_]+);\](?<value>.*), null)' contains logging command keyword '##vso', but it's not a legal command. Please see the list of accepted commands: https://go.microsoft.com/fwlink/?LinkId=817296
```

## Implementation details

Just replace `##vso` with `#####`

## Test coverage

Meh
