### PR TITLE
[ASM] Fix NullReferenceException on HttpTransport get_StatusCode

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -22,7 +22,7 @@ internal abstract class HttpTransportBase
 
     internal abstract bool IsBlocked { get; }
 
-    internal abstract int StatusCode { get; }
+    internal abstract int? StatusCode { get; }
 
     internal abstract IDictionary<string, object>? RouteData { get; }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -170,7 +170,21 @@ internal readonly partial struct SecurityCoordinator
             get => GetItems()?.TryGetValue(BlockingAction.BlockDefaultActionName, out var value) == true && value is true;
         }
 
-        internal override int StatusCode => Context.Response.StatusCode;
+        internal override int? StatusCode
+        {
+            get
+            {
+                try
+                {
+                    return Context.Response.StatusCode;
+                }
+                catch (Exception e) when (e is NullReferenceException or ObjectDisposedException)
+                {
+                    Log.Debug(e, "Exception while trying to access StatusCode of a Context.Response.");
+                    return null;
+                }
+            }
+        }
 
         internal override IDictionary<string, object>? RouteData => Context.GetRouteData()?.Values;
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Util.Http;
+using Datadog.Trace.Vendors.Serilog.Events;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
@@ -185,7 +186,11 @@ internal readonly partial struct SecurityCoordinator
                 }
                 catch (Exception e) when (e is NullReferenceException or ObjectDisposedException)
                 {
-                    Log.Debug(e, "Exception while trying to access StatusCode of a Context.Response.");
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        Log.Debug(e, "Exception while trying to access StatusCode of a Context.Response.");
+                    }
+
                     SetAdditiveContextDisposed(true);
                     return null;
                 }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -174,6 +174,11 @@ internal readonly partial struct SecurityCoordinator
         {
             get
             {
+                if (IsAdditiveContextDisposed())
+                {
+                    return null;
+                }
+
                 try
                 {
                     return Context.Response.StatusCode;
@@ -181,6 +186,7 @@ internal readonly partial struct SecurityCoordinator
                 catch (Exception e) when (e is NullReferenceException or ObjectDisposedException)
                 {
                     Log.Debug(e, "Exception while trying to access StatusCode of a Context.Response.");
+                    SetAdditiveContextDisposed(true);
                     return null;
                 }
             }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -526,7 +526,7 @@ internal readonly partial struct SecurityCoordinator
 
         internal override bool IsBlocked => Context.Items[BlockingAction.BlockDefaultActionName] is true;
 
-        internal override int StatusCode => Context.Response.StatusCode;
+        internal override int? StatusCode => Context.Response.StatusCode;
 
         public override HttpContext Context { get; } = context;
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -63,7 +63,7 @@ internal readonly partial struct SecurityCoordinator
                 return null;
             }
 
-            _security.ApiSecurity.ShouldAnalyzeSchema(lastWafCall, _localRootSpan, args, _httpTransport.StatusCode.ToString(), _httpTransport.RouteData);
+            _security.ApiSecurity.ShouldAnalyzeSchema(lastWafCall, _localRootSpan, args, _httpTransport.StatusCode?.ToString(), _httpTransport.RouteData);
 
             // run the WAF and execute the results
             result = runWithEphemeral


### PR DESCRIPTION
## Summary of changes

Handle the errors when trying to access the `StatusCode` of the `HttpResponse` from the Context.

## Reason for change

Errors in telemetry identified by these stacktraces:

```
System.NullReferenceException
   at Microsoft.AspNetCore.Http.DefaultHttpResponse.get_StatusCode()
   at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.RunWaf(Dictionary`2 args, Boolean lastWafCall, Boolean runWithEphemeral, Boolean isRasp)
```

A `ObjectDisposedException` and a `NullReferenceException` can happen in concurrent access to the `HttpContext`.
This situation of race condition can happen while the request is finished while async jobs still run in the background and the waf for RASP is run.

The HttpContext can be disposed from different manner by the user. You can find more information in this [PR](https://github.com/DataDog/dd-trace-dotnet/pull/6529).

## Implementation details

- The getter for the `StatusCode` has been changed so it could return a `int?` if an exception has been triggered.
- The method `ShouldAnalyzeSchema()` is already working with a null `StatusCode`.
