### PR TITLE
Update to .NET SDK 9.0.102

### DIFF
--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -7,7 +7,7 @@ pr:
 
 # Global variables
 variables:
-  dotnetCoreSdkLatestVersion: 9.0.100
+  dotnetCoreSdkLatestVersion: 9.0.102
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])] # required by update-github-status
   TargetBranch: $[variables['System.PullRequest.TargetBranch']]
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -103,10 +103,10 @@ schedules:
 # Global variables
 variables:
   buildConfiguration: Release
-  dotnetCoreSdkLatestVersion: 9.0.100
+  dotnetCoreSdkLatestVersion: 9.0.102
   # This is required until we're out of rc.
   # After GA we can do a find and replace and get rid of this
-  dotnetCoreSdkLatestVersionShort: 9.0.100
+  dotnetCoreSdkLatestVersionShort: 9.0.102
   nativeBuildDotnetSdkVersion: 7.0.306
   relativeArtifacts: /tracer/src/bin/artifacts
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home

--- a/.github/actions/run-in-docker/action.yml
+++ b/.github/actions/run-in-docker/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         docker build \
-          --build-arg DOTNETSDK_VERSION=9.0.100 \
+          --build-arg DOTNETSDK_VERSION=9.0.102 \
           --tag dd-trace-dotnet/${{ inputs.baseImage }}-builder \
           --target builder \
           --file "${GITHUB_WORKSPACE}/tracer/build/_build/docker/${{ inputs.baseImage }}.dockerfile" \

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Assign to vNext Milestone"
         run: ./tracer/build.sh AssignPullRequestToMilestone

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Check Snapshots"
         run: ./tracer/build.sh SummaryOfSnapshotChanges

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Add labels"
         run: ./tracer/build.sh AssignLabelsToPullRequest

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Output current version"
         id: versions

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: '9.0.102'
 
     - name: Download datadog-ci
       run: |
@@ -101,7 +101,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: '9.0.102'
 
     - name: Download datadog-ci
       run: |

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -33,7 +33,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: '9.0.102'
 
     - name: "Get current version"
       id: versions

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Configure Git Credentials"
         run: |

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion

--- a/.github/workflows/generate_package_versions.yml
+++ b/.github/workflows/generate_package_versions.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Removing existing Datadog.Trace.Trimming.xml"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" -Recurse -File | Remove-Item

--- a/.github/workflows/verify_files_without_nullability.yml
+++ b/.github/workflows/verify_files_without_nullability.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Removing existing missing-nullability-files.csv"
         run: Get-ChildItem –Path ".\tracer\missing-nullability-files.csv" | Remove-Item

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/verify_solution_changes_are_persisted.yml
+++ b/.github/workflows/verify_solution_changes_are_persisted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Regenerating Solutions"
         run: .\tracer\build.ps1 RegenerateSolutions

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 Restore CompileManagedSrc

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.102'
 
       - name: "Regenerate docs/span_metadata.md"
         run: .\tracer\build.ps1 GenerateSpanDocumentation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ build:
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts-out) { remove-item -recurse -force artifacts-out }
-    - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e ENABLE_MULTIPROCESSOR_COMPILATION=false -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e NUGET_CERT_REVOCATION_MODE=offline registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest
+    - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e ENABLE_MULTIPROCESSOR_COMPILATION=false -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e NUGET_CERT_REVOCATION_MODE=offline datadog/dd-trace-dotnet-docker-build:9-0-102
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out
     - remove-item -recurse -force build-out\${CI_JOB_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -334,8 +334,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
     command: dotnet /build/bin/Debug/_build.dll BuildAndRunProfilerIntegrationTests
     volumes:
       - ./:/project
@@ -385,8 +385,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -481,8 +481,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project
@@ -533,8 +533,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -590,8 +590,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests
     volumes:
       - ./:/project
@@ -664,8 +664,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -762,8 +762,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.100}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.102",
     "rollForward": "minor"
   }
 }

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -31,8 +31,8 @@ RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION -Sha256 $ENV
 # Install .NET 9
 # To find these links, visit https://dotnet.microsoft.com/en-us/download, click the Windows, x64 installer, and grab the download url + SHA512 hash
 ENV DOTNET_VERSION="9.0.102" \
