### PR TITLE
Enable dependabot for Azure Functions sample

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,20 @@ updates:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
       - dependency-name: "*" # Ignore patches for all integrations
         update-types: ["version-update:semver-patch"]
+
+  # Azure functions explicit testing - we can't include these with our "normal" process checks
+  # Because they aren't compatible with the dotnet msbuild approach we're using
+  - package-ecosystem: "nuget"
+    directory: "/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "area:dependabot"
+    ignore:
+      - dependency-name: "*" # Ignore patches for all integrations
+        update-types: ["version-update:semver-patch"]
+
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace"

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.SdkV1/Samples.AzureFunctions.V4Isolated.SdkV1.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.SdkV1/Samples.AzureFunctions.V4Isolated.SdkV1.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- We can't build and run these as multi-package versions, so we have to manually update this as required for now -->
-    <ApiVersion Condition="'$(ApiVersion)' == ''">1.24.0</ApiVersion>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
@@ -11,7 +9,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="$(ApiVersion)" />
+    <!-- We can't build and run these as multi-package versions, so we have to manually update this as required for now -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.24.0" />
   </ItemGroup>
 
   <!-- Just reducing duplication, we can evolve these separate if we need to later -->

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">2.0.0</ApiVersion>
     <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
@@ -10,7 +9,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="$(ApiVersion)" />
+    <!-- We can't build and run these as multi-package versions, so we have to manually update this as required for now -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

Try to enable dependabot for the Azure Functions v2 sample

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/6524 we had to remove our "normal" version bumping work, because the Azure Functions samples fundamentally don't work well with the `dotnet msbuild` approach. This PR attempts to give us some of that visibility back by explicitly configuring the azure functions sample in dependabot

## Implementation details

Added the sample directly to the yml. I think this is the most important one to track, as I think it's the only currently developed scenario that we expect to see updates.

## Test coverage

Can't easily test the dependabot changes unfortunately AFAIK
