### PR TITLE
Fix Isolated Azure Functions performance when using `ASP.NET Core` Integration

### DIFF
--- a/Datadog.Trace.Samples.g.sln
+++ b/Datadog.Trace.Samples.g.sln
@@ -129,22 +129,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Generated", "Generated", "{
 		tracer\build\supported_calltargets.g.json = tracer\build\supported_calltargets.g.json
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tracer", "tracer", "{82FFBC1A-6B13-4C0A-896A-90306AE4828F}"
-	ProjectSection(SolutionItems) = preProject
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{07D12F26-2583-4C6F-AFBB-AA30FF339FC6}"
-	ProjectSection(SolutionItems) = preProject
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test-applications", "test-applications", "{F8C637E1-1F4F-4E3B-9E34-AAD61097C3F8}"
-	ProjectSection(SolutionItems) = preProject
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "azure-functions", "azure-functions", "{FE9F14E0-8DFF-413B-BB9E-49CEA4115A5D}"
-	ProjectSection(SolutionItems) = preProject
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ExampleLibrary", "tracer\test\test-applications\integrations\dependency-libs\Samples.ExampleLibrary\Samples.ExampleLibrary.csproj", "{FDB5C8D0-018D-4FF9-9680-C6A5078F819B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ExampleLibraryTracer", "tracer\test\test-applications\integrations\dependency-libs\Samples.ExampleLibraryTracer\Samples.ExampleLibraryTracer.csproj", "{4B243CF1-4269-45C6-A238-1A9BFA58B8CC}"
@@ -444,6 +428,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyLoadContextResolve", "tracer\test\test-applications\regression\AssemblyLoadContextResolve\AssemblyLoadContextResolve.csproj", "{8B1AF6A7-DD41-4347-B637-90C23D69B50E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.SdkV1", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.SdkV1\Samples.AzureFunctions.V4Isolated.SdkV1.csproj", "{18767A3E-9ADC-485C-A8C7-50660D5B579D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1\Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1.csproj", "{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.AspNetCore", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.AspNetCore\Samples.AzureFunctions.V4Isolated.AspNetCore.csproj", "{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1043,6 +1031,14 @@ Global
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9518425A-36A5-4B8F-B0B8-6137DB88441D} = {8CEC2042-F11C-49F5-A674-2355793B600A}
@@ -1063,9 +1059,6 @@ Global
 		{16427BFB-B4C6-46A9-A290-8EA51FF73FEA} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
 		{0884B566-D22E-498C-BAA9-26D50ABCAE3A} = {16427BFB-B4C6-46A9-A290-8EA51FF73FEA}
 		{E1B0F72C-991A-409D-9266-DE5ED1BD940E} = {A0C5FBBB-CFB2-4FB9-B8F0-55676E9DCF06}
-		{07D12F26-2583-4C6F-AFBB-AA30FF339FC6} = {82FFBC1A-6B13-4C0A-896A-90306AE4828F}
-		{F8C637E1-1F4F-4E3B-9E34-AAD61097C3F8} = {07D12F26-2583-4C6F-AFBB-AA30FF339FC6}
-		{FE9F14E0-8DFF-413B-BB9E-49CEA4115A5D} = {F8C637E1-1F4F-4E3B-9E34-AAD61097C3F8}
 		{FDB5C8D0-018D-4FF9-9680-C6A5078F819B} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 		{4B243CF1-4269-45C6-A238-1A9BFA58B8CC} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 		{086FF8A0-9CEE-470A-9751-78B0F1340649} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
@@ -1215,6 +1208,8 @@ Global
 		{2CA0D70C-DFC1-458A-871B-328AB6E87E3A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{D6155F26-8245-4B66-8944-79C3DF9F9DA3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{8B1AF6A7-DD41-4347-B637-90C23D69B50E} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
-		{18767A3E-9ADC-485C-A8C7-50660D5B579D} = {FE9F14E0-8DFF-413B-BB9E-49CEA4115A5D}
+		{18767A3E-9ADC-485C-A8C7-50660D5B579D} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
 	EndGlobalSection
 EndGlobal

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -601,6 +601,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Is
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1\Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1.csproj", "{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.AspNetCore", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.AspNetCore\Samples.AzureFunctions.V4Isolated.AspNetCore.csproj", "{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1441,6 +1443,10 @@ Global
 		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1675,6 +1681,7 @@ Global
 		{A82EB6F8-D8D0-4763-B252-08CA3F39D153} = {AFA0AB23-64F0-4AC1-9050-6CE8FE06F580}
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
 		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
+		{0F8EAB52-0C5B-4F60-92C5-42FAC21F4E77} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}
@@ -1689,6 +1696,7 @@ Global
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{0e036453-2c80-4fc9-a517-771f0071734b}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{0f0f7d45-0e13-42b0-a158-8f303bbe8358}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{0f1d9fb5-4415-40f1-b7b0-6dd5a3bab0c4}*SharedItemsImports = 5
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{0f8eab52-0c5b-4f60-92c5-42fac21f4e77}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{10619ba2-aed1-482a-8570-bb7c7b83dddc}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{18767a3e-9adc-485c-a8c7-50660d5b579d}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{18a6904a-5afd-4816-ac3f-9f5e433720b5}*SharedItemsImports = 5

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.31903.286
 MinimumVisualStudioVersion = 15.0.26124.0
@@ -595,14 +596,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyLoadContextResolve", "tracer\test\test-applications\regression\AssemblyLoadContextResolve\AssemblyLoadContextResolve.csproj", "{8B1AF6A7-DD41-4347-B637-90C23D69B50E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNet.MultipleAppsInDomain", "tracer\test\test-applications\aspnet\Samples.AspNet.MultipleAppsInDomain\Samples.AspNet.MultipleAppsInDomain.csproj", "{A82EB6F8-D8D0-4763-B252-08CA3F39D153}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tracer", "tracer", "{82FFBC1A-6B13-4C0A-896A-90306AE4828F}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{07D12F26-2583-4C6F-AFBB-AA30FF339FC6}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test-applications", "test-applications", "{F8C637E1-1F4F-4E3B-9E34-AAD61097C3F8}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "azure-functions", "azure-functions", "{FE9F14E0-8DFF-413B-BB9E-49CEA4115A5D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.SdkV1", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.SdkV1\Samples.AzureFunctions.V4Isolated.SdkV1.csproj", "{18767A3E-9ADC-485C-A8C7-50660D5B579D}"
 EndProject
@@ -1674,10 +1667,7 @@ Global
 		{D6155F26-8245-4B66-8944-79C3DF9F9DA3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{8B1AF6A7-DD41-4347-B637-90C23D69B50E} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 		{A82EB6F8-D8D0-4763-B252-08CA3F39D153} = {AFA0AB23-64F0-4AC1-9050-6CE8FE06F580}
-		{07D12F26-2583-4C6F-AFBB-AA30FF339FC6} = {82FFBC1A-6B13-4C0A-896A-90306AE4828F}
-		{F8C637E1-1F4F-4E3B-9E34-AAD61097C3F8} = {07D12F26-2583-4C6F-AFBB-AA30FF339FC6}
-		{FE9F14E0-8DFF-413B-BB9E-49CEA4115A5D} = {F8C637E1-1F4F-4E3B-9E34-AAD61097C3F8}
-		{18767A3E-9ADC-485C-A8C7-50660D5B579D} = {FE9F14E0-8DFF-413B-BB9E-49CEA4115A5D}
+		{18767A3E-9ADC-485C-A8C7-50660D5B579D} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}
@@ -1693,6 +1683,7 @@ Global
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{0f0f7d45-0e13-42b0-a158-8f303bbe8358}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{0f1d9fb5-4415-40f1-b7b0-6dd5a3bab0c4}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{10619ba2-aed1-482a-8570-bb7c7b83dddc}*SharedItemsImports = 5
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{18767a3e-9adc-485c-a8c7-50660d5b579d}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{18a6904a-5afd-4816-ac3f-9f5e433720b5}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{1a5e9f40-f3a5-4b59-9898-3dcd65c459c3}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{1b3e6bee-f7ab-433e-a1d9-e8be3782419b}*SharedItemsImports = 5

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -599,6 +599,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNet.MultipleApps
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.SdkV1", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.SdkV1\Samples.AzureFunctions.V4Isolated.SdkV1.csproj", "{18767A3E-9ADC-485C-A8C7-50660D5B579D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1\Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1.csproj", "{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1435,6 +1437,10 @@ Global
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1668,6 +1674,7 @@ Global
 		{8B1AF6A7-DD41-4347-B637-90C23D69B50E} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 		{A82EB6F8-D8D0-4763-B252-08CA3F39D153} = {AFA0AB23-64F0-4AC1-9050-6CE8FE06F580}
 		{18767A3E-9ADC-485C-A8C7-50660D5B579D} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
+		{5D2C6B9C-FCE2-4E46-B4ED-BC3B11CFBB3C} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}
@@ -1724,6 +1731,7 @@ Global
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{56de0d44-e9e5-48da-baea-2934b1e28d4e}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{5a806f4b-39e7-4f38-b36f-f5cfc4f8760a}*SharedItemsImports = 13
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{5c2829c2-ed0d-414c-b5a0-2bfdca07b493}*SharedItemsImports = 5
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{5d2c6b9c-fce2-4e46-b4ed-bc3b11cfbb3c}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{5e290fa1-e87b-4782-b977-eb5fa6c96efe}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{5ee6b6eb-b768-47ec-882b-8dcaca2b1360}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{600953c4-bd8f-4a4b-a275-6d6f9ef48342}*SharedItemsImports = 5

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -280,25 +280,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
             return scope;
         }
 
-        internal static void OverridePropagatedContext<TTarget, TTypeData>(Tracer tracer, TTypeData typedData, bool useNullableHeaders)
-            where TTypeData : ITypedData
-        {
-            if (tracer.Settings.IsIntegrationEnabled(IntegrationId)
-             && tracer.ActiveScope is Scope { Span: { OperationName: OperationName } span })
-            {
-                // The HTTP request represented by TypedData is a duplicate of the original incoming
-                // request that was received by func.exe. This is used to create a span representing
-                // the request from the client. The typed data is then sent by the GRPC connection
-                // to the functions app and is used to invoke the actual function. We intercept that
-                // in the functions app and use it to create a span representing the actual work of the app.
-                // In order for the span hierarchy/parenting to work correctly, we need to replace the parentID
-                // in the GRPC http request representation, which is what we're doing here by overwriting all
-                // the existing datadog headers
-                var context = new PropagationContext(span.Context, Baggage.Current);
-                tracer.TracerManager.SpanContextPropagator.Inject(context, new RpcHttpHeadersCollection<TTarget>(typedData.Http, useNullableHeaders));
-            }
-        }
-
         private static PropagationContext ExtractPropagatedContextFromHttp<T>(T context, string? bindingName)
             where T : IFunctionContext
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -280,7 +280,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
             return scope;
         }
 
-        internal static void OverridePropagatedContext<TTarget, TTypeData>(Tracer tracer, TTypeData typedData, string? useNullableHeadersCapability)
+        internal static void OverridePropagatedContext<TTarget, TTypeData>(Tracer tracer, TTypeData typedData, bool useNullableHeaders)
             where TTypeData : ITypedData
         {
             if (tracer.Settings.IsIntegrationEnabled(IntegrationId)
@@ -294,7 +294,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                 // In order for the span hierarchy/parenting to work correctly, we need to replace the parentID
                 // in the GRPC http request representation, which is what we're doing here by overwriting all
                 // the existing datadog headers
-                var useNullableHeaders = !string.IsNullOrEmpty(useNullableHeadersCapability);
                 var context = new PropagationContext(span.Context, Baggage.Current);
                 tracer.TracerManager.SpanContextPropagator.Inject(context, new RpcHttpHeadersCollection<TTarget>(typedData.Http, useNullableHeaders));
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/GrpcMessageConversionExtensionsToRpcHttpIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/GrpcMessageConversionExtensionsToRpcHttpIntegration.cs
@@ -9,6 +9,7 @@
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
 using Microsoft.AspNetCore.Http;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions;
@@ -31,16 +32,52 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions;
 public class GrpcMessageConversionExtensionsToRpcHttpIntegration
 {
     internal static CallTargetState OnMethodBegin<TTarget, TLogger, TGrpcCapabilities>(TTarget nullInstance, HttpRequest request, TLogger logger, TGrpcCapabilities capabilities)
-        where TGrpcCapabilities : IGrpcCapabilities
     {
-        var capability = capabilities.GetCapabilityState("UseNullableValueDictionaryForHttp");
-        return new CallTargetState(scope: null, state: capability);
+        return new CallTargetState(scope: null, state: capabilities);
     }
 
-    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget nullInstance, TReturn returnValue, Exception exception, in CallTargetState state)
-        where TReturn : ITypedData
+    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget nullInstance, TReturn returnValue, Exception? exception, in CallTargetState state)
+        where TReturn : ITypedData, IDuckType
     {
-        AzureFunctionsCommon.OverridePropagatedContext<TTarget, TReturn>(Tracer.Instance, returnValue, state.State as string);
+        var capabilities = state.State.DuckCast<IGrpcCapabilities>();
+        if (capabilities is null)
+        {
+            // Something went wrong, this shouldn't happen
+            return returnValue;
+        }
+
+        // The HTTP request represented by TypedData is essentially a duplicate of the original incoming
+        // request that was received by func.exe. This is used to create a span representing
+        // the request from the client. The typed data is then sent by the GRPC connection
+        // to the functions app and is used to invoke the actual function. We intercept that
+        // in the functions app and use it to create a span representing the actual work of the app.
+        // In order for the span hierarchy/parenting to work correctly, we need to replace the parentID
+        // in the GRPC http request representation, which is what we're doing here by overwriting all
+        // the existing datadog headers
+        //
+        // However, when using the AspNetCore integration, things work a bit differently. The
+        // func.exe app instead primarily _proxies_ the HTTP request (if it is an HTTP trigger) to the functions
+        // app, instead of sending the bulk of the context as a gRPC message. This means that we _shouldn't_ inject the
+        // context into the gRPC request, because the context is already present in the incoming HTTP request, and is
+        // used preferentially.
+        //
+        // What's more, in the case of HTTP triggers with proxying enabled, the TypedData returnValue returned from
+        // this is method is a shared object, so mutating it can cause issues with other parts of the system.
+        // See https://github.com/Azure/azure-functions-host/blob/420a4686802612857cae35cefea2b685283507c9/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs#L104-L126
+
+        var isHttpProxying = !string.IsNullOrEmpty(capabilities.GetCapabilityState("HttpUri"));
+        if (isHttpProxying)
+        {
+            // The returnValue might not be the singleton instance, but as the HttpRequest is going
+            // to be forwarded anyway with the correct headers, we don't bother injecting here.
+            // TODO: is that _actually_ correct? Do we actually need to create a new TypedInfo object and inject that?
+            return returnValue;
+        }
+
+        // If we're not proxying, we can safely inject the context into the gRPC request
+        var useNullableHeaders = !string.IsNullOrEmpty(capabilities.GetCapabilityState("UseNullableValueDictionaryForHttp"));
+        AzureFunctionsCommon.OverridePropagatedContext<TTarget, TReturn>(Tracer.Instance, returnValue, useNullableHeaders);
+
         return returnValue;
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/IRpcHttp.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/IRpcHttp.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RpcHttpStruct.cs" company="Datadog">
+﻿// <copyright file="IRpcHttp.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -13,15 +13,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions;
 
 /// <summary>
 /// Duck type for RpcHttp
+/// This can't be a [DuckCopy] struct, because we set the Http property on TypedData to an instance of RpcHttp
+/// and a [DuckCopy] struct is _purely_ for extracting properites
 /// </summary>
-[DuckCopy]
-internal struct RpcHttpStruct
+internal interface IRpcHttp
 {
     /// <summary>
-    /// An IDictionary&lt;string, NullableString&gt;
+    /// Gets an IDictionary&lt;string, NullableString&gt;
     /// </summary>
-    public IDictionary NullableHeaders;
-    public IDictionary<string, string> Headers;
+    public IDictionary NullableHeaders { get; }
+
+    public IDictionary<string, string> Headers { get; }
 }
 
 #endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/ITypedData.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/ITypedData.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.DuckTyping;
+
 #if !NETFRAMEWORK
 #nullable enable
 
@@ -13,8 +15,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions;
 /// Interface because used in integration definition
 /// https://github.com/Azure/azure-functions-host/blob/8ceb05a89a4337f07264d4991545538a3e8b58a0/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto#L443
 /// </summary>
-internal interface ITypedData
+///
+internal interface ITypedData : IDuckType
 {
-    public RpcHttpStruct Http { get; }
+    public IRpcHttp Http { get; set; }
 }
 #endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/RpcHttpHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/RpcHttpHeadersCollection.cs
@@ -13,10 +13,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions;
 
 internal readonly struct RpcHttpHeadersCollection<T> : IHeadersCollection
 {
-    private readonly RpcHttpStruct _rpcHttp;
+    private readonly IRpcHttp _rpcHttp;
     private readonly bool _useNullableHeaders;
 
-    public RpcHttpHeadersCollection(RpcHttpStruct rpcHttp, bool useNullableHeaders)
+    public RpcHttpHeadersCollection(IRpcHttp rpcHttp, bool useNullableHeaders)
     {
         _rpcHttp = rpcHttp;
         _useNullableHeaders = useNullableHeaders;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/TypedDataHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/TypedDataHelper.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="TypedDataHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+#if !NETFRAMEWORK
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions;
+
+internal static class TypedDataHelper<TMarkerType>
+{
+    private static readonly ActivatorHelper TypedDataActivator;
+    private static readonly ActivatorHelper HttpActivator;
+
+    static TypedDataHelper()
+    {
+        var assembly = typeof(TMarkerType).Assembly;
+        TypedDataActivator = new ActivatorHelper(assembly.GetType("Microsoft.Azure.WebJobs.Script.Grpc.Messages.TypedData")!);
+        HttpActivator = new ActivatorHelper(assembly.GetType("Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcHttp")!);
+    }
+
+    public static ITypedData CreateTypedData()
+    {
+        // Emulate new TypedData() { Http = new RpcHttp() };
+        var typedData = TypedDataActivator.CreateInstance();
+        var typedDataProxy = typedData.DuckCast<ITypedData>();
+
+        var http = HttpActivator.CreateInstance();
+        typedDataProxy.Http = http.DuckCast<IRpcHttp>();
+
+        return typedDataProxy;
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -45,6 +45,27 @@ public abstract class AzureFunctionsTests : TestHelper
         SetEnvironmentVariable("DD_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS", ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions + ", devstoreaccount1/azure-webjobs-hosts");
     }
 
+    protected static IList<MockSpan> FilterOutSocketsHttpHandler(IImmutableList<MockSpan> spans)
+    {
+        IList<MockSpan> filteredSpans = new List<MockSpan>();
+        foreach (var span in spans)
+        {
+            if (span.Tags.TryGetValue("http-client-handler-type", out var val))
+            {
+                if (val != "System.Net.Http.SocketsHttpHandler")
+                {
+                    filteredSpans.Add(span);
+                }
+            }
+            else
+            {
+                filteredSpans.Add(span);
+            }
+        }
+
+        return filteredSpans;
+    }
+
     protected async Task<ProcessResult> RunAzureFunctionAndWaitForExit(MockTracerAgent agent, string framework = null, int expectedExitCode = 0)
     {
         // run the azure function
@@ -229,6 +250,80 @@ public abstract class AzureFunctionsTests : TestHelper
                 using var s = new AssertionScope();
 
                 await AssertIsolatedSpans(spans);
+
+                spans.Count.Should().Be(expectedSpanCount);
+            }
+        }
+    }
+
+    [UsesVerify]
+    [Collection(nameof(AzureFunctionsTestsCollection))]
+    public class IsolatedRuntimeV4AspNetCore : AzureFunctionsTests
+    {
+        public IsolatedRuntimeV4AspNetCore(ITestOutputHelper output)
+            : base("AzureFunctions.V4Isolated.AspNetCore", output)
+        {
+            SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "dotnet-isolated");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "AzureFunctions")]
+        [Trait("RunOnWindows", "True")]
+        public async Task SubmitsTraces()
+        {
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
+            {
+                const int expectedSpanCount = 26;
+                var spans = agent.WaitForSpans(expectedSpanCount);
+
+                // There are _additional_ spans created for these compared to the non-AspNetCore version
+                // These are http-client-handler-type: System.Net.Http.SocketsHttpHandler that come in around
+                // the same time as some of the `azure-functions.invoke` spans
+                // because of this they cause a lot of flake in the snapshots where they shift places
+                // opting to just scrub them from the snapshots - we also don't think that the spans provide much
+                // value so they may be removed from being traced.
+                var filteredSpans = FilterOutSocketsHttpHandler(spans);
+
+                using var s = new AssertionScope();
+
+                await AssertIsolatedSpans(filteredSpans.ToImmutableList(), $"{nameof(AzureFunctionsTests)}.Isolated.V4.AspNetCore");
+
+                spans.Count.Should().Be(expectedSpanCount);
+            }
+        }
+    }
+
+    [UsesVerify]
+    [Collection(nameof(AzureFunctionsTestsCollection))]
+    public class IsolatedRuntimeV4AspNetCoreV1 : AzureFunctionsTests
+    {
+        public IsolatedRuntimeV4AspNetCoreV1(ITestOutputHelper output)
+            : base("AzureFunctions.V4Isolated.AspNetCore.SdkV1", output)
+        {
+            SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "dotnet-isolated");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "AzureFunctions")]
+        [Trait("RunOnWindows", "True")]
+        public async Task SubmitsTraces()
+        {
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
+            {
+                const int expectedSpanCount = 26;
+                var spans = agent.WaitForSpans(expectedSpanCount);
+
+                var filteredSpans = FilterOutSocketsHttpHandler(spans);
+
+                using var s = new AssertionScope();
+
+                await AssertIsolatedSpans(filteredSpans.ToImmutableList(), $"{nameof(AzureFunctionsTests)}.Isolated.V4.AspNetCore1");
+
+                spans.Count.Should().Be(expectedSpanCount);
             }
         }
     }

--- a/tracer/test/snapshots/AzureFunctionsTests.Isolated.V4.AspNetCore.verified.txt
+++ b/tracer/test/snapshots/AzureFunctionsTests.Isolated.V4.AspNetCore.verified.txt
@@ -1,0 +1,608 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: azure-functions.invoke,
+    Resource: Timer TriggerAllTimer,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.TriggerAllTimer,
+      aas.function.name: TriggerAllTimer,
+      aas.function.trigger: Timer,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: http.request,
+    Resource: GET localhost:00000/api/trigger,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_2,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/trigger,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: azure-functions.invoke,
+    Resource: GET /api/trigger,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_3,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: TriggerCaller,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/trigger,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: azure-functions.invoke,
+    Resource: Http TriggerCaller,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_4,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.Trigger,
+      aas.function.name: TriggerCaller,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: Manual inside Trigger,
+    Resource: Manual inside Trigger,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_5,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: http.request,
+    Resource: GET localhost:00000/api/simple,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/simple,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: http.request,
+    Resource: GET localhost:00000/api/exception,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/exception,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: http.request,
+    Resource: GET localhost:00000/api/error,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/error,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: http.request,
+    Resource: GET localhost:00000/api/badrequest,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Error: 1,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 400.,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 400,
+      http.url: http://localhost:00000/api/badrequest,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: azure-functions.invoke,
+    Resource: GET /api/simple,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_7,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: SimpleHttpTrigger,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/simple,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: azure-functions.invoke,
+    Resource: GET /api/exception,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_8,
+    Error: 1,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: Exception,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      error.msg: Exception while executing function: Functions.Exception,
+      error.stack:
+Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: Functions.Exception
+---> Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException: Result: Failure
+Exception: Task failed successfully.
+Stack:    at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req, ILogger log)
+at Samples.AzureFunctions.V4Isolated.AspNetCore.DirectFunctionExecutor.ExecuteAsync(FunctionContext context),
+      error.type: Microsoft.Azure.WebJobs.Host.FunctionInvocationException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/exception,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: azure-functions.invoke,
+    Resource: GET /api/error,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_9,
+    Error: 1,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: ServerError,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/error,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: azure-functions.invoke,
+    Resource: GET /api/badrequest,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_10,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: BadRequest,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 400,
+      http.url: http://localhost:00000/api/badrequest,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: azure-functions.invoke,
+    Resource: Http SimpleHttpTrigger,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_11,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.SimpleHttpTrigger,
+      aas.function.name: SimpleHttpTrigger,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: azure-functions.invoke,
+    Resource: Http Exception,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_12,
+    Error: 1,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.Exception,
+      aas.function.name: Exception,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      error.msg: Task failed successfully.,
+      error.stack:
+System.InvalidOperationException: Task failed successfully.
+at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req, ILogger log),
+      error.type: System.InvalidOperationException,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: azure-functions.invoke,
+    Resource: Http ServerError,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_13,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.ServerError,
+      aas.function.name: ServerError,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: azure-functions.invoke,
+    Resource: Http BadRequest,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_14,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.BadRequest,
+      aas.function.name: BadRequest,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_19,
+    Name: Manual inside Simple,
+    Resource: Manual inside Simple,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_15,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: Manual inside Exception,
+    Resource: Manual inside Exception,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_16,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_21,
+    Name: Manual inside ServerError,
+    Resource: Manual inside ServerError,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_17,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_22,
+    Name: Manual inside BadRequest,
+    Resource: Manual inside BadRequest,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_18,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  }
+]

