### PR TITLE
Fix dependabot configuration for gh-actions-packages group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,7 +112,7 @@ updates:
       - "/.github/actions/*/*"
     schedule:
       interval: "monthly"
-    groups:
-      gh-actions-packages:
-        patterns:
-          - "*"
+    open-pull-requests-limit: 2
+    ignore: # okay I don't think this works but maybe we can find out live
+      - dependency-name: "*" # Ignore patches for all actions
+        update-types: ["version-update:semver-patch"] # this doesn't seem to work

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,7 +112,7 @@ updates:
       - "/.github/actions/*/*"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 2
-    ignore: # okay I don't think this works but maybe we can find out live
-      - dependency-name: "*" # Ignore patches for all actions
-        update-types: ["version-update:semver-patch"] # this doesn't seem to work
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,7 +112,7 @@ updates:
       - "/.github/actions/*/*"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 3
     ignore: # okay I don't think this works but maybe we can find out live
       - dependency-name: "*" # Ignore patches for all actions
         update-types: ["version-update:semver-patch"] # this doesn't seem to work

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,7 +112,7 @@ updates:
       - "/.github/actions/*/*"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 3
-    ignore: # okay I don't think this works but maybe we can find out live
-      - dependency-name: "*" # Ignore patches for all actions
-        update-types: ["version-update:semver-patch"] # this doesn't seem to work
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,5 @@ updates:
       interval: "monthly"
     groups:
       gh-actions-packages:
-        update-types: ["patch"]
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,6 @@ updates:
       interval: "monthly"
     groups:
       gh-actions-packages:
-        update-types: ["version-update:semver-patch"]
+        update-types: ["patch"]
         patterns:
           - "*"


### PR DESCRIPTION
## Summary of changes

Gave up, just fixed the dependabot file

## Reason for change

It was broken and nothing was running

`The property '#/updates/5/groups/gh-actions-packages/update-types/0' value "version-update:semver-patch" did not match one of the following values: major, minor, patch`

## Implementation details

Deleted `version-update:semver-` not available in group

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
