### PR TITLE
[IAST] Lock vulnerabilities list access

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
@@ -7,15 +7,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.SensitiveData;
 using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Util.Http;
-using Datadog.Trace.Vendors.dnlib;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
 
@@ -31,6 +26,8 @@ internal class VulnerabilityBatch
     private static Lazy<JsonSerializerSettings> _truncatedSettings = new(() => CreateTruncatedSettings());
 
     private readonly int _truncationMaxValueLength;
+    private readonly List<Vulnerability> _vulnerabilities = new List<Vulnerability>();
+    private List<Source>? _sources = null;
     private EvidenceRedactor? _evidenceRedactor;
     private JsonSerializerSettings _serializerSettings;
     private string? _vulnerabilitiesJson;
@@ -52,9 +49,9 @@ internal class VulnerabilityBatch
         }
     }
 
-    public List<Vulnerability> Vulnerabilities { get; } = new List<Vulnerability>();
+    public ICollection<Vulnerability> Vulnerabilities => _vulnerabilities;
 
-    public List<Source>? Sources { get; private set; } = null;
+    public ICollection<Source>? Sources => _sources;
 
     public bool IsTruncated() => _isTruncated;
 
@@ -87,27 +84,30 @@ internal class VulnerabilityBatch
 
     public void Add(Vulnerability vulnerability)
     {
-        _vulnerabilitiesJson = null;
-        var ranges = vulnerability.Evidence?.Ranges;
-
-        if (ranges != null)
+        lock (_vulnerabilities)
         {
-            foreach (var range in ranges)
-            {
-                if (Sources is null)
-                {
-                    Sources = new List<Source>();
-                }
+            _vulnerabilitiesJson = null;
+            var ranges = vulnerability.Evidence?.Ranges;
 
-                if (range.Source != null && !Sources.Contains(range.Source))
+            if (ranges != null)
+            {
+                foreach (var range in ranges)
                 {
-                    range.Source.SetInternalId(Sources.Count);
-                    Sources.Add(range.Source);
+                    if (Sources is null)
+                    {
+                        _sources = new List<Source>();
+                    }
+
+                    if (range.Source != null && _sources is not null && !_sources.Contains(range.Source))
+                    {
+                        range.Source.SetInternalId(_sources.Count);
+                        _sources.Add(range.Source);
+                    }
                 }
             }
-        }
 
-        Vulnerabilities.Add(vulnerability);
+            _vulnerabilities.Add(vulnerability);
+        }
     }
 
     public string ToJson()
@@ -116,32 +116,35 @@ internal class VulnerabilityBatch
         {
             if (_vulnerabilitiesJson == null)
             {
-                if (_evidenceRedactor == null)
+                lock (_vulnerabilities)
                 {
-                    _vulnerabilitiesJson = JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings);
-                }
-                else
-                {
-                    if (Sources != null)
+                    if (_evidenceRedactor == null)
                     {
-                        foreach (var source in Sources)
+                        _vulnerabilitiesJson = JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings);
+                    }
+                    else
+                    {
+                        if (Sources != null)
                         {
-                            _evidenceRedactor.Process(source);
+                            foreach (var source in Sources)
+                            {
+                                _evidenceRedactor.Process(source);
+                            }
                         }
+
+                        for (int x = 0; x < _vulnerabilities.Count; x++)
+                        {
+                            _vulnerabilities[x] = _evidenceRedactor.RedactVulnerability(_vulnerabilities[x]);
+                        }
+
+                        _vulnerabilitiesJson = JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings);
                     }
 
-                    for (int x = 0; x < Vulnerabilities.Count; x++)
+                    if (System.Text.ASCIIEncoding.Unicode.GetByteCount(_vulnerabilitiesJson) > MaxSpanTagSize)
                     {
-                        Vulnerabilities[x] = _evidenceRedactor.RedactVulnerability(Vulnerabilities[x]);
+                        _vulnerabilitiesJson = ToTruncatedJson();
+                        _isTruncated = true;
                     }
-
-                    _vulnerabilitiesJson = JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings);
-                }
-
-                if (System.Text.ASCIIEncoding.Unicode.GetByteCount(_vulnerabilitiesJson) > MaxSpanTagSize)
-                {
-                    _vulnerabilitiesJson = ToTruncatedJson();
-                    _isTruncated = true;
                 }
             }
 
