### PR TITLE
Skip the flaky XUnit named pipes tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitEvpTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 [Collection(nameof(TransportTestsCollection))]
 public class PipesXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output)
 {
-    [SkippableTheory]
+    [SkippableTheory(Skip = "These are currently very flaky - revisit once we move to aspnetcore-based mock agent")]
     [MemberData(nameof(GetData))]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "EndToEnd")]
@@ -43,7 +43,7 @@ public class PipesXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output
         }
     }
 
-    [SkippableTheory]
+    [SkippableTheory(Skip = "These are currently very flaky - revisit once we move to aspnetcore-based mock agent")]
     [MemberData(nameof(GetDataForEarlyFlakeDetection))]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "EndToEnd")]


### PR DESCRIPTION
## Summary of changes

Skip the named pipes tests for now

## Reason for change

These are very flaky, and aren't an explicitly supported scenario.

## Implementation details

Just disable the test - we can look at re-enabling them again once/if we move to an aspnetcore-based internal agent, in the hope that solves the flake

## Test coverage

Less now

## Other details

There is a separate CI Vis flake issue which appears to be a deadlock on arm64, that's being looked at separately