--- a/tracer/test/snapshots/AzureFunctionsTests.Isolated.V4.AspNetCore1.verified.txt
+++ b/tracer/test/snapshots/AzureFunctionsTests.Isolated.V4.AspNetCore1.verified.txt
@@ -1,0 +1,607 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: azure-functions.invoke,
+    Resource: Timer TriggerAllTimer,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.TriggerAllTimer,
+      aas.function.name: TriggerAllTimer,
+      aas.function.trigger: Timer,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: http.request,
+    Resource: GET localhost:00000/api/trigger,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_2,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/trigger,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: azure-functions.invoke,
+    Resource: GET /api/trigger,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_3,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: TriggerCaller,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/trigger,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: azure-functions.invoke,
+    Resource: Http TriggerCaller,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_4,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.Trigger,
+      aas.function.name: TriggerCaller,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: Manual inside Trigger,
+    Resource: Manual inside Trigger,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_5,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: http.request,
+    Resource: GET localhost:00000/api/simple,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/simple,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: http.request,
+    Resource: GET localhost:00000/api/exception,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/exception,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: http.request,
+    Resource: GET localhost:00000/api/error,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/error,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: http.request,
+    Resource: GET localhost:00000/api/badrequest,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Error: 1,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 400.,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 400,
+      http.url: http://localhost:00000/api/badrequest,
+      language: dotnet,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: AzureFunctionsAllTriggers
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: azure-functions.invoke,
+    Resource: GET /api/simple,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_7,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: SimpleHttpTrigger,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/simple,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: azure-functions.invoke,
+    Resource: GET /api/exception,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_8,
+    Error: 1,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: Exception,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      error.msg: Exception while executing function: Functions.Exception,
+      error.stack:
+Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: Functions.Exception
+---> Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException: Result: Failure
+Exception: System.InvalidOperationException: Task failed successfully.
+at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req, ILogger log),
+      error.type: Microsoft.Azure.WebJobs.Host.FunctionInvocationException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/exception,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: azure-functions.invoke,
+    Resource: GET /api/error,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_9,
+    Error: 1,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: ServerError,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/error,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: azure-functions.invoke,
+    Resource: GET /api/badrequest,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_10,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.name: BadRequest,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 400,
+      http.url: http://localhost:00000/api/badrequest,
+      language: dotnet,
+      runtime-id: Guid_2,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: azure-functions.invoke,
+    Resource: Http SimpleHttpTrigger,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_11,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.SimpleHttpTrigger,
+      aas.function.name: SimpleHttpTrigger,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: azure-functions.invoke,
+    Resource: Http Exception,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_12,
+    Error: 1,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.Exception,
+      aas.function.name: Exception,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      error.msg: Task failed successfully.,
+      error.stack:
+System.InvalidOperationException: Task failed successfully.
+at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req, ILogger log),
+      error.type: System.InvalidOperationException,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: azure-functions.invoke,
+    Resource: Http ServerError,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_13,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.ServerError,
+      aas.function.name: ServerError,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: azure-functions.invoke,
+    Resource: Http BadRequest,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_14,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.BadRequest,
+      aas.function.name: BadRequest,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_19,
+    Name: Manual inside Simple,
+    Resource: Manual inside Simple,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_15,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: Manual inside Exception,
+    Resource: Manual inside Exception,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_16,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_21,
+    Name: Manual inside ServerError,
+    Resource: Manual inside ServerError,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_17,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_22,
+    Name: Manual inside BadRequest,
+    Resource: Manual inside BadRequest,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_18,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  }
+]

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -404,7 +404,7 @@ namespace Samples
             {
                 return;
             }
