### PR TITLE
[fleet installer] Update (and fix) return code

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/ReturnCode.cs
+++ b/tracer/src/Datadog.FleetInstaller/ReturnCode.cs
@@ -10,12 +10,12 @@ internal enum ReturnCode
     // The order of these values is important, as they are used to determine the exit code of the process
     // We should always add new error values to the end and not re-order them
     Success = 0,
-    ErrorDuringPrerequisiteVerification, // Not explicitly called, but equivalent
+    ErrorDuringPrerequisiteVerification = 1, // Not explicitly called, but equivalent
+    ErrorRemovingNativeLoaderFiles = 2, // Must not change, special-case handled by fleet installer as it means "don't remove the files"
     ErrorDuringGacInstallation,
     ErrorDuringGacUninstallation,
     ErrorSettingAppPoolVariables,
     ErrorRemovingAppPoolVariables,
-    ErrorRemovingNativeLoaderFiles,
     ErrorRemovingCrashTrackerKey,
     ErrorReadingIisConfiguration,
 }


### PR DESCRIPTION
## Summary of changes

Make `ErrorRemovingNativeLoaderFiles = 2` as it's a special case return code

## Reason for change

This is the only return code other than `0` and `1` which currently matters to the fleet-installer, so moving it to `2` from `6` primarily for aesthetics.

## Implementation details

Move the `ErrorRemovingNativeLoaderFiles` error code and explicitly set its value
