### PR TITLE
[Fleet installer] Add additional pre-verification check for IIS variables

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/Commands/InstallCommand.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/InstallCommand.cs
@@ -66,12 +66,12 @@ internal class InstallCommand : CommandBase
                 var expectedValue = Defaults.InstrumentationInstallTypeValue;
                 if (expectedValue.Equals(value, StringComparison.Ordinal))
                 {
-                    log.WriteInfo("Found existing instrumentation install type. Won't rollback IIS instrumentation if install fails");
+                    log.WriteInfo($"Found existing instrumentation install type with value {expectedValue}. Won't rollback IIS instrumentation if install fails");
                     tryIisRollback = false;
                 }
                 else
                 {
-                    log.WriteInfo($"Found instrumentation install type, but did not have expected value {expectedValue}. Will rollback IIS instrumentation if install fails");
+                    log.WriteInfo($"Found instrumentation install type {value}, but did not have expected value {expectedValue}. Will rollback IIS instrumentation if install fails");
                     tryIisRollback = true;
                 }
             }

--- a/tracer/src/Datadog.FleetInstaller/Defaults.cs
+++ b/tracer/src/Datadog.FleetInstaller/Defaults.cs
@@ -11,6 +11,8 @@ namespace Datadog.FleetInstaller;
 internal class Defaults
 {
     public const string CrashTrackingRegistryKey = @"Software\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules";
+    public const string InstrumentationInstallTypeKey = "DD_INSTRUMENTATION_INSTALL_TYPE";
+    public const string InstrumentationInstallTypeValue = "windows_fleet_installer";
 
     public static string TracerLogDirectory
         => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Datadog .NET Tracer", "logs");

--- a/tracer/src/Datadog.FleetInstaller/ReturnCode.cs
+++ b/tracer/src/Datadog.FleetInstaller/ReturnCode.cs
@@ -17,4 +17,5 @@ internal enum ReturnCode
     ErrorRemovingAppPoolVariables,
     ErrorRemovingNativeLoaderFiles,
     ErrorRemovingCrashTrackerKey,
+    ErrorReadingIisConfiguration,
 }

--- a/tracer/src/Datadog.FleetInstaller/TracerValues.cs
+++ b/tracer/src/Datadog.FleetInstaller/TracerValues.cs
@@ -27,7 +27,7 @@ internal class TracerValues
             { "DD_DOTNET_TRACER_HOME", TracerHomeDirectory },
             { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
-            { "DD_INSTRUMENTATION_INSTALL_TYPE", "windows_fleet_installer" },
+            { Defaults.InstrumentationInstallTypeKey, Defaults.InstrumentationInstallTypeValue },
         });
         FilesToAddToGac =
         [


### PR DESCRIPTION
## Summary of changes

- Add additional pre-install check for whether we can read IIS config before doing anything irreversible
- If the variables have not been set, then if changing the variables fails, try to revert the changes

## Reason for change

Where possible, we want to revert actions safely. On the first install, if modifying IIS fails, we could theoretically end up with a strange state in their IIS config. This attempts to revert the changes if we think it's safe to do so.

## Implementation details

Tries to look for the presence of the `DD_INSTRUMENTATION_INSTALL_TYPE` variable with value `windows_fleet_installer` - if we find it, then we consider this to be an "update" rather than an "initial install". We _don't_ want to rollback the IIS changes in case of an update, so we leave the variables.

## Test coverage

Yeah... I still need to add integration tests

## Other details

With this design, there's still a risk that we remove variables when we _shouldn't_. e.g. if the customer has _manually_ added instrumentation to the app pools using the same method, we would delete these variables.

Similarly, if they have explicitly opted out of instrumentation, by setting `COR_ENABLE_PROFILING=0` for example, then this would be removed. But currently we _already_ stomp on these (which is something else for us to think about behaviour-wise)

Requires
- https://github.com/DataDog/dd-trace-dotnet/pull/6695