### PR TITLE
[ASM] Update active addresses at runtime

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -68,7 +68,7 @@ internal static class RaspModule
     {
         var security = Security.Instance;
 
-        if (!security.RaspEnabled || !security.AddressEnabled(address))
+        if (!security.RaspEnabled)
         {
             return;
         }
@@ -76,6 +76,11 @@ internal static class RaspModule
         var rootSpan = Tracer.Instance.InternalActiveScope?.Root?.Span;
 
         if (rootSpan is null || rootSpan.IsFinished || rootSpan.Type != SpanTypes.Web)
+        {
+            return;
+        }
+
+        if (!security.AddressEnabled(address))
         {
             return;
         }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -81,7 +81,6 @@ namespace Datadog.Trace.AppSec
 
                 RefreshRcmSubscriptions();
                 SetRemoteConfigCapabilites();
-                UpdateActiveAddresses();
             }
             catch (Exception ex)
             {
@@ -674,6 +673,13 @@ namespace Datadog.Trace.AppSec
                 try
                 {
                     _activeAddressesLocker.EnterReadLock();
+
+                    // If we have not updated the active addresses yet, we will do it now
+                    if (_activeAddresses is null)
+                    {
+                        UpdateActiveAddresses();
+                    }
+
                     return _activeAddresses?.Contains(address) ?? false;
                 }
                 finally


### PR DESCRIPTION
## Summary of changes

This PR makes sure that we don't call IsKnowAddressesSuported during initialization or in non request contexts. This change will try to avoid [some errors](https://dd.slack.com/archives/CC7Q58YRG/p1736844505485019) related to this method that have been observed during the security module initialization.

[... more error handling frames, eventually ending up in an ExecutionEngineException]
libcoreclr.so!CallSignalHandlerWrapper0+06
System.Private.CoreLib.dll!System.SpanHelpers.IndexOf
System.Private.CoreLib.dll!System.String.Ctor
System.Private.CoreLib.dll!System.Runtime.InteropServices.Marshal.PtrToStringAnsi
Datadog.Trace.dll!Datadog.Trace.AppSec.Waf.NativeBindings.WafLibraryInvoker.GetKnownAddresses
Datadog.Trace.dll!Datadog.Trace.AppSec.Waf.Waf.GetKnownAddresses
Datadog.Trace.dll!Datadog.Trace.AppSec.Security.UpdateActiveAddresses
Datadog.Trace.dll!Datadog.Trace.AppSec.Security..ctor
Datadog.Trace.dll!Datadog.Trace.AppSec.Security+<>c.<get_Instance>b__21_0
System.Private.CoreLib.dll!System.Threading.LazyInitializer.CoreLib]]
System.Private.CoreLib.dll!System.Threading.LazyInitializer.CoreLib]]
Datadog.Trace.dll!Datadog.Trace.AppSec.Security.get_Instance
Datadog.Trace.dll!Datadog.Trace.ClrProfiler.Instrumentation.InitializeNoNativeParts
Datadog.Trace.dll!Datadog.Trace.ClrProfiler.Instrumentation.Initialize
Datadog.Trace.dll!Datadog.Trace.ClrProfiler.InstrumentationLoader..ctor
System.Private.CoreLib.dll!System.RuntimeType.CreateInstanceDefaultCtor
System.Private.CoreLib.dll!System.Activator.CreateInstance
System.Private.CoreLib.dll!System.Activator.CreateInstance
Datadog.Trace.ClrProfiler.Managed.Loader.dll!Datadog.Trace.ClrProfiler.Managed.Loader.Startup.TryInvokeManagedMethod
Datadog.Trace.ClrProfiler.Managed.Loader.dll!Datadog.Trace.ClrProfiler.Managed.Loader.Startup..cctor

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
