### PR TITLE
[ASM] Fix Blocking Redirect Invalid Status Code

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/BlockingAction.cs
+++ b/tracer/src/Datadog.Trace/AppSec/BlockingAction.cs
@@ -17,8 +17,6 @@ internal record BlockingAction
 
     public const string GenerateStackType = "generate_stack";
 
-    public bool IsPermanentRedirect => StatusCode == 301;
-
     public string ContentType { get; set; }
 
     public int StatusCode { get; set; }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -375,14 +375,17 @@ internal readonly partial struct SecurityCoordinator
             }
         }
 
-        httpResponse.StatusCode = blockingAction.StatusCode;
-
         if (blockingAction.IsRedirect)
         {
-            httpResponse.Redirect(blockingAction.RedirectLocation, blockingAction.IsPermanentRedirect);
+            httpResponse.Redirect(blockingAction.RedirectLocation, false);
+
+            // Redirect() set a status code (301 or 302) and ends the response,
+            // but we want to set the status code to the one we have in the blocking action
+            httpResponse.StatusCode = blockingAction.StatusCode;
         }
         else
         {
+            httpResponse.StatusCode = blockingAction.StatusCode;
             httpResponse.ContentType = blockingAction.ContentType;
             httpResponse.Write(blockingAction.ResponseContent);
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -61,12 +61,12 @@ namespace Datadog.Trace.Security.IntegrationTests
 #pragma warning restore SA1202 // Elements should be ordered by access
 #pragma warning restore SA1401 // Fields should be private
 
-        public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null, string testName = null, bool clearMetaStruct = false)
+        public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null, string testName = null, bool clearMetaStruct = false, bool allowAutoRedirect = true)
             : base(Prefix + sampleName, samplesDir ?? "test/test-applications/security", outputHelper)
         {
             _testName = Prefix + (testName ?? sampleName);
             _cookieContainer = new CookieContainer();
-            var handler = new HttpClientHandler();
+            var handler = new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect };
             handler.CookieContainer = _cookieContainer;
             _httpClient = new HttpClient(handler);
             _shutdownPath = shutdownPath;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -54,9 +54,8 @@ namespace Datadog.Trace.Security.IntegrationTests
             var agent = Fixture.Agent;
 
             const string url = "/";
-            var filename = "Security.AspNetCore5ExternalRules.TestBlockingRedirectInvalidStatusCode." + ruleTriggerStatusCode;
 
-            var settings = VerifyHelper.GetSpanVerifierSettings();
+            var settings = VerifyHelper.GetSpanVerifierSettings(ruleTriggerStatusCode, returnedStatusCode);
             var userAgent = "Canary/v3_" + ruleTriggerStatusCode;
 
             var minDateTime = DateTime.UtcNow;
@@ -64,9 +63,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             ((int)statusCode).Should().Be(returnedStatusCode);
 
             var spans = WaitForSpans(agent, 1, string.Empty, minDateTime, url);
-            await VerifyHelper.VerifySpans(spans, settings)
-                              .UseFileName(filename)
-                              .DisableRequireUniquePrefix();
+            await VerifySpans(spans, settings);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -5,8 +5,10 @@
 
 #if NETCOREAPP3_0_OR_GREATER
 
