### PR TITLE
[Profiler] Add number of CPU samples to the profile

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
@@ -12,7 +12,8 @@
 
 std::vector<SampleValueType> CpuTimeProvider::SampleTypeDefinitions(
     {
-        {"cpu", "nanoseconds"}
+        {"cpu", "nanoseconds"},
+        {"cpu-samples", "count"}
     }
     );
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
@@ -32,8 +32,9 @@ public:
 
     inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        assert(valueOffsets.size() == 1);
+        assert(valueOffsets.size() == 2);
         sample->AddValue(Duration.count(), valueOffsets[0]);
+        sample->AddValue(1, valueOffsets[1]);
     }
 
     std::chrono::nanoseconds Duration;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
@@ -33,8 +33,8 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
 
             runner.Run(agent);
 
-            // only cpu  profiler enabled so should see 1 value per sample
-            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 1);
+            // only cpu profiler enabled so should see 1 value per sample
+            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 2);
         }
 
         [TestAppFact("Samples.Computer01")]
@@ -52,7 +52,7 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
             runner.Run(agent);
 
             // only wall time profiler enabled so should see 1 value per sample
-            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 1);
+            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 2);
         }
 
         [TestAppFact("Samples.Computer01")]
@@ -80,8 +80,7 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
 
             runner.Run(agent);
 
-            // only cpu  profiler enabled so should see 1 value per sample
-            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 1);
+            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 2);
         }
 
         [TestAppFact("Samples.Computer01")]
@@ -101,6 +100,9 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
             // --> could be flacky otherwise
             var totalDuration = runner.TotalTestDurationInMilliseconds * 1000000L;
             Assert.True(cpuDuration <= totalDuration);
+            
+            var cpuSamples = SamplesHelper.GetValueSum(runner.Environment.PprofDir, 1);
+            cpuSamples.Should().BeGreaterThan(0);
         }
 
         [TestAppFact("Samples.Computer01")]

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
@@ -33,7 +33,7 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
 
             runner.Run(agent);
 
-            // only cpu profiler enabled so should see 1 value per sample
+            // only cpu profiler enabled so should see 2 value per sample
             SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 2);
         }
 
@@ -52,7 +52,7 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
             runner.Run(agent);
 
             // only wall time profiler enabled so should see 1 value per sample
-            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 2);
+            SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 1);
         }
 
         [TestAppFact("Samples.Computer01")]

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Datadog.Profiler.IntegrationTests.Helpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
@@ -70,8 +70,9 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             samples.Should().NotBeEmpty();
             foreach (var (_, _, values) in samples)
             {
-                values.Length.Should().Be(1);
-                values.Should().OnlyContain(x => x == long.Parse(samplingInterval) * 1_000_000);
+                values.Length.Should().Be(2);
+                values[0].Should().Be(long.Parse(samplingInterval) * 1_000_000);
+                values[1].Should().BeGreaterThan(0);
             }
         }
 
@@ -90,13 +91,14 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             runner.Run(agent);
 
             var expectedInterval = long.Parse(samplingInterval) * 1_000_000;
-            // only cpu  profiler enabled so should see 1 value per sample and
+            // only cpu  profiler enabled so should see 2 value per sample and
             var samples = SamplesHelper.GetSamples(runner.Environment.PprofDir);
             samples.Should().NotBeEmpty();
             foreach (var (_, _, values) in samples)
             {
-                values.Length.Should().Be(1);
-                values.Should().OnlyContain(x => x == expectedInterval);
+                values.Length.Should().Be(2);
+                values[0].Should().Be(expectedInterval);
+                values[1].Should().BeGreaterThan(0);
             }
         }
 
@@ -120,8 +122,9 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             samples.Should().NotBeEmpty();
             foreach (var (_, _, values) in samples)
             {
-                values.Length.Should().Be(1);
-                values.Should().OnlyContain(x => x == expectedInterval);
+                values.Length.Should().Be(2);
+                values[0].Should().Be(expectedInterval);
+                values[1].Should().BeGreaterThan(0);
             }
         }
     }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -315,7 +315,7 @@ TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
     auto [configuration, mockConfiguration] = CreateConfiguration();
 
     CpuTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration, shared::pmr::get_default_resource());
-    Sample::ValuesCount = 1;
+    Sample::ValuesCount = 2;
     provider.Start();
 
     //                           V-----V-- check these values are correct
@@ -339,11 +339,9 @@ TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
         ASSERT_EQ(currentSample * 1000, sample->GetTimeStamp());
 
         auto values = sample->GetValues();
-        ASSERT_EQ(values.size(), 1);
-        for (size_t current = 0; current < values.size(); current++)
-        {
-            ASSERT_EQ(currentSample * 10, std::chrono::nanoseconds(values[current]));
-        }
+        ASSERT_EQ(values.size(), 2);
+        ASSERT_EQ(currentSample * 10, std::chrono::nanoseconds(values[0]));
+        ASSERT_GT(values[1], 0);
 
         currentSample++;
     }


### PR DESCRIPTION
## Summary of changes

Add CPU samples to the profile.

## Reason for change

Asked by the backend to enable samples indexing `per sample` (https://datadoghq.atlassian.net/browse/PROF-11330)

## Implementation details

- Add `cpu-samples` value so the `CpuProvider` can add it to the `Sample`
- Update tests

## Test coverage

Current tests should suffice.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