-            
+
             var scope = GetActiveScope();
             if (scope is null)
             {
@@ -424,7 +424,7 @@ namespace Samples
                 // handled by the aspnet middleware pipeline, so we "manuallY" unwrap it 
                 SetUserMethod.Invoke(null, new object[] { span, userDetails });
             }
-            catch(System.Reflection.TargetInvocationException ex) when (ex.InnerException != null)
+            catch (System.Reflection.TargetInvocationException ex) when (ex.InnerException != null)
             {
                 System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
             }

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Program.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Hosting;
+
+// this uses the ASP.NET Core integration
+// this will cause the one function app (func.exe) to proxy
+// the HTTP trigger functions HTTP request to the ASP NET Core app
+// instead of sending it (primarily) as a gRPC message
+var host = new HostBuilder()
+    .ConfigureFunctionsWebApplication()
+    .Build();
+
+host.Run();

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Properties/launchSettings.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Properties/launchSettings.json
@@ -1,0 +1,24 @@
+{
+  "profiles": {
+    "Samples.AzureFunctions.AllTriggers": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
+        "DD_VERSION": "1.0.0",
+
+        // local.settings.json only applies to the function script, not the host, so this needs to exist here
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+
+        "DD_AZURE_APP_SERVICES": "1",
+        "DD_TRACE_AZURE_FUNCTIONS_ENABLED": "1",
+        "DD_LOGS_INJECTION": "1",
+        "DD_TRACE_DEBUG": "0"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Properties/serviceDependencies.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Properties/serviceDependencies.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights"
+    },
+    "storage1": {
+      "type": "storage",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Properties/serviceDependencies.local.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Properties/serviceDependencies.local.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights.sdk"
+    },
+    "storage1": {
+      "type": "storage.emulator",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+    <!-- We can't build and run these as multi-package versions, so we have to manually update this as required for now -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.24.0" />
+  </ItemGroup>
+  <!-- Just reducing duplication, we can evolve these separate if we need to later (Program.cs is different here)-->
+  <ItemGroup>
+    <Compile Include="..\Samples.AzureFunctions.V4Isolated\AllTriggers.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+</Project>

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!--.NET 9.0 isn't supported and will give "Invalid combination of TargetFramework and AzureFunctionsVersion is set." -->
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/host.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            }
+        }
+    }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/local.settings.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+    }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Program.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Program.cs
@@ -1,0 +1,13 @@
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.Hosting;
+
+var builder = FunctionsApplication.CreateBuilder(args);
+
+builder.ConfigureFunctionsWebApplication();
+
+// Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4.
+// builder.Services
+//     .AddApplicationInsightsTelemetryWorkerService()
+//     .ConfigureFunctionsApplicationInsights();
+
+builder.Build().Run();

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Program.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Program.cs
@@ -4,10 +4,7 @@ using Microsoft.Extensions.Hosting;
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
-
-// Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4.
-// builder.Services
-//     .AddApplicationInsightsTelemetryWorkerService()
-//     .ConfigureFunctionsApplicationInsights();
+builder.UseFunctionExecutionMiddleware();
+builder.UseOutputBindingsMiddleware();
 
 builder.Build().Run();

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Program.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Program.cs
@@ -3,8 +3,11 @@ using Microsoft.Extensions.Hosting;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
+// this uses the ASP.NET Core integration
+// this will cause the one function app (func.exe) to proxy
+// the HTTP trigger functions HTTP request to the ASP NET Core app
+// instead of sending it (primarily) as a gRPC message
+// Note: this is similar to the V1 Program.cs, just a different way to configure the builder
 builder.ConfigureFunctionsWebApplication();
