### PR TITLE
[build] add `GenerateIntegrationDefinitionFiles` build step

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -379,7 +379,7 @@ partial class Build
         .DependsOn(CompileTracerNativeSrcWindows)
         .DependsOn(CompileNativeSrcMacOs)
         .DependsOn(CompileTracerNativeSrcLinux)
-        .After(CompileManagedSrc);
+        .After(GenerateIntegrationDefinitionFiles);
 
     Target CompileTracerNativeTests => _ => _
         .Unlisted()
@@ -442,10 +442,6 @@ partial class Build
             var toBuild = include.Except(exclude);
 
             DotnetBuild(toBuild, noDependencies: false);
-
-            var nativeGeneratedFilesOutputPath = NativeTracerProject.Directory / "Generated";
-            CallSitesGenerator.GenerateCallSites(TargetFrameworks, tfm => DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath);
-            CallTargetsGenerator.GenerateCallTargets(TargetFrameworks, tfm => DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath, Version, BuildDirectory);
         });
 
     Target CompileTracerNativeTestsWindows => _ => _

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -226,7 +226,7 @@ partial class Build
 
            var testDir = Solution.GetProject(Projects.ClrProfilerIntegrationTests).Directory;
            var dependabotProj = TracerDirectory / "dependabot" / "Datadog.Dependabot.Integrations.csproj";
-           var definitionsFile = BuildDirectory / FileNames.DefinitionsJson;
+           var definitionsFile = BuildDirectory / FileNames.CallTargetDefinitionsJson;
            var currentDependencies = DependabotFileManager.GetCurrentlyTestedVersions(dependabotProj);
            var excludedFromUpdates = ((IncludePackages, ExcludePackages) switch
                                          {

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Amazon.SimpleSystemsManagement.Model;
+using CodeGenerators;
 using DiffMatchPatch;
 using GenerateSpanDocumentation;
 using GeneratePackageVersions;
@@ -471,6 +472,17 @@ partial class Build
                     }
                 });
 
+    Target GenerateIntegrationDefinitionFiles => _ => _
+        .Description("Regenerates integration definition files for call target and call site")
+        .After(CompileManagedSrc)
+        .Executes(() =>
+        {
+            Func<string,string> getDllPath = tfm => DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll";
+            var nativeGeneratedFilesOutputPath = NativeTracerProject.Directory / "Generated";
+
+            CallSitesGenerator.GenerateCallSites(TargetFrameworks, getDllPath, nativeGeneratedFilesOutputPath);
+            CallTargetsGenerator.GenerateCallTargets(TargetFrameworks, getDllPath, nativeGeneratedFilesOutputPath, Version, BuildDirectory);
+        });
 
     private void ReplaceReceivedFilesInSnapshots()
     {

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -254,14 +254,14 @@ partial class Build
 
            var outputPath = TracerDirectory / "build" / "supported_versions.json";
            await GenerateSupportMatrix.GenerateInstrumentationSupportMatrix(outputPath, distinctIntegrations);
-           
+
            Logger.Information("Verifying that updated dependabot file is valid...");
 
            var tempProjectFile = TempDirectory / "dependabot_test" / "Project.csproj";
            CopyFile(dependabotProj, tempProjectFile, FileExistsPolicy.Overwrite);
            DotNetRestore(x => x.SetProjectFile(tempProjectFile));
        });
-    
+
     Target GenerateSpanDocumentation => _ => _
         .Description("Regenerate documentation from our code models")
         .Executes(() =>
@@ -422,7 +422,7 @@ partial class Build
                             Logger.Information("Removing project '{Name}'", x.Name);
                             sln.RemoveProject(x);
                         });
-                    
+
                     sln.Save();
 
                     bool IsTestApplication(Project x)
@@ -513,9 +513,9 @@ partial class Build
             // not in CI
             return false;
         }
-        
+
         return scheduleName == "Daily Debug Run";
