### PR TITLE
[tracer] Serialize span links in meta

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -249,7 +249,7 @@ namespace Datadog.Trace.Agent.MessagePack
 
                 var traceFlags = samplingPriority switch
                 {
-                    null => 0u,             // not set, default to keep
+                    null => 0u,             // not set
                     > 0 => 1u + (1u << 31), // keep
                     <= 0 => 1u << 31,       // drop
                 };
@@ -778,7 +778,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
                 var traceFlags = samplingPriority switch
                 {
-                    null => 0u,              // not set, default to keep
+                    null => 0u,              // not set
                     > 0 => 1u + (1u << 31),  // "keep" bits
                     <= 0 => 1u << 31,        // "drop"
                 };

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
@@ -82,6 +82,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 settings.AddRegexScrubber(traceIdRegexHigh, "TraceIdHigh: LinkIdHigh");
                 settings.AddRegexScrubber(traceIdRegexLow, "TraceIdLow: LinkIdLow");
                 settings.AddRegexScrubber(_timeUnixNanoRegex, @"time_unix_nano"":<DateTimeOffset.Now>");
+
+                var spanLinkTraceIdRegex = new Regex("\"trace_id\":[0-9]+");
+                var spanLinkTraceIdHighRegex = new Regex("\"trace_id_high\":[0-9]+");
+                var spanLinkSpanIdRegex = new Regex("\"span_id\":[0-9]+");
+                settings.AddRegexScrubber(spanLinkTraceIdRegex, "\"trace_id\":link_trace_id_low");
+                settings.AddRegexScrubber(spanLinkTraceIdHighRegex, "\"trace_id_high\":link_trace_id_high");
+                settings.AddRegexScrubber(spanLinkSpanIdRegex, "\"span_id\":link_span_id");
+
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseFileName(nameof(NetActivitySdkTests));
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -123,6 +123,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 settings.AddRegexScrubber(traceStatePRegex, "p:TsParentId");
                 settings.AddRegexScrubber(traceIdRegexHigh, "TraceIdHigh: LinkIdHigh");
                 settings.AddRegexScrubber(traceIdRegexLow, "TraceIdLow: LinkIdLow");
+
+                var spanLinkTraceIdRegex = new Regex("\"trace_id\":[0-9]+");
+                var spanLinkTraceIdHighRegex = new Regex("\"trace_id_high\":[0-9]+");
+                var spanLinkSpanIdRegex = new Regex("\"span_id\":[0-9]+");
+                settings.AddRegexScrubber(spanLinkTraceIdRegex, "\"trace_id\":link_trace_id_low");
+                settings.AddRegexScrubber(spanLinkTraceIdHighRegex, "\"trace_id_high\":link_trace_id_high");
+                settings.AddRegexScrubber(spanLinkSpanIdRegex, "\"span_id\":link_span_id");
+
                 settings.AddRegexScrubber(_versionRegex, "telemetry.sdk.version: sdk-version");
                 settings.AddRegexScrubber(_timeUnixNanoRegex, @"time_unix_nano"":<DateTimeOffset.Now>");
                 settings.AddRegexScrubber(_exceptionStacktraceRegex, @"exception.stacktrace"":""System.ArgumentException: Example argument exception"",""");
@@ -171,6 +179,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 settings.AddRegexScrubber(traceIdRegexLow, "TraceIdLow: LinkIdLow");
                 settings.AddRegexScrubber(_timeUnixNanoRegex, @"time_unix_nano"":<DateTimeOffset.Now>");
                 settings.AddRegexScrubber(_exceptionStacktraceRegex, @"exception.stacktrace"":""System.ArgumentException: Example argument exception"",""");
