### PR TITLE
Point to the new domains / URLs from Microsoft in `dotnet-install`

### DIFF
--- a/tracer/build/_build/bootstrap/dotnet-install.ps1
+++ b/tracer/build/_build/bootstrap/dotnet-install.ps1
@@ -1105,8 +1105,8 @@ function Get-AkaMsLink-And-Version([string] $NormalizedChannel, [string] $Normal
 function Get-Feeds-To-Use()
 {
     $feeds = @(
-    "https://dotnetcli.azureedge.net/dotnet",
-    "https://dotnetbuilds.azureedge.net/public"
+    "https://builds.dotnet.microsoft.com/dotnet",
+    "https://ci.dot.net/public"
     )
 
     if (-not [string]::IsNullOrEmpty($AzureFeed)) {
@@ -1115,8 +1115,8 @@ function Get-Feeds-To-Use()
 
     if ($NoCdn) {
         $feeds = @(
-        "https://dotnetcli.blob.core.windows.net/dotnet",
-        "https://dotnetbuilds.blob.core.windows.net/public"
+        "https://builds.dotnet.microsoft.com/dotnet",
+        "https://ci.dot.net/public"
         )
 
         if (-not [string]::IsNullOrEmpty($UncachedFeed)) {

--- a/tracer/build/_build/bootstrap/dotnet-install.sh
+++ b/tracer/build/_build/bootstrap/dotnet-install.sh
@@ -1298,8 +1298,8 @@ get_download_link_from_aka_ms() {
 get_feeds_to_use()
 {
     feeds=(
-    "https://dotnetcli.azureedge.net/dotnet"
-    "https://dotnetbuilds.azureedge.net/public"
+    "https://builds.dotnet.microsoft.com/dotnet"
+    "https://ci.dot.net/public"
     )
 
     if [[ -n "$azure_feed" ]]; then
@@ -1308,8 +1308,8 @@ get_feeds_to_use()
 
     if [[ "$no_cdn" == "true" ]]; then
         feeds=(
-        "https://dotnetcli.blob.core.windows.net/dotnet"
-        "https://dotnetbuilds.blob.core.windows.net/public"
+        "https://builds.dotnet.microsoft.com/dotnet"
+        "https://ci.dot.net/public"
         )
 
         if [[ -n "$uncached_feed" ]]; then


### PR DESCRIPTION
## Summary of changes

Changes our copies of `dotnet-install.ps1` and `dotnet-install.sh` to point to the new feeds.

## Reason for change

Microsoft is moving to a new CDN for these and they require new URLs. See: https://github.com/dotnet/core/issues/9671

## Implementation details

Followed `User Remediation` defined in https://github.com/dotnet/core/issues/9671#issue-2757062250 

```
dotnetcli.azureedge.net -> builds.dotnet.microsoft.com
dotnetcli.blob.core.windows.net -> builds.dotnet.microsoft.com
dotnetbuilds.azureedge.net -> ci.dot.net
dotnetbuilds.blob.core.windows.net -> ci.dot.net
```

## Test coverage

## Other details

These changes have already been added in the official install scripts. However it looks like they've been added _in addition_ to the old URLs, I wasn't sure if we needed to do that or not.

https://github.com/dotnet/install-scripts/pull/555/files
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
