### PR TITLE
Pack trimming file in Datadog.Trace NuGet, and add trimming smoke tests for the NuGet packages

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5730,6 +5730,81 @@ stages:
         baseImage: alpine
         command: "CheckSmokeTestsForErrors"
 
+- stage: trimmed_installer_smoke_tests
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [package_windows, package_linux, generate_variables, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [linux]
+
+    - job: linux
+      timeoutInMinutes: 45 # should take ~5 mins
+      strategy:
+        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.trimming_installer_linux_smoke_tests_matrix'] ]
+      variables:
+        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+      pool:
+        name: azure-linux-smoke-scale-set
+
+      steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download installer artifacts to smoke test directory
+          inputs:
+            artifact: $(linuxArtifacts)
+            path: $(smokeTestAppDir)/artifacts
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download $(packageName) package
+          inputs:
+            artifact: nuget-packages
+            itemPattern: "$(packageName).$(ToolVersion)$(packageVersionSuffix).nupkg"
+            path: $(smokeTestAppDir)/artifacts
+
+        - script: |
+            mkdir -p artifacts/build_data/snapshots
+            mkdir -p artifacts/build_data/logs
+          displayName: create test data directories
+
+        - script: |
+            docker-compose -p $(DockerComposeProjectName) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              --build-arg INSTALL_CMD="$(installCmd)" \
+              --build-arg PACKAGE_NAME=$(packageName) \
+              --build-arg RUNTIME_IDENTIFIER=$(runtimeId) \
+              --build-arg TOOL_VERSION=$(ToolVersion)$(packageVersionSuffix) \
+              trimming-smoke-tests
+          env:
+            dockerTag: $(dockerTag)
+          displayName: docker-compose build trimming-smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'trimming-smoke-tests'
+            snapshotPrefix: "smoke_test"
+
+        - publish: artifacts/build_data
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+          condition: always()
+          continueOnError: true
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            build: true
+            baseImage: alpine
+            command: "CheckSmokeTestsForErrors"
+
 - stage: dotnet_tool_nuget_smoke_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, generate_variables, merge_commit_id]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1054,6 +1054,31 @@ services:
     depends_on:
       - test-agent
 
+  trimming-smoke-tests:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.trimming.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - INSTALL_CMD=
+        # - TOOL_VERSION=
+        # - PACKAGE_NAME=
+        # - RUNTIME_IDENTIFIER=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-trimming-tester
+    init: true # Without this, crash tests hang, see https://github.com/dotnet/runtime/issues/109779
+    volumes:
+      - ./:/project
+      - ./artifacts/build_data/logs:/var/log/datadog/dotnet
+      - ./artifacts/build_data/dumps:/dumps
+    environment:
+      - dockerTag=${dockerTag:-unset}
+      - DD_TRACE_AGENT_URL=http://test-agent:8126
+    depends_on:
+      - test-agent
+
   StartDependencies.OSXARM64:
     image: andrewlock/wait-for-dependencies
     depends_on:

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1262,7 +1262,7 @@ partial class Build : NukeBuild
                                     dockerTag = dockerTag,
                                     publishFramework = image.PublishFramework,
                                     linuxArtifacts = linuxArtifacts,
-                                    runCrashTest = image.RunCrashTest ? "true" : "false",
+                                    runCrashTest = "false", // this doesn't work yet
                                     runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                     runtimeId = runtimeId,
                                     packageName = pair.package.name,

--- a/tracer/build/_build/docker/smoke.trimming.dockerfile
+++ b/tracer/build/_build/docker/smoke.trimming.dockerfile
@@ -1,0 +1,68 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+# Enable trimming for the app, and add the necessary NuGet packages that include the trimmer files
+ENV PublishTrimmed=true
+ARG TOOL_VERSION
+ARG PACKAGE_NAME
+ARG PUBLISH_FRAMEWORK
+ARG RUNTIME_IDENTIFIER
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet nuget add source /src/artifacts \
+    && echo "Installing $PACKAGE_NAME version $TOOL_VERSION for $RUNTIME_IDENTIFIER" \
+    && dotnet add package $PACKAGE_NAME --version $TOOL_VERSION \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -r $RUNTIME_IDENTIFIER -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+
+WORKDIR /app
+
+# Copy the installer files from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /app/install
+
+ARG INSTALL_CMD
+RUN mkdir -p /opt/datadog \
+    && mkdir -p /var/log/datadog \
+    && cd /app/install \
+    && $INSTALL_CMD \
+    && rm -rf /app/install
+
+# Set the required env vars
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/opt/datadog
+ENV LD_PRELOAD=/opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so
+ENV DD_PROFILING_ENABLED=1
+ENV DD_APPSEC_ENABLED=1
+ENV DD_TRACE_DEBUG=1
+
+## SSI variables
+ENV DD_INJECTION_ENABLED=tracer
+ENV DD_INJECT_FORCE=1
+ENV DD_TELEMETRY_FORWARDER_PATH=/bin/true
+
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
+ENV ASPNETCORE_URLS=http://localhost:5000
+
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["./AspNetCoreSmokeTest"]

--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
@@ -48,7 +48,10 @@
 
   <ItemGroup>
     <None Include="..\..\..\docs\Datadog.Trace\README.md" Pack="true" PackagePath="\" />
+    <None Include="Datadog.Trace.props" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="..\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" Pack="true" PackagePath="build" Visible="false" />
   </ItemGroup>
