### PR TITLE
UseLockedTracerManager

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
@@ -35,7 +35,6 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
         public CiRunCommandTests()
             : base("ci run", enableCiVisibilityMode: true)
         {
-            CIVisibility.UseLockedTracerManager = false;
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CustomTestFramework.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Ci;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,6 +16,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
         public CustomTestFramework(IMessageSink messageSink)
             : base(messageSink)
         {
+            CIVisibility.UseLockedTracerManager = false;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
@@ -18,6 +18,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
   </ItemGroup>
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/xunit.runner.json
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": true
+}


### PR DESCRIPTION
## Summary of changes

Use the locked tracer globally in the runner integration tests.

## Reason for change

The locked tracer was already used in CiRunCommandTests, but it turns out it's also needed for other tests (we just got lucky with the ordering). Rather than discovering them one by one, let's just set it globally. 

## Implementation details

Also added the proper xunit.runner.json file to have more info on the running tests in the CI.

## Other details

Discovered while trying to randomize the order of the tests.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->


UseLockedTracerManager