### PR TITLE
[Dynamic Instrumentation] DEBUG-3223 SymDB compression fix

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/MimeTypes.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/MimeTypes.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MimeTypes.cs" company="Datadog">
+// <copyright file="MimeTypes.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -11,5 +11,6 @@ namespace Datadog.Trace.Agent.Transports
         public const string Json = "application/json";
         public const string MultipartFormData = "multipart/form-data";
         public const string PlainText = "text/plain";
+        public const string Gzip = "application/gzip";
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Configuration
             public const string SymDbThirdPartyDetectionIncludes = "DD_SYMBOL_DATABASE_THIRD_PARTY_DETECTION_INCLUDES";
 
             /// <summary>
-            /// Configuration key for a separated comma list of libraries to include in the 3rd party detection
+            /// Configuration key for a separated comma list of libraries to exclude in the 3rd party detection
             /// Default value is empty.
             /// </summary>
             public const string SymDbThirdPartyDetectionExcludes = "DD_SYMBOL_DATABASE_THIRD_PARTY_DETECTION_EXCLUDES";

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -124,8 +124,7 @@ namespace Datadog.Trace.Debugger
                                          .AsInt32(DefaultCodeOriginExitSpanFrames, frames => frames > 0)
                                          .Value;
 
-            // Force it to false to disable SymDB compression, will be re-enabled in the next PR
-            SymbolDatabaseCompressionEnabled = false;
+            SymbolDatabaseCompressionEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseCompressionEnabled).AsBool(true);
         }
 
         public bool Enabled { get; }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -90,11 +90,13 @@ namespace Datadog.Trace.Debugger.Upload
 #if NETFRAMEWORK
                 using var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(memoryStream);
                 await gzipStream.WriteAsync(symbols.Array, 0, symbols.Array.Length).ConfigureAwait(false);
+                await gzipStream.FlushAsync().ConfigureAwait(false);
 #else
                 using var gzipStream = new GZipStream(memoryStream, CompressionMode.Compress);
                 await gzipStream.WriteAsync(symbols.Array, 0, symbols.Array.Length).ConfigureAwait(false);
+                await gzipStream.FlushAsync().ConfigureAwait(false);
 #endif
-                symbolsItem = new MultipartFormItem("file", "application/gzip", "file.gz", new ArraySegment<byte>(memoryStream.ToArray()));
+                symbolsItem = new MultipartFormItem("file", MimeTypes.Gzip, "file.gz", new ArraySegment<byte>(memoryStream.ToArray()));
             }
             else
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Tests.Debugger
                 NullConfigurationTelemetry.Instance);
 
             settings.Enabled.Should().BeTrue();
-            settings.SymbolDatabaseCompressionEnabled.Should().BeFalse();
+            settings.SymbolDatabaseCompressionEnabled.Should().BeTrue();
             settings.SymbolDatabaseUploadEnabled.Should().BeTrue();
             settings.MaximumDepthOfMembersToCopy.Should().Be(100);
             settings.MaxSerializationTimeInMilliseconds.Should().Be(1000);


### PR DESCRIPTION
## Summary of changes
This PR fix an error that occur when we send compressed symbols.
Since I use a `using` declaration (which extend the idisposable object scope) I have to call `Flush` manually before I use the underline stream.

Future work will be to do the upload in an efficient way by reducing allocation .