### PR TITLE
Add missing build dependency

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3119,7 +3119,7 @@ stages:
 
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [package_arm64, generate_variables, merge_commit_id]
+  dependsOn: [package_arm64, generate_variables, merge_commit_id, build_samples]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]


### PR DESCRIPTION
## Summary of changes

Adds missing dependency

## Reason for change

Without it, the stage can start before the samples are available

## Implementation details

Add the missing value

## Test coverage

This is the test

## Other details

Broke in https://github.com/DataDog/dd-trace-dotnet/pull/6498, didn't notice before because it _shouldn't_ be done first, unless we're under a lot of CI pressure