### PR TITLE
Add smoke tests for fleet installer

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -124,7 +124,7 @@ steps:
 - ${{ else }}:
   - bash: |
       echo "Verifying snapshot session (fail on mis-match)"
-      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
+      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail-with-body "http://localhost:8126$(VERIFY_ENDPOINT)"
     displayName: check snapshots
     env:
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6650,7 +6650,7 @@ stages:
       displayName: CheckSmokeTestsForErrors
 
 - stage: fleet_installer_smoke_tests
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [package_windows, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6650,8 +6650,8 @@ stages:
       displayName: CheckSmokeTestsForErrors
 
 - stage: fleet_installer_smoke_tests
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [generate_variables, merge_commit_id]
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [package_windows, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -6685,22 +6685,12 @@ stages:
           inputs:
             artifact: windows-tracer-home.zip
             path: $(smokeTestAppDir)/artifacts
-            buildType: 'specific'
-            project: 'dd-trace-dotnet'
-            definition: 54
-            buildVersionToDownload: 'specific'
-            pipelineId: 172912
 
         - task: DownloadPipelineArtifact@2
           displayName: Download fleet installer to temp directory
           inputs:
             artifact: fleet-installer
             path: $(smokeTestAppDir)/artifacts/installer
-            buildType: 'specific'
-            project: 'dd-trace-dotnet'
-            definition: 54
-            buildVersionToDownload: 'specific'
-            pipelineId: 172912
 
         - powershell: |
             ls $(smokeTestAppDir)/artifacts
@@ -6720,6 +6710,7 @@ stages:
           env:
             dockerTag: $(dockerTag)
           displayName: docker-compose build smoke-tests
+          retryCountOnTaskFailure: 3
 
         - template: steps/run-snapshot-test.yml
           parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6650,8 +6650,8 @@ stages:
       displayName: CheckSmokeTestsForErrors
 
 - stage: fleet_installer_smoke_tests
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [package_windows, generate_variables, merge_commit_id]
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -6685,12 +6685,22 @@ stages:
           inputs:
             artifact: windows-tracer-home.zip
             path: $(smokeTestAppDir)/artifacts
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'specific'
+            pipelineId: 172912
 
         - task: DownloadPipelineArtifact@2
           displayName: Download fleet installer to temp directory
           inputs:
             artifact: fleet-installer
             path: $(smokeTestAppDir)/artifacts/installer
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'specific'
+            pipelineId: 172912
 
         - powershell: |
             ls $(smokeTestAppDir)/artifacts
@@ -6710,7 +6720,6 @@ stages:
           env:
             dockerTag: $(dockerTag)
           displayName: docker-compose build smoke-tests
-          retryCountOnTaskFailure: 3
 
         - template: steps/run-snapshot-test.yml
           parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6668,7 +6668,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        vmImage: windows-$(windowsYear)
+        vmImage: $(vmImage)
 
       steps:
         - template: steps/install-docker-compose-v1.yml
@@ -6701,7 +6701,7 @@ stages:
 
         - bash: |
             $(dockerComposePath) -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
-              --build-arg BUILD_IMAGE_TAG="$(dotnetCoreSdkLatestVersionShort)-windowsservercore-ltsc$(windowsYear)" \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
               --build-arg CHANNEL="$(channel)" \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6715,7 +6715,7 @@ stages:
         - template: steps/run-snapshot-test.yml
           parameters:
             target: 'fleet-installer-smoke-tests.windows'
-            snapshotPrefix: "smoke_test"
+            snapshotPrefix: "smoke_test_iis"
             isLinux: false
             dockerComposePath: $(dockerComposePath)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6668,7 +6668,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        vmImage: $(vmImage)
+        vmImage: windows-2022
 
       steps:
         - template: steps/install-docker-compose-v1.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1090,7 +1090,7 @@ stages:
           artifact: dd-dotnet-win-x64
           path: $(monitoringHome)/win-x64
 
-      - script: tracer\build.cmd PackageTracerHome
+      - script: tracer\build.cmd PackageTracerHome PublishFleetInstaller
         displayName: Build MSI and Tracer home
         retryCountOnTaskFailure: 1
 
@@ -1106,6 +1106,9 @@ stages:
         displayName: Publish NuGet packages
         artifact: nuget-packages
 
+      - publish: $(artifacts)/Datadog.FleetInstaller
+        displayName: Publish fleet installer
+        artifact: fleet-installer
 
 - stage: build_dd_dotnet_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -6645,6 +6648,85 @@ stages:
     - template: steps/install-latest-dotnet-sdk.yml
     - script: tracer\build.cmd CheckSmokeTestsForErrors
       displayName: CheckSmokeTestsForErrors
+
+- stage: fleet_installer_smoke_tests
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [package_windows, generate_variables, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    dockerComposePath: 'C:/docker-compose/docker-compose.exe'
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [windows]
+
+    - job: windows
+      timeoutInMinutes: 45 # should take ~15 mins as large Windows docker files
+      strategy:
+        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.fleet_installer_windows_smoke_tests_matrix'] ]
+      variables:
+        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+      pool:
+        vmImage: $(vmImage)
+
+      steps:
+        - template: steps/install-docker-compose-v1.yml
+          parameters:
+            dockerComposePath: $(dockerComposePath)
+
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download tracer home zip
+          inputs:
+            artifact: windows-tracer-home.zip
+            path: $(smokeTestAppDir)/artifacts
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download fleet installer to temp directory
+          inputs:
+            artifact: fleet-installer
+            path: $(smokeTestAppDir)/artifacts/installer
+
+        - powershell: |
+            ls $(smokeTestAppDir)/artifacts
+            ls $(smokeTestAppDir)/artifacts/installer
+            mkdir -p artifacts/build_data/snapshots
+            mkdir -p artifacts/build_data/logs
+          displayName: Create test data directories
+
+        - bash: |
+            $(dockerComposePath) -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              --build-arg CHANNEL="$(channel)" \
+              --build-arg TARGET_PLATFORM="$(targetPlatform)" \
+              fleet-installer-smoke-tests.windows
+          env:
+            dockerTag: $(dockerTag)
+          displayName: docker-compose build smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'fleet-installer-smoke-tests.windows'
+            snapshotPrefix: "smoke_test"
+            isLinux: false
+            dockerComposePath: $(dockerComposePath)
+
+        - publish: artifacts/build_data
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+          condition: always()
+          continueOnError: true
+
+        - template: steps/install-latest-dotnet-sdk.yml
+        - script: tracer\build.cmd CheckSmokeTestsForErrors
+          displayName: CheckSmokeTestsForErrors
 
 - stage: dotnet_tool_nuget_smoke_tests_macos
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6668,7 +6668,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        vmImage: $(vmImage)
+        vmImage: windows-$(windowsYear)
 
       steps:
         - template: steps/install-docker-compose-v1.yml
@@ -6701,7 +6701,7 @@ stages:
 
         - bash: |
             $(dockerComposePath) -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
-              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg BUILD_IMAGE_TAG="$(dotnetCoreSdkLatestVersionShort)-windowsservercore-ltsc$(windowsYear)" \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
               --build-arg CHANNEL="$(channel)" \

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -20,7 +20,7 @@ services:
     - ./tracer/build/smoke_test_snapshots:c:/snapshots
     - ./artifacts/build_data/snapshots:c:/debug_snapshots
     ports:
-    - "8126:8126"
+    - "8126"
     environment:
     - SNAPSHOT_CI=1
     - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers #api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -163,7 +163,7 @@ services:
       dockerfile: build/_build/docker/smoke.windows.fleet-installer.dockerfile
         # args:
         # Note that the following build arguments must be provided
-        # - DOTNETSDK_VERSION=
+        # - BUILD_IMAGE_TAG=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
         # - CHANNEL=

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -157,6 +157,27 @@ services:
     depends_on:
     - test-agent.windows
 
+  fleet-installer-smoke-tests.windows:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.windows.fleet-installer.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - CHANNEL=
+        # - TARGET_PLATFORM=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-windows-fleet-installer-tester
+    volumes:
+    - ./:c:/project
+    - ./artifacts/build_data/logs:c:/logs
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent.windows:8126
+    depends_on:
+    - test-agent.windows
+
   dotnet-tool-smoke-tests.windows:
     build:
       context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -163,7 +163,7 @@ services:
       dockerfile: build/_build/docker/smoke.windows.fleet-installer.dockerfile
         # args:
         # Note that the following build arguments must be provided
-        # - BUILD_IMAGE_TAG=
+        # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
         # - CHANNEL=

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -453,8 +453,9 @@ partial class Build : NukeBuild
                 // msi smoke tests
                 GenerateWindowsMsiSmokeTestsMatrix();
 
-                // tracer home smoke tests
+                // tracer home / fleet installer smoke tests
                 GenerateWindowsTracerHomeSmokeTestsMatrix();
+                GenerateWindowsFleetInstalerSmokeTestsMatrix();
 
                 // macos smoke tests
                 GenerateMacosDotnetToolNugetSmokeTestsMatrix();
@@ -1246,6 +1247,35 @@ partial class Build : NukeBuild
                     Logger.Information($"Installer smoke tests tracer-home matrix Windows");
                     Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetOutputVariable("tracer_home_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateWindowsFleetInstalerSmokeTestsMatrix()
+                {
+                    var dockerName = "mcr.microsoft.com/windows/servercore/iis";
+
+                    var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
+                    var runtimeImages = new SmokeTestImage[]
+                    {
+                        new (publishFramework: TargetFramework.NET9_0, "windowsservercore-ltsc2022"),
+                    };
+
+                    var matrix = (
+                                     from platform in platforms
+                                     from image in runtimeImages
+                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
+                                     select new
+                                     {
+                                         dockerTag = dockerTag,
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
+                                         targetPlatform = platform,
+                                         channel = GetInstallerChannel(image.PublishFramework),
+                                         vmImage = $"windows-{image.RuntimeTag.Substring(image.RuntimeTag.Length - 4)}",
+                                     }).ToDictionary(x=>x.dockerTag, x => x);
+
+                    Logger.Information($"Installer smoke tests fleet-installer matrix Windows");
+                    Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetOutputVariable("fleet_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
 
                 void GenerateWindowsNuGetSmokeTestsMatrix()

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1264,7 +1264,7 @@ partial class Build : NukeBuild
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
+                                     let dockerTag = $"{image.PublishFramework}_{platform}_{image.RuntimeTag}".Replace('.', '_')
                                      select new
                                      {
                                          dockerTag = dockerTag,

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1256,8 +1256,9 @@ partial class Build : NukeBuild
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
                     var runtimeImages = new SmokeTestImage[]
                     {
+                        // We can only test Windows 2022 images currently, due to VM + docker image support
                         new (publishFramework: TargetFramework.NET9_0, "4.8-windowsservercore-ltsc2022"),
-                        new (publishFramework: TargetFramework.NET9_0, "4.8-windowsservercore-ltsc2019"),
+                        new (publishFramework: TargetFramework.NET8_0, "4.8-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
@@ -1271,7 +1272,6 @@ partial class Build : NukeBuild
                                          runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel = GetInstallerChannel(image.PublishFramework),
-                                         vmImage = $"windows-{image.RuntimeTag.Substring(image.RuntimeTag.Length - 4)}",
                                      }).ToDictionary(x=>x.dockerTag, x => x);
 
                     Logger.Information($"Installer smoke tests fleet-installer matrix Windows");

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1271,7 +1271,7 @@ partial class Build : NukeBuild
                                          runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel = GetInstallerChannel(image.PublishFramework),
-                                         windowsYear = image.RuntimeTag.Substring(image.RuntimeTag.Length - 4),
+                                         vmImage = $"windows-{image.RuntimeTag.Substring(image.RuntimeTag.Length - 4)}",
                                      }).ToDictionary(x=>x.dockerTag, x => x);
 
                     Logger.Information($"Installer smoke tests fleet-installer matrix Windows");

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1251,12 +1251,13 @@ partial class Build : NukeBuild
 
                 void GenerateWindowsFleetInstalerSmokeTestsMatrix()
                 {
-                    var dockerName = "mcr.microsoft.com/windows/servercore/iis";
+                    var dockerName = "mcr.microsoft.com/dotnet/framework/aspnet";
 
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
                     var runtimeImages = new SmokeTestImage[]
                     {
-                        new (publishFramework: TargetFramework.NET9_0, "windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET9_0, "4.8-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET9_0, "4.8-windowsservercore-ltsc2019"),
                     };
 
                     var matrix = (

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1271,7 +1271,7 @@ partial class Build : NukeBuild
                                          runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel = GetInstallerChannel(image.PublishFramework),
-                                         vmImage = $"windows-{image.RuntimeTag.Substring(image.RuntimeTag.Length - 4)}",
+                                         windowsYear = image.RuntimeTag.Substring(image.RuntimeTag.Length - 4),
                                      }).ToDictionary(x=>x.dockerTag, x => x);
 
                     Logger.Information($"Installer smoke tests fleet-installer matrix Windows");

--- a/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
@@ -18,7 +18,6 @@ WORKDIR /app
 
 ARG CHANNEL
 ARG TARGET_PLATFORM
-COPY ./build/_build/bootstrap/dotnet-install.ps1 .
 
 # Install the hosting bundle
 RUN  $url='https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/' + $env:CHANNEL + '.0/dotnet-hosting-' + $env:CHANNEL + '.0-win.exe'; \
@@ -56,17 +55,14 @@ COPY --from=builder /src/publish /app/.
 RUN Remove-WebSite -Name 'Default Web Site'; \
     $ENABLE_32_BIT='false'; \
     if($env:TARGET_PLATFORM -eq 'x86') { $ENABLE_32_BIT='true' }; \
-    Write-Host "Creating website with 32 bit reg key: $env:ENABLE_32_BIT"; \
-    c:\Windows\System32\inetsrv\appcmd add apppool /startMode:"AlwaysRunning" /autoStart:"false" /name:AspNetCorePool /managedRuntimeVersion:"" /enable32bitapponwin64:$ENABLE_32_BIT; \
+    Write-Host "Creating website with 32 bit enabled: $env:ENABLE_32_BIT"; \
+    c:\Windows\System32\inetsrv\appcmd add apppool /startMode:"AlwaysRunning" /autoStart:"true" /name:AspNetCorePool /managedRuntimeVersion:"" /enable32bitapponwin64:$ENABLE_32_BIT; \
     New-Website -Name 'SmokeTest' -Port 5000 -PhysicalPath 'c:\app' -ApplicationPool 'AspNetCorePool'; \
     Set-ItemProperty "IIS:\Sites\SmokeTest" -Name applicationDefaults.preloadEnabled -Value True;
 
-# Restart IIS
-RUN net stop /y was; \
-    net start w3svc
-
 # We override the normal service monitor entrypoint, because we want the container to shut down after the request is sent
 # We would really like to get the pid of the worker processes, but we can't do that easily
+# This is all way more convoluted than it feels like it should be, but it's the only way I could find to get things to work as required
 RUN echo 'Write-Host \"Running servicemonitor to copy variables\"; Start-Process -NoNewWindow -PassThru -FilePath \"c:/ServiceMonitor.exe\" -ArgumentList @(\"w3svc\", \"AspNetCorePool\");' > C:\app\entrypoint.ps1; \
     echo 'Write-Host \"Starting AspNetCorePool app pool\"; Start-WebAppPool -Name \"AspNetCorePool\" -PassThru;' >> C:\app\entrypoint.ps1; \
     echo 'Write-Host \"Making 404 request\"; curl http://localhost:5000;' >> C:\app\entrypoint.ps1; \

--- a/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
@@ -1,0 +1,51 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-windowsservercore-ltsc2022 as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /inetpub/wwwroot
+
+ARG CHANNEL
+ARG TARGET_PLATFORM
+COPY ./build/_build/bootstrap/dotnet-install.ps1 .
+RUN echo 'Installing ' + $env:TARGET_PLATFORM +  ' dotnet runtime ' + $env:CHANNEL; \
+    ./dotnet-install.ps1 -Architecture $env:TARGET_PLATFORM -Runtime aspnetcore -Channel $env:CHANNEL -InstallDir c:\cli; \
+    [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
+    rm ./dotnet-install.ps1;
+
+# Copy the tracer home file from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /install
+
+RUN mkdir /logs; \
+    mkdir /monitoring-home; \
+    cd /install; \
+    Expand-Archive 'c:\install\windows-tracer-home.zip' -DestinationPath 'c:\monitoring-home\';  \
+    c:\install\installer\Datadog.FleetInstaller.exe install --home-path c:\monitoring-home; \
+    cd /inetpub/wwwroot;
+
+# Set the additional env vars
+ENV DD_PROFILING_ENABLED=1 \
+    DD_TRACE_DEBUG=1 \
+    DD_APPSEC_ENABLED=1 \
+    DD_DOTNET_TRACER_HOME="c:\monitoring-home" \
+    DD_TRACE_LOG_DIRECTORY="C:\logs"
+
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
+# Copy the app across
+COPY --from=builder /src/publish /inetpub/wwwroot/.

--- a/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
@@ -1,8 +1,8 @@
-﻿ARG BUILD_IMAGE_TAG
+﻿ARG DOTNETSDK_VERSION
 ARG RUNTIME_IMAGE
 
 # Build the ASP.NET Core app using the latest SDK
-FROM mcr.microsoft.com/dotnet/sdk:$BUILD_IMAGE_TAG as builder
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-windowsservercore-ltsc2022 as builder
 
 # Build the smoke test app
 WORKDIR /src

--- a/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
@@ -56,7 +56,7 @@ RUN Remove-WebSite -Name 'Default Web Site'; \
     $ENABLE_32_BIT='false'; \
     if($env:TARGET_PLATFORM -eq 'x86') { $ENABLE_32_BIT='true' }; \
     Write-Host "Creating website with 32 bit enabled: $env:ENABLE_32_BIT"; \
-    c:\Windows\System32\inetsrv\appcmd add apppool /startMode:"AlwaysRunning" /autoStart:"true" /name:AspNetCorePool /managedRuntimeVersion:"" /enable32bitapponwin64:$ENABLE_32_BIT; \
+    c:\Windows\System32\inetsrv\appcmd add apppool /startMode:"AlwaysRunning" /autoStart:"false" /name:AspNetCorePool /managedRuntimeVersion:"" /enable32bitapponwin64:$ENABLE_32_BIT; \
     New-Website -Name 'SmokeTest' -Port 5000 -PhysicalPath 'c:\app' -ApplicationPool 'AspNetCorePool'; \
     Set-ItemProperty "IIS:\Sites\SmokeTest" -Name applicationDefaults.preloadEnabled -Value True;
 

--- a/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
@@ -1,8 +1,8 @@
-﻿ARG DOTNETSDK_VERSION
+﻿ARG BUILD_IMAGE_TAG
 ARG RUNTIME_IMAGE
 
 # Build the ASP.NET Core app using the latest SDK
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-windowsservercore-ltsc2022 as builder
+FROM mcr.microsoft.com/dotnet/sdk:$BUILD_IMAGE_TAG as builder
 
 # Build the smoke test app
 WORKDIR /src

--- a/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
@@ -1,0 +1,134 @@
+[
+  [
+    {
+      "trace_id": 4102954709290435042,
+      "span_id": 13101757532572621177,
+      "name": "aspnet_core.request",
+      "resource": "GET /",
+      "service": "AspNetCoreSmokeTest",
+      "type": "web",
+      "start": 1738860347590183400,
+      "duration": 118678500,
+      "meta": {
+        "component": "aspnet_core",
+        "span.kind": "server",
+        "http.useragent": "Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.20348.2849",
+        "http.method": "GET",
+        "http.request.headers.host": "localhost:5000",
+        "http.url": "http://localhost:5000/",
+        "http.status_code": "404",
+        "network.client.ip": "::1",
+        "http.client_ip": "::1",
+        "_dd.appsec.waf.version": "1.22.0",
+        "_dd.p.dm": "-5",
+        "_dd.p.tid": "67a4e73b00000000",
+        "runtime-id": "05dff020-c9cc-4b50-9395-e1fe88603312",
+        "language": "dotnet",
+        "_dd.runtime_family": "dotnet",
+        "_dd.appsec.event_rules.version": "1.13.3"
+      },
+      "metrics": {
+        "_dd.tracer_kr": 0.0,
+        "_dd.appsec.event_rules.loaded": 159.0,
+        "_dd.appsec.event_rules.error_count": 0.0,
+        "process_id": 8928.0,
+        "_dd.appsec.enabled": 1.0,
+        "_sampling_priority_v1": 2.0,
+        "_dd.top_level": 1.0
+      }
+    }
+  ],
+  [
+    {
+      "trace_id": 2840641933888955318,
+      "span_id": 9321253310232366827,
+      "name": "http.request",
+      "resource": "GET localhost:5000/api/values",
+      "service": "AspNetCoreSmokeTest-http-client",
+      "type": "http",
+      "start": 1738860347626847600,
+      "duration": 294488300,
+      "meta": {
+        "span.kind": "client",
+        "component": "HttpMessageHandler",
+        "http.method": "GET",
+        "http.url": "http://localhost:5000/api/values",
+        "http-client-handler-type": "System.Net.Http.HttpClientHandler",
+        "http.status_code": "200",
+        "out.host": "localhost",
+        "_dd.p.dm": "-0",
+        "_dd.p.tid": "67a4e73b00000000",
+        "runtime-id": "05dff020-c9cc-4b50-9395-e1fe88603312",
+        "language": "dotnet",
+        "_dd.base_service": "AspNetCoreSmokeTest"
+      },
+      "metrics": {
+        "_dd.tracer_kr": 0.0,
+        "process_id": 8928.0,
+        "_sampling_priority_v1": 1.0,
+        "_dd.top_level": 1.0
+      }
+    },
+    {
+      "trace_id": 2840641933888955318,
+      "span_id": 14144697471196665604,
+      "name": "aspnet_core_mvc.request",
+      "resource": "GET /api/values",
+      "service": "AspNetCoreSmokeTest",
+      "type": "web",
+      "start": 1738860347774826700,
+      "duration": 157426100,
+      "parent_id": 17774643208189235014,
+      "meta": {
+        "aspnet_core.controller": "values",
+        "aspnet_core.action": "get",
+        "component": "aspnet_core",
+        "aspnet_core.route": "api/values",
+        "span.kind": "server",
+        "_dd.p.dm": "-0",
+        "_dd.p.tid": "67a4e73b00000000",
+        "language": "dotnet"
+      },
+      "metrics": {}
+    },
+    {
+      "trace_id": 2840641933888955318,
+      "span_id": 17774643208189235014,
+      "name": "aspnet_core.request",
+      "resource": "GET /api/values",
+      "service": "AspNetCoreSmokeTest",
+      "type": "web",
+      "start": 1738860347655490300,
+      "duration": 281453300,
+      "parent_id": 9321253310232366827,
+      "meta": {
+        "aspnet_core.endpoint": "AspNetCoreSmokeTest.ValuesController.Get (AspNetCoreSmokeTest)",
+        "component": "aspnet_core",
+        "aspnet_core.route": "api/values",
+        "http.route": "api/values",
+        "span.kind": "server",
+        "http.method": "GET",
+        "http.request.headers.host": "localhost:5000",
+        "http.url": "http://localhost:5000/api/values",
+        "http.status_code": "200",
+        "network.client.ip": "::1",
+        "http.client_ip": "::1",
+        "_dd.appsec.s.req.params": "H4sIAAAAAAAACouuVkpMLsnMz1OyiraI1VFKzs8rKcrPyUktAgvUxgIAtnr++SEAAAA=",
+        "_dd.appsec.s.res.body": "H4sIAAAAAAAACou2iAUA8YntnQMAAAA=",
+        "_dd.appsec.s.req.headers": "H4sIAAAAAAAACouuVqrQTUksSUzJT9ctSCxKzSvRzUxRsoq2iNVRysgvLoEyEYpKihKTUxFqEBLFibkFOZl56boFRZn5RZkllVAVYA0QozENS0wvRlZWXJJYkgoWqI0FAJFO9EWbAAAA",
+        "_dd.appsec.s.res.headers": "H4sIAAAAAAAACouuVkrOzytJzSvRLaksSFWyiraIrY0FAE0e04cWAAAA",
+        "runtime-id": "05dff020-c9cc-4b50-9395-e1fe88603312",
+        "language": "dotnet",
+        "_dd.runtime_family": "dotnet",
+        "_dd.appsec.event_rules.version": "1.13.3"
+      },
+      "metrics": {
+        "_dd.tracer_kr": 0.0,
+        "process_id": 8928.0,
+        "_dd.appsec.enabled": 1.0,
+        "_sampling_priority_v1": 1.0,
+        "_dd.top_level": 1.0
+      }
+    }
+  ]
+]

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Worker.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Worker.cs
@@ -51,10 +51,14 @@ namespace AspNetCoreSmokeTest
                 var server = serviceScope.ServiceProvider.GetRequiredService<IServer>();
                 var addressFeature = server.Features.Get<IServerAddressesFeature>();
                 var address = addressFeature!.Addresses.First();
+                _logger.LogInformation("Found server address: {address}", address);
 
                 var client = new HttpClient();
 
-                _logger.LogInformation("Sending request to self");
+                // By default, IIS uses a wildcard host, so switch that out for localhost
+                address = address.Replace("http://*", "http://localhost").TrimEnd('/');
+
+                _logger.LogInformation("Sending request to self with address {address}", address);
                 var response = await client.GetAsync($"{address}/api/values", stoppingToken);
 
                 if (!response.IsSuccessStatusCode)
@@ -79,8 +83,8 @@ namespace AspNetCoreSmokeTest
                 Program.ExitCode = 1;
             }
 
+            _logger.LogInformation("Shutting down application");
             _lifetime.StopApplication();
-
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Adds a new smoke test stage, for running inside Windows using the fleet installer

## Reason for change

Emulates an end-to-end smoke test for the fleet installer executable. 

## Implementation details

- Build the fleet installer in the AzDo pipeline, as part of the `package-windows` stage
- Adds a new `fleet_installer_smoke_tests` stage for running the smoke tests
- Fix issues in ASP.NET Core test app, so that it works when hosted in IIS
- Add a dockerfile for running the ASP.NET Core app with the fleet installer, hosted in IIS

That latter point proved to be somewhat of a nightmare. The resulting dockerfile feels kind of horrible, but I couldn't find another way to have:

- Delay the start of the app pool until the container image is running (i.e. not during build time)
- Start the worker process when the app pool starts, _without_ an incoming request
- Shut down the app pool when the worker process exits (which is the way the aspnetcore app works)
- Exit the container

The workaround, using the entrypoint script, makes a 404 request to the app to spin up the worker process, manually shuts down the app pool (to make sure the app definitely shuts down and flushes), and then exits. This causes an additional span in the traces, so needed to create new snapshots. 

## Test coverage

This gives basic snapshot testing on 2022 which is the only version I could get to work given the hosted images on AzDo and the available python base images for the test agent. I think that is sufficient - we are going to have additional end-to-end testing of Windows images in system tests anyway.

## Other details

Part of a stack of PRs:

 
- https://github.com/DataDog/dd-trace-dotnet/pull/6643
- https://github.com/DataDog/dd-trace-dotnet/pull/6644
- https://github.com/DataDog/dd-trace-dotnet/pull/6645 👈