### PR TITLE
Fix W3CTraceContextPropagator for non-standard array types

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -665,7 +665,8 @@ namespace Datadog.Trace.Propagators
             return true;
         }
 
-        private static bool TryGetSingle(IEnumerable<string?> values, out string value)
+        // internal for regression testing
+        internal static bool TryGetSingle(IEnumerable<string?> values, out string value)
         {
             // fast path for string[], List<string>, and others
             if (values is IReadOnlyList<string?> list)
@@ -683,28 +684,29 @@ namespace Datadog.Trace.Propagators
             return TryGetSingleRare(values, out value);
         }
 
-        private static bool TryGetSingleRare(IEnumerable<string?> values, out string value)
+        // internal for regression testing
+        internal static bool TryGetSingleRare(IEnumerable<string?> values, out string value)
         {
-            value = string.Empty;
-            var hasValue = false;
+            using var enumerator = values.GetEnumerator();
 
-            foreach (var s in values)
+            if (!enumerator.MoveNext())
             {
-                if (!hasValue)
-                {
-                    // save first item
-                    value = s ?? string.Empty;
-                    hasValue = true;
-                }
-                else
-                {
-                    // we already saved the first item and there is a second one
-                    return false;
-                }
+                // there were no items
+                value = string.Empty;
+                return false;
             }
 
-            // there were no items
-            return false;
+            // store first value
+            value = enumerator.Current ?? string.Empty;
+
+            // is there a second value?
+            if (enumerator.MoveNext())
+            {
+                value = string.Empty;
+                return false; // more than one value
+            }
+
+            return true;
         }
 
         private static string TrimAndJoinStrings(IEnumerable<string?> values)


### PR DESCRIPTION
## Summary of changes

The `W3CTraceContextPropagator` would check whether there was a single `traceparent` header value to determine whether or not it should extract W3C headers further. For non-standard array types it would _always_ return `false` meaning that headers wouldn't be extracted. This pull request fixes that so that non-standard array types will return `true` to allow extraction to happen.

## Reason for change

If we have valid headers we should extract them.

## Implementation details

Swapped to `GetEnumerator` as it seems more readable than the `foreach` route.
If we have one value return `true` instead of `false`.
Swapped the `TryGetSingle` and `TryGetSingleRare` to `internal` to add direct unit tests to them.

## Test coverage

- Added tests for `TryGetSingle` and `TryGetSingleRare` testing fundamental behavior.
- Added tests for `Extract` to test possible behavior we could see.

## Other details
<!-- Fixes #{issue} -->

Fixes #6596

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
