### PR TITLE
Debug what's going on with pipeline monitor

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6999,7 +6999,7 @@ stages:
     - bash: |
         mkdir -p $(Build.SourcesDirectory)/artifacts/build_data
         dotnet build
-        dd-trace run --set-env "DD_TRACE_LOG_DIRECTORY=$(Build.SourcesDirectory)/artifacts/build_data" -- dotnet run --no-restore --no-build -- $(Build.BuildId)
+        dd-trace run --dd-env "apm-dotnet-pipeline-monitoring" --set-env "DD_TRACE_SAMPLE_RATE=100" --set-env "DD_TRACE_DEBUG=1" --set-env "DD_INSTRUMENTATION_TELEMETRY_ENABLED=1" --set-env "DD_TRACE_LOG_DIRECTORY=$(Build.SourcesDirectory)/artifacts/build_data" -- dotnet run --no-restore --no-build -- $(Build.BuildId)
         exit $?
       displayName: "Run"
       workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"

--- a/tracer/tools/PipelineMonitor/Program.cs
+++ b/tracer/tools/PipelineMonitor/Program.cs
@@ -9,9 +9,6 @@ using PipelineMonitor;
 const string azDoApi = "https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/";
 var _cli = new HttpClient();
 
-var tracerSettings = new TracerSettings {Environment = "apm-dotnet-pipeline-monitoring", GlobalSamplingRate = 100};
-Tracer.Configure(tracerSettings);
-
 if (args?.Length == 0)
 {
     Console.WriteLine("please provide a buildid");


### PR DESCRIPTION
## Summary of changes

Enable debug for the pipeline monitor

## Reason for change

Our pipeline monitor started dropping traces recently, and we want to know why

## Implementation details

- Moved some config to the pipeline to avoid needing to re-initialize the tracer
- Enabled telemetry and debug

## Test coverage

This will hopefully give some info
