### PR TITLE
[ASM] Skip all tests for DefaultInterpolatedStringHandler

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/DefaultInterpolatedStringHandlerTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/DefaultInterpolatedStringHandlerTests.cs
@@ -17,7 +17,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AddTainted(TaintedValue);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted1_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -28,7 +28,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted1_GetString_NonVulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -39,7 +39,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertNotTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted2_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -50,7 +50,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted2_GetString_NonVulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -61,7 +61,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertNotTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted3_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -72,7 +72,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted3_GetString_NonVulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -83,7 +83,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertNotTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted4_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -94,7 +94,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted4_GetString_NonVulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -105,7 +105,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertNotTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted5_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -116,7 +116,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted5_GetString_NonVulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -127,7 +127,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertNotTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted6_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -138,7 +138,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted6_GetString_NonVulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -149,7 +149,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertNotTainted(str);
     }
     
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueAppendFormatted7_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -160,7 +160,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingUntaintedValueAppendFormatted7_GetString_NonVulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();
@@ -171,7 +171,7 @@ public class DefaultInterpolatedStringHandlerTests : InstrumentationTestsBase
         AssertNotTainted(str);
     }
 
-    [Fact]
+    [Fact (Skip = "Flaky test")]
     public void GivenAnExplicitInterpolatedString_WhenAddingTaintedValueMultipleValues_GetString_Vulnerable()
     {
         var test = new DefaultInterpolatedStringHandler();


### PR DESCRIPTION
## Summary of changes

Skip all tests from the `DefaultInterpolatedStringHandlerTests` class (as Flaky).

## Reason for change

The tests are flaky and we identified the issues and working on a fix.

The current issue with `DefaultInterpolatedStringHandler` tainting process is because of the current implementation. In IAST we store all tainted objects with a `WeakReference` into a map.
For the case of the `DefaultInterpolatedStringHandler`, we get an `IntPtr` from the struct and store that pointer. However there is no strong reference anywhere and the stored IntPtr can be Garbage Collected at any time thus making the detection of a tainted struct flaky.
