### PR TITLE
don't propagate baggage when http client integration is disabled

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -38,13 +38,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
                 if (scope is not null)
                 {
                     tags.HttpClientHandlerType = instance.GetType().FullName;
+
+                    // add propagation headers to the HTTP request
+                    var context = new PropagationContext(scope.Span.Context, Baggage.Current);
+                    tracer.TracerManager.SpanContextPropagator.Inject(context, new HttpHeadersCollection(headers));
+
                     tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(implementationIntegrationId ?? integrationId);
                 }
             }
-
-            // add propagation headers to the HTTP request
-            var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
-            tracer.TracerManager.SpanContextPropagator.Inject(context, new HttpHeadersCollection(headers));
 
             return scope is null ? CallTargetState.GetDefault() : new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -24,11 +24,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
 
             var tracer = Tracer.Instance;
             var headers = requestMessage.Headers;
-            Scope scope = null;
 
             if (IsTracingEnabled(headers, implementationIntegrationId))
             {
-                scope = ScopeFactory.CreateOutboundHttpScope(
+                var scope = ScopeFactory.CreateOutboundHttpScope(
                     tracer,
                     requestMessage.Method.Method,
                     requestMessage.RequestUri,
@@ -44,10 +43,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
                     tracer.TracerManager.SpanContextPropagator.Inject(context, new HttpHeadersCollection(headers));
 
                     tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(implementationIntegrationId ?? integrationId);
+                    return new CallTargetState(scope);
                 }
             }
 
-            return scope is null ? CallTargetState.GetDefault() : new CallTargetState(scope);
+            return CallTargetState.GetDefault();
         }
 
         public static TResponse OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse responseMessage, Exception exception, in CallTargetState state)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
                         // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
                         // added by us, not the application
-                        var context = new PropagationContext(span?.Context, Baggage.Current);
+                        var context = new PropagationContext(span.Context, Baggage.Current);
                         tracer.TracerManager.SpanContextPropagator.Inject(context, request.Headers.Wrap());
                         HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                         return true;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/StringUtil.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/StringUtil.cs
