### PR TITLE
Move the aspnetcore benchmark

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
-    [BenchmarkAgent1]    
+    [BenchmarkAgent2]
     [BenchmarkCategory(Constants.TracerCategory)]
     public class AspNetCoreBenchmark
     {


### PR DESCRIPTION
## Summary of changes

Move a benchmark from agent 1 to agent 2

## Reason for change

Currently benchmarks are basically never completing for PRs because there's a backlog on agent 1. Digging into this:

- agent 1 runs consistently for ~45 mins, runs 4 benchmarks
- agent 2 runs for 2 mins, runs 0 benchmarks :awkward-monkey:
- agent 3-5 runs for 25 mins, runs 3 benchmarks generally, 2 on 5
- agent 6 runs for 32 mins, runs 3 benchmarks
- agent 7 (ASM) varies somewhat wildly, runs 4 benchmarks

Given that

- Agent 1 is running more benchmarks
- Agent 2 is running _no_ benchmarks
- We're going to move to a new benchmark platform soon _anyway_ which will invalidate previous perf values

This PR moves the slowest benchmark currently running on agent 1 to agent 2

## Implementation details

`[BenchmarkAgent1]` => `[BenchmarkAgent2]`

## Test coverage

This PR is the test

## Other details

We basically should never do this, but otherwise noone gets to see the results of the benchmarks for their PRs, rending the whole benchmark stage pointless 😬 