### PR TITLE
[Profiler] Properly initialize appDomainId

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -232,7 +232,7 @@ void AllocationsProvider::OnAllocation(std::chrono::nanoseconds timestamp,
 
         // TODO: we need to check that threads are not jumping from one AppDomain to the other too frequently
         // because we might be receiving this event 1 second after it has been emitted
-        // It this is the case, we should simply set the AppDomainId to -1 all the time.
+        // It this is the case, we should simply set the AppDomainId to 0 all the time.
         AppDomainID appDomainId;
         if (SUCCEEDED(_pCorProfilerInfo->GetThreadAppDomain(threadInfo->GetClrThreadId(), &appDomainId)))
         {
@@ -240,15 +240,13 @@ void AllocationsProvider::OnAllocation(std::chrono::nanoseconds timestamp,
         }
         else
         {
-            rawSample.AppDomainId = -1;
+            rawSample.AppDomainId = 0;
         }
     }
     else // create a fake IThreadInfo that wraps the OS thread id (no name, no profiler thread id)
     {
         rawSample.ThreadInfo = std::make_shared<FrameworkThreadInfo>(threadId);
-
-        // TODO: do we need to set to -1?
-        // rawSample.AppDomainId = -1;
+        rawSample.AppDomainId = 0;
     }
 
     // rawSample.AllocationSize = objectSize;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -214,15 +214,13 @@ void ContentionProvider::AddContentionSample(std::chrono::nanoseconds timestamp,
             }
             else
             {
-                rawSample.AppDomainId = -1;
+                rawSample.AppDomainId = 0;
             }
         }
         else  // create a fake IThreadInfo that wraps the OS thread id (no name, no profiler thread id)
         {
             rawSample.ThreadInfo = std::make_shared<FrameworkThreadInfo>(threadId);
-
-            // TODO: do we need to set to -1?
-            //rawSample.AppDomainId = -1;
+            rawSample.AppDomainId = 0;
         }
     }
 


### PR DESCRIPTION
## Summary of changes

The contention profiler and the allocation profiler don't set the appDomainId if the managed thread can't be found (it can happen, for instance, if it has exited). Because the `RawSample` isn't zero'd at construction, this causes the field to contain garbage, which can cause crashes down the line.

Also, some error paths set the appDomainId to -1. I changed it to 0 because it's the value expected by the code that uses it and by the CLR.

## Reason for change

This was found thanks to a crash dump in the CI, but there has been crash reports that we failed to understand until now.
