### PR TITLE
[ASM][ATO] user id from sdk overwrite user login tags

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
+++ b/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
@@ -58,6 +58,9 @@ public static class EventTrackingSdk
 
         setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessTrack, Tags.AppSec.EventsUsers.True);
         setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessSdkSource, Tags.AppSec.EventsUsers.True);
+        // cf https://datadoghq.atlassian.net/wiki/spaces/SAAL/pages/2755793809/Application+Security+Events+Tracking+API+SDK#Specification
+        // ADDENDUM 2024-12-18] In both login success and failure, the field usr.login must be passed to root span metadata tags (appsec.events.users.login.(success|failure).usr.login), and to the WAF
+        setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, userId);
         setTag(Tags.User.Id, userId);
 
         if (metadata is { Count: > 0 })
@@ -103,7 +106,8 @@ public static class EventTrackingSdk
         void RunWafAndCollectHeaders()
         {
             securityCoordinator.Value.Reporter.CollectHeaders();
-            var result = securityCoordinator.Value.RunWafForUser(userId: userId, fromSdk: true);
+            // confluence [ADDENDUM 2024-12-18] In both login success and failure, the field usr.login must be passed to the WAF. The value of this field must be sourced from either the user object when available, or copied from the value of the mandatory user ID.
+            var result = securityCoordinator.Value.RunWafForUser(userId: userId, userLogin: userId, fromSdk: true);
             securityCoordinator.Value.BlockAndReport(result);
         }
     }
@@ -153,6 +157,9 @@ public static class EventTrackingSdk
         setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureSdkSource, Tags.AppSec.EventsUsers.True);
         setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId, userId);
         setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserExists, exists ? Tags.AppSec.EventsUsers.True : Tags.AppSec.EventsUsers.False);
+        // cf https://datadoghq.atlassian.net/wiki/spaces/SAAL/pages/2755793809/Application+Security+Events+Tracking+API+SDK#Specification
+        // ADDENDUM 2024-12-18] In both login success and failure, the field usr.login must be passed to root span metadata tags (appsec.events.users.login.(success|failure).usr.login), and to the WAF
+        setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, userId);
 
         if (metadata is { Count: > 0 })
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/HttpContextSetUser.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/HttpContextSetUser.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
                             userId = processPii?.Invoke(claim.Value) ?? claim.Value;
                             tryAddTag(Tags.User.Id, userId);
                             setTag(Tags.AppSec.EventsUsers.InternalUserId, userId);
-                            setTag(Tags.AppSec.EventsUsers.CollectionMode, successAutoMode);
+                            tryAddTag(Tags.AppSec.EventsUsers.CollectionMode, successAutoMode);
 
                             secCoord.Reporter.CollectHeaders();
                             security.SetTraceSamplingPriority(span);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
@@ -113,7 +113,7 @@ public static class SignInManagerPasswordSignInUserIntegration
                     foundLogin = true;
                     var login = processPii?.Invoke(userLogin!) ?? userLogin!;
                     setTag(Tags.AppSec.EventsUsers.InternalLogin, login);
-                    setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, login);
+                    tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, login);
                 }
 
                 var duckCast = instance.TryDuckCast<ISignInManager>(out var value);
@@ -143,7 +143,7 @@ public static class SignInManagerPasswordSignInUserIntegration
                 {
                     var login = processPii?.Invoke(userLogin!) ?? userLogin!;
                     setTag(Tags.AppSec.EventsUsers.InternalLogin, login);
-                    setTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, login);
+                    tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessLogin, login);
                 }
             }
 #endif

--- a/tracer/src/Datadog.Trace/SpanExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.Framework.cs
@@ -32,12 +32,8 @@ namespace Datadog.Trace
                     return;
                 }
 
-                var wafArgs = new Dictionary<string, object>
-                {
-                    { AddressesConstants.UserId, userId },
-                };
-
-                securityCoordinator.Value.BlockAndReport(wafArgs);
+                var result = securityCoordinator.Value.RunWafForUser(userId, fromSdk: true);
+                securityCoordinator.Value.BlockAndReport(result);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.cs
@@ -50,6 +50,7 @@ namespace Datadog.Trace
 
             // usr.id should always be set, even when PropagateId is true
             setTag(Tags.User.Id, userDetails.Id);
