### PR TITLE
Dani/testvis/impacted tests poc rebase

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
-using Datadog.Trace.Agent.StreamFactories;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Ci.CiEnvironment;
 using Datadog.Trace.Ci.Configuration;
@@ -83,6 +82,8 @@ namespace Datadog.Trace.Ci
         internal static IntelligentTestRunnerClient.EarlyFlakeDetectionSettingsResponse EarlyFlakeDetectionSettings { get; private set; }
 
         internal static IntelligentTestRunnerClient.EarlyFlakeDetectionResponse? EarlyFlakeDetectionResponse { get; private set; }
+
+        internal static IntelligentTestRunnerClient.ImpactedTestsDetectionResponse? ImpactedTestsDetectionResponse { get; private set; }
 
         public static void Initialize()
         {
@@ -700,7 +701,10 @@ namespace Datadog.Trace.Ci
 
                 // If any DD_CIVISIBILITY_CODE_COVERAGE_ENABLED or DD_CIVISIBILITY_TESTSSKIPPING_ENABLED has not been set
                 // We query the settings api for those
-                if (settings.CodeCoverageEnabled == null || settings.TestsSkippingEnabled == null || settings.EarlyFlakeDetectionEnabled != false)
+                if (settings.CodeCoverageEnabled == null
+                    || settings.TestsSkippingEnabled == null
+                    || settings.EarlyFlakeDetectionEnabled != false
+                    || settings.ImpactedTestsDetectionEnabled == null)
                 {
                     var itrSettings = await lazyItrClient.Value.GetSettingsAsync().ConfigureAwait(false);
 
@@ -743,6 +747,17 @@ namespace Datadog.Trace.Ci
                         Log.Information("CIVisibility: Flaky Retries has been changed to {Value} by the settings api.", itrSettings.FlakyTestRetries.Value);
                         settings.SetFlakyRetryEnabled(itrSettings.FlakyTestRetries.Value);
                     }
+
+                    if (settings.ImpactedTestsDetectionEnabled == null && itrSettings.ImpactedTestsEnabled.HasValue)
+                    {
+                        Log.Information("CIVisibility: Impacted Tests Detection has been changed to {Value} by the settings api.", itrSettings.ImpactedTestsEnabled.Value);
+                        settings.SetImpactedTestsEnabled(itrSettings.ImpactedTestsEnabled.Value);
+                    }
+
+                    if (settings.ImpactedTestsDetectionEnabled == true)
+                    {
+                        ImpactedTestsDetectionResponse = await lazyItrClient.Value.GetImpactedTestsDetectionFilesAsync().ConfigureAwait(false);
+                    }
                 }
 
                 // Log code coverage status
@@ -753,6 +768,9 @@ namespace Datadog.Trace.Ci
 
                 // Log flaky retries status
                 Log.Information("{V}", settings.FlakyRetryEnabled == true ? "CIVisibility: Flaky retries is enabled." : "CIVisibility: Flaky retries is disabled.");
+
+                // Log impacted tests detection status
+                Log.Information("{V}", settings.ImpactedTestsDetectionEnabled == true ? "CIVisibility: Impacted tests detection is enabled." : "CIVisibility: Impacted tests detection is disabled.");
 
                 // For ITR we need the git metadata upload before consulting the skippable tests.
                 // If ITR is disabled we just need to make sure the git upload task has completed before leaving this method.

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
@@ -26,67 +26,67 @@ internal abstract class CIEnvironmentValues<TValueProvider>(TValueProvider value
 
     internal static CIEnvironmentValues Create(TValueProvider valueProvider)
     {
-        if (valueProvider.GetValue(Constants.Travis) != null)
+        if (valueProvider.GetValue(Constants.Travis) is { Length: > 0 })
         {
             return new TravisEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.CircleCI) != null)
+        if (valueProvider.GetValue(Constants.CircleCI) is { Length: > 0 })
         {
             return new CircleCiEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.JenkinsUrl) != null)
+        if (valueProvider.GetValue(Constants.JenkinsUrl) is { Length: > 0 })
         {
             return new JenkinsEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.GitlabCI) != null)
+        if (valueProvider.GetValue(Constants.GitlabCI) is { Length: > 0 })
         {
             return new GitlabEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.Appveyor) != null)
+        if (valueProvider.GetValue(Constants.Appveyor) is { Length: > 0 })
         {
             return new AppveyorEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.AzureTFBuild) != null)
+        if (valueProvider.GetValue(Constants.AzureTFBuild) is { Length: > 0 })
         {
             return new AzurePipelinesEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.BitBucketCommit) != null)
+        if (valueProvider.GetValue(Constants.BitBucketCommit) is { Length: > 0 })
         {
             return new BitbucketEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.GitHubSha) != null)
+        if (valueProvider.GetValue(Constants.GitHubSha) is { Length: > 0 })
         {
             return new GithubActionsEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.TeamCityVersion) != null)
+        if (valueProvider.GetValue(Constants.TeamCityVersion) is { Length: > 0 })
         {
             return new TeamcityEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.BuildKite) != null)
+        if (valueProvider.GetValue(Constants.BuildKite) is { Length: > 0 })
         {
             return new BuildkiteEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.BitriseBuildSlug) != null)
+        if (valueProvider.GetValue(Constants.BitriseBuildSlug) is { Length: > 0 })
         {
             return new BitriseEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.Buddy) != null)
+        if (valueProvider.GetValue(Constants.Buddy) is { Length: > 0 })
         {
             return new BuddyEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.CodefreshBuildId) != null)
+        if (valueProvider.GetValue(Constants.CodefreshBuildId) is { Length: > 0 })
         {
             return new CodefreshEnvironmentValues<TValueProvider>(valueProvider);
         }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
@@ -26,67 +26,67 @@ internal abstract class CIEnvironmentValues<TValueProvider>(TValueProvider value
 
     internal static CIEnvironmentValues Create(TValueProvider valueProvider)
     {
-        if (valueProvider.GetValue(Constants.Travis) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.Travis)))
         {
             return new TravisEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.CircleCI) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.CircleCI)))
         {
             return new CircleCiEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.JenkinsUrl) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.JenkinsUrl)))
         {
             return new JenkinsEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.GitlabCI) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.GitlabCI)))
         {
             return new GitlabEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.Appveyor) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.Appveyor)))
         {
             return new AppveyorEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.AzureTFBuild) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.AzureTFBuild)))
         {
             return new AzurePipelinesEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.BitBucketCommit) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.BitBucketCommit)))
         {
             return new BitbucketEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.GitHubSha) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.GitHubSha)))
         {
             return new GithubActionsEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.TeamCityVersion) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.TeamCityVersion)))
         {
             return new TeamcityEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.BuildKite) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.BuildKite)))
         {
             return new BuildkiteEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.BitriseBuildSlug) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.BitriseBuildSlug)))
         {
             return new BitriseEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.Buddy) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.Buddy)))
         {
             return new BuddyEnvironmentValues<TValueProvider>(valueProvider);
         }
 
-        if (valueProvider.GetValue(Constants.CodefreshBuildId) is { Length: > 0 })
+        if (!string.IsNullOrEmpty(valueProvider.GetValue(Constants.CodefreshBuildId)))
         {
             return new CodefreshEnvironmentValues<TValueProvider>(valueProvider);
         }

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -8,13 +8,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 
@@ -121,6 +119,9 @@ namespace Datadog.Trace.Ci.Configuration
 
             // Maximum number of retry attempts for the entire session.
             TotalFlakyRetryCount = config.WithKeys(ConfigurationKeys.CIVisibility.TotalFlakyRetryCount).AsInt32(defaultValue: 1_000, validator: val => val >= 1) ?? 1_000;
+
+            // Test Impact Analysis enablement
+            ImpactedTestsDetectionEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.ImpactedTestsDetectionEnabled).AsBool();
         }
 
         /// <summary>
@@ -248,6 +249,8 @@ namespace Datadog.Trace.Ci.Configuration
         /// </summary>
         public int TotalFlakyRetryCount { get; private set; }
 
+        public bool? ImpactedTestsDetectionEnabled { get; private set; }
+
         /// <summary>
         /// Gets the tracer settings
         /// </summary>
@@ -276,6 +279,11 @@ namespace Datadog.Trace.Ci.Configuration
         internal void SetFlakyRetryEnabled(bool value)
         {
             FlakyRetryEnabled = value;
+        }
+
+        internal void SetImpactedTestsEnabled(bool value)
+        {
+            ImpactedTestsDetectionEnabled = value;
         }
 
         internal void SetAgentlessConfiguration(bool enabled, string? apiKey, string? agentlessUrl)

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -88,9 +89,14 @@ internal unsafe ref struct FileBitmap
     }
 
     /// <summary>
-    /// Gets the size of the bitmap.
+    /// Gets the size of the bitmap in Bytes.
     /// </summary>
     public int Size => _size;
+
+    /// <summary>
+    /// Gets the size of the bitmap in bits.
+    /// </summary>
+    public int BitCount => _size * 8;
 
     /// <summary>
     /// Performs a bitwise OR operation on two <see cref="FileBitmap"/> instances.
@@ -117,6 +123,37 @@ internal unsafe ref struct FileBitmap
     /// <returns>The result of the bitwise NOT operation.</returns>
     public static FileBitmap operator ~(FileBitmap fileBitmap)
         => Not(fileBitmap, false);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileBitmap"/> struct with a specified line count.
