### PR TITLE
change some log levels from `info` to `debug`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -304,7 +304,7 @@ namespace Datadog.Trace.ClrProfiler
             // we only support Service Fabric Service Remoting instrumentation on .NET Core (including .NET 5+)
             if (FrameworkDescription.Instance.IsCoreClr())
             {
-                Log.Information("Initializing ServiceFabric instrumentation");
+                Log.Debug("Initializing ServiceFabric instrumentation");
 
                 try
                 {

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -389,7 +389,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(
             moduleHandler->SetModuleMetadata(moduleMetadata);
         }
 
-        Logger::Info("Method enqueued for ReJIT for ", caller.type.name, ".", caller.name,
+        Logger::Debug("Method enqueued for ReJIT for ", caller.type.name, ".", caller.name,
                   "(", caller.method_signature.NumberOfArguments(), " params).");
         EnqueueNewMethod(definition, metadataImport, metadataEmit, moduleInfo, typeDef, rejitRequests, methodDef,
                          functionInfo, moduleHandler);

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -900,7 +900,7 @@ bool RejitPreprocessor<RejitRequestDefinition>::CheckExactSignatureMatch(ComPtr<
     // instrumentation target
     if (numOfArgs != targetMethod.signature_types.size() - 1)
     {
-        Logger::Info("    * Skipping ", functionInfo.type.name, ".", functionInfo.name,
+        Logger::Debug("    * Skipping ", functionInfo.type.name, ".", functionInfo.name,
                      ": the methoddef doesn't have the right number of arguments (", numOfArgs, " arguments).");
         return false;
     }
@@ -923,7 +923,7 @@ bool RejitPreprocessor<RejitRequestDefinition>::CheckExactSignatureMatch(ComPtr<
     }
     if (argumentsMismatch)
     {
-        Logger::Info("    * Skipping ", targetMethod.method_name,
+        Logger::Debug("    * Skipping ", targetMethod.method_name,
                      ": the methoddef doesn't have the right type of arguments.");
         return false;
     }


### PR DESCRIPTION
## Summary of changes

Change the log level of several messages from `info` to `debug`...

## Reason for change

...to reduce log spam.

## Implementation details

Change the log levels.

## Test coverage

N/A

## Other details

N/A

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
