### PR TITLE
[Dynamic Instrumentation] Change the way we are using the gzip stream in SymDB

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -98,6 +98,7 @@ namespace Datadog.Trace.Debugger.Upload
 #endif
                 {
                     await gzipStream.WriteAsync(symbols.Array, 0, symbols.Array.Length).ConfigureAwait(false);
+                    await gzipStream.FlushAsync().ConfigureAwait(false);
                 }
 
                 symbolsItem = new MultipartFormItem("file", MimeTypes.Gzip, "file.gz", new ArraySegment<byte>(memoryStream.ToArray()));

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -84,23 +84,23 @@ namespace Datadog.Trace.Debugger.Upload
 
             MultipartFormItem symbolsItem;
 
-            if (_enableCompression)
+            if (!this._enableCompression)
             {
-                using var memoryStream = new MemoryStream();
-#if NETFRAMEWORK
-                using var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(memoryStream);
-                await gzipStream.WriteAsync(symbols.Array, 0, symbols.Array.Length).ConfigureAwait(false);
-                await gzipStream.FlushAsync().ConfigureAwait(false);
-#else
-                using var gzipStream = new GZipStream(memoryStream, CompressionMode.Compress);
-                await gzipStream.WriteAsync(symbols.Array, 0, symbols.Array.Length).ConfigureAwait(false);
-                await gzipStream.FlushAsync().ConfigureAwait(false);
-#endif
-                symbolsItem = new MultipartFormItem("file", MimeTypes.Gzip, "file.gz", new ArraySegment<byte>(memoryStream.ToArray()));
+                symbolsItem = new MultipartFormItem("file", MimeTypes.Json, "file.json", symbols);
             }
             else
             {
-                symbolsItem = new MultipartFormItem("file", MimeTypes.Json, "file.json", symbols);
+                using var memoryStream = new MemoryStream();
+#if NETFRAMEWORK
+                using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(memoryStream))
+#else
+                using (var gzipStream = new GZipStream(memoryStream, CompressionMode.Compress))
+#endif
+                {
+                    await gzipStream.WriteAsync(symbols.Array, 0, symbols.Array.Length).ConfigureAwait(false);
+                }
+
+                symbolsItem = new MultipartFormItem("file", MimeTypes.Gzip, "file.gz", new ArraySegment<byte>(memoryStream.ToArray()));
             }
 
             var items = new[] { symbolsItem, new MultipartFormItem("event", MimeTypes.Json, "event.json", _eventMetadata) };


### PR DESCRIPTION
## Summary of changes

When we upload symbols, we want to use the underline stream after we are disposing the gzip stream