### PR TITLE
[Profiler] Fix null check in GetMachineBootTime

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -300,11 +300,12 @@ std::chrono::seconds GetMachineBootTime()
         auto pos = sv.find("btime");
         if (std::string_view::npos != pos)
         {
-            auto pos2 = strchr(sv.data() + pos, ' ') + 1;
+            auto pos2 = strchr(sv.data() + pos, ' ');
             if (pos2 == nullptr)
                 break;
 
             // skip whitespaces
+            pos2++;
             pos2 = pos2 + strspn(pos2, " ");
             machineBootTime = std::atoll(pos2);
             break;


### PR DESCRIPTION
## Summary of changes

Fix null check in GetMachineBootTime

## Reason for change

This causes segfaults in some customers.

## Implementation details

`strchr` can return null, but the code was incrementing the return value _before_ checking for null.

## Test coverage

I don't know if we have tests for this function. I'm letting the profiler team decide what should be done.