+
+                var spanLinkTraceIdRegex = new Regex("\"trace_id\":[0-9]+");
+                var spanLinkTraceIdHighRegex = new Regex("\"trace_id_high\":[0-9]+");
+                var spanLinkSpanIdRegex = new Regex("\"span_id\":[0-9]+");
+                settings.AddRegexScrubber(spanLinkTraceIdRegex, "\"trace_id\":link_trace_id_low");
+                settings.AddRegexScrubber(spanLinkTraceIdHighRegex, "\"trace_id_high\":link_trace_id_high");
+                settings.AddRegexScrubber(spanLinkSpanIdRegex, "\"span_id\":link_span_id");
+
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseFileName(filename)
                                   .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -33,7 +33,8 @@ namespace Datadog.Trace.TestHelpers
             .IsOptional("error.type")
             .IsOptional("error.stack")
             .IsOptional("_dd.git.repository_url")
-            .IsOptional("_dd.git.commit.sha");
+            .IsOptional("_dd.git.commit.sha")
+            .IsOptional("_dd.span_links");
 
         public static void DefaultMetricAssertions(SpanTagAssertion<T> s) => s
             .IsOptional("_dd.tracer_kr")

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
@@ -194,10 +194,7 @@ public class SpanMessagePackFormatterTests
                         > 0 => 1u + (1u << 31), // keep
                         <= 0 => 1u << 31,       // drop
                     };