+using System;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,7 +17,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore5ExternalRules : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
         public AspNetCore5ExternalRules(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore5", outputHelper, "/shutdown", testName: nameof(AspNetCore5ExternalRules))
+            : base("AspNetCore5", outputHelper, "/shutdown", testName: nameof(AspNetCore5ExternalRules), allowAutoRedirect: false)
         {
             Fixture = fixture;
             Fixture.SetOutput(outputHelper);
@@ -40,6 +42,31 @@ namespace Datadog.Trace.Security.IntegrationTests
             var settings = VerifyHelper.GetSpanVerifierSettings();
 
             await TestAppSecRequestWithVerifyAsync(agent, DefaultAttackUrl, null, 5, 1, settings);
+        }
+
+        [SkippableTheory]
+        [InlineData(200, 303)]
+        [InlineData(302, 302)]
+        public async Task TestBlockingRedirectInvalidStatusCode(int ruleTriggerStatusCode, int returnedStatusCode)
+        {
+            await Fixture.TryStartApp(this, enableSecurity: true, externalRulesFile: DefaultRuleFile);
+            SetHttpPort(Fixture.HttpPort);
+            var agent = Fixture.Agent;
+
+            const string url = "/";
+            var filename = "Security.AspNetCore5ExternalRules.TestBlockingRedirectInvalidStatusCode." + ruleTriggerStatusCode;
+
+            var settings = VerifyHelper.GetSpanVerifierSettings();
+            var userAgent = "Canary/v3_" + ruleTriggerStatusCode;
+
+            var minDateTime = DateTime.UtcNow;
+            var (statusCode, _) = await SubmitRequest(url, body: null, contentType: null, userAgent: userAgent);
+            ((int)statusCode).Should().Be(returnedStatusCode);
+
+            var spans = WaitForSpans(agent, 1, string.Empty, minDateTime, url);
+            await VerifyHelper.VerifySpans(spans, settings)
+                              .UseFileName(filename)
+                              .DisableRequireUniquePrefix();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
@@ -48,31 +48,6 @@ namespace Datadog.Trace.Security.IntegrationTests
 
             await TestAppSecRequestWithVerifyAsync(fixture.Agent, url, null, 5, 1, settings);
         }
-
-        [SkippableTheory]
-        [InlineData(200, 303)]
-        [InlineData(302, 302)]
-        public async Task TestBlockingRedirectInvalidStatusCode(int ruleTriggerStatusCode, int returnedStatusCode)
-        {
-            await fixture.TryStartApp(this, enableSecurity: true, externalRulesFile: DefaultRuleFile);
-            SetHttpPort(fixture.HttpPort);
-            var agent = fixture.Agent;
-
-            const string url = "/";
-            var filename = "Security.AspNetCoreBare.TestBlockingRedirectInvalidStatusCode." + ruleTriggerStatusCode;
-
-            var settings = VerifyHelper.GetSpanVerifierSettings();
-            var userAgent = "Canary/v3_" + ruleTriggerStatusCode;
-
-            var minDateTime = DateTime.UtcNow;
-            var (statusCode, _) = await SubmitRequest(url, body: null, contentType: null, userAgent: userAgent);
-            ((int)statusCode).Should().Be(returnedStatusCode);
-
-            var spans = WaitForSpans(agent, 1, string.Empty, minDateTime, url);
-            await VerifyHelper.VerifySpans(spans, settings)
-                              .UseFileName(filename)
-                              .DisableRequireUniquePrefix();
-        }
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.3.0.json
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.3.0.json
@@ -12,6 +12,22 @@
         "grpc_status_code": "10",
         "type": "auto"
       }
+    },
+    {
+      "id": "redirectstatuscode_200",
+      "type": "redirect_request",
+      "parameters": {
+        "status_code": 200,
+        "location": "/you-have-been-blocked"
+      }
+    },
+    {
+      "id": "redirectstatuscode_302",
+      "type": "redirect_request",
+      "parameters": {
+        "status_code": 302,
+        "location": "/you-have-been-blocked"
+      }
     }
   ],
   "processors": [
@@ -6020,6 +6036,60 @@
       "transformers": [],
       "on_match": [
         "blockredir"
+      ]
+    },
+    {
+      "id": "canary_rule_redirect_200",
+      "name": "Canary rule redirect 200",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "Canary\\/v3_200"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": [
+        "redirectstatuscode_200"
+      ]
+    },
+    {
+      "id": "canary_rule_redirect_302",
+      "name": "Canary rule redirect 302",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "Canary\\/v3_302"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": [
+        "redirectstatuscode_302"
       ]
     }
   ]

