### PR TITLE
Skip non-linux OCI package creation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
   - benchmarks
 
 include:
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include-wip/landerson/windows-layer/one-pipeline.yml
 
 variables:
   DOTNET_PACKAGE_VERSION:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
   - benchmarks
 
 include:
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include-wip/landerson/windows-layer/one-pipeline.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
 
 variables:
   DOTNET_PACKAGE_VERSION:

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -16,6 +16,11 @@ if [ -z "$ARCH" ]; then
   ARCH=amd64
 fi
 
+if [ "$OS" != "linux" ]; then
+  echo "Only linux packages are supported. Exiting"
+  exit 0
+fi
+
 if [ "$ARCH" == "amd64" ]; then
   SUFFIX=""
 elif [ "$ARCH" == "arm64" ]; then


### PR DESCRIPTION
## Summary of changes
Skips package creation for non-linux packages

## Reason for change
The shared pipeline is introducing support for windows OCI packages. This PR ensure dd-trace-dotnet doesn't generate nonsensical packages. Windows support can be added later