@@ -3,26 +3,47 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
 {
     internal static class StringUtil
     {
+        private static readonly Regex HeaderRegex = new(
+            @"^\[HttpListener\] request header: (?<name>.*?)=(?<value>.*?)\r?$",
+            RegexOptions.Multiline);
+
         /// <summary>
         /// Retrieves a header using a regular expression match.
         /// </summary>
         /// <param name="source">Source string to search.</param>
         /// <param name="name">Name of header to search for.</param>
         /// <returns>Matched string or null if no match</returns>
-        internal static string GetHeader(string source, string name)
+        internal static string? GetHeader(string source, string name)
         {
             var pattern = $@"^\[HttpListener\] request header: {name}=(.*?)\r?$";
             var match = Regex.Match(source, pattern, RegexOptions.Multiline);
 
-            return match.Success
-                       ? match.Groups[1].Value
-                       : null;
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        /// <summary>
+        /// Retrieves all headers using a regular expression match.
+        /// </summary>
+        /// <param name="source">Source string to search.</param>
+        /// <returns>Matched headers.</returns>
+        internal static Dictionary<string, string> GetAllHeaders(string source)
+        {
+            return HeaderRegex.Matches(source)
+                              .Cast<Match>() // required in older runtimes where MatchCollection doesn't implement IEnumerable<Match>
+                              .Where(match => match.Success)
+                              .ToDictionary(
+                                  match => match.Groups["name"].Value,
+                                  match => match.Groups["value"].Value);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/StringUtil.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/StringUtil.cs
@@ -36,14 +36,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
         /// </summary>
         /// <param name="source">Source string to search.</param>
         /// <returns>Matched headers.</returns>
-        internal static Dictionary<string, string> GetAllHeaders(string source)
+        internal static IEnumerable<KeyValuePair<string, string>> GetAllHeaders(string source)
         {
             return HeaderRegex.Matches(source)
                               .Cast<Match>() // required in older runtimes where MatchCollection implements IEnumerable, but not IEnumerable<Match>
-                              .Where(match => match.Success)
-                              .ToDictionary(
-                                  match => match.Groups["name"].Value,
-                                  match => match.Groups["value"].Value);
+                              .Where(m => m.Success)
+                              .Select(m => new KeyValuePair<string, string>(
+                                  m.Groups["name"].Value,
+                                  m.Groups["value"].Value));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/StringUtil.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/StringUtil.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
         internal static Dictionary<string, string> GetAllHeaders(string source)
         {
             return HeaderRegex.Matches(source)
-                              .Cast<Match>() // required in older runtimes where MatchCollection doesn't implement IEnumerable<Match>
+                              .Cast<Match>() // required in older runtimes where MatchCollection implements IEnumerable, but not IEnumerable<Match>
                               .Where(match => match.Success)
                               .ToDictionary(
                                   match => match.Groups["name"].Value,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -213,6 +213,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId).Should().BeNull();
                     StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId).Should().BeNull();
 
+                    // W3C trace context headers
+                    StringUtil.GetHeader(processResult.StandardOutput, W3CTraceContextPropagator.TraceParentHeaderName).Should().BeNull();
+                    StringUtil.GetHeader(processResult.StandardOutput, W3CTraceContextPropagator.TraceStateHeaderName).Should().BeNull();
+
+                    // B3 trace context headers
+                    StringUtil.GetHeader(processResult.StandardOutput, B3SingleHeaderContextPropagator.B3).Should().BeNull();
+                    StringUtil.GetHeader(processResult.StandardOutput, B3MultipleHeaderContextPropagator.TraceId).Should().BeNull();
+                    StringUtil.GetHeader(processResult.StandardOutput, B3MultipleHeaderContextPropagator.SpanId).Should().BeNull();
+                    StringUtil.GetHeader(processResult.StandardOutput, B3MultipleHeaderContextPropagator.Sampled).Should().BeNull();
+
+                    // Baggage header
+                    StringUtil.GetHeader(processResult.StandardOutput, W3CBaggagePropagator.BaggageHeaderName).Should().BeNull();
+
                     using var scope = new AssertionScope();
                     // ignore auto enabled for simplicity
                     telemetry.AssertIntegrationDisabled(IntegrationId.HttpMessageHandler);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -214,6 +214,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     // Datadog trace context headers
                     headers.Should().NotContainKey(HttpHeaderNames.TraceId);
                     headers.Should().NotContainKey(HttpHeaderNames.ParentId);
+                    headers.Should().NotContainKey(HttpHeaderNames.SamplingPriority);
+                    headers.Should().NotContainKey(HttpHeaderNames.Origin);
+                    headers.Should().NotContainKey(HttpHeaderNames.PropagatedTags);
 
                     // W3C trace context headers
                     headers.Should().NotContainKey(W3CTraceContextPropagator.TraceParentHeaderName);


### PR DESCRIPTION
## Summary of changes

When implementing baggage in #6157., we changed the logic in `HttpMessageHandlerCommon` so that it would propagate baggage even if the http client integration was disabled. This changes this behavior so that headers are only injected if the integration is enabled.

Bonus change: cleaned up the integration tests that were modified in this PR
- added `StringUtil.GetAllHeaders()` so we only run the `Regex` once on the stdout instead of a separate regex for each header
- use `FluentAssertions`
- use modern C# constructs like `var` and `using` statements (I recommend ignoring whitespace when viewing the diff)

## Reason for change

This behavior is more correct. Disabling the integration should mean the integration doesn't change any app behavior at all, including injecting http headers. There are separate settings to disable trace and baggage propagators, if needed.

## Implementation details

Move the `Inject()` call into the `if(enabled)` block, where it used to be before #6157.

## Test coverage

- Added assertions to `HttpMessageHandlerTests.TracingDisabled_DoesNotSubmitsTraces()` to verify that _none_ of the known propagation headers are injected when integration is disabled (not just `baggage`).

<!--
## Other details
-->

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