@@ -158,40 +161,43 @@ internal class VulnerabilityBatch
     {
         try
         {
-            byte[] result;
-            Dictionary<string, object> toSerialize;
+            lock (_vulnerabilities)
+            {
+                byte[] result;
+                Dictionary<string, object> toSerialize;
 
-            if (_evidenceRedactor == null)
-            {
-                toSerialize = MetaStructHelper.VulnerabilityBatchToDictionary(this);
-                result = MetaStructHelper.ObjectToByteArray(toSerialize);
-            }
-            else
-            {
-                if (Sources != null)
+                if (_evidenceRedactor == null)
                 {
-                    foreach (var source in Sources)
+                    toSerialize = MetaStructHelper.VulnerabilityBatchToDictionary(this);
+                    result = MetaStructHelper.ObjectToByteArray(toSerialize);
+                }
+                else
+                {
+                    if (Sources != null)
                     {
-                        _evidenceRedactor.Process(source);
+                        foreach (var source in Sources)
+                        {
+                            _evidenceRedactor.Process(source);
+                        }
                     }
+
+                    for (var x = 0; x < _vulnerabilities.Count; x++)
+                    {
+                        _vulnerabilities[x] = _evidenceRedactor.RedactVulnerability(_vulnerabilities[x]);
+                    }
+
+                    toSerialize = MetaStructHelper.VulnerabilityBatchToDictionary(this);
+                    result = MetaStructHelper.ObjectToByteArray(toSerialize);
                 }
 
-                for (var x = 0; x < Vulnerabilities.Count; x++)
+                if (result.Length > MaxSpanTagSize)
                 {
-                    Vulnerabilities[x] = _evidenceRedactor.RedactVulnerability(Vulnerabilities[x]);
+                    result = ToTruncatedMessagePack(toSerialize);
+                    _isTruncated = true;
                 }
 
-                toSerialize = MetaStructHelper.VulnerabilityBatchToDictionary(this);
-                result = MetaStructHelper.ObjectToByteArray(toSerialize);
+                return result;
             }
-
-            if (result.Length > MaxSpanTagSize)
-            {
-                result = ToTruncatedMessagePack(toSerialize);
-                _isTruncated = true;
-            }
-
-            return result;
         }
         catch (Exception ex)
         {
@@ -202,26 +208,32 @@ internal class VulnerabilityBatch
 
     internal string ToTruncatedJson()
     {
-        return JsonConvert.SerializeObject(new TruncatedVulnerabilities(Vulnerabilities), Formatting.Indented, _truncatedSettings.Value);
+        lock (_vulnerabilities)
+        {
+            return JsonConvert.SerializeObject(new TruncatedVulnerabilities(_vulnerabilities), Formatting.Indented, _truncatedSettings.Value);
+        }
     }
 
     internal byte[] ToTruncatedMessagePack(Dictionary<string, object> vulnerabilityBatchDictionary)
     {
-        if (vulnerabilityBatchDictionary["vulnerabilities"] is List<Dictionary<string, object>> vulnerabilities)
+        lock (_vulnerabilities)
         {
-            foreach (var vulnerability in vulnerabilities)
+            if (vulnerabilityBatchDictionary["vulnerabilities"] is List<Dictionary<string, object>> vulnerabilities)
             {
-                if (vulnerability["evidence"] is Dictionary<string, object> evidence)
+                foreach (var vulnerability in vulnerabilities)
                 {
-                    evidence.Clear();
-                    evidence["value"] = TruncatedVulnerabilities.MaxSizeExceeded;
+                    if (vulnerability["evidence"] is Dictionary<string, object> evidence)
+                    {
+                        evidence.Clear();
+                        evidence["value"] = TruncatedVulnerabilities.MaxSizeExceeded;
+                    }
                 }
             }
+
+            vulnerabilityBatchDictionary.Remove("sources");
+
+            return MetaStructHelper.ObjectToByteArray(vulnerabilityBatchDictionary);
         }
-
-        vulnerabilityBatchDictionary.Remove("sources");
-
-        return MetaStructHelper.ObjectToByteArray(vulnerabilityBatchDictionary);
     }
 
     public override string ToString()

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Linq;
 using System.Text;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast;
@@ -166,9 +167,10 @@ public partial class VulnerabilityBatchTests
         batch.Add(vulnerability2);
 
         batch.Vulnerabilities.Count.Should().Be(2);
-        batch.Sources.Count.Should().Be(2);
-        batch.Sources[0].GetInternalId().Should().Be(0);
-        batch.Sources[1].GetInternalId().Should().Be(1);
+        var sources = batch.Sources.ToList();
+        sources.Count.Should().Be(2);
+        sources[0].GetInternalId().Should().Be(0);
+        sources[1].GetInternalId().Should().Be(1);
 
         var json = batch.ToJson();
         var metaStructJson = VulnerabilityBatchMetaStructToJson(batch);


### PR DESCRIPTION
## Summary of changes
Lock access to vulnerabilities list in `VulnerabilityBatch`

## Reason for change
A crash has been reported where a vuln is added when serializing the `VulnerabilityBatch`

## Implementation details
Add lock to `Vulnerabilities` list access

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
