### PR TITLE
Refactor the NGEN tracking fix to be more performant

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -628,28 +628,6 @@ public:
     HRESULT TryParse();
 };
 
-struct ModuleIDMethodDef {
-    ModuleID ModuleId;
-    mdMethodDef MethodDef;
-
-    // Hash function
-    std::size_t operator()(const ModuleIDMethodDef& i) const {
-        return static_cast<std::size_t>(i.ModuleId) ^ (static_cast<std::size_t>(i.MethodDef) << 1);
-    }
-    // Comparison for equality
-    bool operator ()(const ModuleIDMethodDef& lhs, const ModuleIDMethodDef& rhs) const  {
-        return lhs.ModuleId == rhs.ModuleId && lhs.MethodDef == rhs.MethodDef;
-    }
-
-    bool operator ==(const ModuleIDMethodDef& other) const  {
-        return this->ModuleId == other.ModuleId && this->MethodDef == other.MethodDef;
-    }
-
-    bool operator !=(const ModuleIDMethodDef& other) const  {
-        return this->ModuleId != other.ModuleId || this->MethodDef != other.MethodDef;
-    }
-};
-
 RuntimeInformation GetRuntimeInformation(ICorProfilerInfo4* info);
 
 AssemblyInfo GetAssemblyInfo(ICorProfilerInfo4* info, const AssemblyID& assembly_id);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -115,7 +115,7 @@ private:
     //
     // Helper methods
     //
-    void RewritingPInvokeMaps(const ModuleID module_id, const ModuleMetadata& module_metadata, const shared::WSTRING& rewrite_reason,
+    void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const shared::WSTRING& rewrite_reason,
                               const shared::WSTRING& nativemethods_type_name,
                               const shared::WSTRING& library_path = shared::WSTRING());
     static void __stdcall NativeLog(int32_t level, const WCHAR* message, int32_t length);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -78,9 +78,6 @@ private:
     bool call_target_bubble_up_exception_available = false;
     bool call_target_bubble_up_exception_function_available = false;
 
-    // Internal rewrite tokens
-    Synchronized<std::unordered_set<ModuleIDMethodDef, ModuleIDMethodDef, ModuleIDMethodDef>> internal_rewrite_tokens;
-
     //
     // Debugger Members
     //
@@ -101,11 +98,13 @@ private:
     std::vector<std::string> opcodes_names;
 
     //
-    // Module helper variables
+    // Module helper variables and internal tokens (use internal tokens only if the module_ids lock is in place)
     //
     Synchronized<std::vector<ModuleID>> module_ids;
-
-    ModuleID managedProfilerModuleId_;
+    std::vector<ModuleID> managedInternalModules_;
+    mdMethodDef getDistributedTraceMethodDef_;
+    mdMethodDef getNativeTracerVersionMethodDef_;
+    mdMethodDef isManualInstrumentationOnlyMethodDef_;
 
     //
     // Dataflow members

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -60,6 +60,7 @@ private:
     bool first_jit_compilation_completed = false;
 
     bool corlib_module_loaded = false;
+    ModuleID corlib_module_id = 0;
     AppDomainID corlib_app_domain_id = 0;
     bool managed_profiler_loaded_domain_neutral = false;
     std::unordered_map<AppDomainID, Version> managed_profiler_loaded_app_domains;


### PR DESCRIPTION
## Summary of changes

This PR refactor the NGEN tracking fix to remove the `lock` and the `unordered_set` and reuse the `module_ids` lock and a vector + 3 mdMethodDef field.

## Reason for change

After #6588 was merged, @andrewlock saw some performance impact in the Execution Benchmarks.

## Implementation details

Remove a lock and an unordered_set for just a field comparison + a vector Contains if a field is found. 

This should improve everything on the missed hit because is just a comparison over 3 fields.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
