### PR TITLE
[ASM][ATO]Add business logic event address to the waf

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
+++ b/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
@@ -107,9 +107,12 @@ public static class EventTrackingSdk
         void RunWafAndCollectHeaders()
         {
             securityCoordinator.Value.Reporter.CollectHeaders();
-            // confluence [ADDENDUM 2024-12-18] In both login success and failure, the field usr.login must be passed to the WAF. The value of this field must be sourced from either the user object when available, or copied from the value of the mandatory user ID.
-            var result = securityCoordinator.Value.RunWafForUser(userId: userId, userLogin: userId, fromSdk: true, otherTags: new() { { loginSuccess ? AddressesConstants.UserBusinessLoginSuccess : AddressesConstants.UserBusinessLoginFailure, string.Empty } });
-            securityCoordinator.Value.BlockAndReport(result);
+            if (userId is not null)
+            {
+                // confluence [ADDENDUM 2024-12-18] In both login success and failure, the field usr.login must be passed to the WAF. The value of this field must be sourced from either the user object when available, or copied from the value of the mandatory user ID.
+                var result = securityCoordinator.Value.RunWafForUser(userId: userId, userLogin: userId, fromSdk: true, otherTags: new() { { loginSuccess ? AddressesConstants.UserBusinessLoginSuccess : AddressesConstants.UserBusinessLoginFailure, string.Empty } });
+                securityCoordinator.Value.BlockAndReport(result);
+            }
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
+++ b/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
@@ -71,7 +71,7 @@ public static class EventTrackingSdk
             }
         }
 
-        FillUp(internalSpan, userId: userId);
+        FillUp(internalSpan, userId: userId, loginSuccess: true);
     }
 
     /// <summary>
@@ -79,7 +79,8 @@ public static class EventTrackingSdk
     /// </summary>
     /// <param name="span">span</param>
     /// <param name="userId">userid</param>
-    private static void FillUp(Span span, string userId = null)
+    /// <param name="loginSuccess">whether it's a login success</param>
+    private static void FillUp(Span span, string userId = null, bool loginSuccess = false)
     {
         if (span is null)
         {
@@ -107,7 +108,7 @@ public static class EventTrackingSdk
         {
             securityCoordinator.Value.Reporter.CollectHeaders();
             // confluence [ADDENDUM 2024-12-18] In both login success and failure, the field usr.login must be passed to the WAF. The value of this field must be sourced from either the user object when available, or copied from the value of the mandatory user ID.
-            var result = securityCoordinator.Value.RunWafForUser(userId: userId, userLogin: userId, fromSdk: true);
+            var result = securityCoordinator.Value.RunWafForUser(userId: userId, userLogin: userId, fromSdk: true, otherTags: new() { { loginSuccess ? AddressesConstants.UserBusinessLoginSuccess : AddressesConstants.UserBusinessLoginFailure, string.Empty } });
             securityCoordinator.Value.BlockAndReport(result);
         }
     }
@@ -169,7 +170,7 @@ public static class EventTrackingSdk
             }
         }
 
-        FillUp(spanInternal, userId: userId);
+        FillUp(spanInternal, userId: userId, loginSuccess: false);
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
+++ b/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
@@ -71,7 +71,7 @@ public static class EventTrackingSdk
             }
         }
 
-        FillUp(internalSpan, userId: userId, loginSuccess: true);
+        RunSecurityChecksAndReport(internalSpan, userId: userId, loginSuccess: true);
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public static class EventTrackingSdk
     /// <param name="span">span</param>
     /// <param name="userId">userid</param>
     /// <param name="loginSuccess">whether it's a login success</param>
-    private static void FillUp(Span span, string userId = null, bool loginSuccess = false)
+    private static void RunSecurityChecksAndReport(Span span, string userId = null, bool loginSuccess = false)
     {
         if (span is null)
         {
@@ -173,7 +173,7 @@ public static class EventTrackingSdk
             }
         }
 
-        FillUp(spanInternal, userId: userId, loginSuccess: false);
+        RunSecurityChecksAndReport(spanInternal, userId: userId, loginSuccess: false);
     }
 
     /// <summary>
@@ -226,6 +226,6 @@ public static class EventTrackingSdk
             }
         }
 
