### PR TITLE
[Crashtracking] Add more filtering on TypeLoadException

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -586,13 +586,17 @@ internal class CreatedumpCommand : Command
                 "System.InvalidProgramException",
                 "System.MissingFieldException",
                 "System.MissingMemberException",
-                "System.BadImageFormatException",
-                "System.TypeLoadException"
+                "System.BadImageFormatException"
             };
 
             if (exceptionType.StartsWith("Datadog", StringComparison.OrdinalIgnoreCase) || suspiciousExceptionTypes.Contains(exceptionType))
             {
                 isSuspicious = true;
+            }
+            else if (exceptionType == "System.TypeLoadException")
+            {
+                isSuspicious = exception.Message?.Contains("datadog", StringComparison.OrdinalIgnoreCase) == true
+                    || exception.StackTrace.Any(f => f.Method != null && IsMethodSuspicious(f.Method));
             }
         }
 


### PR DESCRIPTION
## Summary of changes

Flag TypeLoadException as suspicious only if it contains "datadog" in the message or the stacktrace.

## Reason for change

There are too many false-positives caused by TypeLoadException. This is an exception that is relatively common in non-instrumented apps.
