### PR TITLE
Add testing for macos-15

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1336,6 +1336,9 @@ partial class Build : NukeBuild
                         { "macos-14_net6.0", new { vmImage = "macos-14", publishFramework = "net6.0" } },
                         { "macos-14_net8.0", new { vmImage = "macos-14", publishFramework = "net8.0" } },
                         { "macos-14_net9.0", new { vmImage = "macos-14", publishFramework = "net9.0" } },
+                        { "macos-15_net6.0", new { vmImage = "macos-15", publishFramework = "net6.0" } },
+                        { "macos-15_net8.0", new { vmImage = "macos-15", publishFramework = "net8.0" } },
+                        { "macos-15_net9.0", new { vmImage = "macos-15", publishFramework = "net9.0" } },
                     };
 
                     Logger.Information($"Installer smoke tests dotnet-tool NuGet matrix MacOs");


### PR DESCRIPTION
## Summary of changes

Adds smoke tests for macos-15

## Reason for change

We want to make sure we're testing on the platforms we support

## Implementation details

Add to the smoke test matrix

## Test coverage

A little more.

Did a test [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=171964&view=results) and showed the macos15 tests pass (the macos12 tests failed but that's expected)

## Other details

Related to
- https://github.com/DataDog/dd-trace-dotnet/pull/6572