### PR TITLE
[IAST] Fix flaky Interpolated Strings tests

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/ITaintedObject.cs
+++ b/tracer/src/Datadog.Trace/Iast/ITaintedObject.cs
@@ -17,4 +17,6 @@ internal interface ITaintedObject
     public ITaintedObject? Next { get; set; }
 
     public int PositiveHashCode { get; }
+
+    public void Invalidate();
 }

--- a/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
+++ b/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
@@ -105,6 +105,7 @@ internal static class DefaultInterpolatedStringHandlerModuleImpl
             var range = new Range(0, result.Length, taintedSelf.Ranges[0].Source, taintedSelf.Ranges[0].SecureMarks);
             taintedObjects.Taint(result, [range]);
             _taintedRefStructs.Dequeue();
+            taintedSelf.Invalidate();
         }
         catch (Exception err)
         {

--- a/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
+++ b/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
@@ -55,14 +55,14 @@ internal static class DefaultInterpolatedStringHandlerModuleImpl
             var rangesResult = new[] { new Range(0, 0, tainted!.Ranges[0].Source, tainted.Ranges[0].SecureMarks) };
             if (!targetIsTainted)
             {
-                object targetObj = target;
-                _taintedRefStructs.Push(targetObj);
-
                 // Safe guard to avoid memory leak
                 while (_taintedRefStructs.Count > 20)
                 {
                     _taintedRefStructs.Pop();
                 }
+
+                object targetObj = target;
+                _taintedRefStructs.Push(targetObj);
 
                 taintedObjects.Taint(targetObj, rangesResult);
             }

--- a/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
+++ b/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Iast.Propagation;
 internal static class DefaultInterpolatedStringHandlerModuleImpl
 {
     [ThreadStatic]
-    private static Stack<object> _taintedRefStructs = new(5);  // Keep alive the tainted ref structs
+    private static readonly Stack<object> _taintedRefStructs = new(8);  // Keep alive the tainted ref structs (very unlikely to have more than 8 nested)
 
     public static unsafe void Append(IntPtr target, string? value)
     {
@@ -56,9 +56,9 @@ internal static class DefaultInterpolatedStringHandlerModuleImpl
             if (!targetIsTainted)
             {
                 // Safe guard to avoid memory leak
-                while (_taintedRefStructs.Count > 20)
+                if (_taintedRefStructs.Count > 16)
                 {
-                    _taintedRefStructs.Pop();
+                    _taintedRefStructs.Clear();
                 }
 
                 object targetObj = target;

--- a/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
+++ b/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
@@ -9,17 +9,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
-using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices;
 
 namespace Datadog.Trace.Iast.Propagation;
 
 internal static class DefaultInterpolatedStringHandlerModuleImpl
 {
+    private const int MaxStackSize = 4;
+
     [ThreadStatic]
-    private static readonly Stack<object> _taintedRefStructs = new(8);  // Keep alive the tainted ref structs (very unlikely to have more than 8 nested)
+    private static readonly Stack<object> _taintedRefStructs = new(MaxStackSize);  // Keep alive the tainted ref structs
 
     public static unsafe void Append(IntPtr target, string? value)
     {
@@ -56,7 +54,7 @@ internal static class DefaultInterpolatedStringHandlerModuleImpl
             if (!targetIsTainted)
             {
                 // Safe guard to avoid memory leak
-                if (_taintedRefStructs.Count > 16)
+                if (_taintedRefStructs.Count >= MaxStackSize)
                 {
                     _taintedRefStructs.Clear();
                 }

--- a/tracer/src/Datadog.Trace/Iast/TaintedObject.cs
+++ b/tracer/src/Datadog.Trace/Iast/TaintedObject.cs
@@ -29,4 +29,9 @@ internal class TaintedObject : ITaintedObject
     public Range[] Ranges { get; set; }
 
     public ITaintedObject? Next { get; set; }
+
+    public void Invalidate()
+    {
+        _weak.Target = null;
+    }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/DefaultTaintedMapTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/DefaultTaintedMapTests.cs
@@ -235,7 +235,7 @@ public class DefaultTaintedMapTests
 
         foreach (var item in disposedObjects)
         {
-            (map.Get(item) as TaintedForTest).SetAlive(false);
+            (map.Get(item) as TaintedForTest).Invalidate();
         }
 
         map.Purge();
@@ -263,7 +263,7 @@ public class DefaultTaintedMapTests
         var tainted = new TaintedForTest(testString, null);
         map.Put(tainted);
         map.Get(testString).Should().NotBeNull();
-        (map.Get(testString) as TaintedForTest).SetAlive(false);
+        (map.Get(testString) as TaintedForTest).Invalidate();
         map.Purge();
         map.Get(testString).Should().BeNull();
     }
@@ -279,7 +279,7 @@ public class DefaultTaintedMapTests
             testString.Hash = 1;
             var tainted = new TaintedForTest(testString, null);
             map.Put(tainted);
-            tainted.SetAlive(false);
+            tainted.Invalidate();
             map.Get(testString).Should().NotBeNull();
         }
 
@@ -313,7 +313,7 @@ public class DefaultTaintedMapTests
             addedObjects.Add(testString);
         }
 
-        (map.Get(addedObjects[disposedIndex]) as TaintedForTest).SetAlive(false);
+        (map.Get(addedObjects[disposedIndex]) as TaintedForTest).Invalidate();
         map.Purge();
 
         for (int i = 0; i < totalObjects; i++)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/TaintedForTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/TaintedForTest.cs
@@ -15,7 +15,7 @@ public class TaintedForTest : ITaintedObject
 {
     private bool _alive = true;
     private Range[] _ranges;
-    private object _value;
+    private object? _value;
 
     internal TaintedForTest(object value, Range[] ranges)
     {
@@ -28,13 +28,18 @@ public class TaintedForTest : ITaintedObject
 
     ITaintedObject? ITaintedObject.Next { get; set; }
 
-    public object Value => _value;
+    public object? Value => _value;
 
     public int PositiveHashCode { get; set; }
 
     public void SetAlive(bool isAlive)
     {
         _alive = isAlive;
+    }
+
+    public void Invalidate()
+    {
+        _alive = false;
     }
 
     internal Range[]? GetRanges()

--- a/tracer/test/snapshots/Iast.SqliInterpolatedString.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqliInterpolatedString.AspNetCore5.IastEnabled.verified.txt
@@ -38,7 +38,7 @@
             "value": "INSERT INTO Orders (CustomerId, EmployeeId, OrderDate, RequiredDate, ShipVia, Freight, ShipName, ShipAddress, ShipCity, ShipPostalCode, ShipCountry) VALUES ('VINET','5','2021-01-01','2021-01-01',"
           },
           {
-            "value": "'3','32,38','Vins et alcools Chevalier','John',",
+            "value": "'3','32','Vins et alcools Chevalier','John',",
             "source": 0
           },
           {

--- a/tracer/test/snapshots/Iast.SqliInterpolatedString.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqliInterpolatedString.AspNetCore5.IastEnabled.verified.txt
@@ -38,15 +38,11 @@
             "value": "INSERT INTO Orders (CustomerId, EmployeeId, OrderDate, RequiredDate, ShipVia, Freight, ShipName, ShipAddress, ShipCity, ShipPostalCode, ShipCountry) VALUES ('VINET','5','2021-01-01','2021-01-01',"
           },
           {
-            "value": "'3','32.38','Vins et alcools Chevalier','John',",
+            "value": "'3','32,38','Vins et alcools Chevalier','John',",
             "source": 0
           },
           {
-            "value": "'Reims','51100','France')",
-            "source": 0
-          },
-          {
-            "value": ";\nSELECT OrderID FROM Orders ORDER BY OrderID DESC LIMIT 1;"
+            "value": "'Reims','51100','France');\nSELECT OrderID FROM Orders ORDER BY OrderID DESC LIMIT 1;"
           }
         ]
       }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/DefaultInterpolatedStringHandlerTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/DefaultInterpolatedStringHandlerTests.cs
@@ -14,17 +14,12 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
 
     public DefaultInterpolatedStringHandlerTests()
     {
-    }
-
-    public void TestInit()
-    {
         AddTainted(TaintedValue);
     }
 
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted1_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(TaintedValue);
 
@@ -36,7 +31,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted1_GetString_NonVulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(UntaintedValue);
 
@@ -48,7 +42,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted2_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(TaintedValue, 0, string.Empty);
 
@@ -60,7 +53,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted2_GetString_NonVulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(UntaintedValue, 0, string.Empty);
 
@@ -72,7 +64,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted3_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, 0, string.Empty);
 
@@ -84,7 +75,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted3_GetString_NonVulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, 0, string.Empty);
 
@@ -96,7 +86,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted4_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue);
 
