### PR TITLE
[Fleet installer] Don't fail uninstall if the GAC lib has additional references

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/GacInstaller.cs
+++ b/tracer/src/Datadog.FleetInstaller/GacInstaller.cs
@@ -171,6 +171,10 @@ internal static class GacInstaller
                 {
                     log.WriteInfo($"Assembly '{gacAssemblyPath}' was already uninstalled from the GAC.");
                 }
+                else if (disposition is Fusion.UninstallDisposition.IASSEMBLYCACHE_UNINSTALL_DISPOSITION_HAS_INSTALL_REFERENCES)
+                {
+                    log.WriteInfo($"Assembly '{gacAssemblyPath}' has additional install references. It was not removed from the GAC, but will be removed when all references are removed.");
+                }
                 else if (retValue == HResult.Code.S_OK)
                 {
                     log.WriteInfo($"Successfully uninstalled assembly '{gacAssemblyPath}' from the GAC.");


### PR DESCRIPTION
## Summary of changes

Don't fail uninstall if the GAC assembly has additional references

## Reason for change

The GAC won't remove a file if it has additional install references. This happens if you try to register the same assembly name (name + version) with multiple paths. If you do this, then when you call uninstall with the path, the uninstall will return `IASSEMBLYCACHE_UNINSTALL_DISPOSITION_HAS_INSTALL_REFERENCES` because the file _isn't_ removed. But this isn't really a fail from our PoV - the file will be cleaned up later when _all_ the references are removed.

## Implementation details

Handle the `IASSEMBLYCACHE_UNINSTALL_DISPOSITION_HAS_INSTALL_REFERENCES` case explicitly and treat it as a success

## Test coverage

I will write tests soon, I promise