-    } 
+    }
 
     private static MSBuildTargetPlatform GetDefaultTargetPlatform()
     {
@@ -531,7 +531,7 @@ partial class Build
 
         return MSBuildTargetPlatform.x64;
     }
-    
+
     private static string GetDefaultRuntimeIdentifier(bool isAlpine)
     {
         // https://learn.microsoft.com/en-us/dotnet/core/rid-catalog
@@ -542,7 +542,7 @@ partial class Build
 
             (PlatformFamily.Linux, "x64") => isAlpine ? "linux-musl-x64" : "linux-x64",
             (PlatformFamily.Linux, "ARM64" or "ARM64EC") => isAlpine ? "linux-musl-arm64" : "linux-arm64",
-            
+
             (PlatformFamily.OSX, "ARM64" or "ARM64EC") => "osx-arm64",
             _ => null
         };

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -189,16 +189,16 @@ partial class Build : NukeBuild
     Target BuildNativeTracerHome => _ => _
         .Unlisted()
         .Description("Builds the native src ")
-        .After(Clean, CompileManagedLoader)
+        .After(Clean, CompileManagedLoader, BuildManagedTracerHome)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(CompileTracerNativeSrc)
-        .DependsOn(PublishNativeTracer);
-
+        .DependsOn(PublishNativeTracer)
+        .DependsOn(GenerateIntegrationDefinitionFiles);
 
     Target BuildManagedTracerHome => _ => _
         .Unlisted()
         .Description("Builds the managed src, and publishes the tracer home directory")
-        .After(Clean, BuildNativeTracerHome)
+        .After(Clean)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(Restore)
         .DependsOn(CompileManagedSrc)

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -197,7 +197,7 @@ partial class Build : NukeBuild
 
     Target BuildManagedTracerHome => _ => _
         .Unlisted()
-        .Description("Builds the native and managed src, and publishes the tracer home directory")
+        .Description("Builds the managed src, and publishes the tracer home directory")
         .After(Clean, BuildNativeTracerHome)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(Restore)
@@ -207,10 +207,10 @@ partial class Build : NukeBuild
         .DependsOn(CopyLibDdwaf)
         .DependsOn(CreateMissingNullabilityFile)
         .DependsOn(CreateTrimmingFile);
-    
+
     Target BuildManagedTracerHomeR2R => _ => _
         .Unlisted()
-        .Description("Builds the native and managed src, and publishes the tracer home directory")
+        .Description("Builds the managed src, and publishes the tracer home directory")
         .After(Clean, BuildNativeTracerHome)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(Restore)

--- a/tracer/build/_build/CodeGenerators/CallSitesGenerator.cs
+++ b/tracer/build/_build/CodeGenerators/CallSitesGenerator.cs
@@ -305,7 +305,7 @@ namespace CodeGenerators
 
 
             if (!Directory.Exists(outputPath)) { Directory.CreateDirectory(outputPath); }
-            var fileName = outputPath / "generated_callsites.g.cpp";
+            var fileName = outputPath / FileNames.CallSitesDefinitionsCpp;
             File.WriteAllText(fileName, sb.ToString());
 
             Logger.Information("CallSite definitions File saved: {File}", fileName);

--- a/tracer/build/_build/CodeGenerators/CallTargetsGenerator.cs
+++ b/tracer/build/_build/CodeGenerators/CallTargetsGenerator.cs
@@ -662,7 +662,7 @@ namespace CodeGenerators
             string jsonString = JsonConvert.SerializeObject(orderedDefinitions, Formatting.Indented);
 
             if (!Directory.Exists(outputPath)) { Directory.CreateDirectory(outputPath); }
-            var fileName = outputPath / FileNames.DefinitionsJson;
+            var fileName = outputPath / FileNames.CallTargetDefinitionsJson;
             File.WriteAllText(fileName, jsonString);
 
             Logger.Information("CallTarget definitions File saved: {File}", fileName);

