### PR TITLE
Reduce flake in Fleet installer tests

### DIFF
--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -37,7 +37,7 @@ namespace AspNetCoreSmokeTest
 
             await CreateHostBuilder(args).Build().RunAsync();
 
-            var completedPath = Path.Join(
+            var completedPath = Path.Combine(
                 Environment.GetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY") ?? ".",
                 "completed.txt");
 

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -35,6 +36,12 @@ namespace AspNetCoreSmokeTest
             Console.WriteLine($"OS description: {RuntimeInformation.OSDescription}");
 
             await CreateHostBuilder(args).Build().RunAsync();
+
+            var completedPath = Path.Join(
+                Environment.GetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY") ?? ".",
+                "completed.txt");
+
+            File.WriteAllText(completedPath, DateTimeOffset.UtcNow.ToString());
 
             return ExitCode;
         }


### PR DESCRIPTION
## Summary of changes

Reduce the flake seen in Fleet installer tests

## Reason for change

The fleet installer tests are currently very flaky. This is mostly due to the nightmare of trying to get the app to behave as it does elsewhere (which _maybe_ we should just give up on, more on that later).

## Implementation details

The simple details are:
- Add a delay after running `ServiceMonitor.exe` before starting the app pool and sending the initial request
- Add a hacky _completed.txt_ file to allow tracking when the app has shutdown.

First, some history...

The design of the test app is that it starts, wait for itself to be ready to handle requests, sends a self-request, and then shuts down. This works great for Docker outside of IIS, because it means we know that we get exactly one request, once the app is ready, and the docker container exits once the sequence is complete. :chef-kiss:

On IIS, this just doesn't work. IIS does its best to make sure the app _is_ always running. There's a bunch of other complexity. One of which is the only way to get the app running in the first place is to send a request to it, which messes with our snapshots (that's already handled). But a bigger issue is the shutdown - I just can't find a way to "wait" for it using the built-in behaviour. And without being able to wait for shutdown, we don't know exactly when the "expected" request has been sent.

So this has a hack - write to a file in the app when the app is shutting down. And spin in the powershell script, waiting for that file to exist.

## Test coverage

I've run the tests repeatedly on this branch, and not seen any failures, so 🤞 

## Other details

Yeah, I know, the arbitrary delay could be a source of flake. I spent _way_ too long trying to capture the output to explicitly wait for the expected output, but no matter what sort of redirection I tried, I couldn't capture it as I needed - it only writes to the redirected output when the process ends, and the process _doesn't_ end 🙄 So yeah, this is a hack, but it works