### PR TITLE
[Debugger] Don't redact env tokens from probe snapshots

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -109,7 +109,6 @@ namespace Datadog.Trace.Debugger.Snapshots
             "dburl",
             "encryptionkey",
             "encryptionkeyid",
-            "env",
             "geolocation",
             "gpgkey",
             "ipaddress",


### PR DESCRIPTION
## Summary of changes

Remove `env` from list of tokens to redact from Dynamic Instrumentation probe snapshots.

Depends on: https://github.com/DataDog/system-tests/pull/3827

## Reason for change

Feature parity

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
