### PR TITLE
Restrict dependabot github actions to patch version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,5 +111,6 @@ updates:
       interval: "monthly"
     groups:
       gh-actions-packages:
+        update-types: ["version-update:semver-patch"]
         patterns:
           - "*"


### PR DESCRIPTION
## Summary of changes

Limit dependabot to only bumping patch version for github actions

## Reason for change

Currently it's doing major bumps, and those are _super_ risky because we can't easily test a lot of our usages.

## Implementation details

[Based on the docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#update-types-groups)

## Test coverage

This will likely test it by triggering another run

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
