### PR TITLE
[ASM] Dont store additive context in httpcontext

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -5,24 +5,26 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using Datadog.Trace.AppSec.Rasp;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.AppSec;
 
-internal class AppSecRequestContext
+internal partial class AppSecRequestContext
 {
     private const string StackKey = "_dd.stack";
     private const string ExploitStackKey = "exploit";
     private const string VulnerabilityStackKey = "vulnerability";
     private const string AppsecKey = "appsec";
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AppSecRequestContext>();
     private readonly object _sync = new();
+    private readonly RaspTelemetryHelper? _raspTelemetryHelper = Security.Instance.RaspEnabled ? new RaspTelemetryHelper() : null;
     private readonly List<object> _wafSecurityEvents = new();
-    private Dictionary<string, List<Dictionary<string, object>>>? _raspStackTraces = null;
-    private RaspTelemetryHelper? _raspTelemetryHelper = Security.Instance.RaspEnabled ? new RaspTelemetryHelper() : null;
+    private Dictionary<string, List<Dictionary<string, object>>>? _raspStackTraces;
 
     internal void CloseWebSpan(TraceTagCollection tags, Span span)
     {
@@ -95,5 +97,38 @@ internal class AppSecRequestContext
 
             _raspStackTraces[stackCategory].Add(stackTrace);
         }
+    }
+}
+
+internal partial class AppSecRequestContext
+{
+    private bool _isAdditiveContextDisposed;
+
+    private IContext? _context;
+
+    /// <summary>
+    /// Disposes the WAF's context stored in HttpContext.Items[]. If it doesn't exist, nothing happens, no crash
+    /// </summary>
+    internal void DisposeAdditiveContext()
+    {
+        _context?.Dispose();
+        _isAdditiveContextDisposed = true;
+    }
+
+    internal IContext? GetOrCreateAdditiveContext(Security security)
+    {
+        if (_isAdditiveContextDisposed)
+        {
+            Log.Debug("Additive context was requested when already disposed");
+            return null;
+        }
+
+        if (_context is not null)
+        {
+            return _context;
+        }
+
+        _context = security.CreateAdditiveContext();
+        return _context;
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
@@ -24,19 +24,6 @@ internal static class AttackerFingerprintHelper
             return;
         }
 
-        var securityCoordinator = SecurityCoordinator.TryGet(Security.Instance, span);
-
-        if (securityCoordinator is null)
-        {
-            return;
-        }
-
-        // We need a context
-        if (securityCoordinator.Value.IsAdditiveContextDisposed())
-        {
-            return;
-        }
-
         AddSpanTags(result.FingerprintDerivatives, span);
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.AppSec.Coordinator;
 
 internal abstract class HttpTransportBase
 {
-    private bool _isAdditiveContextDisposed;
+    internal bool IsHttpContextDisposed { get; set; }
 
     internal abstract bool IsBlocked { get; }
 
@@ -30,24 +30,7 @@ internal abstract class HttpTransportBase
 
     public abstract HttpContext Context { get; }
 
-    internal abstract IContext? GetAdditiveContext();
-
-    /// <summary>
-    /// Disposes the WAF's context stored in HttpContext.Items[]. If it doesn't exist, nothing happens, no crash
-    /// </summary>
-    internal void DisposeAdditiveContext()
-    {
-        GetAdditiveContext()?.Dispose();
-        _isAdditiveContextDisposed = true;
-    }
-
-    internal bool IsAdditiveContextDisposed() => _isAdditiveContextDisposed;
-
-    protected void SetAdditiveContextDisposed(bool value) => _isAdditiveContextDisposed = value;
-
-    internal abstract void SetAdditiveContext(IContext additiveContext);
-
-    internal abstract IHeadersCollection GetRequestHeaders();
+    internal abstract IHeadersCollection? GetRequestHeaders();
 
     internal abstract IHeadersCollection GetResponseHeaders();
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -28,6 +28,7 @@ internal readonly partial struct SecurityCoordinator
     {
         _security = security;
         _localRootSpan = TryGetRoot(span);
+        _appsecRequestContext = _localRootSpan.Context.TraceContext.AppSecRequestContext;
         _httpTransport = transport;
         Reporter = new SecurityReporter(_localRootSpan, transport, true);
     }
@@ -175,11 +176,6 @@ internal readonly partial struct SecurityCoordinator
         {
             get
             {
-                if (IsAdditiveContextDisposed())
-                {
-                    return null;
-                }
-
                 try
                 {
                     return Context.Response.StatusCode;
@@ -191,7 +187,7 @@ internal readonly partial struct SecurityCoordinator
                         Log.Debug(e, "Exception while trying to access StatusCode of a Context.Response.");
                     }
 
-                    SetAdditiveContextDisposed(true);
+                    IsHttpContextDisposed = true;
                     return null;
                 }
             }
@@ -213,44 +209,9 @@ internal readonly partial struct SecurityCoordinator
             }
         }
 
