### PR TITLE
[Profiler] Fix Profiler execution benchmark tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5111,11 +5111,6 @@ stages:
           testName: garbagecollections
           poolName: ProfilerExecBenchAgent11
           framework: net7.0
-        OutgoingHttpRequests:
-          sampleName: ParallelCountSites
-          testName: outgoinghttprequests
-          poolName: ProfilerExecBenchAgent13
-          framework: net9.0
     pool:
       name: $(poolName)
     timeoutInMinutes: 30 #default value
@@ -5210,11 +5205,6 @@ stages:
           testName: garbagecollections
           poolName: ProfilerExecBenchAgent12
           framework: net7.0
-        OutgoingHttpRequests:
-          sampleName: ParallelCountSites
-          testName: outgoinghttprequests
-          poolName: ProfilerExecBenchAgent14
-          framework: net9.0
     pool:
       name: $(poolName)
     timeoutInMinutes: 30 #default value


### PR DESCRIPTION
## Summary of changes

Fix profiler execution benchmark tests.

## Reason for change

The Http profiling feature added the benchmark test but the VMs do not exist. This prevent the job from running.
## Implementation details

Remove the http benchmark tests until the vms are created.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
