### PR TITLE
Wait for background task in ConfigureCiCommand

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
@@ -71,6 +71,8 @@ namespace Datadog.Trace.Tools.Runner
                 return;
             }
 
+            await initResults.UploadRepositoryChangesTask().ConfigureAwait(false);
+
             if (!TryExtractCiName(name, out var ciName))
             {
                 context.ExitCode = 1;


### PR DESCRIPTION
## Summary of changes

After ConfigureCiCommand completes, wait for the "upload repository changes" task to complete.

## Reason for change

We already do this in `RunCiCommand`, not doing it in `ConfigureCiCommand` was an oversight.

## Other details

Discovered while trying to randomize the order of the tests.