+    /// </summary>
+    /// <param name="lines">Line count</param>
+    public static FileBitmap FromLineCount(int lines)
+    {
+        return new FileBitmap(new byte[GetSize(lines)]);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileBitmap"/> struct with an specified range set to 1.
+    /// </summary>
+    /// <param name="fromLine">Start of range</param>
+    /// <param name="toLine">End of range</param>
+    public static FileBitmap FromActiveRange(int fromLine, int toLine)
+    {
+        var res = FromLineCount(toLine);
+
+        if (fromLine <= 0 || toLine < fromLine)
+        {
+            throw new ArgumentException("Invalid range");
+        }
+
+        for (var i = fromLine; i <= toLine; i++)
+        {
+            res.Set(i);
+        }
+
+        return res;
+    }
 
     /// <summary>
     /// Performs a bitwise OR operation on two <see cref="FileBitmap"/> instances.
@@ -809,6 +846,26 @@ internal unsafe ref struct FileBitmap
                 return true;
             }
 #endif
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets if two bitmaps have at least one enabled bit in common.
+    /// </summary>
+    /// <returns>True if both bitmaps has at least 1 bit set to 1 in the same position; otherwise, false..</returns>
+    public bool IntersectsWith(ref FileBitmap other)
+    {
+        var size = Math.Min(_size, other._size);
+
+        // Iterate over each byte of the bitmap
+        for (var i = 0; i < size; i++)
+        {
+            if ((_bitmap[i] & other._bitmap[i]) > 0)
+            {
+                return true;
+            }
         }
 
         return false;

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
@@ -134,10 +134,10 @@ internal unsafe ref struct FileBitmap
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="FileBitmap"/> struct with an specified range set to 1.
+    /// Initializes a new instance of the <see cref="FileBitmap"/> struct and sets all lines in the specified range (inclusive) set to 1.
     /// </summary>
-    /// <param name="fromLine">Start of range</param>
-    /// <param name="toLine">End of range</param>
+    /// <param name="fromLine">One-based index of start of range</param>
+    /// <param name="toLine">One-based index of end of range</param>
     public static FileBitmap FromActiveRange(int fromLine, int toLine)
     {
         var res = FromLineCount(toLine);

--- a/tracer/src/Datadog.Trace/Ci/GitCommandHelper.cs
+++ b/tracer/src/Datadog.Trace/Ci/GitCommandHelper.cs
@@ -1,0 +1,191 @@
+// <copyright file="GitCommandHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.Coverage.Models.Global;
+using Datadog.Trace.Ci.Coverage.Util;
+using Datadog.Trace.Ci.Telemetry;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Ci;
+
+internal static class GitCommandHelper
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(GitCommandHelper));
+
+    // Regex patterns for parsing the diff output
+    private static readonly Regex DiffHeaderRegex = new Regex(@"^diff --git a/(?<file>.+) b/(?<file2>.+)$");
+    private static readonly Regex LineChangeRegex = new Regex(@"^@@ -\d+(,\d+)? \+(?<start>\d+)(,(?<count>\d+))? @@");
+    private static char[] lineSeparators = { '\n', '\r' };
+
+    public static async Task<ProcessHelpers.CommandOutput?> RunGitCommandAsync(string? workingDirectory, string arguments, MetricTags.CIVisibilityCommands ciVisibilityCommand, string? input = null)
+    {
+        TelemetryFactory.Metrics.RecordCountCIVisibilityGitCommand(ciVisibilityCommand);
+        try
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var gitOutput = await ProcessHelpers.RunCommandAsync(
+                                new ProcessHelpers.Command(
+                                    "git",
+                                    arguments,
+                                    workingDirectory,
+                                    outputEncoding: Encoding.Default,
+                                    errorEncoding: Encoding.Default,
+                                    inputEncoding: Encoding.Default,
+                                    useWhereIsIfFileNotFound: true),
+                                input).ConfigureAwait(false);
+            TelemetryFactory.Metrics.RecordDistributionCIVisibilityGitCommandMs(ciVisibilityCommand, sw.Elapsed.TotalMilliseconds);
+            if (gitOutput is null)
+            {
+                TelemetryFactory.Metrics.RecordCountCIVisibilityGitCommandErrors(ciVisibilityCommand, MetricTags.CIVisibilityExitCodes.Unknown);
+                Log.Warning("GitCommand: 'git {Arguments}' command is null", arguments);
+            }
+            else if (gitOutput.ExitCode != 0)
+            {
+                TelemetryFactory.Metrics.RecordCountCIVisibilityGitCommandErrors(MetricTags.CIVisibilityCommands.GetRepository, TelemetryHelper.GetTelemetryExitCodeFromExitCode(gitOutput.ExitCode));
+            }
+
+            if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
+            {
+                Log.Debug("Git command : {Command}", $"git {arguments}");
+                Log.Debug("  exit code : {Output}", gitOutput?.ExitCode);
+                Log.Debug("     output : {Output}", gitOutput?.Output ?? "<NULL>");
+                if (gitOutput is not null && gitOutput.Error is { Length: > 0 } err)
+                {
+                    Log.Debug("     error  : {Error}", err);
+                }
+            }
+
+            return gitOutput;
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            Log.Warning(ex, "GitCommand: 'git {Arguments}' threw Win32Exception - git is likely not available", arguments);
+            TelemetryFactory.Metrics.RecordCountCIVisibilityGitCommandErrors(ciVisibilityCommand, MetricTags.CIVisibilityExitCodes.Missing);
+            return null;
+        }
+    }
+
+    public static async Task<FileCoverageInfo[]> GetGitDiffFilesAndLinesAsync(string workingDirectory, string baseCommit, string? headCommit = null)
+    {
+        try
+        {
+            // Retrieve PR list of modified files
+            var arguments = $"diff -U0 --word-diff=porcelain {baseCommit}";
+            if (!string.IsNullOrEmpty(headCommit))
+            {
+                arguments += $" {headCommit}";
+            }
+
+            var output = await RunGitCommandAsync(workingDirectory, arguments, MetricTags.CIVisibilityCommands.Diff).ConfigureAwait(false);
+            if (output is not null && output.ExitCode == 0 && output.Output is { Length: > 0 })
+            {
+                return ParseGitDiff(output.Output).ToArray();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Information(ex, "Error calling git diff");
+            throw;
+        }
+
+        return Array.Empty<FileCoverageInfo>();
+
+        // Parses the Git diff output to extract modified files and their changed lines
+        static List<FileCoverageInfo> ParseGitDiff(string diffOutput)
+        {
+            var fileChanges = new List<FileCoverageInfo>();
+            FileCoverageInfo? currentFile = null;
+            var modifiedLines = new List<Tuple<int, int>>(100);
+
+            // Split the diff output into lines for processing
+            var lines = SplitLines(diffOutput);
+
+            foreach (var line in lines)
+            {
+                // Check for the start of a new file diff
+                var headerMatch = DiffHeaderRegex.Match(line);
+                if (headerMatch.Success)
+                {
+                    // Add the current file to the result and start a new one
+                    if (currentFile != null)
+                    {
+                        currentFile.ExecutedBitmap = ToFileBitmap(modifiedLines);
+                        fileChanges.Add(currentFile);
+                        modifiedLines.Clear();
+                    }
+
+                    currentFile = new FileCoverageInfo(headerMatch.Groups["file"].Value);
+                    Log.Debug("  Processing {File} ...", currentFile.Path);
+
+                    continue;
+                }
+
+                // Check for the line change marker (e.g., @@ -1,2 +3,4 @@)
+                var lineChangeMatch = LineChangeRegex.Match(line);
+                if (lineChangeMatch.Success)
+                {
+                    int startLine = int.Parse(lineChangeMatch.Groups["start"].Value); // Start tracking new lines
+                    int lineCount = 0;
+                    if (lineChangeMatch.Groups["count"].Value is string countTxt && countTxt.Length > 0)
+                    {
+                        lineCount = int.Parse(countTxt); // Start tracking new lines
+                    }
+
+                    modifiedLines.Add(new Tuple<int, int>(startLine, startLine + lineCount));
+                    var range = modifiedLines[modifiedLines.Count - 1];
+                    Log.Debug<int, int>("    {From}..{To} ...", range.Item1, range.Item2);
+                    continue;
+                }
+            }
+
+            // Add the last file to the result (if any)
+            if (currentFile != null)
+            {
+                currentFile.ExecutedBitmap = ToFileBitmap(modifiedLines);
+                fileChanges.Add(currentFile);
+            }
+
+            return fileChanges;
+
+            static byte[]? ToFileBitmap(List<Tuple<int, int>> modifiedLines)
+            {
+                if (modifiedLines.Count == 0)
+                {
+                    return null;
+                }
+
+                var maxCount = modifiedLines[modifiedLines.Count - 1].Item2;
+
+                var bitmap = FileBitmap.FromLineCount(maxCount);
+                foreach (var tuple in modifiedLines)
+                {
+                    for (int i = tuple.Item1; i <= tuple.Item2; i++)
+                    {
+                        bitmap.Set(i);
+                    }
+                }
+
+                return bitmap.GetInternalArrayOrToArrayAndDispose();
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string[] SplitLines(string text, StringSplitOptions options = StringSplitOptions.RemoveEmptyEntries)
+    {
+        return text.Split(lineSeparators, options);
+    }
+}

--- a/tracer/src/Datadog.Trace/Ci/GitCommandHelper.cs
+++ b/tracer/src/Datadog.Trace/Ci/GitCommandHelper.cs
@@ -78,7 +78,7 @@ internal static class GitCommandHelper
         }
         catch (System.ComponentModel.Win32Exception ex)
         {
-            Log.Warning(ex, "ITR: 'git {Arguments}' threw Win32Exception - git is likely not available", arguments);
+            Log.Warning(ex, "TestVis: 'git {Arguments}' threw Win32Exception - git is likely not available", arguments);
             TelemetryFactory.Metrics.RecordCountCIVisibilityGitCommandErrors(ciVisibilityCommand, MetricTags.CIVisibilityExitCodes.Missing);
             return null;
         }
@@ -96,14 +96,14 @@ internal static class GitCommandHelper
             {
                 return ParseGitDiff(output.Output).ToArray();
             }
+
+            throw new Exception("Empty git diff command output");
         }
         catch (Exception ex)
         {
             Log.Information(ex, "Error calling git diff");
             throw;
         }
-
-        return Array.Empty<FileCoverageInfo>();
 
         // Parses the Git diff output to extract modified files and their changed lines
         static List<FileCoverageInfo> ParseGitDiff(string diffOutput)

--- a/tracer/src/Datadog.Trace/Ci/ImpactedTestsModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/ImpactedTestsModule.cs
@@ -1,0 +1,186 @@
+// <copyright file="ImpactedTestsModule.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.CiEnvironment;
+using Datadog.Trace.Ci.Coverage.Models.Global;
+using Datadog.Trace.Ci.Coverage.Util;
+using Datadog.Trace.Ci.Tagging;
+using Datadog.Trace.Ci.Telemetry;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka;
+using Datadog.Trace.Iast;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Pdb;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Ci;
+
+internal static class ImpactedTestsModule
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ImpactedTestsModule));
+
+    private static FileCoverageInfo[]? modifiedFiles = null;
+
+    public static bool IsEnabled => CIVisibility.Settings.ImpactedTestsDetectionEnabled ?? false;
+
+    private static string? CurrentCommit => CIEnvironmentValues.Instance.HeadCommit ?? CIEnvironmentValues.Instance.Commit;
+
+    private static string? BaseCommit => CIEnvironmentValues.Instance.PrBaseCommit ?? GetBaseCommitFromBackend();
+
+    public static void Analyze(Test test)
+    {
+        try
+        {
+            if (IsEnabled)
+            {
+                Log.Debug("Impacted Tests Detection is enabled for {TestName}", test.Name);
+
+                var tags = test.GetTags();
+                bool modified = false;
+                var testFiles = GetTestCoverage(tags);
+                var modifiedFiles = GetModifiedFiles();
+
+                foreach (var testFile in testFiles)
+                {
+                    var modifiedFile = modifiedFiles.FirstOrDefault(x => x.Path == testFile.Path);
+                    if (modifiedFile is not null)
+                    {
+                        Log.Debug("DiffFile found {File} ...", modifiedFile.Path);
+
+                        if (testFile.ExecutedBitmap is null || modifiedFile.ExecutedBitmap is null)
+                        {
+                            Log.Debug("  No line info");
+                            modified = true;
+                            break;
+                        }
+
+                        var testFileBitmap = new FileBitmap(testFile.ExecutedBitmap);
+                        var modifiedFileBitmap = new FileBitmap(modifiedFile.ExecutedBitmap);
+
+                        if (testFileBitmap.IntersectsWith(ref modifiedFileBitmap))
+                        {
+                            Log.Debug("  Intersecting lines. Marking test {TestName} as modified.", test.Name);
+                            modified = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (modified)
+                {
+                    tags.IsModified = "true";
+                    TelemetryFactory.Metrics.RecordCountCIVisibilityImpactedTestsIsModified();
+                }
+            }
+            else
+            {
+                Log.Debug("Impacted Tests Detection is DISABLED for {TestName}", test.Name);
+            }
+        }
+        catch (Exception err)
+        {
+            Log.Error(err, "Error analyzing Impacted Tests for {TestName}", test.Name);
+        }
+    }
+
+    private static FileCoverageInfo[] GetTestCoverage(TestSpanTags tags)
+    {
+        if (tags.SourceFile is null || tags.SourceStart is null || tags.SourceEnd is null)
+        {
+            Log.Warning("No test definition file found for {TestName}", tags.Name);
+            return Array.Empty<FileCoverageInfo>();
+        }
+
+        // Milestone 1 : Return only the test definition file
+        var file = new FileCoverageInfo(tags.SourceFile);
+
+        // Milestone 1.5 : Return the test definition lines
+        var prBase = BaseCommit;
+        if (prBase is not null)
+        {
+            var executedBitmap = FileBitmap.FromActiveRange((int)tags.SourceStart, (int)tags.SourceEnd);
+            file.ExecutedBitmap = executedBitmap.GetInternalArrayOrToArrayAndDispose();
+            Log.Debug<string, int, int>("TestCoverage for {TestFile}: {Start}..{End}", tags.SourceFile, (int)tags.SourceStart, (int)tags.SourceEnd);
+        }
+
+        return [file];
+    }
+
+    private static FileCoverageInfo[] GetModifiedFiles()
+    {
+        if (modifiedFiles is null)
+        {
+            lock (Log)
+            {
+                if (modifiedFiles is null)
+                {
+                    var workspacePath = CIEnvironmentValues.Instance.WorkspacePath ?? string.Empty;
+                    var prBase = BaseCommit;
+                    var commit = CurrentCommit;
+                    if (prBase is { Length: > 0 })
+                    {
+                        Log.Debug("PR detected. Retrieving diff lines from Git CLI for {Path} {BaseCommit}...{CurrentCommit}", workspacePath, prBase, commit);
+                        // Milestone 1.5 : Retrieve diff files and lines from Git Diff CLI
+                        try
+                        {
+                            modifiedFiles = AsyncUtil.RunSync(() => GitCommandHelper.GetGitDiffFilesAndLinesAsync(workspacePath, prBase, commit));
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Debug(ex, "Git command failed.");
+                        }
+                    }
+                    else
+                    {
+                        Log.Debug("No PR detected.");
+                    }
+
+                    if (modifiedFiles is null)
+                    {
+                        // Milestone 1 : Retrieve diff files from Backend
+                        modifiedFiles = GetDiffFilesFromBackend();
+                    }
+                }
+            }
+        }
+
+        return modifiedFiles;
+    }
+
+    private static FileCoverageInfo[] GetDiffFilesFromBackend()
+    {
+        Log.Debug("Retrieving diff files from backend...");
+
+        if (CIVisibility.ImpactedTestsDetectionResponse is { } response && response.Files is { Length: > 0 } files)
+        {
+            var res = new List<FileCoverageInfo>();
+            foreach (var file in files)
+            {
+                res.Add(new FileCoverageInfo(file));
+            }
+
+            return res.ToArray();
+        }
+
+        return Array.Empty<FileCoverageInfo>();
+    }
+
+    private static string? GetBaseCommitFromBackend()
+    {
+        if (CIVisibility.ImpactedTestsDetectionResponse is { } response && response.BaseSha is { Length: > 0 } baseSha)
+        {
+            return baseSha;
+        }
+
+        return null;
+    }
+}

--- a/tracer/src/Datadog.Trace/Ci/ImpactedTestsModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/ImpactedTestsModule.cs
@@ -52,7 +52,9 @@ internal static class ImpactedTestsModule
 
                 foreach (var testFile in testFiles)
                 {
-                    var modifiedFile = modifiedFiles.FirstOrDefault(x => x.Path == testFile.Path);
+                    if (string.IsNullOrEmpty(testFile.Path)) { continue; }
+
+                    var modifiedFile = modifiedFiles.FirstOrDefault(x => testFile.Path!.EndsWith(x.Path!));
                     if (modifiedFile is not null)
                     {
                         Log.Debug("DiffFile found {File} ...", modifiedFile.Path);

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -49,6 +50,7 @@ internal class IntelligentTestRunnerClient
     private const string TestParamsType = "test_params";
     private const string SettingsType = "ci_app_test_service_libraries_settings";
     private const string EarlyFlakeDetectionRequestType = "ci_app_libraries_tests_request";
+    private const string ImpactedTestsDetectionRequestType = "ci_app_tests_diffs_request";
 
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(IntelligentTestRunnerClient));
     private static readonly Regex ShaRegex = new("[0-9a-f]+", RegexOptions.Compiled);
@@ -66,6 +68,7 @@ internal class IntelligentTestRunnerClient
     private readonly Uri _packFileUrl;
     private readonly Uri _skippableTestsUrl;
     private readonly Uri _earlyFlakeDetectionTestsUrl;
+    private readonly Uri _impactedTestsDetectionTestsUrl;
     private readonly EventPlatformProxySupport _eventPlatformProxySupport;
     private readonly string _repositoryUrl;
     private readonly string _branchName;
@@ -94,6 +97,7 @@ internal class IntelligentTestRunnerClient
         const string packFileUrlPath = "api/v2/git/repository/packfile";
         const string skippableTestsUrlPath = "api/v2/ci/tests/skippable";
         const string efdTestsUrlPath = "api/v2/ci/libraries/tests";
+        const string itdTestsUrlPath = "api/v2/ci/tests/diffs";
 
         if (_settings.Agentless)
         {
@@ -106,6 +110,7 @@ internal class IntelligentTestRunnerClient
                 _packFileUrl = new UriBuilder(agentlessUrl) { Path = packFileUrlPath }.Uri;
                 _skippableTestsUrl = new UriBuilder(agentlessUrl) { Path = skippableTestsUrlPath }.Uri;
                 _earlyFlakeDetectionTestsUrl = new UriBuilder(agentlessUrl) { Path = efdTestsUrlPath }.Uri;
+                _impactedTestsDetectionTestsUrl = new UriBuilder(agentlessUrl) { Path = itdTestsUrlPath }.Uri;
             }
             else
             {
@@ -138,6 +143,12 @@ internal class IntelligentTestRunnerClient
                     host: "api." + _settings.Site,
                     port: 443,
                     pathValue: efdTestsUrlPath).Uri;
+
+                _impactedTestsDetectionTestsUrl = new UriBuilder(
+                    scheme: "https",
+                    host: "api." + _settings.Site,
+                    port: 443,
+                    pathValue: itdTestsUrlPath).Uri;
             }
         }
         else
@@ -152,6 +163,7 @@ internal class IntelligentTestRunnerClient
                     _packFileUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v2/{packFileUrlPath}");
                     _skippableTestsUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v2/{skippableTestsUrlPath}");
                     _earlyFlakeDetectionTestsUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v2/{efdTestsUrlPath}");
+                    _impactedTestsDetectionTestsUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v2/{itdTestsUrlPath}");
                     break;
                 case EventPlatformProxySupport.V4:
                     _settingsUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v4/{settingsUrlPath}");
@@ -159,6 +171,7 @@ internal class IntelligentTestRunnerClient
                     _packFileUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v4/{packFileUrlPath}");
                     _skippableTestsUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v4/{skippableTestsUrlPath}");
                     _earlyFlakeDetectionTestsUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v4/{efdTestsUrlPath}");
+                    _impactedTestsDetectionTestsUrl = _apiRequestFactory.GetEndpoint($"evp_proxy/v4/{itdTestsUrlPath}");
                     break;
                 default:
                     throw new NotSupportedException("Event platform proxy not supported by the agent.");
@@ -796,6 +809,114 @@ internal class IntelligentTestRunnerClient
         }
     }
 
