### PR TITLE
Downgrade two common errors to warnings

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValuesGenerics.cs
@@ -211,7 +211,7 @@ internal abstract class CIEnvironmentValues<TValueProvider>(TValueProvider value
 
                 if (string.IsNullOrEmpty(defaultValue))
                 {
-                    Log.Error("The Git repository couldn't be automatically extracted.");
+                    Log.Warning("The Git repository couldn't be automatically extracted.");
                 }
 
                 // If not set use the default value
@@ -245,7 +245,7 @@ internal abstract class CIEnvironmentValues<TValueProvider>(TValueProvider value
 
                 if (string.IsNullOrEmpty(defaultValue))
                 {
-                    Log.Error("The Git commit sha couldn't be automatically extracted.");
+                    Log.Warning("The Git commit sha couldn't be automatically extracted.");
                 }
 
                 // If not set use the default value


### PR DESCRIPTION
## Summary of changes

Downgrades two common error logs to warnings.

## Reason for change

There are a lot of them and they don't seem to be very actionable.

## Implementation details

`Error` -> `Warning`

## Test coverage

🙈 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