-builder.UseFunctionExecutionMiddleware();
-builder.UseOutputBindingsMiddleware();
 
 builder.Build().Run();

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Properties/launchSettings.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Properties/launchSettings.json
@@ -1,0 +1,24 @@
+{
+  "profiles": {
+    "Samples.AzureFunctions.AllTriggers": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
+        "DD_VERSION": "1.0.0",
+
+        // local.settings.json only applies to the function script, not the host, so this needs to exist here
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+
+        "DD_AZURE_APP_SERVICES": "1",
+        "DD_TRACE_AZURE_FUNCTIONS_ENABLED": "1",
+        "DD_LOGS_INJECTION": "1",
+        "DD_TRACE_DEBUG": "0"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Properties/serviceDependencies.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Properties/serviceDependencies.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights"
+    },
+    "storage1": {
+      "type": "storage",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Properties/serviceDependencies.local.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Properties/serviceDependencies.local.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights.sdk"
+    },
+    "storage1": {
+      "type": "storage.emulator",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Samples.AzureFunctions.V4Isolated.AspNetCore.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Samples.AzureFunctions.V4Isolated.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Samples.AzureFunctions.V4Isolated.AspNetCore.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Samples.AzureFunctions.V4Isolated.AspNetCore.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
+  </ItemGroup>
+  <!-- Just reducing duplication, we can evolve these separate if we need to later (Program.cs is different here)-->
+  <ItemGroup>
+    <Compile Include="..\Samples.AzureFunctions.V4Isolated\AllTriggers.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+</Project>

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/host.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            }
+        }
+    }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/local.settings.json
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+    }
+}

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.SdkV1/Samples.AzureFunctions.V4Isolated.SdkV1.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.SdkV1/Samples.AzureFunctions.V4Isolated.SdkV1.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!--.NET 9.0 isn't supported and will give "Invalid combination of TargetFramework and AzureFunctionsVersion is set." -->
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.SdkV1/Samples.AzureFunctions.V4Isolated.SdkV1.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.SdkV1/Samples.AzureFunctions.V4Isolated.SdkV1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
@@ -58,7 +58,7 @@ public class AllTriggers
         // brutally kill the host, as can't find any other way to signal it should stop
         foreach (var process in Process.GetProcessesByName("func"))
         {
-            _logger.LogInformation("Killing {PID} ({Name}", process.Id, process.ProcessName);
+            _logger.LogInformation("Killing {PID} ({Name})", process.Id, process.ProcessName);
             process.Kill();
         }
     }


