### PR TITLE
[Crashtracking] Tag reports with is_crash: true

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
@@ -77,7 +77,7 @@ int32_t CrashReporting::Initialize()
         return 1;
     }
 
-    return AddTag("severity", "crash");
+    AddTag("severity", "crash");
     return AddTag("is_crash", "true");
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
@@ -78,6 +78,7 @@ int32_t CrashReporting::Initialize()
     }
 
     return AddTag("severity", "crash");
+    return AddTag("is_crash", "true");
 }
 
 void CrashReporting::SetLastError(ddog_Error error)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -274,6 +274,7 @@ public class CreatedumpTests : ConsoleTestHelper
         File.Exists(reportFile.Path).Should().BeTrue();
 
         var report = JObject.Parse(reportFile.GetContent());
+        report["tags"]["is_crash"].Value<string>().Should().Be("true");
 
         var metadataTags = (JArray)report["metadata"]!["tags"];
 


### PR DESCRIPTION
## Summary of changes

Add `is_crash:true` tag to crash reports.

## Reason for change

This is the accepted way to identify crash reports, but I completely forgot to implement it.

## Implementation details

Added a tag.

## Test coverage

Added an assertion in the crashtracking tests.
