### PR TITLE
[Crashtracking] Fix crashtracking in single-file apps

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1262,7 +1262,7 @@ partial class Build : NukeBuild
                                     dockerTag = dockerTag,
                                     publishFramework = image.PublishFramework,
                                     linuxArtifacts = linuxArtifacts,
-                                    runCrashTest = image.RunCrashTest ? "true" : "false",
+                                    runCrashTest = "false", // this doesn't work on Linux
                                     runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                     runtimeId = runtimeId,
                                     packageName = pair.package.name,

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1262,7 +1262,7 @@ partial class Build : NukeBuild
                                     dockerTag = dockerTag,
                                     publishFramework = image.PublishFramework,
                                     linuxArtifacts = linuxArtifacts,
-                                    runCrashTest = "false", // this doesn't work yet
+                                    runCrashTest = image.RunCrashTest ? "true" : "false",
                                     runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                     runtimeId = runtimeId,
                                     packageName = pair.package.name,


### PR DESCRIPTION
## Summary of changes

Register the crashtracking WER handler even if we fail to unregister the .NET one.

## Reason for change

For crashtracking to work, we need to unregister the WER handler registered by .NET, because it claims the crash and we won't be called. To unregister it, we need two information: the path to `coreclr.dll`, and its address in memory. It fails in single-file apps because there is no `coreclr.dll`. However, it also means that the .NET registration is invalid, so we will still be called if we register our own handler.

Regardless, even if the .NET WER handler registration is correct, it doesn't hurt to still register our own.

## Test coverage

Tested on my machine. I don't think it's worth the hassle of publishing Samples.Console as single file.