+    public async Task<ImpactedTestsDetectionResponse> GetImpactedTestsDetectionFilesAsync()
+    {
+        Log.Debug("ITR: Getting impacted tests detection modified files...");
+        var framework = FrameworkDescription.Instance;
+        var repository = await _getRepositoryUrlTask.ConfigureAwait(false);
+        var branch = await _getBranchNameTask.ConfigureAwait(false);
+        var currentSha = await _getShaTask.ConfigureAwait(false);
+        if (string.IsNullOrEmpty(repository))
+        {
+            Log.Warning("ITR: 'git config --get remote.origin.url' command returned null or empty");
+            return default;
+        }
+
+        if (string.IsNullOrEmpty(currentSha))
+        {
+            Log.Warning("ITR: 'git rev-parse HEAD' command returned null or empty");
+            return default;
+        }
+
+        var query = new DataEnvelope<Data<ImpactedTestsDetectionQuery>>(
+            new Data<ImpactedTestsDetectionQuery>(
+                currentSha,
+                ImpactedTestsDetectionRequestType,
+                new ImpactedTestsDetectionQuery(
+                    _serviceName,
+                    _environment,
+                    repository,
+                    branch,
+                    currentSha)),
+            default);
+        var jsonQuery = JsonConvert.SerializeObject(query, SerializerSettings);
+        var jsonQueryBytes = Encoding.UTF8.GetBytes(jsonQuery);
+        Log.Debug("ITR: Efd.JSON RQ = {Json}", jsonQuery);
+
+        return await WithRetries(InternalGetImpactedTestsDetectionFilesAsync, jsonQueryBytes, MaxRetries).ConfigureAwait(false);
+
+        async Task<ImpactedTestsDetectionResponse> InternalGetImpactedTestsDetectionFilesAsync(byte[] state, bool finalTry)
+        {
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                // We currently always send the request uncompressed
+                TelemetryFactory.Metrics.RecordCountCIVisibilityImpactedTestsDetectionRequest(MetricTags.CIVisibilityRequestCompressed.Uncompressed);
+                var request = _apiRequestFactory.Create(_impactedTestsDetectionTestsUrl);
+                SetRequestHeader(request);
+
+                if (Log.IsEnabled(LogEventLevel.Debug))
+                {
+                    Log.Debug("ITR: Getting Impacted test file diffs: {Url}", _impactedTestsDetectionTestsUrl.ToString());
+                }
+
+                string? responseContent;
+                try
+                {
+                    using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
+                    responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                    if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                    {
+                        TelemetryFactory.Metrics.RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(errorType);
+                    }
+
+                    CheckResponseStatusCode(response, responseContent, finalTry);
+                    try
+                    {
+                        if (response.ContentLength is { } contentLength and > 0)
+                        {
+                            // TODO: Check for compressed responses - currently these are not handled and will throw when we attempt to deserialize
+                            TelemetryFactory.Metrics.RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(MetricTags.CIVisibilityResponseCompressed.Uncompressed, contentLength);
+                        }
+                    }
+                    catch
+                    {
+                        // If calling ContentLength throws we just ignore it
+                    }
+                }
+                catch (Exception ex)
+                {
+                    TelemetryFactory.Metrics.RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(MetricTags.CIVisibilityErrorType.Network);
+                    Log.Error(ex, "ITR: Impacted tests file diffs request failed.");
+                    throw;
+                }
+
+                Log.Debug("ITR: Efd.JSON RS = {Json}", responseContent);
+                if (string.IsNullOrEmpty(responseContent))
+                {
+                    return default;
+                }
+
+                var deserializedResult = JsonConvert.DeserializeObject<DataEnvelope<Data<ImpactedTestsDetectionResponse>?>>(responseContent);
+                var finalResponse = deserializedResult.Data?.Attributes ?? default;
+
+                // Count the number of tests for telemetry
+                var filesCount = 0;
+                if (finalResponse.Files is { Length: > 0 } files)
+                {
+                    filesCount = files.Length;
+                }
+
+                TelemetryFactory.Metrics.RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(filesCount);
+                return finalResponse;
+            }
+            finally
+            {
+                TelemetryFactory.Metrics.RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(sw.Elapsed.TotalMilliseconds);
+            }
+        }
+    }
+
     private async Task<SearchCommitResponse> GetCommitsAsync()
     {
         var gitLogOutput = RunGitCommand("log --format=%H -n 1000 --since=\"1 month ago\"", MetricTags.CIVisibilityCommands.GetLocalCommits);
@@ -1107,7 +1228,7 @@ internal class IntelligentTestRunnerClient
 
                 if (isSocketException)
                 {
-                    Log.Debug(sourceException, "Unable to communicate with the server");
+                    Log.Debug(sourceException, "ITR: Unable to communicate with the server");
                 }
 
                 if (sourceException is RateLimitException { DelayTimeInSeconds: { } delayTimeInSeconds })
@@ -1126,7 +1247,7 @@ internal class IntelligentTestRunnerClient
                 continue;
             }
 
-            Log.Debug("Request was completed successfully.");
+            Log.Debug("ITR: Request was completed successfully.");
             return response;
         }
     }
@@ -1192,16 +1313,6 @@ internal class IntelligentTestRunnerClient
             {
                 TelemetryFactory.Metrics.RecordCountCIVisibilityGitCommandErrors(MetricTags.CIVisibilityCommands.GetRepository, TelemetryHelper.GetTelemetryExitCodeFromExitCode(gitOutput.ExitCode));
             }
-
-            return gitOutput;
-        }
-        catch (System.ComponentModel.Win32Exception ex)
-        {
-            Log.Warning(ex, "ITR: 'git {Arguments}' threw Win32Exception - git is likely not available", arguments);
-            TelemetryFactory.Metrics.RecordCountCIVisibilityGitCommandErrors(ciVisibilityCommand, MetricTags.CIVisibilityExitCodes.Missing);
-            return null;
-        }
-    }
 
     private readonly struct SearchCommitResponse
     {
@@ -1378,6 +1489,9 @@ internal class IntelligentTestRunnerClient
         [JsonProperty("require_git")]
         public readonly bool? RequireGit;
 
+        [JsonProperty("impacted_tests_enabled")]
+        public readonly bool? ImpactedTestsEnabled;
+
         [JsonProperty("flaky_test_retries_enabled")]
         public readonly bool? FlakyTestRetries;
 
@@ -1447,6 +1561,42 @@ internal class IntelligentTestRunnerClient
         public class EfdResponseModules : Dictionary<string, EfdResponseSuites?>
         {
         }
+    }
+
+    public readonly struct ImpactedTestsDetectionQuery
+    {
+        [JsonProperty("service")]
+        public readonly string Service;
+
+        [JsonProperty("env")]
+        public readonly string Environment;
+
+        [JsonProperty("repository_url")]
+        public readonly string RepositoryUrl;
+
+        [JsonProperty("branch")]
+        public readonly string Branch;
+
+        [JsonProperty("sha")]
+        public readonly string Sha;
+
+        public ImpactedTestsDetectionQuery(string service, string environment, string repositoryUrl, string branch, string sha)
+        {
+            Service = service;
+            Environment = environment;
+            RepositoryUrl = repositoryUrl;
+            Branch = branch;
+            Sha = sha;
+        }
+    }
+
+    public readonly struct ImpactedTestsDetectionResponse
+    {
+        [JsonProperty("base_sha")]
+        public readonly string? BaseSha;
+
+        [JsonProperty("files")]
+        public readonly string[]? Files;
     }
 
     private class ObjectPackFilesResult

--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
@@ -113,4 +113,7 @@ internal partial class TestSpanTags : TestSuiteSpanTags
 
     [Tag(BrowserTags.IsRumActive)]
     public string? IsRumActive { get; set; }
