### PR TITLE
Fix broken `DataStreamsMonitoringRabbitMQTests`

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.DataStreams.RabbitMQ/Samples.DataStreams.RabbitMQ.csproj
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.RabbitMQ/Samples.DataStreams.RabbitMQ.csproj
@@ -10,7 +10,6 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

Fix broken `DataStreamsMonitoringRabbitMQTests` by removing TFM limit

## Reason for change

https://github.com/DataDog/dd-trace-dotnet/pull/6479 added support for RabbitMQ v7, but also [accidentally restricted](https://github.com/DataDog/dd-trace-dotnet/pull/6479/files#diff-2959b3f13b7bcc3bb95f4bf3347a455806ff69e5ff84b461e142cdbe2e93b21c) the `Samples.DataStreams.RabbitMQ` project to only building for .NET 8, which was picked up in the version bump PR: https://github.com/DataDog/dd-trace-dotnet/pull/6558.

I'm surprised we didn't notice it before... I need to look into _why_

## Implementation details

Remove the TFM restriction

## Test coverage

Will do a [full run](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=172950&view=results) to be sure
