### PR TITLE
fix: dispose HttpWebResponses to avoid leaking FDs

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -177,7 +177,7 @@ namespace Datadog.Trace.Agent.Transports
         {
             try
             {
-                using var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
+                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
                 return new ApiWebResponse(httpWebResponse);
             }
             catch (WebException exception)

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -177,7 +177,7 @@ namespace Datadog.Trace.Agent.Transports
         {
             try
             {
-                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
+                using var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
                 return new ApiWebResponse(httpWebResponse);
             }
             catch (WebException exception)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -43,7 +43,7 @@ internal abstract class LambdaCommon
         var request = requestBuilder.GetStartInvocationRequest();
         WriteRequestPayload(request, data);
         WriteRequestHeaders(request, context);
-        var response = (HttpWebResponse)request.GetResponse();
+        using var response = (HttpWebResponse)request.GetResponse();
 
         var headers = response.Headers.Wrap();
         if (!ValidateOkStatus(response))

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -59,7 +59,9 @@ internal abstract class LambdaCommon
     {
         var request = requestBuilder.GetEndInvocationRequest(scope, isError);
         WriteRequestPayload(request, data);
-        if (!ValidateOkStatus((HttpWebResponse)request.GetResponse()))
+        using var response = (HttpWebResponse)request.GetResponse();
+
+        if (!ValidateOkStatus(response))
         {
             Log("Extension does not send a status 200 OK", debug: false);
         }


### PR DESCRIPTION
## Summary of changes

Ensure `HttpWebResponse` instances are disposed.

## Reason for change

We are "leaking" file descriptors in AWS Lambda. .NET's finalizer eventually closes the underlying sockets, but they spike up and down to several hundred FDs before they are cleaned up.

## Implementation details

use `using`

## Test coverage

Tested locally and in AWS Lambda.

Confirmed via our automated test suite:
<img width="2520" alt="image" src="https://github.com/user-attachments/assets/4e24109b-77c2-4c8a-b617-77083f396f36" />

## Other details
n/a
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