### PR DESCRIPTION
## Summary of changes

This fixes an application performance issue when using Isolated Azure Functions with the `ASP.NET Core` Integration caused by us modifying a `static` `TypedData` object when requests were being proxied via HTTP.

https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?tabs=hostbuilder%2Cwindows#aspnet-core-integration

## Reason for change

When using the `ASP.NET Core` integration with an Isolated Azure Functions application (`ConfigureFunctionsWebApplication`) under load the worker `ASP.NET Core` application would start to timeout on requests or hang waiting for responses from the function application.

Ultimately it appears that within `GrpcMessageConversionExtensions` a `static` instance of the `TypedData` that we used for injection was added specifically when the requests were being proxied via HTTP requests. Under load we'd end up modifying this shared object with our propagated headers which would ultimately cause requests to start timing out as we shouldn't have been modifying those headers.

## Implementation details

We now check for when the requests are being proxied and if so we generate a new, non-`static` `TypedData` instance that we can safely inject headers into. 

Additionally, injection into these will now correctly adhere to whether or not the Functions automatic instrumentation is enabled or not.

I was able to reliably reproduce the issue prior to the fix and haven't seen the issue post-fix.

## Test coverage

- Added new Azure Functions Sample projects (and tests):
  - `Samples.AzureFunctions.V4Isolated.AspNetCore.SdkV1` tests `ASP.NET Core` integration with V1 of the NuGets
  - `Samples.AzureFunctions.V4Isolated.AspNetCore.Sdk` tests `ASP.NET Core` integration with V2 of the NuGets
- Dependabot is now enabled for these sample projects as Azure Functions fell outside of our automated version range testing
- Load tested each version of the Azure Functions model locally both pre and post fix to validate that the fix worked.
- Manually tested and checked traces / spans emitted from both `ASP.NET Core` and `gRPC` Function models.

## Other details
<!-- Fixes #{issue} -->

Fixes #6494 

Noted some potential improvements in the signal-to-noise ratio of the traces / spans produced by the Functions integration that we'll bring up as future improvements.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