-        internal override void MarkBlocked()
-        {
-            var items = GetItems();
-            if (items is not null)
-            {
-                items[BlockingAction.BlockDefaultActionName] = true;
-            }
-        }
-
-        internal override IContext? GetAdditiveContext() => IsAdditiveContextDisposed() ? null : GetContextFeatures()?.Get<IContext>();
-
-        internal override void SetAdditiveContext(IContext additiveContext) => Context.Features.Set(additiveContext);
-
-        internal override IHeadersCollection GetRequestHeaders() => new HeadersCollectionAdapter(Context.Request.Headers);
-
-        internal override IHeadersCollection GetResponseHeaders() => new HeadersCollectionAdapter(Context.Response.Headers);
-
-        // In some edge situations we can get an ObjectDisposedException when accessing the context features or other
-        // properties such as Context.Items or Context.Response.Headers that ultimately rely on features
-        // This means that the context has been uninitialized, and we should not try to access it anymore
-        // Unfortunately, there is no way to know that but catching the exception or using reflection
-        private IFeatureCollection? GetContextFeatures()
-        {
-            try
-            {
-                return Context.Features;
-            }
-            catch (ObjectDisposedException)
-            {
-                Log.Debug("ObjectDisposedException while trying to access a Context.");
-                SetAdditiveContextDisposed(true);
-                return null;
-            }
-        }
-
         private IDictionary<object, object>? GetItems()
         {
-            if (IsAdditiveContextDisposed())
+            if (IsHttpContextDisposed)
             {
                 return null;
             }
@@ -264,11 +225,35 @@ internal readonly partial struct SecurityCoordinator
             catch (Exception e) when (e is ObjectDisposedException or NullReferenceException)
             {
                 Log.Debug(e, "Exception while trying to access Items of a Context.");
-                SetAdditiveContextDisposed(true);
+                IsHttpContextDisposed = true;
                 return null;
             }
         }
+
+        internal override void MarkBlocked()
+        {
+            var items = GetItems();
+            if (items is not null)
+            {
+                items[BlockingAction.BlockDefaultActionName] = true;
+            }
+        }
+
+        internal override IHeadersCollection? GetRequestHeaders()
+        {
+            try
+            {
+                return new HeadersCollectionAdapter(Context.Request.Headers);
+            }
+            catch (Exception e) when (e is ObjectDisposedException or NullReferenceException)
+            {
+                Log.Debug(e, "Exception while trying to access Items of a Context.");
+                IsHttpContextDisposed = true;
+                return null;
+            }
+        }
+
+        internal override IHeadersCollection GetResponseHeaders() => new HeadersCollectionAdapter(Context.Response.Headers);
     }
 }
 #endif
-

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -32,6 +32,7 @@ internal readonly partial struct SecurityCoordinator
     {
         _security = security;
         _localRootSpan = TryGetRoot(span);
+        _appsecRequestContext = _localRootSpan.Context.TraceContext.AppSecRequestContext;
         _httpTransport = transport;
         Reporter = new SecurityReporter(_localRootSpan, transport, true);
     }
@@ -519,8 +520,6 @@ internal readonly partial struct SecurityCoordinator
 
     internal class HttpTransport(HttpContext context) : HttpTransportBase
     {
-        private const string WafKey = "waf";
-
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<HttpTransport>();
 
         private static bool _canReadHttpResponseHeaders = true;
@@ -540,10 +539,6 @@ internal readonly partial struct SecurityCoordinator
         }
 
         internal override void MarkBlocked() => Context.Items[BlockingAction.BlockDefaultActionName] = true;
-
-        internal override IContext? GetAdditiveContext() => Context.Items[WafKey] as IContext;
-
-        internal override void SetAdditiveContext(IContext additiveContext) => Context.Items[WafKey] = additiveContext;
 
         internal override IHeadersCollection GetRequestHeaders() => new NameValueHeadersCollection(Context.Request.Headers);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
@@ -132,7 +132,7 @@ internal class BlockingMiddleware
                             securityReporter.TryReport(blockException.Result, endedResponse);
                         }
 
