### PR TITLE
Fix `DisabledIntegrationNames` not correctly disabling the integration

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationConfigurationSource.cs
@@ -86,6 +86,7 @@ internal class ManualInstrumentationConfigurationSource : DictionaryObjectConfig
     private static object RemapResult(string key, object value) => key switch
     {
         TracerSettingKeyConstants.AgentUriKey => value is Uri uri ? uri.ToString() : value,
+        TracerSettingKeyConstants.DisabledIntegrationNamesKey => value is HashSet<string> set ? string.Join(";", set) : value,
         TracerSettingKeyConstants.HttpServerErrorCodesKey => value is List<int> list
                                                                  ? string.Join(",", list.Select(i => i.ToString(CultureInfo.InvariantCulture)))
                                                                  : value,

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationLegacyConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/ManualInstrumentationLegacyConfigurationSource.cs
@@ -1,4 +1,4 @@
-// <copyright file="ManualInstrumentationLegacyConfigurationSource.cs" company="Datadog">
+﻿// <copyright file="ManualInstrumentationLegacyConfigurationSource.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -383,6 +383,7 @@ internal class ManualInstrumentationLegacyConfigurationSource : DictionaryObject
     private static object RemapResult(string key, object value) => key switch
     {
         TracerSettingKeyConstants.AgentUriKey => value is Uri uri ? uri.ToString() : value,
+        TracerSettingKeyConstants.DisabledIntegrationNamesKey => value is HashSet<string> set ? string.Join(";", set) : value,
         TracerSettingKeyConstants.HttpServerErrorCodesKey => value is List<int> list
                                                                  ? string.Join(",", list.Select(i => i.ToString(CultureInfo.InvariantCulture)))
                                                                  : value,


### PR DESCRIPTION
## Summary of changes

Fixes the case where `DisabledIntegrationNames` is modified in code but ignored.

## Reason for change

This code:

```csharp
var settings = TracerSettings.FromDefaultSources();
settings.DisabledIntegrationNames.Add("Kafka");
Tracer.Configure(settings);
```

does _not_ cause the Kafka integration to be disabled as it should be.

## Implementation details

We were missing a remapping. The `IConfigurationSource` expects to read objects as strings, so when we transfer from manual <> automatic we have to convert the provided `HashSet<string>` to a string (to then later be converted _back_ to a `HashSet<>`&hellip;I know, I know). This conversion was missing, the calling code was expecting a `string`, so it failed.

## Test coverage

Updated the unit tests to demonstrates the breaking behaviour (this was a missing part of the tests, because the mapping with `DisabledIntegrationNames` and `Integrations` is a bit of a confusing mess unfortunately). After the fix, the tests pass.

## Other details

Fixes #6657

There are multiple workarounds to this behaviour currently. You can set env vars like this;

- `DD_TRACE_Kafka_Enabled="false"`
- `DD_DISABLED_INTEGRATIONS="Kafka"`

Or you can use the `Integrations` property:

```csharp
var settings = TracerSettings.FromDefaultSources();
settings.Integrations["Kafka"].Enabled = false;
Tracer.Configure(settings);
```