### PR TITLE
Use the gitlab mirror to avoid pulling issues

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ build:
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `
         -e NUGET_CERT_REVOCATION_MODE=offline `
-        datadog/dd-trace-dotnet-docker-build:9-0-102 `
+        registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest `
         Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PackageTracerHome ZipSymbols SignDlls SignMsi
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out


### PR DESCRIPTION
## Summary of changes

Use the mirrored docker build image to avoid pull issues

## Reason for change

We should build using the mirrored images

## Implementation details

Update to use the mirrored image

## Test coverage

This is the test

## Other details

Requires https://github.com/DataDog/images/pull/6496