-                    if (expectedTraceFlags > 0)
-                    {
-                        actualSpanLink.TraceFlags.Should().Be(expectedTraceFlags);
-                    }
+                    actualSpanLink.TraceFlags.Should().Be(expectedTraceFlags);
 
                     if (expectedSpanlink.Attributes is { Count: > 0 })
                     {

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -16,7 +16,7 @@
       some_tag: value,
       span.kind: server,
       version: 1.0.0,
-      _dd.span_links: [{"trace_id":15438478407209366795,"trace_id_high":17216991746876858190,"span_id":3589328166953650349,"flags":2147483648,"tracestate":"","attributes":{"some_string":"five","some_string[].0":"a","some_string[].1":"b","some_string[].2":"c","some_bool":"False","some_bool[].0":"True","some_bool[].1":"False","some_int":"5","some_int[].0":"5","some_int[].1":"55","some_int[].2":"555"}},{"trace_id":15438478407209366795,"trace_id_high":17216991746876858190,"span_id":17969566649073959363,"flags":2147483649,"tracestate":"dd=s:2;p:TsParentId;t.dm:-4,foo=1,bar=baz","attributes":{}}]
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483648,"tracestate":"","attributes":{"some_string":"five","some_string[].0":"a","some_string[].1":"b","some_string[].2":"c","some_bool":"False","some_bool[].0":"True","some_bool[].1":"False","some_int":"5","some_int[].0":"5","some_int[].1":"55","some_int[].2":"555"}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"dd=s:2;p:TsParentId;t.dm:-4,foo=1,bar=baz","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -142,7 +142,7 @@
       otel.trace_id: Guid_4,
       span.kind: server,
       version: 1.0.0,
-      _dd.span_links: [{"trace_id":15929601038321682839,"trace_id_high":7906680399874829483,"span_id":10898628043581561393,"flags":2147483648,"tracestate":"","attributes":{}}]
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483648,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       attribute-int: 1.0

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -15,7 +15,8 @@
       runtime-id: Guid_2,
       some_tag: value,
       span.kind: server,
-      version: 1.0.0
+      version: 1.0.0,
+      _dd.span_links: [{"trace_id":15438478407209366795,"trace_id_high":17216991746876858190,"span_id":3589328166953650349,"flags":2147483648,"tracestate":"","attributes":{"some_string":"five","some_string[].0":"a","some_string[].1":"b","some_string[].2":"c","some_bool":"False","some_bool[].0":"True","some_bool[].1":"False","some_int":"5","some_int[].0":"5","some_int[].1":"55","some_int[].2":"555"}},{"trace_id":15438478407209366795,"trace_id_high":17216991746876858190,"span_id":17969566649073959363,"flags":2147483649,"tracestate":"dd=s:2;p:TsParentId;t.dm:-4,foo=1,bar=baz","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -140,7 +141,8 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_4,
       span.kind: server,
-      version: 1.0.0
+      version: 1.0.0,
+      _dd.span_links: [{"trace_id":15929601038321682839,"trace_id_high":7906680399874829483,"span_id":10898628043581561393,"flags":2147483648,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       attribute-int: 1.0

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -911,7 +911,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -949,7 +950,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
@@ -911,7 +911,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -949,7 +950,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
@@ -806,7 +806,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -841,7 +842,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_up_to_1_5_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_up_to_1_5_0.verified.txt
@@ -806,7 +806,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -841,7 +842,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_up_to_1_7_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_up_to_1_7_0.verified.txt
@@ -911,7 +911,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -949,7 +950,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
@@ -806,7 +806,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -841,7 +842,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_up_to_1_5_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_up_to_1_5_0.verified.txt
@@ -806,7 +806,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -841,7 +842,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       service.name: MyServiceName,
       service.version: 1.0.x,
       span.kind: internal,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_up_to_1_7_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_up_to_1_7_0.verified.txt
@@ -911,7 +911,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,
@@ -949,7 +950,8 @@ at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       telemetry.sdk.language: dotnet,
       telemetry.sdk.name: opentelemetry,
       telemetry.sdk.version: sdk-version,
-      _dd.base_service: CustomServiceName
+      _dd.base_service: CustomServiceName,
+      _dd.span_links: [{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}},{"trace_id":link_trace_id_low,"trace_id_high":link_trace_id_high,"span_id":link_span_id,"flags":2147483649,"tracestate":"","attributes":{}}]
     },
     Metrics: {
       process_id: 0,


### PR DESCRIPTION
## Summary of changes
This PR does two things:
1. Serialize span links in meta under `Span[meta][_dd.span_links]`. Previously, span links were only under `Span[span_links]`
2. Always serialize trace flags in span links, even if the sampling priority is unset.

## Reason for change
1. Span links should be serialized under both `Span[span_links]` and `Span[meta][_dd.span_links]`. This is how span links work in all other tracers. See https://datadoghq.atlassian.net/wiki/spaces/TS/pages/3404366375/Troubleshooting+Span+Links
2. Also, we should always serialize trace flags in span links, even if it's just empty (`0`). (This is how the other tracers also work). Some downstream services on the backend or agent expect this field. e.g. this code errors if the trace flags field is missing: https://github.com/DataDog/libdatadog/blob/787d15e9867a9b8998b34d281a9cf5ce0301cd10/trace-utils/src/trace_utils.rs#L42-L47

These fixes are prerequisites for a new feature I'm working on called 'span pointers'. Span pointers will be implemented in a future PR, but I opened a similar PR in Java if you want more context: https://github.com/DataDog/dd-trace-java/pull/8075.

## Implementation details

Updates SpanMessagePackFormatter.cs to (1) always serialize trace flags, and (2) construct the json string of the span links to store under the span meta. There is a performance overhead of this json string construction, but this code only runs if the span actually has span links. 

## Test coverage

Unit tests in `SpanMessagePackFormatterTests.cs`.

Also, manual testing shows we no longer get panics in libdatadog due to failing to pass the trace flags. 

I also tested manually, and the span links are correctly serialized in `Span[meta][_dd.span_links]`, which allows the frontend to properly detect them.
<img width="740" alt="Screenshot 2025-02-11 at 3 17 08 PM" src="https://github.com/user-attachments/assets/09570029-5aa6-4ff6-89d1-c98bd800a24d" />

Integration tests were updated:
```
./build.sh Clean BuildTracerHome
./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "NetActivitySdkTests" --SampleName "NetActivitySdk"
./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "OpenTelemetrySdkTests" --SampleName "OpenTelemetrySdk"
```

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
