### PR TITLE
Indentation: fix wrapping issues with rider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -78,3 +78,7 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+# Rider
+csharp_keep_existing_initializer_arrangement=true
+csharp_keep_existing_arrangement=true


### PR DESCRIPTION
## Summary of changes

When using ctrl+k,d on Rider, lines like 
` var addressesDictionary = new Dictionary<string, object>
        {
            { AddressesConstants.RequestMethod, request.Method },
            { AddressesConstants.ResponseStatus, request.HttpContext.Response.StatusCode.ToString() },
            { AddressesConstants.RequestUriRaw, request.GetUrlForWaf() },
            { AddressesConstants.RequestClientIp, _localRootSpan.GetTag(Tags.HttpClientIp) }
        };
` 
end up in one single line.
This is because of a [Rider limitation](https://youtrack.jetbrains.com/issue/RSRP-486359)  one can circumvent using: https://www.jetbrains.com/help/resharper/EditorConfig_CSHARP_LineBreaksPageSchema.html#Arrangement_of_initializers
https://youtrack.jetbrains.com/issue/RIDER-20834/csharpnewlinebeforemembersinobjectinitializers-highlights-as-unknown-but-it-works

## Reason for change

Better indentation 

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
