### PR TITLE
Add NuGet API verification check

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
           echo "Pushing package to test NuGet API key validity"
-          if ! dotnet nuget push "Datadog.Trace.Annotations.1.0.0.nupkg" --api-key "meh" --skip-duplicate --source https://api.nuget.org/v3/index.json; then
+          if ! dotnet nuget push "Datadog.Trace.Annotations.1.0.0.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json; then
             echo "Push failed - the API key is likely not valid" >&2
             echo "Create a new NuGet api key at nuget.org, with glob permissions * to push to the Datadog org and" >&2
             echo "replace the NUGET_API_KEY GitHub secret with the new key at https://github.com/DataDog/dd-trace-dotnet/settings/secrets/actions " >&2

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -47,6 +47,26 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
+      - name: "Check NuGet token validity"
+        run: |
+          echo "Downloading test package"
+          if ! curl -fL -o Datadog.Trace.Annotations.1.0.0.nupkg https://www.nuget.org/api/v2/package/Datadog.Trace.Annotations/1.0.0; then
+            echo "Download failed!" >&2
+            exit 1
+          fi
+
+          echo "Pushing package to test NuGet API key validity"
+          if ! dotnet nuget push "Datadog.Trace.Annotations.1.0.0.nupkg" --api-key "meh" --skip-duplicate --source https://api.nuget.org/v3/index.json; then
+            echo "Push failed - the API key is likely not valid" >&2
+            echo "Create a new NuGet api key at nuget.org, with glob permissions * to push to the Datadog org and" >&2
+            echo "replace the NUGET_API_KEY GitHub secret with the new key at https://github.com/DataDog/dd-trace-dotnet/settings/secrets/actions " >&2
+            echo "and then try running this release again" >&2
+            exit 1
+          fi
+          
+          echo "Push succeeded, cleaning up"
+          rm Datadog.Trace.Annotations.1.0.0.nupkg
+
       - name: "Check GitLab status"
         if: ${{ !github.event.inputs.ignore_gitlab_failures }}
         run: ./tracer/build.sh VerifyReleaseReadiness


### PR DESCRIPTION
## Summary of changes

Adds an early stage in the create_draft_release workflow to check that the Nuget API key is valid

## Reason for change

We recently did a release, and the "upload NuGet packages step failed". Unfortunately, this happens _after_ the draft release is created which is essentially a one-way trip (it triggers downstream things).

## Implementation details

Unfortunately, due to 
- https://github.com/NuGet/Home/issues/13475
- https://github.com/NuGet/NuGetGallery/issues/8283

There's no good way to test the key _Without_ pushing a package.

So this takes a hacky approach:
- Download one of our packages
- Try to push the package (and set `--skip-duplicate` so that it becomes a no-op)
- If it succeeds, it's a no-op, if the key is invalid, it fails, and we bail

## Test coverage

Tested the steps locally, and they work so 🤞 
