### PR TITLE
Remove `MemberNotNull` to fix build

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -361,7 +361,6 @@ namespace Datadog.Trace.Configuration
             }
 
 #if NETCOREAPP3_1_OR_GREATER
-            [MemberNotNull(nameof(MetricsHostname))]
             bool SetUds(string unixSocket, string original, string absoluteUri, string? source, out MetricsTransportSettings settings)
             {
                 // Only called in the constructor;
@@ -385,7 +384,6 @@ namespace Datadog.Trace.Configuration
                 return probablyValid;
             }
 #endif
-            [MemberNotNull(nameof(MetricsHostname))]
             bool SetUdp(string hostname, string? hostnameSource, int port, string? portSource, out MetricsTransportSettings settings)
             {
                 var probablyValid = true;


### PR DESCRIPTION
## Summary of changes

Updated VS and MSBuild locally and can no longer build.

## Reason for change

Build wasn't working and I think these are covered as we have nullable enabled and `MetricsHostname` is get only

## Implementation details

Delete

## Test coverage

Build works now

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
