### PR TITLE
Tack on apm-idm-dotnet reviewers to auto-bump PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     labels:
       - "dependencies"
       - "area:dependabot"
+    reviewers:
+      - "DataDog/apm-idm-dotnet"
     ignore:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
       - dependency-name: "*" # Ignore patches for all integrations
@@ -22,6 +24,8 @@ updates:
     labels:
       - "dependencies"
       - "area:dependabot"
+    reviewers:
+      - "DataDog/apm-idm-dotnet"
     ignore:
       - dependency-name: "*" # Ignore patches for all integrations
         update-types: ["version-update:semver-patch"]
@@ -34,6 +38,8 @@ updates:
     labels:
       - "dependencies"
       - "area:tracer"
+    reviewers:
+      - "DataDog/apm-idm-dotnet"
     ignore:
       ### Start Datadog.Trace.csproj ignored dependencies
       # DiagnosticSource is kept at the lowest supported version for widest compatibility
@@ -59,6 +65,8 @@ updates:
     labels:
       - "dependencies"
       - "area:opentracing"
+    reviewers:
+      - "DataDog/apm-idm-dotnet"
     ignore:
       ### Start Datadog.Trace.csproj ignored dependencies
       # DiagnosticSource is kept at the lowest supported version for widest compatibility
@@ -80,6 +88,8 @@ updates:
     labels:
       - "dependencies"
       - "area:benchmarks"
+    reviewers:
+      - "DataDog/apm-idm-dotnet"
     ignore:
       ### Start Datadog.Trace.csproj ignored dependencies
       # DiagnosticSource is kept at the lowest supported version for widest compatibility

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -45,7 +45,9 @@ jobs:
           base: master
           title: "[Test Package Versions Bump] Updating package versions "
           milestone: "${{steps.rename.outputs.milestone}}"
-          reviewers: "DataDog/apm-dotnet"
+          team-reviewers: |
+            DataDog/apm-dotnet
+            Datadog/apm-idm-dotnet
           body: |
             Updates the package versions for integration tests.
             


### PR DESCRIPTION
## Summary of changes

Adds `apm-idm-dotnet` as a reviewer to auto PRs. 

## Reason for change

I get a summary of open PRs, but these are missing

## Implementation details

Added the teams
Updated to `team-reviewers` as that seems to be more correct according to documentation

## Test coverage

## Other details
<!-- Fixes #{issue} -->

Note: this shouldn't make `apm-idm-dotnet` a _required_ reviewer. If it does then revert this change.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