+
+    [Tag(BrowserTags.IsModified)]
+    public string? IsModified { get; set; }
 }

--- a/tracer/src/Datadog.Trace/Ci/Tags/BrowserTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/BrowserTags.cs
@@ -35,4 +35,9 @@ internal static class BrowserTags
     /// Is RUM active tag
     /// </summary>
     public const string IsRumActive = "test.is_rum_active";
+
+    /// <summary>
+    /// Test is modified
+    /// </summary>
+    public const string IsModified = "test.is_modified";
 }

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -199,6 +199,8 @@ public sealed class Test
             tags.SourceStart = startLine;
             tags.SourceEnd = methodSymbol.EndLine;
 
+            ImpactedTestsModule.Analyze(this);
+
             if (CIEnvironmentValues.Instance.CodeOwners is { } codeOwners)
             {
                 var match = codeOwners.Match("/" + CIEnvironmentValues.Instance.MakeRelativePathFromSourceRoot(methodSymbol.File, false));

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -612,6 +612,11 @@ namespace Datadog.Trace.Configuration
             /// Configuration key for the maximum number of retry attempts for the entire session.
             /// </summary>
             public const string TotalFlakyRetryCount = "DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT";
+
+            /// <summary>
+            /// Configuration key for enabling Impacted Tests Detection.
+            /// </summary>
+            public const string ImpactedTestsDetectionEnabled = "DD_CIVISIBILITY_IMPACTED_TESTS_DETECTION_ENABLED";
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -50,6 +50,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
         private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
+        // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
+        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -71,6 +73,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.browser.name" => BrowserName,
                 "test.browser.version" => BrowserVersion,
                 "test.is_rum_active" => IsRumActive,
+                "test.is_modified" => IsModified,
                 _ => base.GetTag(key),
             };
         }
@@ -126,6 +129,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.is_rum_active": 
                     IsRumActive = value;
+                    break;
+                case "test.is_modified": 
+                    IsModified = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -213,6 +219,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (IsRumActive is not null)
             {
                 processor.Process(new TagItem<string>("test.is_rum_active", IsRumActive, IsRumActiveBytes));
+            }
+
+            if (IsModified is not null)
+            {
+                processor.Process(new TagItem<string>("test.is_modified", IsModified, IsModifiedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -329,6 +340,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.is_rum_active (tag):")
                   .Append(IsRumActive)
+                  .Append(',');
+            }
+
+            if (IsModified is not null)
+            {
+                sb.Append("test.is_modified (tag):")
+                  .Append(IsModified)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 371;
+    private const int CountCIVisibilityLength = 394;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -231,7 +231,8 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git.command_errors, index = 202
+            new(new[] { "command:diff" }),
+            // git.command_errors, index = 203
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -304,10 +305,18 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:pack_objects", "exit_code:127" }),
             new(new[] { "command:pack_objects", "exit_code:128" }),
             new(new[] { "command:pack_objects", "exit_code:129" }),
-            // git_requests.search_commits, index = 274
+            new(new[] { "command:diff", "exit_code:missing" }),
+            new(new[] { "command:diff", "exit_code:unknown" }),
+            new(new[] { "command:diff", "exit_code:-1" }),
+            new(new[] { "command:diff", "exit_code:1" }),
+            new(new[] { "command:diff", "exit_code:2" }),
+            new(new[] { "command:diff", "exit_code:127" }),
+            new(new[] { "command:diff", "exit_code:128" }),
+            new(new[] { "command:diff", "exit_code:129" }),
+            // git_requests.search_commits, index = 283
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 276
+            // git_requests.search_commits_errors, index = 285
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -319,10 +328,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 287
+            // git_requests.objects_pack, index = 296
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 289
+            // git_requests.objects_pack_errors, index = 298
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -334,10 +343,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 300
+            // git_requests.settings, index = 309
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 302
+            // git_requests.settings_errors, index = 311
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -349,7 +358,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 313
+            // git_requests.settings_response, index = 322
             new(null),
             new(new[] { "coverage_enabled" }),
             new(new[] { "itrskip_enabled" }),
@@ -366,10 +375,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "coverage_enabled", "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
-            // itr_skippable_tests.request, index = 329
+            // itr_skippable_tests.request, index = 338
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 331
+            // itr_skippable_tests.request_errors, index = 340
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -381,33 +390,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 342
+            // itr_skippable_tests.response_tests, index = 351
             new(null),
-            // itr_skippable_tests.response_suites, index = 343
+            // itr_skippable_tests.response_suites, index = 352
             new(null),
-            // itr_skipped, index = 344
+            // itr_skipped, index = 353
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 348
+            // itr_unskippable, index = 357
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 352
+            // itr_forced_run, index = 361
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 356
+            // code_coverage.is_empty, index = 365
             new(null),
-            // code_coverage.errors, index = 357
+            // code_coverage.errors, index = 366
             new(null),
-            // early_flake_detection.request, index = 358
+            // early_flake_detection.request, index = 367
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // early_flake_detection.request_errors, index = 360
+            // early_flake_detection.request_errors, index = 369
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -419,6 +428,23 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.request, index = 380
+            new(null),
+            new(new[] { "rq_compressed:true" }),
+            // impacted_tests_detection.request_errors, index = 382
+            new(new[] { "error_type:timeout" }),
+            new(new[] { "error_type:network" }),
+            new(new[] { "error_type:status_code" }),
+            new(new[] { "error_type:status_code_4xx_response" }),
+            new(new[] { "error_type:status_code_5xx_response" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:400" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:401" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:403" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.is_modified, index = 393
+            new(null),
         };
 
     /// <summary>
@@ -427,7 +453,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 9, 72, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, };
+        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -490,111 +516,128 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 202 + ((int)tag1 * 8) + (int)tag2;
+        var index = 203 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 274 + (int)tag;
+        var index = 283 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 276 + (int)tag;
+        var index = 285 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 287 + (int)tag;
+        var index = 296 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 298 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 300 + (int)tag;
+        var index = 309 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 302 + (int)tag;
+        var index = 311 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
-        var index = 313 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 329 + (int)tag;
+        var index = 338 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 331 + (int)tag;
+        var index = 340 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[342], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[351], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[343], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[352], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 344 + (int)tag;
+        var index = 353 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 348 + (int)tag;
+        var index = 357 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 352 + (int)tag;
+        var index = 361 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[356], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[365], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[357], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[366], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 358 + (int)tag;
+        var index = 367 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 360 + (int)tag;
+        var index = 369 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+        var index = 380 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+        var index = 382 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+        Interlocked.Add(ref _buffer.CountCIVisibility[393], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int DistributionCIVisibilityLength = 31;
+    private const int DistributionCIVisibilityLength = 36;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> values.
@@ -41,30 +41,38 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git_requests.search_commits_ms, index = 17
+            new(new[] { "command:diff" }),
+            // git_requests.search_commits_ms, index = 18
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // git_requests.objects_pack_ms, index = 19
+            // git_requests.objects_pack_ms, index = 20
             new(null),
-            // git_requests.objects_pack_bytes, index = 20
+            // git_requests.objects_pack_bytes, index = 21
             new(null),
-            // git_requests.objects_pack_files, index = 21
+            // git_requests.objects_pack_files, index = 22
             new(null),
-            // git_requests.settings_ms, index = 22
+            // git_requests.settings_ms, index = 23
             new(null),
-            // itr_skippable_tests.request_ms, index = 23
+            // itr_skippable_tests.request_ms, index = 24
             new(null),
-            // itr_skippable_tests.response_bytes, index = 24
-            new(null),
-            new(new[] { "rs_compressed:true" }),
-            // code_coverage.files, index = 26
-            new(null),
-            // early_flake_detection.request_ms, index = 27
-            new(null),
-            // early_flake_detection.response_bytes, index = 28
+            // itr_skippable_tests.response_bytes, index = 25
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // early_flake_detection.response_tests, index = 30
+            // code_coverage.files, index = 27
+            new(null),
+            // early_flake_detection.request_ms, index = 28
+            new(null),
+            // early_flake_detection.response_bytes, index = 29
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // early_flake_detection.response_tests, index = 31
+            new(null),
+            // impacted_tests_detection.request_ms, index = 32
+            new(null),
+            // impacted_tests_detection.response_bytes, index = 33
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // impacted_tests_detection.response_files, index = 35
             new(null),
         };
 
@@ -74,7 +82,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] DistributionCIVisibilityEntryCounts { get; }
-        = new int[]{ 2, 2, 2, 2, 9, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, };
+        = new int[]{ 2, 2, 2, 2, 10, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, };
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
@@ -108,59 +116,75 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 17 + (int)tag;
+        var index = 18 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.DistributionCIVisibility[19].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[24].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 24 + (int)tag;
+        var index = 25 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.DistributionCIVisibility[26].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[28].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 28 + (int)tag;
+        var index = 29 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
-        _buffer.DistributionCIVisibility[30].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[31].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+        _buffer.DistributionCIVisibility[32].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+        var index = 33 + (int)tag;
+        _buffer.DistributionCIVisibility[index].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+        _buffer.DistributionCIVisibility[35].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 29;
+    public const int Length = 32;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -51,6 +51,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "code_coverage.errors",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "early_flake_detection.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "early_flake_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "impacted_tests_detection.request",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "impacted_tests_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             _ => null!,
         };
 
@@ -102,6 +105,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class DistributionCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 19;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -38,6 +38,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "early_flake_detection.request_ms",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "early_flake_detection.response_bytes",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "early_flake_detection.response_tests",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "impacted_tests_detection.request_ms",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "impacted_tests_detection.response_bytes",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "impacted_tests_detection.response_files",
             _ => null!,
         };
 
@@ -76,6 +79,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -66,4 +66,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -40,4 +40,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value);
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -50,6 +50,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
         private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
+        // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
+        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -71,6 +73,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.browser.name" => BrowserName,
                 "test.browser.version" => BrowserVersion,
                 "test.is_rum_active" => IsRumActive,
+                "test.is_modified" => IsModified,
                 _ => base.GetTag(key),
             };
         }
@@ -126,6 +129,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.is_rum_active": 
                     IsRumActive = value;
