### PR TITLE
Revert "[Profiler] Make `timer_create`-based CPU profiler default"

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -25,13 +25,6 @@ std::string const Configuration::DefaultEmptyString = "";
 std::chrono::seconds const Configuration::DefaultDevUploadInterval = 20s;
 std::chrono::seconds const Configuration::DefaultProdUploadInterval = 60s;
 std::chrono::milliseconds const Configuration::DefaultCpuProfilingInterval = 9ms;
-CpuProfilerType const Configuration::DefaultCpuProfilerType =
-#ifdef _WINDOWS
-    CpuProfilerType::ManualCpuTime;
-#else
-    CpuProfilerType::TimerCreate;
-#endif
-
 
 Configuration::Configuration()
 {
@@ -105,7 +98,7 @@ Configuration::Configuration()
     _ssiLongLivedThreshold = ExtractSsiLongLivedThreshold();
     _isTelemetryToDiskEnabled = GetEnvironmentValue(EnvironmentVariables::TelemetryToDiskEnabled, false);
     _isSsiTelemetryEnabled = GetEnvironmentValue(EnvironmentVariables::SsiTelemetryEnabled, false);
-    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
+    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, CpuProfilerType::ManualCpuTime);
 }
 
 fs::path Configuration::ExtractLogDirectory()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -117,7 +117,6 @@ private:
     static std::chrono::seconds const DefaultDevUploadInterval;
     static std::chrono::seconds const DefaultProdUploadInterval;
     static std::chrono::milliseconds const DefaultCpuProfilingInterval;
-    static CpuProfilerType const DefaultCpuProfilerType;
 
     bool _isProfilingEnabled;
     bool _isCpuProfilingEnabled;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
@@ -47,13 +47,10 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var logFile = Directory.GetFiles(runner.Environment.LogDir)
                 .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
 
-            File.ReadLines(logFile)
-                .Count(l => l.Contains("Successfully setup signal handler for User defined signal 1 signal"))
-                .Should().Be(1);
+            var nbSignalHandlerInstallation = File.ReadLines(logFile)
+                .Count(l => l.Contains("Successfully setup signal handler for"));
 
-            File.ReadLines(logFile)
-                .Count(l => l.Contains("Successfully setup signal handler for Profiling timer expired signal"))
-                .Should().Be(1);
+            nbSignalHandlerInstallation.Should().Be(1);
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1043,38 +1043,20 @@ TEST_F(ConfigurationTest, CheckDefaultCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr(""));
     auto configuration = Configuration{};
-    auto expected =
-#ifdef _WINDOWS
-        CpuProfilerType::ManualCpuTime;
-#else
-        CpuProfilerType::TimerCreate;
-#endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
 }
 
 TEST_F(ConfigurationTest, CheckDefaultCpuProfilerTypeWhenEnvVarNotSet)
 {
     auto configuration = Configuration{};
-    auto expected =
-#ifdef _WINDOWS
-        CpuProfilerType::ManualCpuTime;
-#else
-        CpuProfilerType::TimerCreate;
-#endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
 }
 
 TEST_F(ConfigurationTest, CheckUnknownCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("UnknownCpuProfilerType"));
     auto configuration = Configuration{};
-    auto expected =
-#ifdef _WINDOWS
-        CpuProfilerType::ManualCpuTime;
-#else
-        CpuProfilerType::TimerCreate;
-#endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
 }
 
 TEST_F(ConfigurationTest, CheckManualCpuProfilerType)


### PR DESCRIPTION
Reverts DataDog/dd-trace-dotnet#6315

We have to revert because when threads are shutting down, we might face crashes, deadlock because the CLR calls `pthread_exit`.
https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=172042&view=logs&j=5635f724-ec42-5e82-7816-fb263b6cfcc0&t=e80b9b00-921f-539a-741c-f91926c040ef

TL;DR
`pthread_exit` is called by the CLR, which starts cleaning up the thread thread_locals. But at the same time, the CPU `timer_create`-base kicks in and tries using, indirectly, those thread_locals.