-                        securityReporter.AddResponseHeadersToSpanAndCleanup();
+                        securityReporter.AddResponseHeadersToSpan();
                     }
                     else
                     {

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -171,12 +171,7 @@ namespace Datadog.Trace.PlatformHelpers
                 if (security.AppsecEnabled)
                 {
                     var securityCoordinator = SecurityCoordinator.Get(security, span, new SecurityCoordinator.HttpTransport(httpContext));
-                    securityCoordinator.Reporter.AddResponseHeadersToSpanAndCleanup();
-                }
-                else
-                {
-                    // remember security could have been disabled while a request is still executed
-                    new SecurityCoordinator.HttpTransport(httpContext).DisposeAdditiveContext();
+                    securityCoordinator.Reporter.AddResponseHeadersToSpan();
                 }
 
                 CoreHttpContextStore.Instance.Remove();

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -119,9 +119,7 @@ namespace Datadog.Trace
         internal bool WafExecuted { get; set; }
 
         internal static TraceContext? GetTraceContext(in ArraySegment<Span> spans) =>
-            spans.Count > 0 ?
-                spans.Array![spans.Offset].Context.TraceContext :
-                null;
+            spans.Count > 0 ? spans.Array![spans.Offset].Context.TraceContext : null;
 
         internal void EnableIastInRequest()
         {
@@ -172,10 +170,12 @@ namespace Datadog.Trace
                         }
                     }
 
-                    _appSecRequestContext?.CloseWebSpan(Tags, span);
+                    if (_appSecRequestContext is not null)
+                    {
+                        _appSecRequestContext.CloseWebSpan(Tags, span);
+                        _appSecRequestContext.DisposeAdditiveContext();
+                    }
                 }
-
-                _appSecRequestContext?.DisposeAdditiveContext();
             }
 
             if (!string.Equals(span.ServiceName, Tracer.DefaultServiceName, StringComparison.OrdinalIgnoreCase))

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -152,25 +152,30 @@ namespace Datadog.Trace
             ArraySegment<Span> spansToWrite = default;
 
             // Propagate the resource name to the profiler for root web spans
-            if (span is { IsRootSpan: true, Type: SpanTypes.Web })
+            if (span.IsRootSpan)
             {
-                Profiler.Instance.ContextTracker.SetEndpoint(span.RootSpanId, span.ResourceName);
-
-                var iastInstance = Iast.Iast.Instance;
-                if (iastInstance.Settings.Enabled)
+                if (span.Type == SpanTypes.Web)
                 {
-                    if (_iastRequestContext is { } iastRequestContext)
+                    Profiler.Instance.ContextTracker.SetEndpoint(span.RootSpanId, span.ResourceName);
+
+                    var iastInstance = Iast.Iast.Instance;
+                    if (iastInstance.Settings.Enabled)
                     {
-                        iastRequestContext.AddIastVulnerabilitiesToSpan(span);
-                        iastInstance.OverheadController.ReleaseRequest();
+                        if (_iastRequestContext is { } iastRequestContext)
+                        {
+                            iastRequestContext.AddIastVulnerabilitiesToSpan(span);
+                            iastInstance.OverheadController.ReleaseRequest();
+                        }
+                        else
+                        {
+                            IastRequestContext.AddIastDisabledFlagToSpan(span);
+                        }
                     }
-                    else
-                    {
-                        IastRequestContext.AddIastDisabledFlagToSpan(span);
-                    }
+
+                    _appSecRequestContext?.CloseWebSpan(Tags, span);
                 }
 
-                _appSecRequestContext?.CloseWebSpan(Tags, span);
+                _appSecRequestContext?.DisposeAdditiveContext();
             }
 
             if (!string.Equals(span.ServiceName, Tracer.DefaultServiceName, StringComparison.OrdinalIgnoreCase))

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/EmptyDatadogTracer.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/EmptyDatadogTracer.cs
@@ -1,0 +1,29 @@
+// <copyright file="EmptyDatadogTracer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Configuration;
+// <copyright file="EmptyDatadogTracer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Security.Unit.Tests
+{
+    public class EmptyDatadogTracer : IDatadogTracer
+    {
+        public string DefaultServiceName => "My Service Name";
+
+        public TracerSettings Settings => new(new NullConfigurationSource());
+
+        IGitMetadataTagsProvider IDatadogTracer.GitMetadataTagsProvider => new NullGitMetadataProvider();
+
+        PerTraceSettings IDatadogTracer.PerTraceSettings => null;
+
+        void IDatadogTracer.Write(ArraySegment<Span> span)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

First part of https://datadoghq.atlassian.net/jira/software/c/projects/APPSEC/boards/2876/backlog?selectedIssue=APPSEC-55247

Store waf context in trace context instead

## Reason for change

avoid httpcontext related errors when retrieving the waf context

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
