### PR TITLE
Update framing of GitHub Issues for clarity

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,4 +1,4 @@
-name: "Bug Report (Low Priority)"
+name: "Bug Report (Public)"
 description: "Create a public Bug Report. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult."
 title: "[BUG]: "
 labels: type:bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Bug Report (High Priority)
+  - name: Bug Report (Helpdesk)
     url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:.net
     about: Create an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private. Please do not create a GitHub issue to report a bug.
-  - name: Feature Request (High Priority)
+  - name: Feature Request (Helpdesk)
     url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:.net&tf_1260825272270=pt_apm_category_feature_request
     about: Create an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private. Please do not create a GitHub issue to request a feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Library Version(s)
       description: "If your feature request is to add instrumentation support for a library please provide the version you use"
-      placeholder: 5.2
+      placeholder: "5.2"
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,4 +1,4 @@
-name: Feature Request (Low Priority)
+name: Feature Request (Public)
 description: Create a public Feature Request. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult.
 title: "[FEATURE]: "
 labels: type:enhancement


### PR DESCRIPTION
## Summary of changes

This changes wording from `Low Priority` and `High Priority` to be `Public` and `Helpdesk` for clarity.

Additionally, fixes an issue causing the Feature Request option to not show up.

## Reason for change

I think it more accurately represents what the various options mean.

## Implementation details

I changed the letters to the new letters.

## Test coverage

🚫 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
