### PR TITLE
Remove Security and IAST statics in `AspNetCoreDiagnosticObserver`

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -138,7 +138,6 @@ src/Datadog.Trace/HttpOverStreams/HttpMessage.cs
 src/Datadog.Trace/HttpOverStreams/HttpRequest.cs
 src/Datadog.Trace/HttpOverStreams/HttpResponse.cs
 src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
-src/Datadog.Trace/Iast/Iast.cs
 src/Datadog.Trace/Iast/ITaintedMap.cs
 src/Datadog.Trace/Iast/SourceType.cs
 src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs

--- a/tracer/src/Datadog.Trace/Iast/Iast.cs
+++ b/tracer/src/Datadog.Trace/Iast/Iast.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Threading;
 using Datadog.Trace.Agent.DiscoveryService;
@@ -19,12 +21,12 @@ namespace Datadog.Trace.Iast;
 /// </summary>
 internal class Iast
 {
-    private static Iast _instance;
+    private static Iast? _instance;
     private static bool _globalInstanceInitialized;
     private static object _globalInstanceLock = new();
     private readonly IastSettings _settings;
     private readonly OverheadController _overheadController;
-    private IDiscoveryService _discoveryService;
+    private IDiscoveryService? _discoveryService;
     private bool _spanMetaStructs;
 
     static Iast()
@@ -35,16 +37,21 @@ internal class Iast
     /// Initializes a new instance of the <see cref="Iast"/> class with default settings.
     /// </summary>
     public Iast()
-        : this(null, null)
+        : this(IastSettings.FromDefaultSources())
     {
     }
 
-    internal Iast(IastSettings settings, IDiscoveryService discoveryService)
+    internal Iast(IastSettings settings)
     {
-        _settings = settings ?? IastSettings.FromDefaultSources();
+        _settings = settings;
+        _overheadController = new OverheadController(_settings.MaxConcurrentRequests, _settings.RequestSampling);
+    }
+
+    internal Iast(IastSettings settings, IDiscoveryService discoveryService)
+        : this(settings)
+    {
         _discoveryService = discoveryService;
         SubscribeToDiscoveryService(_discoveryService);
-        _overheadController = new OverheadController(_settings.MaxConcurrentRequests, _settings.RequestSampling);
     }
 
     internal IastSettings Settings => _settings;
@@ -56,7 +63,7 @@ internal class Iast
     /// </summary>
     public static Iast Instance
     {
-        get => LazyInitializer.EnsureInitialized(ref _instance, ref _globalInstanceInitialized, ref _globalInstanceLock);
+        get => LazyInitializer.EnsureInitialized(ref _instance, ref _globalInstanceInitialized, ref _globalInstanceLock)!;
 
         set
         {

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -13,8 +13,11 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.DiagnosticListeners;
+using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -426,7 +429,8 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             var tracer = GetTracer(writer, configSource);
 
             var security = new AppSec.Security();
-            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security) };
+            var iast = new Iast.Iast(new IastSettings(configSource, NullConfigurationTelemetry.Instance), NullDiscoveryService.Instance);
+            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security, iast) };
 
             using (var diagnosticManager = new DiagnosticManager(observers))
             {

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -9,8 +9,13 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.DiagnosticListeners;
+using Datadog.Trace.Iast.Settings;
+using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using Microsoft.AspNetCore.Builder;
@@ -41,7 +46,8 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
             var testServer = new TestServer(builder);
             var client = testServer.CreateClient();
             var tracer = GetTracer();
-            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security: null) };
+            var (security, iast) = GetSecurity();
+            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver(tracer, security, iast) };
             string retValue = null;
 
             using (var diagnosticManager = new DiagnosticManager(observers))
@@ -64,8 +70,9 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
         public void HttpRequestIn_PopulateSpan()
         {
             var tracer = GetTracer();
+            var (security, iast) = GetSecurity();
 
-            IObserver<KeyValuePair<string, object>> observer = new AspNetCoreDiagnosticObserver(tracer, null);
+            IObserver<KeyValuePair<string, object>> observer = new AspNetCoreDiagnosticObserver(tracer, security, iast);
 
             var context = new HostingApplication.Context { HttpContext = GetHttpContext() };
 
@@ -99,6 +106,21 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
             var samplerMock = new Mock<ITraceSampler>();
 
             return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+        }
+
+        private static (Security Security, Iast.Iast Iast) GetSecurity()
+        {
+            var settings = new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.AppSec.Enabled, "0" },
+                { ConfigurationKeys.Iast.Enabled, "0" },
+            });
+            // This still uses a _bunch_ of shared state. Ideally we should pass that in instead of accessing statics
+            var security = new Security(
+                new SecuritySettings(settings, NullConfigurationTelemetry.Instance),
+                rcmSubscriptionManager: Mock.Of<IRcmSubscriptionManager>());
+            var iast = new Iast.Iast(new IastSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance), NullDiscoveryService.Instance);
+            return (security, iast);
         }
 
         private static HttpContext GetHttpContext()

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.BenchmarkDotNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
@@ -42,7 +43,7 @@ public class StringAspectsBenchmark
                 { ConfigurationKeys.Iast.IsIastDeduplicationEnabled, false },
             });
             var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
-            Datadog.Trace.Iast.Iast.Instance = new Datadog.Trace.Iast.Iast(iastSettings);
+            Datadog.Trace.Iast.Iast.Instance = new Datadog.Trace.Iast.Iast(iastSettings, NullDiscoveryService.Instance);
 
             IastModule.OnWeakRandomness("fake", false); // Add fake span
             var tracer = Tracer.Instance;


### PR DESCRIPTION
## Summary of changes

- Allow using a "local" instance of `Iast` in the `AspNetCoreDiagnosticObserver` to reduce interactions across tests
- Remove some of the static accesses in these types

## Reason for change

We pass in an instance of the `Tracer` and `Security` into `AspNetCoreDiagnosticObserver` to make it easier to test - accessing `static` instances create cross-test interactions that are hard to debug and hard to untangle.

However, _just_ moving the `Iast` to inject an instance isn't really enough, because the non-static instances of `Security` and `Iast` access global singleton values. That means there's easily a chance for cross-talk between tests via these static instances. Ideally we should refactor those to allow them to be optionally injected in the constructor, and then to do that in the tests.

## Implementation details

- Optionally inject an instance of `Iast` into the diagnostic observer, and use it preferentially
- Allow providing an `IDiscoveryService` to Iast, and use it if it's provided
- Update tests to provide instances of `Security` and `Iast` to the diagnostic observer
- Update benchmarks to use stub versions of the values to try to reduce variation

## Test coverage

Coverage is the same

