### PR TITLE
Add fixes for release process

### DIFF
--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -47,6 +47,11 @@ elif [ "$OS" == "windows" ]; then
     exit 0
   fi
 
+  if [ -n "$CI_COMMIT_TAG" ]; then
+    echo "Creating public release, skipping Windows artifacts"
+    exit 0
+  fi
+
   # unzip the tracer home directory, and remove the xml files
   mkdir -p sources/library
   unzip ../artifacts/windows/windows-tracer-home.zip -d sources/library

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1419,6 +1419,8 @@ partial class Build
         // buildHttpClient.GetArtifactContentZipAsync doesn't seem to work due to 'Redirect' response status.
         // instead of downloading resources from https://dev.azure.com/ resource url starts with https://artprodcus3.artifacts.visualstudio.com
         var temporary = new HttpClient();
+        // some of these files are _huge_ so give a long time to download them
+        temporary.Timeout = TimeSpan.FromMinutes(10);
         temporary.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{token}")));
 
         var resourceDownloadUrl = artifact.Resource.DownloadUrl;
@@ -1466,6 +1468,7 @@ partial class Build
         // We don't actually need the file now, we just need to make sure it's available, so that we can
         // use it in GitLab later to build the OCI image.
         var tempDir = TempDirectory / Path.GetRandomFileName();
+        Directory.CreateDirectory(tempDir);
         await DownloadArtifact(client, tempDir, $"{awsUri}fleet-installer.zip");
 
         return;


### PR DESCRIPTION
## Summary of changes

- Increase HttpClient download timeout for Azure Devops release artifacts
- Make sure destination temp directory has been created
- Fix issue in GitLab release pipeline for Windows

## Reason for change

Saw failures due to all of these issues in latest release.

## Implementation details

Increase the timeout to download the release artifacts from "ridiculous" (100s) to "ludicrous" (6000s), in the hope that we don't hit it again. It's safe to just retry in the UI here anyway, so this will hopefully be sufficient.

Additionally, a recent additional check (the fleet installer) was failing because the target directory for the download hadn't been created, so fixed that.

Finally, the `3.11.0` release is broken because of a bug in the script, which only manifests when running for a tag

## Test coverage

Ran the Build stage locally - they both failed previously and now both pass.

We can't easily test the gitlab change unfortunately
