### PR TITLE
fix(telemetry): only report SSI configuration if set

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -608,8 +608,15 @@ namespace Datadog.Trace.Configuration
             telemetry.Record(ConfigTelemetryData.ManagedTracerTfm, value: ConfigTelemetryData.ManagedTracerTfmValue, recordValue: true, ConfigurationOrigins.Default);
 
             // these are SSI variables that would be useful for correlation purposes
-            telemetry.Record(ConfigTelemetryData.SsiInjectionEnabled, value: EnvironmentHelpers.GetEnvironmentVariable("DD_INJECTION_ENABLED"), recordValue: true, ConfigurationOrigins.EnvVars);
-            telemetry.Record(ConfigTelemetryData.SsiAllowUnsupportedRuntimesEnabled, value: EnvironmentHelpers.GetEnvironmentVariable("DD_INJECT_FORCE"), recordValue: true, ConfigurationOrigins.EnvVars);
+            var injectionEnabled = EnvironmentHelpers.GetEnvironmentVariable("DD_INJECTION_ENABLED");
+            if (!string.IsNullOrEmpty(injectionEnabled)) {
+                telemetry.Record(ConfigTelemetryData.SsiInjectionEnabled, value: injectionEnabled, recordValue: true, ConfigurationOrigins.EnvVars);
+            }
+
+            var injectionForced = EnvironmentHelpers.GetEnvironmentVariable("DD_INJECT_FORCE");
+            if (!string.IsNullOrEmpty(injectionForced)) {
+                telemetry.Record(ConfigTelemetryData.SsiAllowUnsupportedRuntimesEnabled, value: injectionForced, recordValue: true, ConfigurationOrigins.EnvVars);
+            }
 
             if (AzureAppServiceMetadata is not null)
             {


### PR DESCRIPTION
### What does this PR do?
This PR ensures that telemetry configuration is only reported when it has valid values. Since the `value` field is mandatory for configuration entries (as specified in the [schema](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/conf_key_value.md)), reporting entries without values results in invalid payloads that our intake do not or entirely process.

### Motivation
To reduce the number of invalid payloads and ensure the tracer conforms to the expected schema.

## Reason for change

## Implementation details

## Test coverage

## Other details
This is a bandaid. The telemetry API currently accepts `null` for values while this should be forbidden but I lack the time and knowledge on the tracer to offer a better PR at the moment. 
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