-        FillUp(internalSpan);
+        RunSecurityChecksAndReport(internalSpan);
     }
 }

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginSdkOnly.success=False.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginSdkOnly.success=False.verified.txt
@@ -1,0 +1,37 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.failure.some-key: some-value,
+      appsec.events.users.login.failure.track: true,
+      appsec.events.users.login.failure.usr.exists: true,
+      appsec.events.users.login.failure.usr.id: user-dog,
+      appsec.events.users.login.failure.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=False,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.events.users.login.failure.sdk: true
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginSdkOnly.success=True.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOff.extendedmode-TestLoginSdkOnly.success=True.verified.txt
@@ -1,0 +1,36 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.success.some-key: some-value,
+      appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=True,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      usr.id: user-dog,
+      _dd.appsec.events.users.login.success.sdk: true
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginSdkOnly.success=False.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginSdkOnly.success=False.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.failure.some-key: some-value,
+      appsec.events.users.login.failure.track: true,
+      appsec.events.users.login.failure.usr.exists: true,
+      appsec.events.users.login.failure.usr.id: user-dog,
+      appsec.events.users.login.failure.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=False,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.events.users.login.failure.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginSdkOnly.success=True.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.anonmode-TestLoginSdkOnly.success=True.verified.txt
@@ -1,0 +1,46 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.success.some-key: some-value,
+      appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=True,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      usr.id: user-dog,
+      _dd.appsec.events.users.login.success.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginSdkOnly.success=False.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginSdkOnly.success=False.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.failure.some-key: some-value,
+      appsec.events.users.login.failure.track: true,
+      appsec.events.users.login.failure.usr.exists: true,
+      appsec.events.users.login.failure.usr.id: user-dog,
+      appsec.events.users.login.failure.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=False,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.events.users.login.failure.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginSdkOnly.success=True.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.defaultmode-TestLoginSdkOnly.success=True.verified.txt
@@ -1,0 +1,46 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.success.some-key: some-value,
+      appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=True,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      usr.id: user-dog,
+      _dd.appsec.events.users.login.success.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginSdkOnly.success=False.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginSdkOnly.success=False.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.failure.some-key: some-value,
+      appsec.events.users.login.failure.track: true,
+      appsec.events.users.login.failure.usr.exists: true,
+      appsec.events.users.login.failure.usr.id: user-dog,
+      appsec.events.users.login.failure.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=False,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.events.users.login.failure.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginSdkOnly.success=True.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.extendedmode-TestLoginSdkOnly.success=True.verified.txt
@@ -1,0 +1,46 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.success.some-key: some-value,
+      appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=True,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      usr.id: user-dog,
+      _dd.appsec.events.users.login.success.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginSdkOnly.success=False.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginSdkOnly.success=False.verified.txt
@@ -1,0 +1,47 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.failure.some-key: some-value,
+      appsec.events.users.login.failure.track: true,
+      appsec.events.users.login.failure.usr.exists: true,
+      appsec.events.users.login.failure.usr.id: user-dog,
+      appsec.events.users.login.failure.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=False,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.events.users.login.failure.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginSdkOnly.success=True.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AutoUserEvents.SecurityOn.identmode-TestLoginSdkOnly.success=True.verified.txt
@@ -1,0 +1,46 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /user/trackloginsdk,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      appsec.events.users.login.success.some-key: some-value,
+      appsec.events.users.login.success.track: true,
+      appsec.events.users.login.success.usr.login: user-dog,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.UserController.TrackLoginSdk (Samples.Security.AspNetCore5),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.route: {controller=home}/{action=index}/{id?},
+      http.status_code: 200,
+      http.url: http://localhost:00000/User/TrackLoginSdk?success=True,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      usr.id: user-dog,
+      _dd.appsec.events.users.login.success.sdk: true,
+      _dd.appsec.fp.http.endpoint: http-get-6dad8221-aee40884-,
+      _dd.appsec.fp.http.header: hdr-0000000000-3626b5f8-1-4740ae63,
+      _dd.appsec.fp.http.network: net-1-1000000000,
+      _dd.appsec.fp.session: ssn-0f71a057---<SessionFp>,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -53,6 +53,7 @@ namespace Samples
         private static readonly MethodInfo RunCommandMethod = ProcessHelpersType?.GetMethod("TestingOnly_RunCommand", BindingFlags.NonPublic | BindingFlags.Static);
         private static readonly MethodInfo SetUserIdMethod = UserDetailsType?.GetProperty("Id", BindingFlags.Public | BindingFlags.Instance)?.SetMethod;
         private static readonly MethodInfo TrackUserLoginSuccessEventMethod = EventTrackingSdk?.GetMethod("TrackUserLoginSuccessEvent", BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(string), typeof(IDictionary<string, string>) }, null);
+        private static readonly MethodInfo TrackUserLoginFailureEventMethod = EventTrackingSdk?.GetMethod("TrackUserLoginFailureEvent", BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(string), typeof(bool), typeof(IDictionary<string, string>) }, null);
 #if NETCOREAPP
         private static readonly MethodInfo SetUserMethod = SpanExtensionsType?.GetMethod("SetUser", BindingFlags.Public | BindingFlags.Static | BindingFlags.DoNotWrapExceptions);
 #else
@@ -406,6 +407,11 @@ namespace Samples
         public static void TrackUserLoginSuccessEvent(string userId, IDictionary<string, string> metadata)
         {
             TrackUserLoginSuccessEventMethod.Invoke(null, new object[] { userId, metadata });
+        }
+        
+        public static void TrackUserLoginFailureEvent(string userId, bool exists, IDictionary<string, string> metadata)
+        {
+            TrackUserLoginFailureEventMethod.Invoke(null, new object[] { userId, exists, metadata });
         }
 
         public static void SetUser(string userId)

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/UserController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/UserController.cs
@@ -1,26 +1,32 @@
+#nullable enable
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Samples.Security.AspNetCore5.Models;
-using System;
-using System.Diagnostics;
-using System.Linq;
+using System.Collections.Generic;
 
 namespace Samples.Security.AspNetCore5.Controllers
 {
-    public class UserController : Controller
+    public class UserController(ILogger<HomeController> logger) : Controller
     {
-        private readonly ILogger<HomeController> _logger;
-
-        public UserController(ILogger<HomeController> logger)
+        public IActionResult Index(string? userId = null)
         {
-            _logger = logger;
+            SampleHelpers.SetUser(userId ?? "user3");
+            return View();
         }
 
-        public IActionResult Index(string userId = null)
+        public IActionResult TrackLoginSdk(bool success, string? userId = null)
         {
-            Samples.SampleHelpers.SetUser(userId ?? "user3");
+            var metadata = new Dictionary<string, string> { { "some-key", "some-value" } };
+            var defaultUserId = "user-dog";
+            if (success)
+            {
+                SampleHelpers.TrackUserLoginSuccessEvent(userId ?? defaultUserId, metadata);
+            }
+            else
+            {
+                SampleHelpers.TrackUserLoginFailureEvent(userId ?? defaultUserId, true, metadata);
+            }
 
-            return View();
+            return View("Index");
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Add business logic event address to the waf on sdk login success / failure events

## Reason for change

Otherwise, no fingerprint is generated on sdk custom events

## Implementation details

## Test coverage

Add some sdk test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