-    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.102-win-x64.exe" \
-    DOTNET_SHA512="91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
+    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/10bb041d-e705-473e-9654-27c0e038f5bd/447c0c10654c2949872fa6154b8c27b5/dotnet-sdk-9.0.102-win-x64.exe" \
+    DOTNET_SHA512="a12ee028f7dff8f330dbe1914534d237eb6e19cc105139ce5de69df1b4b07ee3c1a3e396574ca776a452e805052e799df14a348ace50191af514c9dc4705ecf0"
 
 COPY install_dotnet.ps1 .
 RUN powershell -Command .\install_dotnet.ps1  -Version $ENV:DOTNET_VERSION -Sha512 $ENV:DOTNET_SHA512 $ENV:DOTNET_DOWNLOAD_URL

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -31,8 +31,8 @@ RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION -Sha256 $ENV
 # Install .NET 9
 # To find these links, visit https://dotnet.microsoft.com/en-us/download, click the Windows, x64 installer, and grab the download url + SHA512 hash
 ENV DOTNET_VERSION="9.0.102" \
-    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/10bb041d-e705-473e-9654-27c0e038f5bd/447c0c10654c2949872fa6154b8c27b5/dotnet-sdk-9.0.102-win-x64.exe" \
-    DOTNET_SHA512="a12ee028f7dff8f330dbe1914534d237eb6e19cc105139ce5de69df1b4b07ee3c1a3e396574ca776a452e805052e799df14a348ace50191af514c9dc4705ecf0"
+    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.102-win-x64.exe" \
+    DOTNET_SHA512="91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
 
 COPY install_dotnet.ps1 .
 RUN powershell -Command .\install_dotnet.ps1  -Version $ENV:DOTNET_VERSION -Sha512 $ENV:DOTNET_SHA512 $ENV:DOTNET_DOWNLOAD_URL

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -30,8 +30,8 @@ RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION -Sha256 $ENV
 
 # Install .NET 9
 # To find these links, visit https://dotnet.microsoft.com/en-us/download, click the Windows, x64 installer, and grab the download url + SHA512 hash
-ENV DOTNET_VERSION="9.0.100" \
-    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/10bb041d-e705-473e-9654-27c0e038f5bd/447c0c10654c2949872fa6154b8c27b5/dotnet-sdk-9.0.100-win-x64.exe" \
+ENV DOTNET_VERSION="9.0.102" \
+    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/10bb041d-e705-473e-9654-27c0e038f5bd/447c0c10654c2949872fa6154b8c27b5/dotnet-sdk-9.0.102-win-x64.exe" \
     DOTNET_SHA512="a12ee028f7dff8f330dbe1914534d237eb6e19cc105139ce5de69df1b4b07ee3c1a3e396574ca776a452e805052e799df14a348ace50191af514c9dc4705ecf0"
 
 COPY install_dotnet.ps1 .

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -11,7 +11,7 @@ $BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 $IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 &docker build `
-   --build-arg DOTNETSDK_VERSION=9.0.100 `
+   --build-arg DOTNETSDK_VERSION=9.0.102 `
    --tag $IMAGE_NAME `
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -7,7 +7,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=9.0.100 \
+   --build-arg DOTNETSDK_VERSION=9.0.102 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/alpine.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
## Summary of changes

Bump the version of the SDK we use to build

## Reason for change

The 9.0.0 includes possible seg faults, we're hoping this will reduce random flake

## Implementation details

Bump from 9.0.100 -> 9.0.102

## Test coverage

Did a test with the updated gitlab build image [here](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/776427699) and looks OK, will revert the temporary change.

## Other details

The VMs will need updating after this + we'll need to update the gitlab build image
