### PR TITLE
Stop intalling all the .NET SDK versions in benchmark agents

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3595,7 +3595,7 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
 
-    - template: steps/install-dotnet-sdks.yml
+    - template: steps/install-latest-dotnet-sdk.yml
     - template: steps/restore-working-directory.yml
 
     - task: DownloadPipelineArtifact@2
@@ -4976,7 +4976,7 @@ stages:
       parameters:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
-    - template: steps/install-dotnet-sdks.yml
+    - template: steps/install-latest-dotnet-sdk.yml
     - template: steps/restore-working-directory.yml
 
     - task: DownloadPipelineArtifact@2
@@ -5108,7 +5108,7 @@ stages:
       parameters:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
-    - template: steps/install-dotnet-sdks.yml
+    - template: steps/install-latest-dotnet-sdk.yml
       parameters:
         includeX86: true
 


### PR DESCRIPTION
## Summary of changes

Only install the SDK version specified in the global.json

## Reason for change

Currently the benchmark agents are installing _every_ patch release of _every_ TFM we ever test against. That means they slowly run out of space. We're only (currently) running benchmarks against EOL TFMs anyway, so there _aren't_ new versions of these to test against anyway, so this is purely just a maintenance burden.

## Implementation details

Use `install-latest-dotnet-sdk.yml` instead of `install-dotnet-sdks.yml`

## Test coverage

Meh, I'm sure it'll be fine. 

## Other details

Yeah "latest" is not a great description for the task but ah well 🙈 