### PR TITLE
regenerate solutions as part of building the managed tracer

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -206,7 +206,8 @@ partial class Build : NukeBuild
         .DependsOn(DownloadLibDdwaf)
         .DependsOn(CopyLibDdwaf)
         .DependsOn(CreateMissingNullabilityFile)
-        .DependsOn(CreateTrimmingFile);
+        .DependsOn(CreateTrimmingFile)
+        .DependsOn(RegenerateSolutions);
     
     Target BuildManagedTracerHomeR2R => _ => _
         .Unlisted()


### PR DESCRIPTION
## Summary of changes

the target `RegenerateSolutions` was not called by anything else. Added it to `BuildManagedTracerHome` so that it'd run on `BuildTracerHome`, which I assume(d) would regenerate everything that needs to