### PR TITLE
Add `DD_INSTRUMENTATION_INSTALL_TYPE` variables for known install methods

### DIFF
--- a/shared/src/msi-installer/shared/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/shared/EnvironmentVariables.wxs
@@ -7,6 +7,7 @@
     <ComponentGroup Id="Shared.EnvironmentVariables.Machine" Directory="INSTALLFOLDER">
       <Component Id="EnvironmentVariablesShared" Guid="{C314A305-9C24-4E46-9ECF-E5EEA703BDEA}" Win64="$(var.Win64)">
         <CreateFolder/>
+        <Environment Id="DD_INSTRUMENTATION_INSTALL_TYPE" Name="DD_INSTRUMENTATION_INSTALL_TYPE" Action="set" Permanent="no" System="yes" Value="dotnet_msi" Part="all" />
         <Environment Id="COR_PROFILER" Name="COR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
         <Environment Id="CORECLR_PROFILER" Name="CORECLR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
   

--- a/tracer/src/Datadog.FleetInstaller/TracerValues.cs
+++ b/tracer/src/Datadog.FleetInstaller/TracerValues.cs
@@ -27,6 +27,7 @@ internal class TracerValues
             { "DD_DOTNET_TRACER_HOME", TracerHomeDirectory },
             { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
+            { "DD_INSTRUMENTATION_INSTALL_TYPE", "windows_fleet_installer" },
         });
         FilesToAddToGac =
         [

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -609,6 +609,12 @@ namespace Datadog.Trace.Tools.Runner
                 envVars["COR_PROFILER_PATH_ARM64"] = tracerProfilerArm64;
             }
 
+            const string installTypeKey = "DD_INSTRUMENTATION_INSTALL_TYPE";
+            if (string.IsNullOrEmpty(GetEnvironmentVariable(installTypeKey)))
+            {
+                envVars[installTypeKey] = "dd_trace_tool";
+            }
+
             if (!string.IsNullOrEmpty(devPath))
             {
                 envVars["DEVPATH"] = devPath;

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
@@ -149,6 +149,12 @@ internal class Utils
             envVars["COR_PROFILER_PATH_ARM64"] = tracerProfilerArm64;
         }
 
+        const string installTypeKey = "DD_INSTRUMENTATION_INSTALL_TYPE";
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(installTypeKey)))
+        {
+            envVars[installTypeKey] = "dd_dotnet_launcher";
+        }
+
         return envVars;
     }
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/RunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/RunCommandTests.cs
@@ -55,6 +55,7 @@ public class RunCommandTests
         environmentVariables.Should().Contain("DD_TRACE_AGENT_URL", "http://localhost:1111");
         environmentVariables.Should().Contain("VAR1", "A");
         environmentVariables.Should().Contain("VAR2", "B");
+        environmentVariables.Should().Contain("DD_INSTRUMENTATION_INSTALL_TYPE", "dd_dotnet_launcher");
         environmentVariables.Should().NotContainKey("DD_CIVISIBILITY_ENABLED");
     }
 


### PR DESCRIPTION
## Summary of changes

Add the `DD_INSTRUMENTATION_INSTALL_TYPE` for install types for which we can set it

## Reason for change

The `DD_INSTRUMENTATION_INSTALL_TYPE` is used to record when ssi instrumentation is used (for example). I think it makes sense to set this value for some of our installation methods (the ones that set variables automatically for users)

## Implementation details

Add `DD_INSTRUMENTATION_INSTALL_TYPE` for:
- The windows fleet installer (`windows_fleet_installer`)
- The MSI (`dotnet_msi`)
- `dd-trace` tool (`dd_trace_tool`)
- `dd-dotnet` launcher (`dd_dotnet_launcher`)

## Test coverage

Added a small test to the `dd-dotnet` test (because it was easy, and we were already testing this sort of thing). I don't think it's worth the effort to automatically test the rest personally, but if _someone_ wants to ruin my day they have a great excuse.

## Other details

Note that `dd-dotnet` _doesn't_ use a get env var wrapper, but that's by-design as it doesn't run in partial trust, and there are bigger problems if that fails! 