### PR TITLE
Try fix pipeline monitor

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -7011,7 +7011,7 @@ stages:
     - bash: |
         mkdir -p $(Build.SourcesDirectory)/artifacts/build_data
         dotnet build
-        dd-trace run --dd-env "apm-dotnet-pipeline-monitoring" --set-env "DD_TRACE_SAMPLE_RATE=100" --set-env "DD_TRACE_DEBUG=1" --set-env "DD_INSTRUMENTATION_TELEMETRY_ENABLED=1" --set-env "DD_TRACE_LOG_DIRECTORY=$(Build.SourcesDirectory)/artifacts/build_data" -- dotnet run --no-restore --no-build -- $(Build.BuildId)
+        dd-trace run --dd-env "apm-dotnet-pipeline-monitoring" --set-env "DD_TRACE_SAMPLE_RATE=1" --set-env "DD_TRACE_PARTIAL_FLUSH_ENABLED=1" --set-env "DD_INSTRUMENTATION_TELEMETRY_ENABLED=1" --set-env "DD_TRACE_LOG_DIRECTORY=$(Build.SourcesDirectory)/artifacts/build_data" -- dotnet run --no-restore --no-build -- $(Build.BuildId)
         exit $?
       displayName: "Run"
       workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"


### PR DESCRIPTION
## Summary of changes

Tries to fix the pipeline monitor

## Reason for change

The pipeline monitor job we run at the end of our pipeline, which drives some of our dashboards, started failing on master for some reason recently. #6576 added some debug logs to try to figure out what's going on. As expected, the issue was that we were creating giant traces, and the spans were being dropped 😅 

## Implementation details

- Fix the sample rate config value (it's a value from 0-1, setting it to 100 is a bit over the top)
- Disable debug logs (it was actually the instrumentation telemetry that allowed me to diagnose this)
- Enable partial flush

## Test coverage

This is the test

## Other details

We could consider adding a debug log mentioning when an overfull buffer is encountered. Currently we log that spans were dropped, but not explicitly _why_ in this case. There's an argument for not doing it though - if an app is generating sufficient spans to hit this limit, it's possible enabling debug logs to try to find this issue could cause their server to fall over. Then again, one _more_ log probably isn't going to make the difference as to whether they _can_ enable it or not, so maybe best to do it anyway?