+                    break;
+                case "test.is_modified": 
+                    IsModified = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -213,6 +219,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (IsRumActive is not null)
             {
                 processor.Process(new TagItem<string>("test.is_rum_active", IsRumActive, IsRumActiveBytes));
+            }
+
+            if (IsModified is not null)
+            {
+                processor.Process(new TagItem<string>("test.is_modified", IsModified, IsModifiedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -329,6 +340,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.is_rum_active (tag):")
                   .Append(IsRumActive)
+                  .Append(',');
+            }
+
+            if (IsModified is not null)
+            {
+                sb.Append("test.is_modified (tag):")
+                  .Append(IsModified)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 371;
+    private const int CountCIVisibilityLength = 394;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -231,7 +231,8 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git.command_errors, index = 202
+            new(new[] { "command:diff" }),
+            // git.command_errors, index = 203
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -304,10 +305,18 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:pack_objects", "exit_code:127" }),
             new(new[] { "command:pack_objects", "exit_code:128" }),
             new(new[] { "command:pack_objects", "exit_code:129" }),
-            // git_requests.search_commits, index = 274
+            new(new[] { "command:diff", "exit_code:missing" }),
+            new(new[] { "command:diff", "exit_code:unknown" }),
+            new(new[] { "command:diff", "exit_code:-1" }),
+            new(new[] { "command:diff", "exit_code:1" }),
+            new(new[] { "command:diff", "exit_code:2" }),
+            new(new[] { "command:diff", "exit_code:127" }),
+            new(new[] { "command:diff", "exit_code:128" }),
+            new(new[] { "command:diff", "exit_code:129" }),
+            // git_requests.search_commits, index = 283
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 276
+            // git_requests.search_commits_errors, index = 285
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -319,10 +328,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 287
+            // git_requests.objects_pack, index = 296
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 289
+            // git_requests.objects_pack_errors, index = 298
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -334,10 +343,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 300
+            // git_requests.settings, index = 309
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 302
+            // git_requests.settings_errors, index = 311
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -349,7 +358,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 313
+            // git_requests.settings_response, index = 322
             new(null),
             new(new[] { "coverage_enabled" }),
             new(new[] { "itrskip_enabled" }),
@@ -366,10 +375,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "coverage_enabled", "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
-            // itr_skippable_tests.request, index = 329
+            // itr_skippable_tests.request, index = 338
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 331
+            // itr_skippable_tests.request_errors, index = 340
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -381,33 +390,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 342
+            // itr_skippable_tests.response_tests, index = 351
             new(null),
-            // itr_skippable_tests.response_suites, index = 343
+            // itr_skippable_tests.response_suites, index = 352
             new(null),
-            // itr_skipped, index = 344
+            // itr_skipped, index = 353
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 348
+            // itr_unskippable, index = 357
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 352
+            // itr_forced_run, index = 361
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 356
+            // code_coverage.is_empty, index = 365
             new(null),
-            // code_coverage.errors, index = 357
+            // code_coverage.errors, index = 366
             new(null),
-            // early_flake_detection.request, index = 358
+            // early_flake_detection.request, index = 367
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // early_flake_detection.request_errors, index = 360
+            // early_flake_detection.request_errors, index = 369
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -419,6 +428,23 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.request, index = 380
+            new(null),
+            new(new[] { "rq_compressed:true" }),
+            // impacted_tests_detection.request_errors, index = 382
+            new(new[] { "error_type:timeout" }),
+            new(new[] { "error_type:network" }),
+            new(new[] { "error_type:status_code" }),
+            new(new[] { "error_type:status_code_4xx_response" }),
+            new(new[] { "error_type:status_code_5xx_response" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:400" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:401" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:403" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.is_modified, index = 393
+            new(null),
         };
 
     /// <summary>
@@ -427,7 +453,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 9, 72, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, };
+        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -490,111 +516,128 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 202 + ((int)tag1 * 8) + (int)tag2;
+        var index = 203 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 274 + (int)tag;
+        var index = 283 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 276 + (int)tag;
+        var index = 285 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 287 + (int)tag;
+        var index = 296 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 298 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 300 + (int)tag;
+        var index = 309 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 302 + (int)tag;
+        var index = 311 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
-        var index = 313 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 329 + (int)tag;
+        var index = 338 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 331 + (int)tag;
+        var index = 340 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[342], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[351], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[343], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[352], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 344 + (int)tag;
+        var index = 353 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 348 + (int)tag;
+        var index = 357 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 352 + (int)tag;
+        var index = 361 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[356], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[365], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[357], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[366], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 358 + (int)tag;
+        var index = 367 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 360 + (int)tag;
+        var index = 369 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+        var index = 380 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+        var index = 382 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+        Interlocked.Add(ref _buffer.CountCIVisibility[393], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int DistributionCIVisibilityLength = 31;
+    private const int DistributionCIVisibilityLength = 36;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> values.
@@ -41,30 +41,38 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git_requests.search_commits_ms, index = 17
+            new(new[] { "command:diff" }),
+            // git_requests.search_commits_ms, index = 18
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // git_requests.objects_pack_ms, index = 19
+            // git_requests.objects_pack_ms, index = 20
             new(null),
-            // git_requests.objects_pack_bytes, index = 20
+            // git_requests.objects_pack_bytes, index = 21
             new(null),
-            // git_requests.objects_pack_files, index = 21
+            // git_requests.objects_pack_files, index = 22
             new(null),
-            // git_requests.settings_ms, index = 22
+            // git_requests.settings_ms, index = 23
             new(null),
-            // itr_skippable_tests.request_ms, index = 23
+            // itr_skippable_tests.request_ms, index = 24
             new(null),
-            // itr_skippable_tests.response_bytes, index = 24
-            new(null),
-            new(new[] { "rs_compressed:true" }),
-            // code_coverage.files, index = 26
-            new(null),
-            // early_flake_detection.request_ms, index = 27
-            new(null),
-            // early_flake_detection.response_bytes, index = 28
+            // itr_skippable_tests.response_bytes, index = 25
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // early_flake_detection.response_tests, index = 30
+            // code_coverage.files, index = 27
+            new(null),
+            // early_flake_detection.request_ms, index = 28
+            new(null),
+            // early_flake_detection.response_bytes, index = 29
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // early_flake_detection.response_tests, index = 31
+            new(null),
+            // impacted_tests_detection.request_ms, index = 32
+            new(null),
+            // impacted_tests_detection.response_bytes, index = 33
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // impacted_tests_detection.response_files, index = 35
             new(null),
         };
 
@@ -74,7 +82,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] DistributionCIVisibilityEntryCounts { get; }
-        = new int[]{ 2, 2, 2, 2, 9, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, };
+        = new int[]{ 2, 2, 2, 2, 10, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, };
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
@@ -108,59 +116,75 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 17 + (int)tag;
+        var index = 18 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.DistributionCIVisibility[19].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[24].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 24 + (int)tag;
+        var index = 25 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.DistributionCIVisibility[26].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[28].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 28 + (int)tag;
+        var index = 29 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
-        _buffer.DistributionCIVisibility[30].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[31].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+        _buffer.DistributionCIVisibility[32].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+        var index = 33 + (int)tag;
+        _buffer.DistributionCIVisibility[index].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+        _buffer.DistributionCIVisibility[35].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 29;
+    public const int Length = 32;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -51,6 +51,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "code_coverage.errors",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "early_flake_detection.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "early_flake_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "impacted_tests_detection.request",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "impacted_tests_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             _ => null!,
         };
 
@@ -102,6 +105,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class DistributionCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 19;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -38,6 +38,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "early_flake_detection.request_ms",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "early_flake_detection.response_bytes",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "early_flake_detection.response_tests",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "impacted_tests_detection.request_ms",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "impacted_tests_detection.response_bytes",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "impacted_tests_detection.response_files",
             _ => null!,
         };
 
@@ -76,6 +79,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -66,4 +66,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -40,4 +40,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value);
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -50,6 +50,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
         private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
+        // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
+        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -71,6 +73,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.browser.name" => BrowserName,
                 "test.browser.version" => BrowserVersion,
                 "test.is_rum_active" => IsRumActive,
+                "test.is_modified" => IsModified,
                 _ => base.GetTag(key),
             };
         }
@@ -126,6 +129,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.is_rum_active": 
                     IsRumActive = value;
+                    break;
+                case "test.is_modified": 
+                    IsModified = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -213,6 +219,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (IsRumActive is not null)
             {
                 processor.Process(new TagItem<string>("test.is_rum_active", IsRumActive, IsRumActiveBytes));
+            }
+
+            if (IsModified is not null)
+            {
+                processor.Process(new TagItem<string>("test.is_modified", IsModified, IsModifiedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -329,6 +340,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.is_rum_active (tag):")
                   .Append(IsRumActive)
+                  .Append(',');
+            }
+
+            if (IsModified is not null)
+            {
+                sb.Append("test.is_modified (tag):")
+                  .Append(IsModified)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 371;
+    private const int CountCIVisibilityLength = 394;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -231,7 +231,8 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git.command_errors, index = 202
+            new(new[] { "command:diff" }),
+            // git.command_errors, index = 203
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -304,10 +305,18 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:pack_objects", "exit_code:127" }),
             new(new[] { "command:pack_objects", "exit_code:128" }),
             new(new[] { "command:pack_objects", "exit_code:129" }),
-            // git_requests.search_commits, index = 274
+            new(new[] { "command:diff", "exit_code:missing" }),
+            new(new[] { "command:diff", "exit_code:unknown" }),
+            new(new[] { "command:diff", "exit_code:-1" }),
+            new(new[] { "command:diff", "exit_code:1" }),
+            new(new[] { "command:diff", "exit_code:2" }),
+            new(new[] { "command:diff", "exit_code:127" }),
+            new(new[] { "command:diff", "exit_code:128" }),
+            new(new[] { "command:diff", "exit_code:129" }),
+            // git_requests.search_commits, index = 283
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 276
+            // git_requests.search_commits_errors, index = 285
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -319,10 +328,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 287
+            // git_requests.objects_pack, index = 296
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 289
+            // git_requests.objects_pack_errors, index = 298
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -334,10 +343,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 300
+            // git_requests.settings, index = 309
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 302
+            // git_requests.settings_errors, index = 311
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -349,7 +358,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 313
+            // git_requests.settings_response, index = 322
             new(null),
             new(new[] { "coverage_enabled" }),
             new(new[] { "itrskip_enabled" }),
@@ -366,10 +375,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "coverage_enabled", "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
-            // itr_skippable_tests.request, index = 329
+            // itr_skippable_tests.request, index = 338
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 331
+            // itr_skippable_tests.request_errors, index = 340
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -381,33 +390,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 342
+            // itr_skippable_tests.response_tests, index = 351
             new(null),
-            // itr_skippable_tests.response_suites, index = 343
+            // itr_skippable_tests.response_suites, index = 352
             new(null),
-            // itr_skipped, index = 344
+            // itr_skipped, index = 353
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 348
+            // itr_unskippable, index = 357
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 352
+            // itr_forced_run, index = 361
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 356
+            // code_coverage.is_empty, index = 365
             new(null),
-            // code_coverage.errors, index = 357
+            // code_coverage.errors, index = 366
             new(null),
-            // early_flake_detection.request, index = 358
+            // early_flake_detection.request, index = 367
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // early_flake_detection.request_errors, index = 360
+            // early_flake_detection.request_errors, index = 369
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -419,6 +428,23 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.request, index = 380
+            new(null),
+            new(new[] { "rq_compressed:true" }),
+            // impacted_tests_detection.request_errors, index = 382
+            new(new[] { "error_type:timeout" }),
+            new(new[] { "error_type:network" }),
+            new(new[] { "error_type:status_code" }),
+            new(new[] { "error_type:status_code_4xx_response" }),
+            new(new[] { "error_type:status_code_5xx_response" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:400" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:401" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:403" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.is_modified, index = 393
+            new(null),
         };
 
     /// <summary>
@@ -427,7 +453,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 9, 72, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, };
+        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -490,111 +516,128 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 202 + ((int)tag1 * 8) + (int)tag2;
+        var index = 203 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 274 + (int)tag;
+        var index = 283 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 276 + (int)tag;
+        var index = 285 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 287 + (int)tag;
+        var index = 296 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 298 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 300 + (int)tag;
+        var index = 309 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 302 + (int)tag;
+        var index = 311 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
-        var index = 313 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 329 + (int)tag;
+        var index = 338 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 331 + (int)tag;
+        var index = 340 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[342], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[351], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[343], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[352], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 344 + (int)tag;
+        var index = 353 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 348 + (int)tag;
+        var index = 357 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 352 + (int)tag;
+        var index = 361 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[356], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[365], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[357], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[366], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 358 + (int)tag;
+        var index = 367 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 360 + (int)tag;
+        var index = 369 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+        var index = 380 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+        var index = 382 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+        Interlocked.Add(ref _buffer.CountCIVisibility[393], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int DistributionCIVisibilityLength = 31;
+    private const int DistributionCIVisibilityLength = 36;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> values.
@@ -41,30 +41,38 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git_requests.search_commits_ms, index = 17
+            new(new[] { "command:diff" }),
+            // git_requests.search_commits_ms, index = 18
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // git_requests.objects_pack_ms, index = 19
+            // git_requests.objects_pack_ms, index = 20
             new(null),
-            // git_requests.objects_pack_bytes, index = 20
+            // git_requests.objects_pack_bytes, index = 21
             new(null),
-            // git_requests.objects_pack_files, index = 21
+            // git_requests.objects_pack_files, index = 22
             new(null),
-            // git_requests.settings_ms, index = 22
+            // git_requests.settings_ms, index = 23
             new(null),
-            // itr_skippable_tests.request_ms, index = 23
+            // itr_skippable_tests.request_ms, index = 24
             new(null),
-            // itr_skippable_tests.response_bytes, index = 24
-            new(null),
-            new(new[] { "rs_compressed:true" }),
-            // code_coverage.files, index = 26
-            new(null),
-            // early_flake_detection.request_ms, index = 27
-            new(null),
-            // early_flake_detection.response_bytes, index = 28
+            // itr_skippable_tests.response_bytes, index = 25
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // early_flake_detection.response_tests, index = 30
+            // code_coverage.files, index = 27
+            new(null),
+            // early_flake_detection.request_ms, index = 28
+            new(null),
+            // early_flake_detection.response_bytes, index = 29
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // early_flake_detection.response_tests, index = 31
+            new(null),
+            // impacted_tests_detection.request_ms, index = 32
+            new(null),
+            // impacted_tests_detection.response_bytes, index = 33
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // impacted_tests_detection.response_files, index = 35
             new(null),
         };
 
@@ -74,7 +82,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] DistributionCIVisibilityEntryCounts { get; }
-        = new int[]{ 2, 2, 2, 2, 9, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, };
+        = new int[]{ 2, 2, 2, 2, 10, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, };
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
@@ -108,59 +116,75 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 17 + (int)tag;
+        var index = 18 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.DistributionCIVisibility[19].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[24].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 24 + (int)tag;
+        var index = 25 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.DistributionCIVisibility[26].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[28].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 28 + (int)tag;
+        var index = 29 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
-        _buffer.DistributionCIVisibility[30].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[31].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+        _buffer.DistributionCIVisibility[32].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+        var index = 33 + (int)tag;
+        _buffer.DistributionCIVisibility[index].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+        _buffer.DistributionCIVisibility[35].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 29;
+    public const int Length = 32;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -51,6 +51,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "code_coverage.errors",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "early_flake_detection.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "early_flake_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "impacted_tests_detection.request",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "impacted_tests_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             _ => null!,
         };
 
@@ -102,6 +105,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class DistributionCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 19;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -38,6 +38,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "early_flake_detection.request_ms",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "early_flake_detection.response_bytes",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "early_flake_detection.response_tests",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "impacted_tests_detection.request_ms",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "impacted_tests_detection.response_bytes",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "impacted_tests_detection.response_files",
             _ => null!,
         };
 
