### PR TITLE
[CI Visibility] Disable ImpactedTests flaky test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
@@ -86,6 +86,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [Trait("Category", "TestIntegrations")]
         public Task EnabledBySettings(string packageVersion)
         {
+            Skip.If(EnvironmentHelper.IsAlpine(), "This test is currently flaky in alpine due to a Detached Head status. An issue has been opened to handle the situation. Meanwhile we are skipping it.");
+
             InjectGitHubActionsSession(true, null);
             return SubmitTests(packageVersion, 2, TestIsModified);
         }


### PR DESCRIPTION
## Summary of changes
This PR disables a test failing in Alpine due to a Detached Head status. We are working in a way to handle this situation.

## Reason for change
Test failing in Alpine

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
