### PR TITLE
[CI Visibility] Fix detached head situation

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -88,8 +88,16 @@ internal class IntelligentTestRunnerClient
         _customConfigurations = GetCustomTestsConfigurations(_settings.TracerSettings.GlobalTags);
 
         _repositoryUrl = GetRepositoryUrl();
-        _branchName = GetBranchName();
+        _repositoryUrl = GetRepositoryUrl();
         _commitSha = GetCommitSha();
+        _branchName = GetBranchName();
+
+        if (string.IsNullOrEmpty(_branchName))
+        {
+            Log.Warning("ITR: empty branch indicates a detached head at commit {Commit}", _commitSha);
+            _branchName = $"detached-at-{_commitSha}";
+        }
+
         _apiRequestFactory = CIVisibility.GetRequestFactory(_settings.TracerSettings, TimeSpan.FromSeconds(45));
 
         const string settingsUrlPath = "api/v2/libraries/tests/services/setting";

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -91,12 +91,6 @@ internal class IntelligentTestRunnerClient
         _commitSha = GetCommitSha();
         _branchName = GetBranchName();
 
-        if (string.IsNullOrEmpty(_branchName))
-        {
-            Log.Warning("ITR: empty branch indicates a detached head at commit {Commit}", _commitSha);
-            _branchName = $"detached-at-{_commitSha}";
-        }
-
         _apiRequestFactory = CIVisibility.GetRequestFactory(_settings.TracerSettings, TimeSpan.FromSeconds(45));
 
         const string settingsUrlPath = "api/v2/libraries/tests/services/setting";
@@ -1276,7 +1270,15 @@ internal class IntelligentTestRunnerClient
         }
 
         var gitOutput = GitCommandHelper.RunGitCommand(_workingDirectory, "branch --show-current", MetricTags.CIVisibilityCommands.GetBranch);
-        return gitOutput?.Output.Replace("\n", string.Empty) ?? string.Empty;
+        var res = gitOutput?.Output.Replace("\n", string.Empty) ?? string.Empty;
+
+        if (string.IsNullOrEmpty(res))
+        {
+            Log.Warning("ITR: empty branch indicates a detached head at commit {Commit}", _commitSha);
+            res = $"detached-at-{_commitSha}";
+        }
+
+        return res;
     }
 
     private string GetCommitSha()

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -88,7 +88,6 @@ internal class IntelligentTestRunnerClient
         _customConfigurations = GetCustomTestsConfigurations(_settings.TracerSettings.GlobalTags);
 
         _repositoryUrl = GetRepositoryUrl();
-        _repositoryUrl = GetRepositoryUrl();
         _commitSha = GetCommitSha();
         _branchName = GetBranchName();
 

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -1275,7 +1275,7 @@ internal class IntelligentTestRunnerClient
         if (string.IsNullOrEmpty(res))
         {
             Log.Warning("ITR: empty branch indicates a detached head at commit {Commit}", _commitSha);
-            res = $"detached-at-{_commitSha}";
+            res = $"auto:git-detached-head";
         }
 
         return res;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
@@ -257,7 +257,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     baseSha = output.Output.Trim();
                     if (string.IsNullOrEmpty(branch))
                     {
-                        branch = $"detached-at-{baseSha}";
+                        branch = $"auto:git-detached-head";
                     }
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
@@ -28,8 +28,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             SetServiceName("xunit-tests");
             SetServiceVersion("1.0.0");
-
-            SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
@@ -28,6 +28,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             SetServiceName("xunit-tests");
             SetServiceVersion("1.0.0");
+
+            SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
         }
 
         [SkippableTheory]


### PR DESCRIPTION
## Summary of changes
In a detached head situation, create a synthetic branch name like `auto:git-detached-head`.

## Reason for change
An empty branch name (as when a detached head happens) leads to many of the TestVis features to be disabled.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
