### PR TITLE
[Fleet Installer] Don't block uninstall if IIS isn't available

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/Commands/CommandBase.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/CommandBase.cs
@@ -6,6 +6,7 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading.Tasks;
@@ -35,18 +36,24 @@ internal abstract class CommandBase : Command
             return false;
         }
 
+        return true;
+    }
+
+    protected bool HasValidIIsVersion(ILogger commandResult, [NotNullWhen(false)] out string? errorMessage)
+    {
         if (!RegistryHelper.TryGetIisVersion(Log.Instance, out var version))
         {
-            commandResult.ErrorMessage = "This installer requires IIS 10.0 or later. Could not determine the IIS version; is the IIS feature enabled?";
+            errorMessage = "This installer requires IIS 10.0 or later. Could not determine the IIS version; is the IIS feature enabled?";
             return false;
         }
 
         if (version.Major < 10)
         {
-            commandResult.ErrorMessage = $"This installer requires IIS 10.0 or later. Detected IIS version {version.Major}.{version.Minor}";
+            errorMessage = $"This installer requires IIS 10.0 or later. Detected IIS version {version.Major}.{version.Minor}";
             return false;
         }
 
+        errorMessage = null;
         return true;
     }
 }

--- a/tracer/src/Datadog.FleetInstaller/Commands/InstallCommand.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/InstallCommand.cs
@@ -88,6 +88,12 @@ internal class InstallCommand : CommandBase
             return;
         }
 
+        if (!HasValidIIsVersion(Log.Instance, out var errorMessage))
+        {
+            commandResult.ErrorMessage = errorMessage;
+            return;
+        }
+
         var path = commandResult.GetValueForOption(_versionedPathOption);
         if (path is not null && !FileHelper.TryVerifyFilesExist(Log.Instance, new TracerValues(path), out var err))
         {


### PR DESCRIPTION
## Summary of changes

If IIS is uninstalled _before_ you run the `uninstall-product` command, don't fail the uninstall.

## Reason for change

It's a niche issue. We block install if IIS isn't available or is <10.0, but we currently also block the _uninstall_. This PR makes it so that if the customer uninstalls IIS after installing the product, we don't block the uninstall

## Implementation details

If they uninstalled IIS, there's not really anything _to_ uninstall, as this stage just removes the env vars from the apps (which isn't possible once IIS is uninstalled). So basically just move the check from being a global check to an install-only check.

## Test coverage

:shhh:
