### PR TITLE
Disable profiling in smoke tests

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -151,7 +151,9 @@ steps:
       do
         echo "$line"  # Output the log line to stdout in real-time
         LOGS+="$line"$'\n'  # Capture each line into LOGS variable
-      done < <(${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
+        # Profiling is disabled using DD_PROFILING_ENABLED=0 because there is a flaky freeze we are working around
+        # Once we figure out the freeze, we can re-enable
+      done < <(${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e DD_PROFILING_ENABLED=0 -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
 
       # check logs for evidence of crash detection in the output
       expected="The crash may have been caused by automatic instrumentation"

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2255,10 +2255,12 @@ partial class Build
            {
                // Profiler is not yet supported on Arm64
                knownPatterns.Add(new(@".*Profiler is deactivated because it runs on an unsupported architecture", RegexOptions.Compiled));
-               knownPatterns.Add(new(@".*Error getting IClassFactory from: .*/Datadog\.Profiler\.Native\.so", RegexOptions.Compiled));
-               knownPatterns.Add(new(@".*DynamicDispatcherImpl::LoadClassFactory: Error trying to load continuous profiler class factory.*", RegexOptions.Compiled));
-               knownPatterns.Add(new(@".*Error loading all cor profiler class factories\.", RegexOptions.Compiled));
            }
+
+           // We disable the profiler in crash tests, so we expect these logs
+           knownPatterns.Add(new(@".*Error getting IClassFactory from: .*/Datadog\.Profiler\.Native\.so", RegexOptions.Compiled));
+           knownPatterns.Add(new(@".*DynamicDispatcherImpl::LoadClassFactory: Error trying to load continuous profiler class factory.*", RegexOptions.Compiled));
+           knownPatterns.Add(new(@".*Error loading all cor profiler class factories\.", RegexOptions.Compiled));
 
            // profiler occasionally throws this if shutting down
            knownPatterns.Add(new(@".*LinuxStackFramesCollector::CollectStackSampleImplementation: Unable to send signal .*Error code: No such process", RegexOptions.Compiled));


### PR DESCRIPTION
## Summary of changes

Disables profiling in the crash smoke tests

## Reason for change

There's a freeze we sometimes hit in the smoke tests. It was similar to an issue we saw in some integration tests. Disabling the profiler in those tests (in https://github.com/DataDog/dd-trace-dotnet/pull/6497) resolved the issue, so we think it will resolve it here. We'll investigate the freeze separately, this is just trying to reduce flake.

## Implementation details

Explicitly set `DD_PROFILING_ENABLED=0`

## Test coverage

This is the test