+            setTag(Tags.AppSec.EventsUsers.CollectionMode, Tags.AppSec.EventsUsers.Sdk);
 
             if (userDetails.PropagateId)
             {

--- a/tracer/src/Datadog.Trace/Tags.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Tags.AppSec.cs
@@ -25,6 +25,7 @@ public static partial class Tags
             internal const string InternalLogin = $"{PropagatedPrefix}.login";
             internal const string True = "true";
             internal const string False = "false";
+            internal const string Sdk = "sdk";
 
             internal static class LoginEvent
             {

--- a/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -326,7 +326,8 @@
       usr.name: Bits,
       usr.role: Mascot,
       usr.scope: test-scope,
-      usr.session_id: abc123
+      usr.session_id: abc123,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -496,6 +497,7 @@ CustomException: Exception of type 'CustomException' was thrown.
       appsec.events.users.login.success.key-1: val-1,
       appsec.events.users.login.success.key-2: val-2,
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: my-id,
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
@@ -589,6 +591,7 @@ CustomException: Exception of type 'CustomException' was thrown.
       appsec.events.users.login.failure.track: true,
       appsec.events.users.login.failure.usr.exists: true,
       appsec.events.users.login.failure.usr.id: my-id,
+      appsec.events.users.login.failure.usr.login: my-id,
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,

--- a/tracer/test/snapshots/Security.AspNetCore5AsmDataSecurityDisabled.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AsmDataSecurityDisabled.__test=blocking-user_url=_user.verified.txt
@@ -20,7 +20,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -50,7 +51,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/Security.AspNetCore5AsmDataSecurityEnabled.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AsmDataSecurityEnabled.__test=blocking-user_url=_user.verified.txt
@@ -24,6 +24,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
+      _dd.appsec.user.collection_mode: sdk,
       _dd.runtime_family: dotnet
     },
     Metrics: {
@@ -70,6 +71,7 @@
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.fp.session: ssn-5860faf0---,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"blk-001-002","name":"Block User Addresses","tags":{"category":"security_response","type":"block_user"}},"rule_matches":[{"operator":"exact_match","operator_value":"","parameters":[{"address":"usr.id","highlight":["user3"],"key_path":[],"value":"user3"}]}]}]},
+      _dd.appsec.user.collection_mode: sdk,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginWithSdk.blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginWithSdk.blocked-user.verified.txt
@@ -9,6 +9,7 @@
     Tags: {
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginWithSdk.not-blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginWithSdk.not-blocked-user.verified.txt
@@ -9,6 +9,7 @@
     Tags: {
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: not-blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginWithSdk.blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginWithSdk.blocked-user.verified.txt
@@ -12,7 +12,7 @@
       appsec.event: true,
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: anon_eb97d409396a3e5392936dad92b909da,
+      appsec.events.users.login.success.usr.login: blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginWithSdk.not-blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginWithSdk.not-blocked-user.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: anon_eb97d409396a3e5392936dad92b909da,
+      appsec.events.users.login.success.usr.login: not-blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginWithSdk.blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginWithSdk.blocked-user.verified.txt
@@ -12,7 +12,7 @@
       appsec.event: true,
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: TestUser,
+      appsec.events.users.login.success.usr.login: blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginWithSdk.not-blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginWithSdk.not-blocked-user.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: TestUser,
+      appsec.events.users.login.success.usr.login: not-blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginWithSdk.blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginWithSdk.blocked-user.verified.txt
@@ -12,7 +12,7 @@
       appsec.event: true,
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: TestUser,
+      appsec.events.users.login.success.usr.login: blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginWithSdk.not-blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginWithSdk.not-blocked-user.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: TestUser,
+      appsec.events.users.login.success.usr.login: not-blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginWithSdk.blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginWithSdk.blocked-user.verified.txt
@@ -12,7 +12,7 @@
       appsec.event: true,
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: TestUser,
+      appsec.events.users.login.success.usr.login: blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginWithSdk.not-blocked-user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginWithSdk.not-blocked-user.verified.txt
@@ -9,7 +9,7 @@
     Tags: {
       appsec.events.users.login.success.some-metadata: some-value,
       appsec.events.users.login.success.track: true,
-      appsec.events.users.login.success.usr.login: TestUser,
+      appsec.events.users.login.success.usr.login: not-blocked-user,
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.AccountController.Index (Samples.Security.AspNetCore5),
       aspnet_core.route: {controller=home}/{action=index}/{id?},
       component: aspnet_core,

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
@@ -39,7 +39,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -88,7 +89,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
@@ -45,6 +45,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
+      _dd.appsec.user.collection_mode: sdk,
       _dd.runtime_family: dotnet
     },
     Metrics: {
@@ -112,6 +113,7 @@
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.fp.session: ssn-5860faf0---,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"blk-001-002","name":"Block User Addresses","tags":{"category":"security_response","type":"block_user"}},"rule_matches":[{"operator":"exact_match","operator_value":"","parameters":[{"address":"usr.id","highlight":["user3"],"key_path":[],"value":"user3"}]}]}]},
+      _dd.appsec.user.collection_mode: sdk,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
@@ -39,7 +39,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -88,7 +89,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
@@ -45,6 +45,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
+      _dd.appsec.user.collection_mode: sdk,
       _dd.runtime_family: dotnet
     },
     Metrics: {
@@ -113,6 +114,7 @@
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.fp.session: ssn-5860faf0---,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"blk-001-002","name":"Block User Addresses","tags":{"category":"security_response","type":"block_user"}},"rule_matches":[{"operator":"exact_match","operator_value":"","parameters":[{"address":"usr.id","highlight":["user3"],"key_path":[],"value":"user3"}]}]}]},
+      _dd.appsec.user.collection_mode: sdk,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetWebApiAsmData.Classic.enableSecurity=False.__test=blocking-user_url=_api_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApiAsmData.Classic.enableSecurity=False.__test=blocking-user_url=_api_user.verified.txt
@@ -38,7 +38,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -86,7 +87,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/Security.AspNetWebApiAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_api_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApiAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_api_user.verified.txt
@@ -42,6 +42,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
+      _dd.appsec.user.collection_mode: sdk,
       _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
