### PR TITLE
Fix typo in `Override version bump PR checks` action

### DIFF
--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -21,7 +21,7 @@ jobs:
           set -o pipefail
 
           # These checks won't run automatically on the version bump PR, so need to force this
-          contexts=("code_freeze" "verify_source_generators" "verify_app_trimming_descriptor_generator", "verify_solution_changes_are_persisted")
+          contexts=("code_freeze" "verify_source_generators" "verify_app_trimming_descriptor_generator" "verify_solution_changes_are_persisted")
 
           sha="${{ github.sha }}"
           targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/override_version_bump_pr_checks.yml"


### PR DESCRIPTION
## Summary of changes

Fixes a typo in `Override version bump PR checks` GitHub action

## Reason for change

There's a trailing comma which is breaking the action

## Implementation details

Delete one character

## Test coverage

I'll test it on this PR specifically