+
 
   <!--To match the Datadog.Trace requirements-->
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.props
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.props
@@ -1,0 +1,19 @@
+﻿<!--
+***********************************************************************************************
+Datadog.Trace.props
+Copyright 2017 Datadog, Inc.
+***********************************************************************************************
+-->
+<Project>
+
+  <PropertyGroup>
+    <!-- IL2007: Could not resolve assembly specified in descriptor file -->
+    <!-- IL2008: Could not resolve type specified in descriptor file -->
+    <NoWarn>IL2007;IL2008</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)Datadog.Trace.Trimming.xml" />
+  </ItemGroup>
+
+</Project>

--- a/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
+++ b/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
@@ -28,7 +28,6 @@
   <files>
     <file src="build\Datadog.Trace.Trimming.props" target="build\Datadog.Trace.Trimming.props" />
     <file src="build\Datadog.Trace.Trimming.xml" target="build\Datadog.Trace.Trimming.xml" />
-    <file src="Sdk\Sdk.props" target="Sdk\Sdk.props" />
     <file src="..\..\..\datadog-logo-256x256.png" target="datadog-logo-256x256.png" />
     <file src="README.md" target="README.md" />
   </files>

--- a/tracer/src/Datadog.Trace.Trimming/Sdk/Sdk.props
+++ b/tracer/src/Datadog.Trace.Trimming/Sdk/Sdk.props
@@ -1,9 +1,0 @@
-<!--
-***********************************************************************************************
-Sdk.props
-Copyright 2017 Datadog, Inc.
-***********************************************************************************************
--->
-<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\build\Datadog.Trace.Trimming.props" />
-</Project>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -43,6 +43,7 @@
     </Compile>
   </ItemGroup>
 
+
   <ItemGroup>
     <ProjectReference Include="..\Datadog.Trace.SourceGenerators\Datadog.Trace.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -43,7 +43,6 @@
     </Compile>
   </ItemGroup>
 
-
   <ItemGroup>
     <ProjectReference Include="..\Datadog.Trace.SourceGenerators\Datadog.Trace.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
@@ -9,12 +9,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishTrimmed)' == 'true'">
-    <PublishTrimmed>true</PublishTrimmed>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
     <NoWarn>IL2007;IL2008;IL2026;IL2104</NoWarn>
     <DefineConstants>$(DefineConstants);PUBLISH_TRIMMED</DefineConstants>
-    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2'))">

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
@@ -1,10 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(PublishTrimmed)' != 'true'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(PublishTrimmed)' != 'true' AND '$(OS)' == 'Windows_NT'">net462;$(TargetFrameworks)</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishTrimmed)' == 'true'">
+    <PublishTrimmed>true</PublishTrimmed>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <NoWarn>IL2007;IL2008;IL2026;IL2104</NoWarn>
+    <DefineConstants>$(DefineConstants);PUBLISH_TRIMMED</DefineConstants>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2'))">

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -43,6 +43,17 @@ namespace AspNetCoreSmokeTest
 
             File.WriteAllText(completedPath, DateTimeOffset.UtcNow.ToString());
 
+#if PUBLISH_TRIMMED
+            // this is a hacky way of simply making sure the controller isn't trimmed
+            try
+            {
+                _ = new ValuesController(null).Get();
+            }
+            catch
+            {
+                // this will throw, but we don't care
+            }
+#endif
             return ExitCode;
         }
 


### PR DESCRIPTION
## Summary of changes

- Pack the trimming file into the _Datadog.Trace_ NuGet package
- Add smoke tests for the _Datadog.Trace_ and _Datadog.Trace.Trimming_ NuGet packages
- Remove the unnecessary sdk.props file from _Datadog.Trace.Trimming_

## Reason for change

When users are building trimmed (non-aot) apps, they need to reference our trimming file, which is currently exposed via the _Datadog.Trace.Trimming_ NuGet package. We created this as a separate package, because we didn't want people to have to reference the _Datadog.Trace_ NuGet if they didn't need it. 

However, there's not really a good reason to force people to _have_ to reference another NuGet package if they are _already_ referencing _Datadog.Trace_. And there's no harm in including the trimming file for non-trimmed apps, it has no impact. 

## Implementation details

- Pack the same trimming.XML file into the _Datadog.Trace_ NuGet package
- Include a _Datadog.Trace.props_ file to automatically reference the trimmer file when the NuGet is referenced
- Added smoke tests that confirm the _NuGet_ packaging is correct for both the new package, and the existing package
  - We already had "integration" tests that confirm the trimmer file works, but we didn't have any tests that were using the NuGet package, to confirm the `props` are correctly added etc.
- Removed the `sdk/sdk.props` file from _Datadog.Trace.Trimming_ as it's unused. This file is only useful if you're creating a "[custom .NET SDK](https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2022#use-the-sdk-attribute-on-the-project-element)" to reference in the `<Project SDK="Some.SDK">` element (which we're not).

## Test coverage

Added smoke tests to confirm both the _Datadog.Trace_ and _Datadog.Trace.Trimming_ packages work as expected. For now, these are:

- `linux-x64`/`linux-musl-x64` only
- `net8.0`/`net9.0` only

We could expand that further if we want, but I'm not massively inclined to do so - we primarily want to ensure the _packages_ are valid, and we don't really need to run that across all the different platforms IMO. Plus it will just increase the chance of flake.

## Other details

As part of this, noticed that crash tracking didn't work. 
- Disabled crash tracking in these tests for now
- https://github.com/DataDog/dd-trace-dotnet/pull/6677 was raised in response
- Ideally we should merge this, and then re-enable the crash tracking tests in that PR

I've kept these in the "standard, every PR" set of smoke tests for now, but maybe we should move them to the master-only set? 🤷‍♂️ 