@@ -109,6 +110,7 @@
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.fp.session: ssn-5860faf0---,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"blk-001-002","name":"Block User Addresses","tags":{"category":"security_response","type":"block_user"}},"rule_matches":[{"operator":"exact_match","operator_value":"","parameters":[{"address":"usr.id","highlight":["user3"],"key_path":[],"value":"user3"}]}]}]},
+      _dd.appsec.user.collection_mode: sdk,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetWebApiAsmData.Integrated.enableSecurity=False.__test=blocking-user_url=_api_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApiAsmData.Integrated.enableSecurity=False.__test=blocking-user_url=_api_user.verified.txt
@@ -38,7 +38,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -86,7 +87,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/Security.AspNetWebApiAsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_api_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApiAsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_api_user.verified.txt
@@ -42,6 +42,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
+      _dd.appsec.user.collection_mode: sdk,
       _dd.runtime_family: dotnet
     },
     Metrics: {
@@ -108,6 +109,7 @@
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.fp.session: ssn-5860faf0---,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"blk-001-002","name":"Block User Addresses","tags":{"category":"security_response","type":"block_user"}},"rule_matches":[{"operator":"exact_match","operator_value":"","parameters":[{"address":"usr.id","highlight":["user3"],"key_path":[],"value":"user3"}]}]}]},
+      _dd.appsec.user.collection_mode: sdk,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Classic.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Classic.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
@@ -16,7 +16,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -42,7 +43,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
@@ -20,6 +20,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
+      _dd.appsec.user.collection_mode: sdk,
       _dd.appsec.waf.version: 1.22.0,
       _dd.runtime_family: dotnet
     },
@@ -64,6 +65,7 @@
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.fp.session: ssn-5860faf0---,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"blk-001-002","name":"Block User Addresses","tags":{"category":"security_response","type":"block_user"}},"rule_matches":[{"operator":"exact_match","operator_value":"","parameters":[{"address":"usr.id","highlight":["user3"],"key_path":[],"value":"user3"}]}]}]},
+      _dd.appsec.user.collection_mode: sdk,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Integrated.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Integrated.enableSecurity=False.__test=blocking-user_url=_user.verified.txt
@@ -16,7 +16,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,
@@ -42,7 +43,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      usr.id: user3
+      usr.id: user3,
+      _dd.appsec.user.collection_mode: sdk
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebFormsAsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
@@ -20,6 +20,7 @@
       span.kind: server,
       usr.id: user3,
       _dd.appsec.event_rules.version: 1.13.3,
+      _dd.appsec.user.collection_mode: sdk,
       _dd.runtime_family: dotnet
     },
     Metrics: {
@@ -62,6 +63,7 @@
       _dd.appsec.fp.http.network: net-1-1000000000,
       _dd.appsec.fp.session: ssn-5860faf0---,
       _dd.appsec.json: {"triggers":[{"rule":{"id":"blk-001-002","name":"Block User Addresses","tags":{"category":"security_response","type":"block_user"}},"rule_matches":[{"operator":"exact_match","operator_value":"","parameters":[{"address":"usr.id","highlight":["user3"],"key_path":[],"value":"user3"}]}]}]},
+      _dd.appsec.user.collection_mode: sdk,
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },


### PR DESCRIPTION
## Summary of changes

Copy user id from sdk to login field , for span and waf
Add collection_mode on the set user api 
change snapshots accordingly

## Reason for change

Addendum in Confluence [ADDENDUM 2024-12-18] In both login success and failure, the field usr.login must be passed to root span metadata tags (appsec.events.users.login.(success|failure).usr.login), and to the WAF. The value of this field must be sourced from either the user object when available, or copied from the value of the mandatory user ID.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
