### PR TITLE
[Debugger] Don't redact config/address tokens

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -81,7 +81,6 @@ namespace Datadog.Trace.Debugger.Snapshots
         {
             "2fa",
             "accesstoken",
-            "address",
             "aiohttpsession",
             "apikey",
             "appkey",
@@ -96,7 +95,6 @@ namespace Datadog.Trace.Debugger.Snapshots
             "cipher",
             "clientid",
             "clientsecret",
-            "config",
             "connectionstring",
             "connectsid",
             "cookie",


### PR DESCRIPTION
## Summary of changes

Stop redacting `config` and `address` tokens when collecting probe snapshots in Dynamic Instrumentation.

## Reason for change

Align with the other tracing languages.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
