### PR TITLE
[ASM] Fix errors exceptions on HttpContext get_Items

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -22,6 +22,8 @@ internal abstract class HttpTransportBase
 
     internal abstract bool IsBlocked { get; }
 
+    internal bool IsContextUninitialized { get; set; }
+
     internal abstract int StatusCode { get; }
 
     internal abstract IDictionary<string, object>? RouteData { get; }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -22,8 +22,6 @@ internal abstract class HttpTransportBase
 
     internal abstract bool IsBlocked { get; }
 
-    internal bool IsContextUninitialized { get; set; }
-
     internal abstract int StatusCode { get; }
 
     internal abstract IDictionary<string, object>? RouteData { get; }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -176,15 +176,15 @@ internal readonly partial struct SecurityCoordinator
             {
                 IDictionary<object, object?>? items;
 
-                // In some situations the HttpContext could have already been Uninitialized and the features
-                // are set to null, thus throwing an exception when trying to access the Items
+                // In some situations the HttpContext could have already been Uninitialized,
+                // thus throwing an exception when trying to access the Items
                 try
                 {
                     items = Context.Items;
                 }
-                catch (NullReferenceException e)
+                catch (Exception e) when (e is ObjectDisposedException or NullReferenceException)
                 {
-                    Log.Debug(e, "NullReferenceException while trying to access Items of a Context.");
+                    Log.Debug(e, "Exception while trying to access Items of a Context.");
                     IsContextUninitialized = true;
                     return false;
                 }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -174,7 +174,22 @@ internal readonly partial struct SecurityCoordinator
         {
             get
             {
-                if (Context.Items.TryGetValue(ReportedExternalWafsRequestHeadersStr, out var value))
+                IDictionary<object, object?>? items;
+
+                // In some situations the HttpContext could have already been Uninitialized and the features
+                // are set to null, thus throwing an exception when trying to access the Items
+                try
+                {
+                    items = Context.Items;
+                }
+                catch (NullReferenceException e)
+                {
+                    Log.Debug(e, "NullReferenceException while trying to access Items of a Context.");
+                    IsContextUninitialized = true;
+                    return false;
+                }
+
+                if (items.TryGetValue(ReportedExternalWafsRequestHeadersStr, out var value))
                 {
                     return value is bool boolValue && boolValue;
                 }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -185,7 +185,7 @@ internal readonly partial struct SecurityCoordinator
                 catch (Exception e) when (e is ObjectDisposedException or NullReferenceException)
                 {
                     Log.Debug(e, "Exception while trying to access Items of a Context.");
-                    IsContextUninitialized = true;
+                    SetAdditiveContextDisposed(true);
                     return false;
                 }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
@@ -177,7 +177,7 @@ internal partial class SecurityReporter
     internal void TryReport(IResult result, bool blocked, int? status = null)
     {
         IHeadersCollection? headers = null;
-        if (!_httpTransport.ReportedExternalWafsRequestHeaders && !_httpTransport.IsContextUninitialized)
+        if (!_httpTransport.ReportedExternalWafsRequestHeaders && !_httpTransport.IsAdditiveContextDisposed())
         {
             headers = _httpTransport.GetRequestHeaders();
             AddHeaderTags(_span, headers, ExternalWafsRequestHeaders, SpanContextPropagator.HttpRequestHeadersTagPrefix);
@@ -220,7 +220,7 @@ internal partial class SecurityReporter
             _span.SetMetric(Metrics.AppSecWafDuration, result.AggregatedTotalRuntime);
             _span.SetMetric(Metrics.AppSecWafAndBindingsDuration, result.AggregatedTotalRuntimeWithBindings);
 
-            if (headers is null && !_httpTransport.IsContextUninitialized)
+            if (headers is null && !_httpTransport.IsAdditiveContextDisposed())
             {
                 headers = _httpTransport.GetRequestHeaders();
             }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
@@ -169,7 +169,7 @@ internal partial class SecurityReporter
 
     /// <summary>
     /// This functions reports the security scan result and the schema extraction if there was one
-    /// Dont try to test if result should be reported, it's all in here
+    /// Don't try to test if result should be reported, it's all in here
     /// </summary>
     /// <param name="result">waf's result</param>
     /// <param name="blocked">if request was blocked</param>
@@ -177,7 +177,7 @@ internal partial class SecurityReporter
     internal void TryReport(IResult result, bool blocked, int? status = null)
     {
         IHeadersCollection? headers = null;
-        if (!_httpTransport.ReportedExternalWafsRequestHeaders)
+        if (!_httpTransport.ReportedExternalWafsRequestHeaders && !_httpTransport.IsContextUninitialized)
         {
             headers = _httpTransport.GetRequestHeaders();
             AddHeaderTags(_span, headers, ExternalWafsRequestHeaders, SpanContextPropagator.HttpRequestHeadersTagPrefix);
@@ -219,8 +219,16 @@ internal partial class SecurityReporter
 
             _span.SetMetric(Metrics.AppSecWafDuration, result.AggregatedTotalRuntime);
             _span.SetMetric(Metrics.AppSecWafAndBindingsDuration, result.AggregatedTotalRuntimeWithBindings);
-            headers ??= _httpTransport.GetRequestHeaders();
-            AddHeaderTags(_span, headers, RequestHeaders, SpanContextPropagator.HttpRequestHeadersTagPrefix);
+
+            if (headers is null && !_httpTransport.IsContextUninitialized)
+            {
+                headers = _httpTransport.GetRequestHeaders();
+            }
+
+            if (headers is not null)
+            {
+                AddHeaderTags(_span, headers, RequestHeaders, SpanContextPropagator.HttpRequestHeadersTagPrefix);
+            }
 
             if (status is not null)
             {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
@@ -5,11 +5,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Web;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.AppSec.Waf.NativeBindings;
+using Datadog.Trace.Configuration;
 using FluentAssertions;
 #if NETCOREAPP
 using Microsoft.AspNetCore.Http;
@@ -54,6 +54,37 @@ namespace Datadog.Trace.Security.Unit.Tests
             var securityCoordinator = SecurityCoordinator.TryGet(AppSec.Security.Instance, span);
             var result = securityCoordinator.Value.RunWaf(new(), runWithEphemeral: true, isRasp: true);
             result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GivenHttpTransportInstanceWithUninitializedContext_WhenGetItems_ThenItemsIsNull()
+        {
+            var contextMoq = new Mock<HttpContext>();
+            contextMoq.Setup(x => x.Items).Throws(new NullReferenceException("Test exception"));
+            var context = contextMoq.Object;
+            HttpTransport transport = new(context);
+            transport.ReportedExternalWafsRequestHeaders.Should().BeFalse();
+        }
+
+        [Fact]
+        public void GivenHttpTransportInstanceWithUninitializedContext_WhenRunWaf_ThenResultIsNull()
+        {
+            var settings = TracerSettings.Create(new Dictionary<string, object>());
+            var tracer = new Tracer(settings, null, null, null, null);
+            var rootTestScope = (Scope)tracer.StartActive("test.trace");
+
+            var contextMoq = new Mock<HttpContext>();
+            contextMoq.Setup(x => x.Items).Throws(new NullReferenceException("Test exception"));
+            var context = contextMoq.Object;
+            CoreHttpContextStore.Instance.Set(context);
+
+            var securityCoordinator = SecurityCoordinator.TryGet(AppSec.Security.Instance, rootTestScope.Span);
+            securityCoordinator.HasValue.Should().BeTrue();
+
+            var result = new Result(new DdwafResultStruct(), WafReturnCode.Match, 0, 0);
+            securityCoordinator.Value.Reporter.TryReport(result, true);
+
+            rootTestScope.Span.Tags.GetTag(Tags.AppSecBlocked).Should().Be("true");
         }
 #endif
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Web;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.AppSec.Waf;


### PR DESCRIPTION
## Summary of changes

Handle the errors when trying to access the Items features of the `HttpContext`.

All usage of Context.Items int the SecurityCoordinator has been changed so the errors are caught.

Should fix these example stacktraces:

```
System.NullReferenceException
   at Microsoft.AspNetCore.Http.DefaultHttpContext.get_Items()
   at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.HttpTransport.get_ReportedExternalWafsRequestHeaders()
   at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.TryReport(IResult result, Boolean blocked, Nullable`1 status)
   at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.ReportAndBlock(IResult result)
   at Datadog.Trace.AppSec.Rasp.RaspModule.RunWafRasp(Dictionary`2 arguments, Span rootSpan, String address)
   at Datadog.Trace.AppSec.VulnerabilitiesModule.OnSSRF(String uriText)
   at Datadog.Trace.Iast.Aspects.System.Net.HttpClientAspect.Review(String parameter)
```

```
System.ObjectDisposedException
   at Microsoft.AspNetCore.Http.Features.FeatureReferences`1.ThrowContextDisposed()
   at Microsoft.AspNetCore.Http.DefaultHttpContext.get_Items()
   at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.HttpTransport.get_ReportedExternalWafsRequestHeaders()
   at Datadog.Trace.AppSec.Coordinator.SecurityReporter.TryReport(IResult result, Boolean blocked, Nullable`1 status)
   at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.ReportAndBlock(IResult result)
   at Datadog.Trace.AppSec.Rasp.RaspModule.RunWafRasp(Dictionary`2 arguments, Span rootSpan, String address)
   at Datadog.Trace.AppSec.VulnerabilitiesModule.OnSSRF(String uriText)
   at Datadog.Trace.Iast.Aspects.System.Net.HttpClientAspect.Review(String parameter)
```


## Reason for change

A `ObjectDisposedException` and a `NullReferenceException` can happen in concurrent access to the `HttpContext`.
This situation of race condition can happen while the request is finished while async jobs still run in the background and the waf for RASP is run.

The HttpContext can be disposed from different manner by the user. You can find more information in this [PR](https://github.com/DataDog/dd-trace-dotnet/pull/6529).

## Implementation details

A new boolean have been added that reflect the state if the Items threw an exception, thus making the code not access the HttpContext anymore in the `TryReport` method.

## Test coverage

Added a unit test verifying that our code doesn't throw exceptions when the `Items` of the `HttpContext` isn't available.

## Other details

Related PRs:
- https://github.com/DataDog/dd-trace-dotnet/pull/6529
- https://github.com/DataDog/dd-trace-dotnet/pull/6030
- https://github.com/DataDog/dd-trace-dotnet/pull/6017