### PR TITLE
Build the FleetInstaller executable and include in Windows OCI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ build:
         -e SIGN_WINDOWS=true `
         -e NUGET_CERT_REVOCATION_MODE=offline `
         registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest `
-        Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet BuildFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi
+        Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out
     - remove-item -recurse -force build-out\${CI_JOB_ID}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 
 stages:
   - build
+  - publish
   - package
   - shared-pipeline
   - publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ build:
         -e SIGN_WINDOWS=true `
         -e NUGET_CERT_REVOCATION_MODE=offline `
         registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest `
-        Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PackageTracerHome ZipSymbols SignDlls SignMsi
+        Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet BuildFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out
     - remove-item -recurse -force build-out\${CI_JOB_ID}
@@ -96,18 +96,22 @@ download-single-step-artifacts:
   image: registry.ddbuild.io/docker:20.10.13-gbi-focal
   timeout: 45m
   tags: [ "arch:amd64" ]
-  needs: []
+  needs:
+    - job: build
+      optional: true
+      artifacts: true
   rules:
     - if: $DOTNET_PACKAGE_VERSION
       when: on_success
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/' # Manually triggered as artifacts are from the Github release
       when: manual
       allow_failure: false
-    - when: delayed # Artifacts come from Azure pipeline, wait a reasonable time before polling
-      start_in: 15 minutes
+    - when: on_success # Artifacts come from Azure pipeline, but as we already depend on build, we already have a delayed start
   script:
     - .gitlab/download-single-step-artifacts.sh
     - cp tracer/build/artifacts/requirements.json artifacts/requirements.json
+    # We currently only copy the windows artifacts if we're _not_ building a tag, because we don't want to push these images to prod yet
+    - if [ -z "$CI_COMMIT_TAG" ]; then cp -r artifacts-out artifacts/windows; fi
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -16,6 +16,18 @@ if [ -n "$CI_COMMIT_TAG" ] || [ -n "$DOTNET_PACKAGE_VERSION" ]; then
       "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${VERSION}/datadog-dotnet-apm-${VERSION}${SUFFIX}.tar.gz"
   done
 
+  if [ -n "$CI_COMMIT_SHA" ]; then
+    echo "Downloading Windows fleet-installer from S3"
+
+    # Put this in the same place the "build" stage does
+    win_target_dir=artifacts-out
+    mkdir -p $win_target_dir
+
+    curl --location --fail \
+        --output $win_target_dir/serverless-artifacts.zip \
+        "https://dd-windowsfilter.s3.amazonaws.com/builds/tracer/${CI_COMMIT_SHA}/fleet-installer.zip"
+  fi
+
   echo -n $VERSION > $target_dir/version.txt
   exit 0
 fi

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -52,9 +52,9 @@ elif [ "$OS" == "windows" ]; then
   unzip ../artifacts/windows/windows-tracer-home.zip -d sources/library
   find sources/library -type f -name "*.xml" -delete
 
-  # Copy the fleet installer to the sub-directory
+  # Unzip the fleet installer to the sub-directory
   mkdir -p sources/installer
-  cp -r ../artifacts/windows/Datadog.FleetInstaller/. sources/installer/
+  unzip ../artifacts/windows/fleet-installer.zip -d sources/installer/
 
 fi
 

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -16,32 +16,46 @@ if [ -z "$ARCH" ]; then
   ARCH=amd64
 fi
 
-if [ "$OS" != "linux" ]; then
-  echo "Only linux packages are supported. Exiting"
-  exit 0
+if [ "$OS" == "linux" ]; then
+  if [ "$ARCH" == "amd64" ]; then
+    SUFFIX=""
+  elif [ "$ARCH" == "arm64" ]; then
+    SUFFIX=".arm64"
+  else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+  fi
+
+  SRC_TAR="../artifacts/datadog-dotnet-apm-$PACKAGE_VERSION${SUFFIX}.tar.gz"
+
+  if [ ! -f $SRC_TAR ]; then
+     echo "$SRC_TAR was not found!"
+     exit 1
+  fi
+
+  mkdir -p sources
+
+  # extract the tarball, making sure to preserve the owner and permissions
+  tar --same-owner -pxvzf $SRC_TAR -C sources
+
+  cp ../artifacts/requirements.json sources/requirements.json
+
+elif [ "$OS" == "windows" ]; then
+
+  if [ "$ARCH" != "amd64" ]; then
+    echo "Unsupported architecture: win-$ARCH"
+    exit 0
+  fi
+
+  # unzip the tracer home directory, and remove the xml files
+  mkdir -p sources/library
+  unzip ../artifacts/windows/windows-tracer-home.zip -d sources/library
+  find sources/library -type f -name "*.xml" -delete
+
+  # Copy the fleet installer to the sub-directory
+  mkdir -p sources/installer
+  cp -r ../artifacts/windows/Datadog.FleetInstaller/. sources/installer/
+
 fi
