### PR TITLE
Fix "auto bump test package versions" workflow 

### DIFF
--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29 # v3.10.0
+        uses: peter-evans/create-pull-request@dd2324fc52d5d43c699a5636bcf19fceaa70c284 # v7.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "bot/test-package-versions-bump"

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -45,9 +45,6 @@ jobs:
           base: master
           title: "[Test Package Versions Bump] Updating package versions "
           milestone: "${{steps.rename.outputs.milestone}}"
-          team-reviewers: |
-            DataDog/apm-dotnet
-            Datadog/apm-idm-dotnet
           body: |
             Updates the package versions for integration tests.
             


### PR DESCRIPTION
## Summary of changes

- Fixes the broken workflow
- Updates the version of `peter-evans/create-pull-request` (as a safe test of the newer version)

## Reason for change

https://github.com/DataDog/dd-trace-dotnet/pull/6665 tried to automatically add reviewers to the auto-created PR, but tl;dr; it didn't work, and was causing the action to fail. We could look at using a PAT to work around the issue, but IMO it's not worth it, so reverted.

As I was testing it anyway, also bumped the version of the action - we can look at bumping it everywhere if this doesn't run into issues.

## Implementation details

Remove the `team-reviewers` option and manually update the package version

## Test coverage

Did a test run [here](https://github.com/DataDog/dd-trace-dotnet/actions/runs/13519784696/job/37776296046) and it worked

## Other details

Partially reverts https://github.com/DataDog/dd-trace-dotnet/pull/6665