### PR TITLE
[ASM] Add a lock to handle WAF active addresses

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -42,6 +42,7 @@ namespace Datadog.Trace.AppSec
         /// <summary>
         /// _waf locker needs to have a longer lifecycle than the Waf object as it's used to dispose it as well
         /// </summary>
+        private readonly Concurrency.ReaderWriterLock _activeAddressesLocker;
         private ISubscription? _rcmSubscription;
         private LibraryInitializationResult? _libraryInitializationResult;
         private IWaf? _waf;
@@ -52,7 +53,6 @@ namespace Datadog.Trace.AppSec
         private bool _spanMetaStructs;
         private string? _blockedHtmlTemplateCache;
         private string? _blockedJsonTemplateCache;
-        private readonly Concurrency.ReaderWriterLock _activeAddressesLocker;
         private HashSet<string>? _activeAddresses;
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -42,7 +42,6 @@ namespace Datadog.Trace.AppSec
         /// <summary>
         /// _waf locker needs to have a longer lifecycle than the Waf object as it's used to dispose it as well
         /// </summary>
-        private readonly Concurrency.ReaderWriterLock _wafLocker;
         private ISubscription? _rcmSubscription;
         private LibraryInitializationResult? _libraryInitializationResult;
         private IWaf? _waf;
@@ -53,6 +52,7 @@ namespace Datadog.Trace.AppSec
         private bool _spanMetaStructs;
         private string? _blockedHtmlTemplateCache;
         private string? _blockedJsonTemplateCache;
+        private readonly Concurrency.ReaderWriterLock _activeAddressesLocker;
         private HashSet<string>? _activeAddresses;
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Datadog.Trace.AppSec
         public Security(SecuritySettings? settings = null, IWaf? waf = null, IRcmSubscriptionManager? rcmSubscriptionManager = null, ConfigurationState? configurationState = null)
         {
             _rcmSubscriptionManager = rcmSubscriptionManager ?? RcmSubscriptionManager.Instance;
-            _wafLocker = new Concurrency.ReaderWriterLock();
+            _activeAddressesLocker = new Concurrency.ReaderWriterLock();
 
             try
             {
@@ -482,7 +482,7 @@ namespace Datadog.Trace.AppSec
         {
             _waf?.Dispose();
             Encoder.Pool.Dispose();
-            _wafLocker.Dispose();
+            _activeAddressesLocker.Dispose();
         }
 
         private void SetRemoteConfigCapabilites()
@@ -637,11 +637,27 @@ namespace Datadog.Trace.AppSec
             {
                 var addresses = _waf.GetKnownAddresses();
                 Log.Debug("Updating WAF active addresses to {Addresses}", addresses);
-                _activeAddresses = addresses is null ? null : new HashSet<string>(addresses);
+                try
+                {
+                    _activeAddressesLocker.EnterWriteLock();
+                    _activeAddresses = addresses is null ? null : new HashSet<string>(addresses);
+                }
+                finally
+                {
+                    _activeAddressesLocker.ExitWriteLock();
+                }
             }
             else
             {
-                _activeAddresses = null;
+                try
+                {
+                    _activeAddressesLocker.EnterWriteLock();
+                    _activeAddresses = null;
+                }
+                finally
+                {
+                    _activeAddressesLocker.ExitWriteLock();
+                }
             }
         }
 
@@ -655,7 +671,15 @@ namespace Datadog.Trace.AppSec
 
             if (_waf?.IsKnowAddressesSuported() == true)
             {
-                return _activeAddresses?.Contains(address) ?? false;
+                try
+                {
+                    _activeAddressesLocker.EnterReadLock();
+                    return _activeAddresses?.Contains(address) ?? false;
+                }
+                finally
+                {
+                    _activeAddressesLocker.ExitReadLock();
+                }
             }
             else
             {

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <!-- We can't build and run these as multi-package versions, so we have to manually update this as required for now -->


### PR DESCRIPTION
## Summary of changes

The field _activeAddresses should be thread safe to avoid concurrency issues.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
