### PR TITLE
Fix broken nullability checks on master

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -329,7 +329,6 @@ src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.UnreachableLocal
 src/Datadog.Trace/Debugger/Snapshots/ExceptionSnapshotSerializerFieldsAndPropsSelector.cs
 src/Datadog.Trace/Debugger/Snapshots/LazySnapshotSerializerFieldsAndPropsSelector.cs
 src/Datadog.Trace/Debugger/Snapshots/OldStyleTupleSnapshotSerializerFieldsAndPropsSelector.cs
-src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
 src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
 src/Datadog.Trace/Debugger/Snapshots/SnapshotSerializerFieldsAndPropsSelector.cs
 src/Datadog.Trace/Debugger/Snapshots/SnapshotSummary.cs


### PR DESCRIPTION
## Summary of changes

Fix broken nullability checks on master

## Reason for change

A recent debugger test added `#nullable enable` to the `src/Datadog.Trace/Debugger/Snapshots/Redaction.cs` file. This should have required removing the file from the nullability file.

## Implementation details

Removes the file entry, as described in the action

## Test coverage

N/A

## Other details

I re-enabled the nullability check as a required stage for PRs. I can't remember why this was disabled originally, but it was only meant to be temporary