### PR TITLE
[Fleet Installer] Don't throw when deleting registry value if it's already deleted

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/RegistryHelper.cs
+++ b/tracer/src/Datadog.FleetInstaller/RegistryHelper.cs
@@ -51,7 +51,7 @@ internal class RegistryHelper
         try
         {
             var key = Registry.LocalMachine.OpenSubKey(registryKeyName, writable: true);
-            key?.DeleteValue(crashHandlerPath);
+            key?.DeleteValue(crashHandlerPath, throwOnMissingValue: false);
             log.WriteInfo($"Crash tracking handler path '{crashHandlerPath}' removed from '{registryKeyName}'");
 
             return true;
@@ -83,6 +83,8 @@ internal class RegistryHelper
             var minor = key.GetValue("MinorVersion") as int? ?? 0;
 
             version = new(major: major, minor: minor);
+
+            log.WriteInfo($"Found IIS version: '{major}.{minor}'");
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary of changes

Don't throw when deleting registry value if it's already deleted.

## Reason for change

The uninstall command should be idempotent. Currently, if you run it twice, it will fail, because it can't find the crash-tracking key to delete.

## Implementation details

I assumed `RegistryKey.DeleteValue()` worked like `File.Delete()`. It doesn't, you need to pass `throwOnMissingValue`.

## Test coverage

Yeah... I still need to write integration tests, and this will be part of them