@@ -108,7 +97,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted4_GetString_NonVulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue);
 
@@ -120,7 +108,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted5_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, 0);
 
@@ -132,7 +119,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted5_GetString_NonVulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, 0);
 
@@ -144,7 +130,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted6_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, string.Empty);
 
@@ -156,7 +141,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted6_GetString_NonVulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, string.Empty);
 
@@ -168,7 +152,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted7_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, 0, string.Empty);
 
@@ -180,7 +163,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted7_GetString_NonVulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, 0, string.Empty);
 
@@ -192,7 +174,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueMultipleValues_GetString_Vulnerable()
     {
-        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendLiteral(UntaintedValue);
         test.AppendFormatted(new ReadOnlySpan<char>([' ', 'w', 'o', 'r', 'l', 'd', ' ']));
@@ -203,9 +184,23 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     }
 
     [Fact]
+    public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValuesAndGCCollects_GetString_Vulnerable()
+    {
+        var test = new DefaultInterpolatedStringHandler();
+        test.AppendLiteral(UntaintedValue);
+        test.AppendFormatted(new ReadOnlySpan<char>([' ', 'w', 'o', 'r', 'l', 'd', ' ']));
+        test.AppendFormatted(TaintedValue);
+        test.AppendFormatted(42);
+
+        GC.Collect();
+
+        AssertTainted(test.ToStringAndClear());
+    }
+
+
+    [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingTaintedValue_GetString_Vulnerable()
     {
-        TestInit();
         var number = 5;
         var str = $"Hello {TaintedValue} {number}";
         str.Should().Be("Hello " + TaintedValue + " " + number);
@@ -215,7 +210,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingUntaintedValue_GetString_NonVulnerable()
     {
-        TestInit();
         var number = 5;
         var str = $"Hello {UntaintedValue} {number}";
         str.Should().Be("Hello " + UntaintedValue + " " + number);
@@ -225,7 +219,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingTaintedValueAsObject_GetString_Vulnerable()
     {
-        TestInit();
         var number = 5;
         var str = $"Hello {(object)TaintedValue} {number}";
         str.Should().Be("Hello " + TaintedValue + " " + number);
@@ -235,7 +228,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingMultipleValuesWithTaintedValues_GetString_Vulnerable()
     {
-        TestInit();
         var order = new
         {
             CustomerId = "VINET",
@@ -266,7 +258,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenImplicitInterpolatedString_WhenAddingTaintedValuesNested_GetString_Vulnerable()
     {
-        TestInit();
         const int number = 42;
         var date = new DateTime(2024, 11, 22, 15, 30, 0);
         const decimal decimalValue = 123;
@@ -286,7 +277,6 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenImplicitInterpolatedString_WhenAddingTaintedValuesComplex_GetString_Vulnerable()
     {
-        TestInit();
         var interpolatedString = $"""
                                   Hello "{TaintedValue}" and "{UntaintedValue}"..
                                   """;

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/DefaultInterpolatedStringHandlerTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/DefaultInterpolatedStringHandlerTests.cs
@@ -14,12 +14,17 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
 
     public DefaultInterpolatedStringHandlerTests()
     {
+    }
+
+    public void TestInit()
+    {
         AddTainted(TaintedValue);
     }
 
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted1_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(TaintedValue);
 
@@ -31,6 +36,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted1_GetString_NonVulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(UntaintedValue);
 
@@ -42,6 +48,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted2_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(TaintedValue, 0, string.Empty);
 
@@ -53,6 +60,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted2_GetString_NonVulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted(UntaintedValue, 0, string.Empty);
 
@@ -64,6 +72,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted3_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, 0, string.Empty);
 
@@ -75,6 +84,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted3_GetString_NonVulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, 0, string.Empty);
 
@@ -86,6 +96,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted4_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue);
 
@@ -97,6 +108,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted4_GetString_NonVulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue);
 
@@ -108,6 +120,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted5_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, 0);
 
@@ -119,6 +132,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted5_GetString_NonVulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, 0);
 
@@ -130,6 +144,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted6_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, string.Empty);
 
@@ -141,6 +156,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted6_GetString_NonVulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, string.Empty);
 