-
-if [ "$ARCH" == "amd64" ]; then
-  SUFFIX=""
-elif [ "$ARCH" == "arm64" ]; then
-  SUFFIX=".arm64"
-else
-  echo "Unsupported architecture: $ARCH"
-  exit 1
-fi
-
-SRC_TAR="../artifacts/datadog-dotnet-apm-$PACKAGE_VERSION${SUFFIX}.tar.gz"
-
-if [ ! -f $SRC_TAR ]; then
-   echo "$SRC_TAR was not found!"
-   exit 1
-fi
-
-mkdir -p sources
-
-# extract the tarball, making sure to preserve the owner and permissions
-tar --same-owner -pxvzf $SRC_TAR -C sources
 
 echo -n $VERSION > sources/version
-
-cp ../artifacts/requirements.json sources/requirements.json

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -743,10 +743,10 @@ partial class Build
         .DependsOn(PublishNativeTracerUnix)
         .DependsOn(PublishNativeTracerOsx);
 
-    Target BuildFleetInstaller => _ => _
+    Target PublishFleetInstaller => _ => _
         .Unlisted()
-        .Description("Builds the fleet installer binary files from the repo")
-        .After(Clean, Restore)
+        .Description("Builds and publishes the fleet installer binary files as a zip")
+        .After(Clean, Restore, CompileManagedSrc)
         .Before(SignDlls)
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
@@ -754,11 +754,20 @@ partial class Build
             // Build the fleet installer project
             var project = SourceDirectory / "Datadog.FleetInstaller" / "Datadog.FleetInstaller.csproj";
             var tfms = Solution.GetProject(project).GetTargetFrameworks();
+            // we should only have a single tfm for fleet installer
+            if (tfms.Count != 1)
+            {
+                throw new ApplicationException("Fleet installer should only have a single target framework but found: " + string.Join(", ", tfms));
+            }
+
+            var publishFolder = ArtifactsDirectory / "Datadog.FleetInstaller";
             DotNetPublish(s => s
                               .SetProject(project)
                               .SetConfiguration(BuildConfiguration)
-                              .SetOutput(ArtifactsDirectory / "Datadog.FleetInstaller")
+                              .SetOutput(publishFolder)
                               .CombineWith(tfms, (p, tfm) => p.SetFramework(tfm)));
+
+            CompressZip(publishFolder, ArtifactsDirectory / "fleet-installer.zip", fileMode: FileMode.Create);
         });
 
     Target BuildMsi => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -743,6 +743,24 @@ partial class Build
         .DependsOn(PublishNativeTracerUnix)
         .DependsOn(PublishNativeTracerOsx);
 
+    Target BuildFleetInstaller => _ => _
+        .Unlisted()
+        .Description("Builds the fleet installer binary files from the repo")
+        .After(Clean, Restore)
+        .Before(SignDlls)
+        .OnlyWhenStatic(() => IsWin)
+        .Executes(() =>
+        {
+            // Build the fleet installer project
+            var project = SourceDirectory / "Datadog.FleetInstaller" / "Datadog.FleetInstaller.csproj";
+            var tfms = Solution.GetProject(project).GetTargetFrameworks();
+            DotNetPublish(s => s
+                              .SetProject(project)
+                              .SetConfiguration(BuildConfiguration)
+                              .SetOutput(ArtifactsDirectory / "Datadog.FleetInstaller")
+                              .CombineWith(tfms, (p, tfm) => p.SetFramework(tfm)));
+        });
+
     Target BuildMsi => _ => _
         .Unlisted()
         .Description("Builds the .msi files from the repo")


### PR DESCRIPTION
## Summary of changes

- Build the fleet installer exe in GitLab
- Include the fleet installer exe in Windows OCI
- Produce Windows OCI images in Staging

## Reason for change

We need to build the fleet installer executable, and include it in a Windows OI image

## Implementation details

- Add a stage `BuildFleetInstaller` to explicitly publish the fleet installer
- Update the `download-single-step-artifacts` to grab the `windows-tracer-home.zip` and fleet installer artifact from the `Build` stage
- Update the OCI image

For tagged releases this flow is a bit more convoluted. We need to grab the fleet-instller.exe artifact from the s3 upload that's done in the `publish` step, because we don't store it on the GitHub release. It's a bit ugly, but it works.

## Test coverage

This is the test - if it builds, and the OCI image contains the expected files, we're good

## Other details

Note that _currently_, the final OCI images will _not_ contain Windows layers, until we unblock that both in our gitlab YAML, and in the libdatadog-build one pipeline.


Part of a stack of PRs:
 
- https://github.com/DataDog/dd-trace-dotnet/pull/6643
- https://github.com/DataDog/dd-trace-dotnet/pull/6644 👈
- https://github.com/DataDog/dd-trace-dotnet/pull/6645
 