### PR TITLE
Don't log a warning for CORPROF_E_PROFILER_CANCEL_ACTIVATION

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
@@ -29,11 +29,8 @@ HRESULT STDMETHODCALLTYPE CorProfilerClassFactory::QueryInterface(REFIID riid, v
         this->AddRef();
 
         // We try to load the class factory of all target cor profilers.
-        if (FAILED(m_dispatcher->LoadClassFactory(riid)))
-        {
-            Log::Warn("Error loading all cor profiler class factories.");
-        }
-
+        // Errors are already logged in the dispatcher.
+        m_dispatcher->LoadClassFactory(riid);
         return S_OK;
     }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -164,8 +164,15 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_continuousProfilerInstance->LoadClassFactory(riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load continuous profiler class factory in: ",
-                     m_continuousProfilerInstance->GetFilePath());
+                if (result == CORPROF_E_PROFILER_CANCEL_ACTIVATION)
+                {
+                    Log::Info("The continuous profiler is disabled");
+                }
+                else
+                {
+                    Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load continuous profiler class factory in: ",
+                        m_continuousProfilerInstance->GetFilePath());
+                }
 
                 // If we cannot load the class factory we release the instance.
                 m_continuousProfilerInstance.release();
@@ -178,7 +185,14 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_tracerInstance->LoadClassFactory(riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ", m_tracerInstance->GetFilePath());
+                if (result == CORPROF_E_PROFILER_CANCEL_ACTIVATION)
+                {
+                    Log::Info("The tracer is disabled");
+                }
+                else
+                {
+                    Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ", m_tracerInstance->GetFilePath());
+                }
 
                 // If we cannot load the class factory we release the instance.
                 m_tracerInstance.release();
@@ -211,7 +225,7 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_continuousProfilerInstance->LoadInstance(pUnkOuter, riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
+                    Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
                      m_continuousProfilerInstance->GetFilePath());
 
                 // If we cannot load the class factory we release the instance.

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
@@ -58,7 +58,14 @@ namespace datadog::shared::nativeloader
         }
         else
         {
-            Log::Warn("DynamicInstanceImpl::LoadClassFactory: Error getting IClassFactory from: ", m_mainLibrary.GetFilePath());
+            if (res == CORPROF_E_PROFILER_CANCEL_ACTIVATION)
+            {
+                Log::Info("DynamicInstanceImpl::LoadClassFactory: The IClassFactory from ", m_mainLibrary.GetFilePath(), " is disabled");
+            }
+            else
+            {
+                Log::Warn("DynamicInstanceImpl::LoadClassFactory: Error getting IClassFactory from: ", m_mainLibrary.GetFilePath());
+            }
         }
 
         Log::Debug("DynamicInstanceImpl::LoadClassFactory: ", res);


### PR DESCRIPTION
## Summary of changes

Don't log a warning if the classfactory of the tracer or the profiler returns CORPROF_E_PROFILER_CANCEL_ACTIVATION.

## Reason for change

The tracer and the profiler return this error code when explicitly disabled (either by an `DD_{0}_ENABLED` setting, or by process exclusion). This is expected and therefore should be logged as info rather than warning.

## Implementation details

Just check the HResult. As a bonus, removed a superfluous log.

## Test coverage

Tested on my machine.