--- a/tracer/test/snapshots/Security.AspNetCore5ExternalRules.__ruleTriggerStatusCode=200_returnedStatusCode=303.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5ExternalRules.__ruleTriggerStatusCode=200_returnedStatusCode=303.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.blocked: true,
+      appsec.event: true,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not... Canary/v3_200,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.response.headers.content-length: 0,
+      http.status_code: 303,
+      http.url: http://localhost:00000/,
+      http.useragent: Mistake Not... Canary/v3_200,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.fp.http.header: hdr-0000000000-e03dd41c-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"canary_rule_redirect_200","name":"Canary rule redirect 200","tags":{"category":"attack_attempt","type":"security_scanner"}},"rule_matches":[{"operator":"match_regex","operator_value":"Canary\\/v3_200","parameters":[{"address":"server.request.headers.no_cookies","highlight":["Canary/v3_200"],"key_path":["user-agent"],"value":"Mistake Not... Canary/v3_200"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      appsec: 
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5ExternalRules.__ruleTriggerStatusCode=302_returnedStatusCode=302.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5ExternalRules.__ruleTriggerStatusCode=302_returnedStatusCode=302.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.blocked: true,
+      appsec.event: true,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not... Canary/v3_302,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.response.headers.content-length: 0,
+      http.status_code: 302,
+      http.url: http://localhost:00000/,
+      http.useragent: Mistake Not... Canary/v3_302,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.fp.http.header: hdr-0000000000-b1e858a9-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"canary_rule_redirect_302","name":"Canary rule redirect 302","tags":{"category":"attack_attempt","type":"security_scanner"}},"rule_matches":[{"operator":"match_regex","operator_value":"Canary\\/v3_302","parameters":[{"address":"server.request.headers.no_cookies","highlight":["Canary/v3_302"],"key_path":["user-agent"],"value":"Mistake Not... Canary/v3_302"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      appsec: 
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetWebForms.Integrated.enableSecurity=True.__ruleTriggerStatusCode=200_returnedStatusCode=303.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebForms.Integrated.enableSecurity=True.__ruleTriggerStatusCode=200_returnedStatusCode=303.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /,
+    Service: sample,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.blocked: true,
+      appsec.event: true,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not... Canary/v3_200,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.response.headers.content-type: text/html; charset=utf-8,
+      http.status_code: 303,
+      http.url: http://localhost:00000/,
+      http.useragent: Mistake Not... Canary/v3_200,
+      language: dotnet,
+      network.client.ip: ::1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.fp.http.endpoint: http-get-8a5edab2--,
+      _dd.appsec.fp.http.header: hdr-0000000000-e03dd41c-3-98425651,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"canary_rule_redirect_200","name":"Canary rule redirect 200","tags":{"category":"attack_attempt","type":"security_scanner"}},"rule_matches":[{"operator":"match_regex","operator_value":"Canary\\/v3_200","parameters":[{"address":"server.request.headers.no_cookies","highlight":["Canary/v3_200"],"key_path":["user-agent"],"value":"Mistake Not... Canary/v3_200"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      appsec: 
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetWebForms.Integrated.enableSecurity=True.__ruleTriggerStatusCode=302_returnedStatusCode=302.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebForms.Integrated.enableSecurity=True.__ruleTriggerStatusCode=302_returnedStatusCode=302.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /,
+    Service: sample,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.blocked: true,
+      appsec.event: true,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not... Canary/v3_302,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.response.headers.content-type: text/html; charset=utf-8,
+      http.status_code: 302,
+      http.url: http://localhost:00000/,
+      http.useragent: Mistake Not... Canary/v3_302,
+      language: dotnet,
+      network.client.ip: ::1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.fp.http.endpoint: http-get-8a5edab2--,
+      _dd.appsec.fp.http.header: hdr-0100000000-b1e858a9-3-98425651,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"canary_rule_redirect_302","name":"Canary rule redirect 302","tags":{"category":"attack_attempt","type":"security_scanner"}},"rule_matches":[{"operator":"match_regex","operator_value":"Canary\\/v3_302","parameters":[{"address":"server.request.headers.no_cookies","highlight":["Canary/v3_302"],"key_path":["user-agent"],"value":"Mistake Not... Canary/v3_302"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      appsec: 
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes

This PR fixes the returned status code of the response when a request has been blocked. The configured status code from the blocking action was not applied. It was always `302` or `301` that was applied on the response.

## Reason for change

Incorrect status code value applied.
(Detected by System Tests: the test wasn't passing).

## Implementation details

The `Redirect()` method from either the .NET Framework or .NET Core sets the status code when called. But in our implementation we were setting the blocking action status code and after we called that method, thus overriding the status code.

## Test coverage

Integrations tests have been implemented for both .NET Framework and .NET Core.