### PR TITLE
Actually include child processes when requested during a memory dump in tests - part 2 :D 

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
@@ -129,7 +129,7 @@ namespace Datadog.Trace.TestHelpers
 
         public static bool CaptureMemoryDump(Process process, IProgress<string> output = null, bool includeChildProcesses = false)
         {
-            return CaptureMemoryDump(process.Id, output);
+            return CaptureMemoryDump(process.Id, output, includeChildProcesses);
         }
 
         private static bool CaptureMemoryDump(int pid, IProgress<string> output = null, bool includeChildProcesses = false)

--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.Children.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.Children.cs
@@ -49,6 +49,12 @@ public partial class ProcessHelper
             Console.WriteLine($"Error retrieving child processes: {ex.Message}");
         }
 
+        // Now we will check for children of the children (recursively)
+        foreach (var childPid in childPids.ToArray())
+        {
+            childPids.AddRange(GetChildrenIds(childPid));
+        }
+
         return childPids;
     }
 


### PR DESCRIPTION
## Summary of changes

Fix "dump child processes" not working

## Reason for change

#6401 added the ability to say "dump the child processes too", except we didn't wire up the parameter.
#6520 tried to fix it, but was missing another call.

## Implementation details

Wire up the parameter
