### PR TITLE
Update `CONTRIBUTING` with external PR policies

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,19 @@
-As an open source project we welcome contributions of many forms. Please reach out before starting
-work on any major code changes. This will ensure we avoid duplicating work, or that
-your code can't be merged due to a rapidly changing code base. If you would like support
-for a library that is not listed, [contact support][1] to share a request.
+We welcome contributions of many forms to our open source project.
+However, please be aware of some of the policies below, and we *strongly* recommend reaching out before starting *any* code changes.
+
+## External Pull Request Policies
+
+Because of security policies in place, external pull requests have the following policies:
+
+- **Fork Required**: You **must** create pull requests from a fork of the repository. Only approved Datadog engineers have push access.
+- **Limited Testing Access**: External pull requests **cannot** run our full automated test suite.
+- **Merge Process**: Pull requests from forks **cannot be merged directly**. A `dd-trace-dotnet` contributor must create a new pull request after re-pushing your branch. Your commit attributes will remain.
+
+## Requesting Support for New Libraries
+
+If a library is not yet supported by automatic instrumentation, please submit a feature request through our [support team][1].
+
+If a new version of an already instrumented library is unsupported by the .NET Tracer, please submit a feature request through our [support team][1].
+
 
 [1]: https://docs.datadoghq.com/help

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing to `dd-trace-dotnet`
+
 We welcome contributions of many forms to our open source project.
 However, please be aware of some of the policies below, and we *strongly* recommend reaching out before starting *any* code changes.
 
@@ -7,7 +9,7 @@ Because of security policies in place, external pull requests have the following
 
 - **Fork Required**: You **must** create pull requests from a fork of the repository. Only approved Datadog engineers have push access.
 - **Limited Testing Access**: External pull requests **cannot** run our full automated test suite.
-- **Merge Process**: Pull requests from forks **cannot be merged directly**. A `dd-trace-dotnet` contributor must create a new pull request after re-pushing your branch. Your commit attributes will remain.
+- **Merge Process**: Pull requests from forks **cannot be merged directly**. A `dd-trace-dotnet` contributor must first create a branch from your fork and run the CI suite against it. This ensures the build and test results apply to your commit. If the CI suite passes, the contributor will then merge your PR.
 
 ## Requesting Support for New Libraries
 


### PR DESCRIPTION
## Summary of changes

Updates `CONTRIBUTING` to be more transparent to contributors about how external PRs need to be made and that they'll need to be re-created by a core contributor.

Also expanded on new library and updated version to point to the helpdesk as that is the quickest route usually.

## Reason for change

These policies / limitations have been in place for a long time, but not well communicated.

Attempting to be more transparent

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
