### PR TITLE
Make sure we upload hotfix artifacts to Azure

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4573,7 +4573,7 @@ stages:
               ne(variables['push_artifacts_to_azure_storage'], 'false'),
               or(
                 eq(variables['push_artifacts_to_azure_storage'], 'true'),
-                eq(variables.isMainBranch, true)
+                eq(variables.isMainOrReleaseBranch, true)
               )
             )
           env:


### PR DESCRIPTION
## Summary of changes

Make sure we upload the hotfix artifacts to azure

## Reason for change

The Serverless release process relies on the artifacts from the build being uploaded to Azure. Currently, we only upload the artifacts on `master` builds. This ensures we upload it on all release branches i.e. `hotfix/*` (or `release/*`) branches

## Implementation details

`isMainBranch` -> `isMainOrReleaseBranch`

## Test coverage

YOLO

## Other details

Discovered during the release of 3.10.1