@@ -76,6 +79,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -66,4 +66,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -40,4 +40,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value);
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -50,6 +50,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
         private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
+        // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
+        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -71,6 +73,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.browser.name" => BrowserName,
                 "test.browser.version" => BrowserVersion,
                 "test.is_rum_active" => IsRumActive,
+                "test.is_modified" => IsModified,
                 _ => base.GetTag(key),
             };
         }
@@ -126,6 +129,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.is_rum_active": 
                     IsRumActive = value;
+                    break;
+                case "test.is_modified": 
+                    IsModified = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -213,6 +219,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (IsRumActive is not null)
             {
                 processor.Process(new TagItem<string>("test.is_rum_active", IsRumActive, IsRumActiveBytes));
+            }
+
+            if (IsModified is not null)
+            {
+                processor.Process(new TagItem<string>("test.is_modified", IsModified, IsModifiedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -329,6 +340,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.is_rum_active (tag):")
                   .Append(IsRumActive)
+                  .Append(',');
+            }
+
+            if (IsModified is not null)
+            {
+                sb.Append("test.is_modified (tag):")
+                  .Append(IsModified)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 371;
+    private const int CountCIVisibilityLength = 394;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -231,7 +231,8 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git.command_errors, index = 202
+            new(new[] { "command:diff" }),
+            // git.command_errors, index = 203
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -304,10 +305,18 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:pack_objects", "exit_code:127" }),
             new(new[] { "command:pack_objects", "exit_code:128" }),
             new(new[] { "command:pack_objects", "exit_code:129" }),
-            // git_requests.search_commits, index = 274
+            new(new[] { "command:diff", "exit_code:missing" }),
+            new(new[] { "command:diff", "exit_code:unknown" }),
+            new(new[] { "command:diff", "exit_code:-1" }),
+            new(new[] { "command:diff", "exit_code:1" }),
+            new(new[] { "command:diff", "exit_code:2" }),
+            new(new[] { "command:diff", "exit_code:127" }),
+            new(new[] { "command:diff", "exit_code:128" }),
+            new(new[] { "command:diff", "exit_code:129" }),
+            // git_requests.search_commits, index = 283
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 276
+            // git_requests.search_commits_errors, index = 285
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -319,10 +328,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 287
+            // git_requests.objects_pack, index = 296
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 289
+            // git_requests.objects_pack_errors, index = 298
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -334,10 +343,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 300
+            // git_requests.settings, index = 309
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 302
+            // git_requests.settings_errors, index = 311
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -349,7 +358,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 313
+            // git_requests.settings_response, index = 322
             new(null),
             new(new[] { "coverage_enabled" }),
             new(new[] { "itrskip_enabled" }),
@@ -366,10 +375,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
             new(new[] { "coverage_enabled", "itrskip_enabled", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true" }),
-            // itr_skippable_tests.request, index = 329
+            // itr_skippable_tests.request, index = 338
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 331
+            // itr_skippable_tests.request_errors, index = 340
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -381,33 +390,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 342
+            // itr_skippable_tests.response_tests, index = 351
             new(null),
-            // itr_skippable_tests.response_suites, index = 343
+            // itr_skippable_tests.response_suites, index = 352
             new(null),
-            // itr_skipped, index = 344
+            // itr_skipped, index = 353
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 348
+            // itr_unskippable, index = 357
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 352
+            // itr_forced_run, index = 361
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 356
+            // code_coverage.is_empty, index = 365
             new(null),
-            // code_coverage.errors, index = 357
+            // code_coverage.errors, index = 366
             new(null),
-            // early_flake_detection.request, index = 358
+            // early_flake_detection.request, index = 367
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // early_flake_detection.request_errors, index = 360
+            // early_flake_detection.request_errors, index = 369
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -419,6 +428,23 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.request, index = 380
+            new(null),
+            new(new[] { "rq_compressed:true" }),
+            // impacted_tests_detection.request_errors, index = 382
+            new(new[] { "error_type:timeout" }),
+            new(new[] { "error_type:network" }),
+            new(new[] { "error_type:status_code" }),
+            new(new[] { "error_type:status_code_4xx_response" }),
+            new(new[] { "error_type:status_code_5xx_response" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:400" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:401" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:403" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
+            new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // impacted_tests_detection.is_modified, index = 393
+            new(null),
         };
 
     /// <summary>
@@ -427,7 +453,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 9, 72, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, };
+        = new int[]{ 40, 100, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 16, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -490,111 +516,128 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 202 + ((int)tag1 * 8) + (int)tag2;
+        var index = 203 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 274 + (int)tag;
+        var index = 283 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 276 + (int)tag;
+        var index = 285 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 287 + (int)tag;
+        var index = 296 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 298 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 300 + (int)tag;
+        var index = 309 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 302 + (int)tag;
+        var index = 311 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
-        var index = 313 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 329 + (int)tag;
+        var index = 338 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 331 + (int)tag;
+        var index = 340 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[342], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[351], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[343], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[352], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 344 + (int)tag;
+        var index = 353 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 348 + (int)tag;
+        var index = 357 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 352 + (int)tag;
+        var index = 361 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[356], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[365], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[357], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[366], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 358 + (int)tag;
+        var index = 367 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 360 + (int)tag;
+        var index = 369 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+        var index = 380 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+        var index = 382 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+        Interlocked.Add(ref _buffer.CountCIVisibility[393], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int DistributionCIVisibilityLength = 31;
+    private const int DistributionCIVisibilityLength = 36;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> values.
@@ -41,30 +41,38 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_local_commits" }),
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
-            // git_requests.search_commits_ms, index = 17
+            new(new[] { "command:diff" }),
+            // git_requests.search_commits_ms, index = 18
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // git_requests.objects_pack_ms, index = 19
+            // git_requests.objects_pack_ms, index = 20
             new(null),
-            // git_requests.objects_pack_bytes, index = 20
+            // git_requests.objects_pack_bytes, index = 21
             new(null),
-            // git_requests.objects_pack_files, index = 21
+            // git_requests.objects_pack_files, index = 22
             new(null),
-            // git_requests.settings_ms, index = 22
+            // git_requests.settings_ms, index = 23
             new(null),
-            // itr_skippable_tests.request_ms, index = 23
+            // itr_skippable_tests.request_ms, index = 24
             new(null),
-            // itr_skippable_tests.response_bytes, index = 24
-            new(null),
-            new(new[] { "rs_compressed:true" }),
-            // code_coverage.files, index = 26
-            new(null),
-            // early_flake_detection.request_ms, index = 27
-            new(null),
-            // early_flake_detection.response_bytes, index = 28
+            // itr_skippable_tests.response_bytes, index = 25
             new(null),
             new(new[] { "rs_compressed:true" }),
-            // early_flake_detection.response_tests, index = 30
+            // code_coverage.files, index = 27
+            new(null),
+            // early_flake_detection.request_ms, index = 28
+            new(null),
+            // early_flake_detection.response_bytes, index = 29
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // early_flake_detection.response_tests, index = 31
+            new(null),
+            // impacted_tests_detection.request_ms, index = 32
+            new(null),
+            // impacted_tests_detection.response_bytes, index = 33
+            new(null),
+            new(new[] { "rs_compressed:true" }),
+            // impacted_tests_detection.response_files, index = 35
             new(null),
         };
 
@@ -74,7 +82,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] DistributionCIVisibilityEntryCounts { get; }
-        = new int[]{ 2, 2, 2, 2, 9, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, };
+        = new int[]{ 2, 2, 2, 2, 10, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, };
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
@@ -108,59 +116,75 @@ internal partial class CiVisibilityMetricsTelemetryCollector
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 17 + (int)tag;
+        var index = 18 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.DistributionCIVisibility[19].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.DistributionCIVisibility[20].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.DistributionCIVisibility[21].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.DistributionCIVisibility[22].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[23].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[24].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 24 + (int)tag;
+        var index = 25 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.DistributionCIVisibility[26].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionRequestMs(double value)
     {
-        _buffer.DistributionCIVisibility[27].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[28].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
     {
-        var index = 28 + (int)tag;
+        var index = 29 + (int)tag;
         _buffer.DistributionCIVisibility[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
-        _buffer.DistributionCIVisibility[30].TryEnqueue(value);
+        _buffer.DistributionCIVisibility[31].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+        _buffer.DistributionCIVisibility[32].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+        var index = 33 + (int)tag;
+        _buffer.DistributionCIVisibility[index].TryEnqueue(value);
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+        _buffer.DistributionCIVisibility[35].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 29;
+    public const int Length = 32;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -51,6 +51,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "code_coverage.errors",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "early_flake_detection.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "early_flake_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "impacted_tests_detection.request",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "impacted_tests_detection.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             _ => null!,
         };
 
@@ -102,6 +105,9 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageErrors => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EarlyFlakeDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequest => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsDetectionRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/DistributionCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class DistributionCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 19;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -38,6 +38,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "early_flake_detection.request_ms",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "early_flake_detection.response_bytes",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "early_flake_detection.response_tests",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "impacted_tests_detection.request_ms",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "impacted_tests_detection.response_bytes",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "impacted_tests_detection.response_files",
             _ => null!,
         };
 
@@ -76,6 +79,9 @@ internal static partial class DistributionCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionRequestMs => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseBytes => "civisibility",
             Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.EarlyFlakeDetectionResponseTests => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionRequestMs => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseBytes => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.DistributionCIVisibility.ImpactedTestsDetectionResponseFiles => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -66,4 +66,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -40,4 +40,10 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
 
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value);
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value);
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -127,4 +127,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityEarlyFlakeDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_DistributionCIVisibility.g.cs
@@ -75,4 +75,16 @@ internal partial class NullMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEarlyFlakeDetectionResponseTests(double value)
     {
     }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionRequestMs(double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityResponseCompressed tag, double value)
+    {
+    }
+
+    public void RecordDistributionCIVisibilityImpactedTestsDetectionResponseFiles(double value)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CountCIVisibility.cs" company="Datadog">
+// <copyright file="CountCIVisibility.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -215,4 +215,27 @@ internal enum CountCIVisibility
     /// </summary>
     [TelemetryMetric<MetricTags.CIVisibilityErrorType>
         ("early_flake_detection.request_errors", isCommon: true, NS.CIVisibility)] EarlyFlakeDetectionRequestErrors,
+
+    /// <summary>
+    /// The number of requests sent to the modified files endpoint, regardless of success.
+    /// Tagged with a boolean flag set to true if request body is compressed
+    /// </summary>
+    [TelemetryMetric<MetricTags.CIVisibilityRequestCompressed>
+        ("impacted_tests_detection.request", isCommon: true, NS.CIVisibility)] ImpactedTestsDetectionRequest,
+
+    /// <summary>
+    /// The number of known modified files requests sent to the endpoint that errored, tagget by the error type
+    /// (e.g. `error_type:timeout`, `error_type:network`, `error_type:status_code_4xx_response`, `error_type:status_code_5xx_response`)
+    /// and status code (400,401,403,404,408,429)
+    /// </summary>
+    [TelemetryMetric<MetricTags.CIVisibilityErrorType>
+        ("impacted_tests_detection.request_errors", isCommon: true, NS.CIVisibility)] ImpactedTestsDetectionRequestErrors,
+
+    /// <summary>
+    /// The number of tests marked as Modified by Impacted Tests Detection
+    /// </summary>
+    /// <summary>
+    /// Counts the number of tainted objects after a request
+    /// </summary>
+    [TelemetryMetric("impacted_tests_detection.is_modified", isCommon: true, NS.CIVisibility)] ImpactedTestsIsModified,
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
@@ -234,8 +234,5 @@ internal enum CountCIVisibility
     /// <summary>
     /// The number of tests marked as Modified by Impacted Tests Detection
     /// </summary>
-    /// <summary>
-    /// Counts the number of tainted objects after a request
-    /// </summary>
     [TelemetryMetric("impacted_tests_detection.is_modified", isCommon: true, NS.CIVisibility)] ImpactedTestsIsModified,
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/DistributionCIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/DistributionCIVisibility.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DistributionCIVisibility.cs" company="Datadog">
+// <copyright file="DistributionCIVisibility.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -99,7 +99,23 @@ internal enum DistributionCIVisibility
         ("early_flake_detection.response_bytes", isCommon: true, NS.CIVisibility)] EarlyFlakeDetectionResponseBytes,
 
     /// <summary>
-    /// The number of bytes received by the endpoint by CI Visibility
+    /// The number of tests received by the endpoint by CI Visibility
     /// </summary>
     [TelemetryMetric("early_flake_detection.response_tests", isCommon: true, NS.CIVisibility)] EarlyFlakeDetectionResponseTests,
+
+    /// <summary>
+    /// The time it takes to get the response of the early flake detection endpoint request in ms by CI Visibility
+    /// </summary>
+    [TelemetryMetric("impacted_tests_detection.request_ms", isCommon: true, NS.CIVisibility)] ImpactedTestsDetectionRequestMs,
+
+    /// <summary>
+    /// The number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed
+    /// </summary>
+    [TelemetryMetric<MetricTags.CIVisibilityResponseCompressed>
+        ("impacted_tests_detection.response_bytes", isCommon: true, NS.CIVisibility)] ImpactedTestsDetectionResponseBytes,
+
+    /// <summary>
+    /// The number of modified files received by the endpoint by CI Visibility
+    /// </summary>
+    [TelemetryMetric("impacted_tests_detection.response_files", isCommon: true, NS.CIVisibility)] ImpactedTestsDetectionResponseFiles,
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -464,6 +464,7 @@ internal static class MetricTags
         [Description("command:get_local_commits")] GetLocalCommits,
         [Description("command:get_objects")] GetObjects,
         [Description("command:pack_objects")] PackObjects,
+        [Description("command:diff")] Diff,
     }
 
     public enum CIVisibilityExitCodes

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Coverage/FileBitmapTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Coverage/FileBitmapTests.cs
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.Ci.Coverage.Util;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Coverage;
@@ -188,5 +190,46 @@ public class FileBitmapTests
 
         // Assert that we have iterated over the correct number of bits
         Assert.Equal(expectedBitStates.Length, index);
+    }
+
+    [Theory]
+    [InlineData(0, 10, true)]
+    [InlineData(15, 10, true)]
+    [InlineData(1, 10, false)]
+    [InlineData(5, 15, false)]
+    [InlineData(5, 5, false)]
+    public void GivenARange_WhenCreatingFileBitmap_ProperBitsAreSet(int from, int to, bool shouldThrow)
+    {
+        if (shouldThrow)
+        {
+            Assert.Throws<ArgumentException>(() => _ = FileBitmap.FromActiveRange(from, to));
+        }
+        else
+        {
+            using var bitmap = FileBitmap.FromActiveRange(from, to);
+
+            bitmap.BitCount.Should().BeGreaterThanOrEqualTo(to);
+
+            for (int x = 1; x <= bitmap.BitCount; x++)
+            {
+                var bit = bitmap.Get(x);
+                bit.Should().Be(x >= from && x <= to);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(1, 10, 11, 15, false)]
+    [InlineData(11, 15, 1, 10, false)]
+    [InlineData(1, 10, 8, 15, true)]
+    [InlineData(8, 15, 10, 15, true)]
+    [InlineData(8, 15, 15, 16, true)]
+    [InlineData(30, 36, 35, 35, true)]
+    public void GivenTwoRanges_WhenIntersectingFileBitmaps_ResultIsExpected(int from1, int to1, int from2, int to2, bool intersects)
+    {
+        var bitmap1 = FileBitmap.FromActiveRange(from1, to1);
+        var bitmap2 = FileBitmap.FromActiveRange(from2, to2);
+
+        bitmap1.IntersectsWith(ref bitmap2).Should().Be(intersects);
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
@@ -1,0 +1,278 @@
+// <copyright file="TestingFrameworkImpactedTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.CiEnvironment;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.Ci;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
+{
+    [UsesVerify]
+    public abstract class TestingFrameworkImpactedTests : TestingFrameworkTest
+    {
+#pragma warning disable SA1401 // FieldsMustBePrivate
+        protected const int ExpectedTestCount = 16;
+        protected const string GitHubSha = "c7fd869e31de6b621750c7542822c5001d06e421";
+        protected const string GitHubBaseSha = "340fa40ce6b5c6c8c45b6a07cfa90e84718f1ab6";
+        protected string buildDir = string.Empty;
+        protected string repo = string.Empty;
+        protected string branch = string.Empty;
+        protected bool gitAvailable = false;
+#pragma warning restore SA1401 // FieldsMustBePrivate
+
+        public TestingFrameworkImpactedTests(string sampleAppName, ITestOutputHelper output)
+        : base(sampleAppName, output)
+        {
+            InitGit();
+            SetCIEnvironmentValues();
+            SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Enabled, "1");
+            SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Logs, "1");
+        }
+
+        protected string GetSettingsJson(bool enabled = false)
+        {
+            var enabledValue = enabled ? "true" : "false";
+            return $$"""
+            {
+                "data":
+                {
+                    "id":"511938a3f19c12f8bb5e5caa695ca24f4563de3f",
+                    "type":"ci_app_tracers_test_service_settings",
+                    "attributes":
+                    {
+                        "code_coverage":false,
+                        "flaky_test_retries_enabled":true,
+                        "itr_enabled":false,
+                        "require_git":false,
+                        "tests_skipping":false,
+                        "impacted_tests_enabled":{{enabledValue}},
+                        "early_flake_detection":
+                        {
+                            "enabled":false,
+                            "slow_test_retries":{"10s":5,"30s":3,"5m":2,"5s":10},
+                            "faulty_session_threshold":100
+                        }
+                     }
+                 }
+             }
+            """;
+        }
+
+        protected string GetDiffFilesJson(bool baseCommit = true)
+        {
+            var commitValue = baseCommit ? GitHubBaseSha : string.Empty;
+            return $$"""
+            {
+              "data": {
+                "type": "ci_app_tests_diffs_response",
+                "id": "123456",
+                "attributes": {
+                  "base_sha": "{{commitValue}}",
+                  "files": [
+                     "tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs"
+                  ]
+                }
+              }
+            }
+            """;
+        }
+
+        protected void ProcessAgentRequest(MockTracerAgent.EvpProxyPayload request, List<MockCIVisibilityTest> receivedTests)
+        {
+            if (request.PathAndQuery.EndsWith("libraries/tests/services/setting"))
+            {
+                request.Response = new MockTracerResponse(GetSettingsJson(true), 200);
+                return;
+            }
+
+            if (request.PathAndQuery.EndsWith("ci/tests/diffs"))
+            {
+                request.Response = new MockTracerResponse(GetDiffFilesJson(true), 200);
+                return;
+            }
+
+            if (request.PathAndQuery.EndsWith("api/v2/citestcycle"))
+            {
+                var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(request.BodyInJson);
+                if (payload.Events?.Length > 0)
+                {
+                    foreach (var @event in payload.Events)
+                    {
+                        if (@event.Content.ToString() is { } eventContent)
+                        {
+                            if (@event.Type == SpanTypes.Test)
+                            {
+                                receivedTests.Add(JsonConvert.DeserializeObject<MockCIVisibilityTest>(eventContent));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        protected async Task SubmitTests(string packageVersion, string scenario, int expectedTests, Func<MockCIVisibilityTest, bool> testFilter = null, Action<MockTracerAgent.EvpProxyPayload, List<MockCIVisibilityTest>> agentRequestProcessor = null)
+        {
+            var tests = new List<MockCIVisibilityTest>();
+            using var agent = GetAgent(tests, agentRequestProcessor);
+
+            using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1);
+            var deadline = DateTime.UtcNow.AddMilliseconds(5000);
+            testFilter ??= _ => true; // t => t.Meta.ContainsKey("is_modified")
+
+            List<MockCIVisibilityTest> filteredTests = tests;
+            while (DateTime.UtcNow < deadline)
+            {
+                filteredTests = tests.Where(testFilter).ToList();
+                if (tests.Count() >= ExpectedTestCount)
+                {
+                    break;
+                }
+
+                Thread.Sleep(500);
+            }
+
+            // Sort and aggregate
+            var results = filteredTests.Select(t => t.Resource).Distinct().OrderBy(t => t).ToList();
+
+            tests.Count().Should().BeGreaterOrEqualTo(ExpectedTestCount, "Expected test count not met");
+            results.Count().Should().Be(expectedTests, "Expected filtered test count not met");
+        }
+
+        protected override Dictionary<string, string> DefineCIEnvironmentValues(Dictionary<string, string> values)
+        {
+            // Base sets Azure CI values. Take those we can reuse for Git Hub
+            buildDir = values[CIEnvironmentValues.Constants.AzureBuildSourcesDirectory];
+            repo = values[CIEnvironmentValues.Constants.AzureBuildRepositoryUri];
+            branch = values[CIEnvironmentValues.Constants.AzureBuildSourceBranch];
+
+            return values;
+        }
+
+        protected void InjectGitHubActionsSession(bool setupPr = true, bool? enabled = true)
+        {
+            // Check for GIT availability
+            Skip.IfNot(gitAvailable, "Git not available or not properly configured in current environment");
+
+            // Reset all the envVars for spawned process (override possibly existing env vars)
+            foreach (var field in typeof(CIEnvironmentValues.Constants).GetFields())
+            {
+                var fieldName = field.GetValue(null) as string;
+                SetEnvironmentVariable(fieldName, string.Empty);
+            }
+
+            // Set relevant GitHub variables
+            SetEnvironmentVariable(CIEnvironmentValues.Constants.GitHubRepository, repo);
+            SetEnvironmentVariable(CIEnvironmentValues.Constants.GitHubBaseRef, branch);
+            SetEnvironmentVariable(CIEnvironmentValues.Constants.GitHubWorkspace, buildDir);
+            SetEnvironmentVariable(CIEnvironmentValues.Constants.GitHubSha, GitHubSha);
+            if (setupPr)
+            {
+                SetEnvironmentVariable(CIEnvironmentValues.Constants.GitHubEventPath, GetEventJsonFile());
+            }
+
+            if (enabled is not null)
+            {
+                SetEnvironmentVariable(ConfigurationKeys.CIVisibility.ImpactedTestsDetectionEnabled, enabled.Value ? "True" : "False");
+            }
+
+            static string GetEventJsonFile()
+            {
+                string content = $$"""
+                {
+                  "pull_request": {
+                    "head": {
+                      "sha": "{{GitHubSha}}"
+                    },
+                    "base": {
+                      "sha": "{{GitHubBaseSha}}"
+                    }
+                  }
+                }
+                """;
+                var tmpFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + "_event.json");
+                File.WriteAllText(tmpFileName, content);
+                return tmpFileName;
+            }
+        }
+
+        private MockTracerAgent GetAgent(List<MockCIVisibilityTest> receivedTests, Action<MockTracerAgent.EvpProxyPayload, List<MockCIVisibilityTest>> processRequest = null)
+        {
+            var agent = EnvironmentHelper.GetMockAgent();
+            agent.EventPlatformProxyPayloadReceived += (sender, e) =>
+            {
+                if (processRequest != null)
+                {
+                    processRequest(e.Value, receivedTests);
+                    return;
+                }
+
+                ProcessAgentRequest(e.Value, receivedTests);
+            };
+
+            return agent;
+        }
+
+        private void InitGit()
+        {
+            // Check git availability
+            var output = RunGitCommandAsync("branch --show-current");
+            if (output.ExitCode < 0)
+            {
+                // Try to fix the git path
+                RunGitCommandAsync("config --global --add safe.directory '*'");
+                output = RunGitCommandAsync("branch --show-current");
+            }
+
+            if (output.ExitCode == 0)
+            {
+                gitAvailable = true;
+                Output.WriteLine($"Git NOT available. ExitCode: {output.ExitCode} Error: {output.Error}");
+            }
+        }
+
+        private ProcessHelpers.CommandOutput RunGitCommandAsync(string arguments)
+        {
+            try
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                var gitOutput = AsyncUtil.RunSync<ProcessHelpers.CommandOutput>(() => ProcessHelpers.RunCommandAsync(
+                                    new ProcessHelpers.Command(
+                                        "git",
+                                        arguments,
+                                        EnvironmentTools.GetSolutionDirectory(),
+                                        outputEncoding: Encoding.Default,
+                                        errorEncoding: Encoding.Default,
+                                        inputEncoding: Encoding.Default,
+                                        useWhereIsIfFileNotFound: true),
+                                    null));
+
+                if (gitOutput is null || (gitOutput.ExitCode < 0 && gitOutput.Error is not { Length: > 0 }))
+                {
+                    return new ProcessHelpers.CommandOutput(null, "git command returned null output", -1);
+                }
+
+                return gitOutput;
+            }
+            catch (Exception err)
+            {
+                return new ProcessHelpers.CommandOutput(null, err.ToString(), -1);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestingFrameworkTest.cs" company="Datadog">
+// <copyright file="TestingFrameworkTest.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -218,7 +218,7 @@ public abstract class TestingFrameworkTest : TestHelper
     protected void SetCIEnvironmentValues()
     {
         var current = GitInfo.GetCurrent();
-        var ciDictionaryValues = new Dictionary<string, string>
+        var ciDictionaryValues = DefineCIEnvironmentValues(new Dictionary<string, string>
         {
             [CIEnvironmentValues.Constants.AzureTFBuild] = "1",
             [CIEnvironmentValues.Constants.AzureSystemTeamProjectId] = "TeamProjectId",
@@ -240,7 +240,7 @@ public abstract class TestingFrameworkTest : TestHelper
             [CIEnvironmentValues.Constants.AzureBuildSourceVersionMessage] = "Fake commit for testing",
             [CIEnvironmentValues.Constants.AzureBuildRequestedForId] = "AuthorName",
             [CIEnvironmentValues.Constants.AzureBuildRequestedForEmail] = "author@company.com",
-        };
+        });
 
         foreach (var item in ciDictionaryValues)
         {
@@ -248,5 +248,10 @@ public abstract class TestingFrameworkTest : TestHelper
         }
 
         CIValues = CIEnvironmentValues.Create(ciDictionaryValues);
+    }
+
+    protected virtual Dictionary<string, string> DefineCIEnvironmentValues(Dictionary<string, string> values)
+    {
+        return values;
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
     public class XUnitImpactedTests : TestingFrameworkImpactedTests
     {
         private const int ExpectedSpanCount = 41;
+        private const string IsModifiedTag = "test.is_modified";
 
         public XUnitImpactedTests(ITestOutputHelper output)
             : base("XUnitTests", output)
@@ -36,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         public Task BaseShaFromPr(string packageVersion)
         {
             InjectGitHubActionsSession();
-            return SubmitTests(packageVersion, $"baseShaFromPr", 2, (t) => t.Meta.ContainsKey("test.is_modified") && t.Meta["test.is_modified"] == "true");
+            return SubmitTests(packageVersion, 2, TestIsModified);
         }
 
         [SkippableTheory]
@@ -46,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         public Task BaseShaFromBackend(string packageVersion)
         {
             InjectGitHubActionsSession(false);
-            return SubmitTests(packageVersion, $"baseShaFromPr", 2, (t) => t.Meta.ContainsKey("test.is_modified") && t.Meta["test.is_modified"] == "true");
+            return SubmitTests(packageVersion, 2, TestIsModified);
         }
 
         [SkippableTheory]
@@ -66,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                 ProcessAgentRequest(request, receivedTests);
             };
-            return SubmitTests(packageVersion, $"baseShaFromPr", 12, (t) => t.Meta.ContainsKey("test.is_modified") && t.Meta["test.is_modified"] == "true", agentRequestProcessor);
+            return SubmitTests(packageVersion, 12, TestIsModified, agentRequestProcessor);
         }
 
         [SkippableTheory]
@@ -76,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         public Task DisabledByEnvVar(string packageVersion)
         {
             InjectGitHubActionsSession(true, false);
-            return SubmitTests(packageVersion, $"baseShaFromPr", 0, (t) => t.Meta.ContainsKey("is_modified"));
+            return SubmitTests(packageVersion, 0, TestIsModified);
         }
 
         [SkippableTheory]
@@ -86,7 +87,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         public Task EnabledBySettings(string packageVersion)
         {
             InjectGitHubActionsSession(true, null);
-            return SubmitTests(packageVersion, $"baseShaFromPr", 0, (t) => t.Meta.ContainsKey("is_modified"));
+            return SubmitTests(packageVersion, 2, TestIsModified);
         }
+
+        private static bool TestIsModified(MockCIVisibilityTest t) => t.Meta.ContainsKey(IsModifiedTag) && t.Meta[IsModifiedTag] == "true";
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="XUnitImpactedTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.CiEnvironment;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.Ci;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
+{
+    [UsesVerify]
+    public class XUnitImpactedTests : TestingFrameworkImpactedTests
+    {
+        private const int ExpectedSpanCount = 41;
+
+        public XUnitImpactedTests(ITestOutputHelper output)
+            : base("XUnitTests", output)
+        {
+            SetServiceName("xunit-tests");
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "TestIntegrations")]
+        public Task BaseShaFromPr(string packageVersion)
+        {
+            InjectGitHubActionsSession();
+            return SubmitTests(packageVersion, $"baseShaFromPr", 2, (t) => t.Meta.ContainsKey("test.is_modified") && t.Meta["test.is_modified"] == "true");
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "TestIntegrations")]
+        public Task BaseShaFromBackend(string packageVersion)
+        {
+            InjectGitHubActionsSession(false);
+            return SubmitTests(packageVersion, $"baseShaFromPr", 2, (t) => t.Meta.ContainsKey("test.is_modified") && t.Meta["test.is_modified"] == "true");
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "TestIntegrations")]
+        public Task FilesFromBackend(string packageVersion)
+        {
+            InjectGitHubActionsSession(false);
+            Action<MockTracerAgent.EvpProxyPayload, List<MockCIVisibilityTest>> agentRequestProcessor = (request, receivedTests) =>
+            {
+                if (request.PathAndQuery.EndsWith("ci/tests/diffs"))
+                {
+                    request.Response = new MockTracerResponse(GetDiffFilesJson(false), 200);
+                    return;
+                }
+
+                ProcessAgentRequest(request, receivedTests);
+            };
+            return SubmitTests(packageVersion, $"baseShaFromPr", 12, (t) => t.Meta.ContainsKey("test.is_modified") && t.Meta["test.is_modified"] == "true", agentRequestProcessor);
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "TestIntegrations")]
+        public Task DisabledByEnvVar(string packageVersion)
+        {
+            InjectGitHubActionsSession(true, false);
+            return SubmitTests(packageVersion, $"baseShaFromPr", 0, (t) => t.Meta.ContainsKey("is_modified"));
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "TestIntegrations")]
+        public Task EnabledBySettings(string packageVersion)
+        {
+            InjectGitHubActionsSession(true, null);
+            return SubmitTests(packageVersion, $"baseShaFromPr", 0, (t) => t.Meta.ContainsKey("is_modified"));
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
@@ -43,15 +43,18 @@ public class MetricTests
         { "git_requests.settings_errors", ["status_code"] },
         { "itr_skippable_tests.request_errors", ["status_code"] },
         { "early_flake_detection.request_errors", ["status_code"] },
+        { "impacted_tests_detection.request_errors", ["status_code"] },
         { "endpoint_payload.requests", ["rq_compressed"] },
         { "git_requests.search_commits", ["rq_compressed"] },
         { "git_requests.objects_pack", ["rq_compressed"] },
         { "git_requests.settings", ["rq_compressed"] },
         { "itr_skippable_tests.request", ["rq_compressed"] },
         { "early_flake_detection.request", ["rq_compressed"] },
+        { "impacted_tests_detection.request", ["rq_compressed"] },
         { "git_requests.search_commits_ms", ["rs_compressed"] },
         { "itr_skippable_tests.response_bytes", ["rs_compressed"] },
         { "early_flake_detection.response_bytes", ["rs_compressed"] },
+        { "impacted_tests_detection.response_bytes", ["rs_compressed"] },
         { "rasp.rule.eval", ["rule_variant"] },
         { "rasp.rule.match", ["rule_variant"] },
         { "rasp.timeout", ["rule_variant"] },
@@ -118,7 +121,7 @@ public class MetricTests
 
                 if (permutationPrefixes.Count == 0)
                 {
-                    permutationPrefixes.Should().HaveCount(expectedPrefixes.Count);
+                    permutationPrefixes.Should().HaveCount(expectedPrefixes.Count, $"{implementation.Metric} tags has unexpected prefixes ({string.Join(",", expectedMetric.TagPrefixes)})");
                 }
                 else
                 {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -1360,6 +1360,61 @@
       "description": "The number of known tests returned by the endpoint",
       "send_to_user": false,
       "user_tags": []
+    },
+    "impacted_tests_detection.request": {
+      "tags": [
+        "rq_compressed"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of requests sent to the modified files endpoint, regardless of success. Tagged with a boolean flag set to true if request body is compressed",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "impacted_tests_detection.request_ms": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "milliseconds",
+      "description": "The time it takes to get the response of the modified files endpoint request in ms",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "impacted_tests_detection.request_errors": {
+      "tags": [
+        "error_type",
+        "status_code"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of known modified files requests sent to the endpoint that errored, tagget by the error type  (e.g. `error_type:timeout`, `error_type:network`, `error_type:status_code_4xx_response`, `error_type:status_code_5xx_response`) and status code (400,401,403,404,408,429)",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "impacted_tests_detection.response_bytes": {
+      "tags": [
+        "rs_compressed"
+      ],
+      "metric_type": "distribution",
+      "data_type": "bytes",
+      "description": "The number of bytes received by the endpoint. Tagged with a boolean flag set to true if response body is compressed",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "impacted_tests_detection.response_files": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "files",
+      "description": "The number of modified files received by the endpoint",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "impacted_tests_detection.is_modified": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "tests",
+      "description": "The number of tests detected as modified",
+      "send_to_user": false,
+      "user_tags": []
     }
   },
   "profilers": {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -392,6 +392,7 @@
   "DD_CIVISIBILITY_FLAKY_RETRY_ENABLED": "ci_visibility_flaky_retry_enabled",
   "DD_CIVISIBILITY_FLAKY_RETRY_COUNT": "ci_visibility_flaky_retry_count",
   "DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT": "ci_visibility_total_flaky_retry_count",
+  "DD_CIVISIBILITY_IMPACTED_TESTS_DETECTION_ENABLED":  "dd_civisibility_impacted_tests_detection_enabled",
   "DD_TEST_SESSION_NAME": "test_session_name",
   "DD_PROXY_HTTPS": "proxy_https",
   "DD_PROXY_NO_PROXY": "proxy_no_proxy",

--- a/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
@@ -32,7 +32,6 @@ namespace Samples.XUnitTests
         {
             _output.WriteLine("Test:SimpleErrorTest");
             int i = 0;
-
             int z = 0 / i;
         }
 
@@ -63,8 +62,6 @@ namespace Samples.XUnitTests
         {
             _output.WriteLine("Test:TraitErrorTest");
             int i = 0;
-
-
             int z = 0 / i;
         }
 

--- a/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
@@ -32,6 +32,7 @@ namespace Samples.XUnitTests
         {
             _output.WriteLine("Test:SimpleErrorTest");
             int i = 0;
+
             int z = 0 / i;
         }
 
@@ -62,6 +63,8 @@ namespace Samples.XUnitTests
         {
             _output.WriteLine("Test:TraitErrorTest");
             int i = 0;
+
+
             int z = 0 / i;
         }
 


### PR DESCRIPTION
## Summary of changes
Implementer Milestones 1.0 and 1.5 of Impacted Tests Detection [RFC](https://docs.google.com/document/d/1oV3qRzfdEAOazjjzsA7z-yAFh8gPOMRQnf7EtIwhsKo/edit)

## Reason for change
Detecting which tests have changed in a commit and mark them  will enable future actions over them, like launching Early Flake Detection

## Implementation details
Milestone 1.5 requires having access to Git CLI, and being in a PR. Retrieves changed files and lines by Git Diff from base commit and intersects them with the test definition file. If collision is detected, the test is marked as modified.

## Test coverage
Added unit and integration tests.
Integration tests relies on two predefined commits with known changes to certain tests, which get checked for the `is_modifed` tag in a verify snapshot.

## Notes
Superseeding https://github.com/DataDog/dd-trace-dotnet/pull/6366 because of heavy rebase conflicts

Related GO PRs:
 - [EnvVar](https://github.com/DataDog/dd-go/pull/166974)
 - [Metrics](https://github.com/DataDog/dd-go/commit/300c27c131ffa01e2d52429cdc3bba2f462c3619)
