### PR TITLE
Perf optimization for protobuf instrumentation

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/BufferMessageInternalMergeFromIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/BufferMessageInternalMergeFromIntegration.cs
@@ -8,6 +8,7 @@
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.CallTarget.Handlers;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Protobuf;
 
@@ -28,14 +29,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Protobuf;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class BufferMessageInternalMergeFromIntegration
 {
+    // For performance reasons, we want to do the actual instrumentation work with a Duck constraint,
+    // but to be able to disable the instrumentation we need the raw type
+    // so we use 2 different methods to have access to both when we need it.
+    // Note: Disabling OnMethodBegin means the OnMethodEnd will not be called afterward.
+
     internal static CallTargetState OnMethodBegin<TTarget, TOutput>(TTarget instance, ref TOutput? output)
+    {
+        Helper.DisableInstrumentationIfInternalProtobufType<TTarget>();
+        return CallTargetState.GetDefault();
+    }
+
+    internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, in CallTargetState state)
         where TTarget : IMessageProxy
     {
-        if (Helper.TryGetDescriptor(instance, out var descriptor))
+        if (instance.Instance != null)
         {
-            SchemaExtractor.EnrichActiveSpanWith(descriptor, "deserialization");
+            SchemaExtractor.EnrichActiveSpanWith(instance.Descriptor, "deserialization");
         }
 
-        return CallTargetState.GetDefault();
+        return CallTargetReturn.GetDefault();
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/Helper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/Helper.cs
@@ -4,7 +4,7 @@
 // </copyright>
 
 #nullable enable
-using Datadog.Trace.ClrProfiler.CallTarget;
+using System;
 using Datadog.Trace.ClrProfiler.CallTarget.Handlers;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Protobuf;
@@ -15,7 +15,7 @@ internal static class Helper
     public static void DisableInstrumentationIfInternalProtobufType<TMessage>()
     {
         var typeName = typeof(TMessage).FullName;
-        if (typeName != null && typeName.StartsWith("Google.Protobuf."))
+        if (typeName != null && typeName.StartsWith("Google.Protobuf.", StringComparison.OrdinalIgnoreCase))
         {
             // Google uses protobuf internally in the protobuf library, we don't want to capture those.
             // We disable the integrations once and for all here.

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/IMessageProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/IMessageProxy.cs
@@ -17,8 +17,6 @@ internal interface IMessageProxy : IDuckType
 {
     /// <summary>
     /// Gets the descriptor.
-    /// Accessing this property can generate a nullref in some cases,
-    /// use <see cref="Helper.TryGetDescriptor"/> to avoid that.
     /// </summary>
     [Duck(ExplicitInterfaceTypeName = "Google.Protobuf.IMessage")]
     MessageDescriptorProxy Descriptor { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/MessageWriteToIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/MessageWriteToIntegration.cs
@@ -5,8 +5,10 @@
 
 #nullable enable
 
+using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.CallTarget.Handlers;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Protobuf;
 
@@ -27,14 +29,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Protobuf;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class MessageWriteToIntegration
 {
+    // For performance reasons, we want to do the actual instrumentation work with a Duck constraint,
+    // but to be able to disable the instrumentation we need the raw type
+    // so we use 2 different methods to have access to both when we need it.
+    // Note: Disabling OnMethodBegin means the OnMethodEnd will not be called afterward.
+
     internal static CallTargetState OnMethodBegin<TTarget, TOutput>(TTarget instance, ref TOutput? output)
+    {
+        Helper.DisableInstrumentationIfInternalProtobufType<TTarget>();
+        return CallTargetState.GetDefault();
+    }
+
+    internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, in CallTargetState state)
         where TTarget : IMessageProxy
     {
-        if (instance.Instance is not null)
+        if (instance.Instance != null)
         {
             SchemaExtractor.EnrichActiveSpanWith(instance.Descriptor, "serialization");
         }
 
-        return CallTargetState.GetDefault();
+        return CallTargetReturn.GetDefault();
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/SchemaExtractor.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/SchemaExtractor.cs
@@ -53,13 +53,6 @@ internal class SchemaExtractor
             return;
         }
 
-        if (descriptor.Value.File.Name.StartsWith("google/protobuf/", StringComparison.OrdinalIgnoreCase))
-        {
-            // it's a protobuf operation internal to the protobuf library, not the one we want
-            Log.Debug("Skipping instrumentation for internal protobuf schema {Schema}", descriptor.Value.File.Name);
-            return;
-        }
-
         activeSpan.SetTag(Tags.SchemaType, "protobuf");
         activeSpan.SetTag(Tags.SchemaName, descriptor.Value.Name);
         activeSpan.SetTag(Tags.SchemaOperation, operationName);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GoogleProtobufTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GoogleProtobufTests.cs
@@ -46,7 +46,7 @@ public class GoogleProtobufTests : TracingIntegrationTest
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
         using var telemetry = this.ConfigureTelemetry();
         using var agent = EnvironmentHelper.GetMockAgent();
-        using (await RunSampleAndWaitForExit(agent, $"{TestPrefix}"))
+        using (await RunSampleAndWaitForExit(agent, "AddressBook"))
         {
             using var assertionScope = new AssertionScope();
             var spans = agent.WaitForSpans(2);
@@ -74,12 +74,29 @@ public class GoogleProtobufTests : TracingIntegrationTest
 
     [Fact]
     [Trait("Category", "EndToEnd")]
+    public async Task NoInstrumentationForGoogleTypes()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
+        using var telemetry = this.ConfigureTelemetry();
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using (await RunSampleAndWaitForExit(agent, "TimeStamp"))
+        {
+            var spans = agent.WaitForSpans(2);
+            foreach (var span in spans)
+            {
+                span.Tags.Should().NotContain(t => t.Key.StartsWith("schema."));
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "EndToEnd")]
     public async Task OnlyEnabledWithDsm()
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "0");
         using var telemetry = this.ConfigureTelemetry();
         using var agent = EnvironmentHelper.GetMockAgent();
-        using (await RunSampleAndWaitForExit(agent, $"{TestPrefix}"))
+        using (await RunSampleAndWaitForExit(agent, "AddressBook"))
         {
             var spans = agent.WaitForSpans(2);
             foreach (var span in spans)

--- a/tracer/test/test-applications/integrations/Samples.GoogleProtobuf/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.GoogleProtobuf/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Sample;
 using static Sample.Person.Types;
 
@@ -7,28 +8,49 @@ namespace Samples.GoogleProtobuf;
 
 internal class Program
 {
-    private static void Main()
+    private const string Usage = "Usage: GoogleProtobuf.exe [AddressBook|TimeStamp]";
+
+    private static void Main(string[] args)
     {
-        // sample data
-        var john = new Person { Name = "John Doe", Email = "john@doe.com", Phones = { new PhoneNumber { Number = "12345", Type = PhoneType.Home } } };
-        var jane = new Person { Name = "Jane Doe", Email = "jane@doe.com", Phones = { new PhoneNumber { Number = "67890", Type = PhoneType.Work }, new PhoneNumber { Number = "54321", Type = PhoneType.Mobile } } };
-        var addressBook = new AddressBook { People = { { 12, john }, { 21, jane } } };
+        if (args.Length == 0)
+        {
+            throw new ArgumentException(Usage);
+        }
+
+        IMessage outMessage;
+        IMessage inMessage;
+        if (args[0].Equals("TimeStamp", StringComparison.OrdinalIgnoreCase))
+        {
+            // use a raw google protobuf type (shouldn't be instrumented)
+            outMessage = Timestamp.FromDateTime(DateTime.UtcNow);
+            inMessage = new Timestamp();
+        }
+        else if (args[0].Equals("AddressBook", StringComparison.OrdinalIgnoreCase))
+        {
+            // our own sample data
+            var john = new Person { Name = "John Doe", Email = "john@doe.com", Phones = { new PhoneNumber { Number = "12345", Type = PhoneType.Home } } };
+            var jane = new Person { Name = "Jane Doe", Email = "jane@doe.com", Phones = { new PhoneNumber { Number = "67890", Type = PhoneType.Work }, new PhoneNumber { Number = "54321", Type = PhoneType.Mobile } } };
+            outMessage = new AddressBook { People = { { 12, john }, { 21, jane } } };
+            inMessage = new AddressBook();
+        }
+        else
+        {
+            throw new ArgumentException(Usage);
+        }
 
         // serialization
-
         byte[] serialized;
         using (SampleHelpers.CreateScope("Ser"))
         {
-            serialized = addressBook.ToByteArray();
+            serialized = outMessage.ToByteArray();
         }
 
         // deserialization
-        var deserialized = new AddressBook();
         using (SampleHelpers.CreateScope("Deser"))
         {
-            deserialized.MergeFrom(serialized);
+            inMessage.MergeFrom(serialized);
         }
 
-        Console.WriteLine(deserialized.People.Count);
+        Console.WriteLine(inMessage.ToString());
     }
 }


### PR DESCRIPTION
## Summary of changes

Stop relying on the proto source file to know if we're dealing with an internal protobuf message.
Instead, we check the type at the very beginning, and disable the instrumentation for that type if we detect it's a google type.
This means we can also get rid of all the dark magic we had around making sure we can access the descriptor, because we now know we'll only do it for regular messages.

## Reason for change

it's better perf

## Implementation details

I use an other `OnMethodXxx` method to be able to access the raw type, I explained it in the comments.
See [this thread](https://dd.slack.com/archives/CC7Q58YRG/p1740062564566959) for more.

## Test coverage

added a path in the integration tests that checks that

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