@@ -152,6 +168,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted7_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)TaintedValue, 0, string.Empty);
 
@@ -163,6 +180,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted7_GetString_NonVulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendFormatted((object)UntaintedValue, 0, string.Empty);
 
@@ -174,6 +192,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
     [Fact]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueMultipleValues_GetString_Vulnerable()
     {
+        TestInit();
         var test = new DefaultInterpolatedStringHandler();
         test.AppendLiteral(UntaintedValue);
         test.AppendFormatted(new ReadOnlySpan<char>([' ', 'w', 'o', 'r', 'l', 'd', ' ']));
@@ -183,36 +202,40 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(test.ToStringAndClear());
     }
 
-    [Fact (Skip = "Flaky test")]
+    [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingTaintedValue_GetString_Vulnerable()
     {
+        TestInit();
         var number = 5;
         var str = $"Hello {TaintedValue} {number}";
         str.Should().Be("Hello " + TaintedValue + " " + number);
         AssertTainted(str);
     }
 
-    [Fact (Skip = "Flaky test")]
+    [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingUntaintedValue_GetString_NonVulnerable()
     {
+        TestInit();
         var number = 5;
         var str = $"Hello {UntaintedValue} {number}";
         str.Should().Be("Hello " + UntaintedValue + " " + number);
         AssertNotTainted(str);
     }
 
-    [Fact (Skip = "Flaky test")]
+    [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingTaintedValueAsObject_GetString_Vulnerable()
     {
+        TestInit();
         var number = 5;
         var str = $"Hello {(object)TaintedValue} {number}";
         str.Should().Be("Hello " + TaintedValue + " " + number);
         AssertTainted(str);
     }
 
-    [Fact (Skip = "Flaky test")]
+    [Fact]
     public void GivenAnImplicitInterpolatedString_WhenAddingMultipleValuesWithTaintedValues_GetString_Vulnerable()
     {
+        TestInit();
         var order = new
         {
             CustomerId = "VINET",
@@ -240,9 +263,10 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(sql);
     }
 
-    [Fact (Skip = "Flaky test")]
+    [Fact]
     public void GivenImplicitInterpolatedString_WhenAddingTaintedValuesNested_GetString_Vulnerable()
     {
+        TestInit();
         const int number = 42;
         var date = new DateTime(2024, 11, 22, 15, 30, 0);
         const decimal decimalValue = 123;
@@ -259,9 +283,10 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(finalString);
     }
 
-    [Fact (Skip = "Flaky test")]
+    [Fact]
     public void GivenImplicitInterpolatedString_WhenAddingTaintedValuesComplex_GetString_Vulnerable()
     {
+        TestInit();
         var interpolatedString = $"""
                                   Hello "{TaintedValue}" and "{UntaintedValue}"..
                                   """;

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -1209,7 +1209,7 @@ namespace Samples.Security.AspNetCore5.Controllers
                 OrderDate = new DateTime(2021, 1, 1),
                 RequiredDate = new DateTime(2021, 1, 1),
                 ShipVia = 3,
-                Freight = 32.38M,
+                Freight = 32,
                 ShipName = "Vins et alcools Chevalier",
                 ShipAddress = name,
                 ShipCity = "Reims",
@@ -1222,7 +1222,7 @@ namespace Samples.Security.AspNetCore5.Controllers
                       "ShipCity, ShipPostalCode, ShipCountry" +
                       ") VALUES (" +
                       $"'{order.CustomerId}','{order.EmployeeId}','{order.OrderDate:yyyy-MM-dd}','{order.RequiredDate:yyyy-MM-dd}'," +
-                      $"'{order.ShipVia}','{order.Freight:0.00}','{order.ShipName}','{order.ShipAddress}'," +
+                      $"'{order.ShipVia}','{order.Freight}','{order.ShipName}','{order.ShipAddress}'," +
                       $"'{order.ShipCity}','{order.ShipPostalCode}','{order.ShipCountry}')";
             sql += ";\nSELECT OrderID FROM Orders ORDER BY OrderID DESC LIMIT 1;";
 

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -1222,7 +1222,7 @@ namespace Samples.Security.AspNetCore5.Controllers
                       "ShipCity, ShipPostalCode, ShipCountry" +
                       ") VALUES (" +
                       $"'{order.CustomerId}','{order.EmployeeId}','{order.OrderDate:yyyy-MM-dd}','{order.RequiredDate:yyyy-MM-dd}'," +
-                      $"'{order.ShipVia}','{order.Freight}','{order.ShipName}','{order.ShipAddress}'," +
+                      $"'{order.ShipVia}','{order.Freight:0.00}','{order.ShipName}','{order.ShipAddress}'," +
                       $"'{order.ShipCity}','{order.ShipPostalCode}','{order.ShipCountry}')";
             sql += ";\nSELECT OrderID FROM Orders ORDER BY OrderID DESC LIMIT 1;";
 


### PR DESCRIPTION
## Summary of changes
Fix test flakiness by keeping alive the tainted boxed object during the lifespan of the ref struct

## Reason for change
If a GC collect happened between the tainting of the `DefaultInterpolatedStringHandler` and the call to `ToString` the boxed object was collected and the weak reference was lost, causing the loss of the tainted status.
Thanks to @e-n-0 for finding what was happening

IDK who said flakiness was bad

## Implementation details
Added a thread local queue to hold the boxed object of the tainted ref structs

## Test coverage
Added a unit test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