--- a/tracer/build/_build/CodeGenerators/CallTargetsGenerator.cs
+++ b/tracer/build/_build/CodeGenerators/CallTargetsGenerator.cs
@@ -13,9 +13,7 @@ namespace CodeGenerators
 {
     internal static class CallTargetsGenerator
     {
-        private const string NullLiteral = "null";
-
-        public static void GenerateCallTargets(IEnumerable<TargetFramework> targetFrameworks, Func<string, string> getDllPath, AbsolutePath outputPath, string version, AbsolutePath dependabotPath) 
+        public static void GenerateCallTargets(IEnumerable<TargetFramework> targetFrameworks, Func<string, string> getDllPath, AbsolutePath outputPath, string version, AbsolutePath dependabotPath)
         {
             Logger.Debug("Generating CallTarget definitions file ...");
 
@@ -536,7 +534,7 @@ namespace CodeGenerators
             {
                 signatureTexts.Add(GetSignature(definition.Key));
             }
-           
+
             var signatures = new Dictionary<string, string>();
             foreach (var sig in signatureTexts.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
             {
@@ -595,7 +593,6 @@ namespace CodeGenerators
                 }
                 }
                 """);
-
 
             if (!Directory.Exists(outputPath)) { Directory.CreateDirectory(outputPath); }
             var fileName = outputPath / "generated_calltargets.g.cpp";

--- a/tracer/build/_build/CodeGenerators/CallTargetsGenerator.cs
+++ b/tracer/build/_build/CodeGenerators/CallTargetsGenerator.cs
@@ -595,7 +595,7 @@ namespace CodeGenerators
                 """);
 
             if (!Directory.Exists(outputPath)) { Directory.CreateDirectory(outputPath); }
-            var fileName = outputPath / "generated_calltargets.g.cpp";
+            var fileName = outputPath / FileNames.CallTargetDefinitionsCpp;
             File.WriteAllText(fileName, sb.ToString());
 
             Logger.Information("CallTarget definitions File saved: {File}", fileName);

--- a/tracer/build/_build/Projects.cs
+++ b/tracer/build/_build/Projects.cs
@@ -54,7 +54,7 @@ public static class FileNames
     public const string AfterInstallScript = "after-install.sh";
     public const string AfterRemoveScript = "after-remove.sh";
 
-    public const string DefinitionsJson = "supported_calltargets.g.json";
+    public const string CallTargetDefinitionsJson = "supported_calltargets.g.json";
     public const string CallTargetDefinitionsCpp = "generated_calltargets.g.cpp";
     public const string CallSitesDefinitionsCpp = "generated_callsites.g.cpp";
 }

--- a/tracer/build/_build/Projects.cs
+++ b/tracer/build/_build/Projects.cs
@@ -55,4 +55,6 @@ public static class FileNames
     public const string AfterRemoveScript = "after-remove.sh";
 
     public const string DefinitionsJson = "supported_calltargets.g.json";
+    public const string CallTargetDefinitionsCpp = "generated_calltargets.g.cpp";
+    public const string CallSitesDefinitionsCpp = "generated_callsites.g.cpp";
 }


### PR DESCRIPTION
## Summary of changes

Factor out the code that generates the integration definition files into a separate build step.

## Reason for change

Moving this code into it's own step allows running this step individually. It also better represents the fact that this code in neither part of compiling managed C# source code or compiling native C++ source code. It's an intermediate step that depends on the C# code to be compiled first, and is required before compiling the C++ code.

```
CompileManagedSrc -> GenerateIntegrationDefinitionFiles -> CompileTracerNativeSrc
```

## Implementation details

- add new `GenerateIntegrationDefinitionFiles` Nuke build step
- set up dependencies between steps
- use string constants for filenames
- misc clean up

## Test coverage

- [ ] test the build when adding a new integration

<!-- ## Other details -->
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
