### PR TITLE
Stop using EventIdHash to compare messages in telemetry logs

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
@@ -29,8 +29,8 @@ internal class RedactedErrorLogCollector
     private TaskCompletionSource<bool> _tcs = new(TaskOptions);
     private bool _isEnabled = true;
 
-    private ConcurrentDictionary<uint, int> _logCounts = new();
-    private ConcurrentDictionary<uint, int> _logCountsReserve = new();
+    private ConcurrentDictionary<LogKey, int> _logCounts = new();
+    private ConcurrentDictionary<LogKey, int> _logCountsReserve = new();
 
     public List<List<LogMessageData>>? GetLogs()
     {
@@ -44,7 +44,7 @@ internal class RedactedErrorLogCollector
         {
             var logSize = log.GetApproximateSerializationSize();
             // modify the message to add the final log count
-            var eventId = EventIdHash.Compute(log.Message, log.StackTrace);
+            var eventId = new LogKey(log.Message, log.StackTrace);
             if (logCounts.TryGetValue(eventId, out var count) && count > 1)
             {
                 log.Count = count;
@@ -91,9 +91,9 @@ internal class RedactedErrorLogCollector
     {
         if (Volatile.Read(ref _isEnabled))
         {
-            var eventId = EventIdHash.Compute(message, stackTrace);
+            var logKey = new LogKey(message, stackTrace);
             var logCounts = _logCounts;
-            var newCount = logCounts.AddOrUpdate(eventId, addValue: 1, updateValueFactory: static (_, prev) => prev + 1);
+            var newCount = logCounts.AddOrUpdate(logKey, addValue: 1, updateValueFactory: static (_, prev) => prev + 1);
             if (newCount != 1)
             {
                 // already have this log, so don't enqueue it again
@@ -142,5 +142,11 @@ internal class RedactedErrorLogCollector
         while (_queue.TryDequeue(out _))
         {
         }
+    }
+
+    private readonly record struct LogKey(string Message, string? StackTrace)
+    {
+        public readonly string Message = Message;
+        public readonly string? StackTrace = StackTrace;
     }
 }


### PR DESCRIPTION
## Summary of changes

Compare the full log message and stack trace when determining uniqueness

## Reason for change

We were using a computed hash value to compare two log messages for uniqueness. There's no good reason for that really, and we were getting some hash collisions which was causing flakiness in tests (and potentially, in real life). This should resolve the flakiness

## Implementation details

Use a `readonly record struct` to hold both the message and the stack trace as the dictionary key.

## Test coverage

Covered by existing tests

## Other details

Would like to have used `ValueTuple` but we can't have nice things with .NET FX 4.6.1