### PR TITLE
[fleet installer] Add some integration tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2336,7 +2336,7 @@ stages:
     - script: tracer\build.cmd BuildWindowsIntegrationTests  -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: BuildWindowsIntegrationTests
 
-    - script: tracer\build.cmd RunWindowsIntegrationTests -filter FleetInstaller=True -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+    - script: tracer\build.cmd RunIntegrationTests -filter FleetInstaller=True -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: RunWindowsIisIntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2231,7 +2231,7 @@ stages:
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [msi_tests]
+      jobs: [msi_tests, fleet_installer_tests]
 
   - job: msi_tests
     timeoutInMinutes: 60 #default value
@@ -2305,6 +2305,51 @@ stages:
 
     - publish: artifacts/build_data
       displayName: Uploading integration_tests_windows_msi tracer logs
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+      condition: always()
+      continueOnError: true
+
+    - publish: tracer/test/snapshots
+      displayName: Uploading snapshots
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
+      condition: always()
+      continueOnError: true
+
+    - script: tracer\build.cmd CheckBuildLogsForErrors
+      displayName: Check logs for errors
+
+  - job: fleet_installer_tests
+    timeoutInMinutes: 60 #default value
+    pool:
+      name: azure-windows-scale-set-3
+    variables:
+      framework: net462
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        targetShaId: $(targetShaId)
+        targetBranch: $(targetBranch)
+    - template: steps/install-latest-dotnet-sdk.yml
+    - template: steps/restore-working-directory.yml
+
+    - script: tracer\build.cmd BuildWindowsIntegrationTests  -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+      displayName: BuildWindowsIntegrationTests
+
+    - script: tracer\build.cmd RunWindowsIntegrationTests -filter FleetInstaller=True -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+      displayName: RunWindowsIisIntegrationTests
+      env:
+        DD_LOGGER_DD_API_KEY: $(ddApiKey)
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: VSTest
+        testResultsFiles: artifacts/build_data/results/**/*.trx
+      condition: succeededOrFailed()
+
+    - publish: artifacts/build_data
+      displayName: Uploading tracer logs
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()
       continueOnError: true

--- a/tracer/src/Datadog.FleetInstaller/Datadog.FleetInstaller.csproj
+++ b/tracer/src/Datadog.FleetInstaller/Datadog.FleetInstaller.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Datadog.Trace.IntegrationTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010025b855c8bc41b1d47e777fc247392999ca6f553cdb030fac8e3bd010171ded9982540d988553935f44f7dd58cb4b17fbb92653d5c2dc5112696886665b317c6f92795bf64beab2405c501c8a30cb1b31b1541ed66e27d9823169ec2815b00ceeeecc8d5a1bf43db67d2961a3e9bea1397f043ec07491709649252f5565b756c5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>

--- a/tracer/src/Datadog.FleetInstaller/RegistryHelper.cs
+++ b/tracer/src/Datadog.FleetInstaller/RegistryHelper.cs
@@ -26,7 +26,7 @@ internal class RegistryHelper
                 key = Registry.LocalMachine.CreateSubKey(registryKeyName, writable: true);
                 if (key is null)
                 {
-                    log.WriteError($"Registry key '{registryKeyName}' did not ");
+                    log.WriteError($"Registry key '{registryKeyName}' could not be created ");
                     return false;
                 }
             }

--- a/tracer/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+    <ProjectReference Include="..\..\src\Datadog.FleetInstaller\Datadog.FleetInstaller.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FileHelperTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FileHelperTests.cs
@@ -4,8 +4,12 @@
 // </copyright>
 #if NETFRAMEWORK
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Datadog.FleetInstaller;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,9 +20,25 @@ namespace Datadog.Trace.IntegrationTests.FleetInstaller;
 [Trait("IIS", "True")] // these are to stop the tests being run in other stages
 [Trait("MSI", "True")] // these are to stop the tests being run in other stages
 [Trait("FleetInstaller", "True")]
-public class FileHelperTests(ITestOutputHelper output)
+public class FileHelperTests(ITestOutputHelper output) : IDisposable
 {
     private readonly FleetInstallerLogger _log = new(output);
+    private string _homeDirectory;
+
+    public void Dispose()
+    {
+        if (_homeDirectory is { } dir)
+        {
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch
+            {
+                // Ignore, something is locking it
+            }
+        }
+    }
 
     [SkippableFact]
     public void CreateLogDirectory_WhenDirectoryDoesntExist_CreatesDirectory()
@@ -56,6 +76,114 @@ public class FileHelperTests(ITestOutputHelper output)
     {
         var tempDirectory = Path.Combine("X:", "-1");
         FileHelper.CreateLogDirectory(_log, tempDirectory).Should().BeFalse();
+    }
+
+    [SkippableFact]
+    public void TryVerifyFilesExist_WhenFilesExist_ReturnsTrue()
+    {
+        var homeDirectory = CreateMonitoringHomeCopy();
+
+        var values = new TracerValues(homeDirectory);
+        FileHelper.TryVerifyFilesExist(_log, values, out var error)
+                  .Should().BeTrue();
+        error.Should().BeNull();
+    }
+
+    [SkippableFact]
+    public void TryVerifyFilesExist_WhenDirectoryDoesntExist_ReturnsFalse()
+    {
+        var homeDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.Exists(homeDirectory).Should().BeFalse();
+
+        var values = new TracerValues(homeDirectory);
+        FileHelper.TryVerifyFilesExist(_log, values, out var error)
+                  .Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [SkippableFact]
+    public void TryVerifyFilesExist_WhenX64NativeLoaderDoesNotExist_ReturnsFalse()
+    {
+        var homeDirectory = CreateMonitoringHomeCopy();
+
+        var values = new TracerValues(homeDirectory);
+        File.Delete(values.NativeLoaderX64Path);
+
+        FileHelper.TryVerifyFilesExist(_log, values, out var error)
+                  .Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [SkippableFact]
+    public void TryVerifyFilesExist_WhenX86NativeLoaderDoesNotExist_ReturnsFalse()
+    {
+        var homeDirectory = CreateMonitoringHomeCopy();
+
+        var values = new TracerValues(homeDirectory);
+        File.Delete(values.NativeLoaderX86Path);
+
+        FileHelper.TryVerifyFilesExist(_log, values, out var error)
+                  .Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(Data.IndexesOfFilesToGac), MemberType = typeof(Data))]
+    public void TryVerifyFilesExist_WhenFileToGacDoesNotExist_ReturnsFalse(int index)
+    {
+        var homeDirectory = CreateMonitoringHomeCopy();
+
+        var values = new TracerValues(homeDirectory);
+        File.Delete(values.FilesToAddToGac.Skip(index).First());
+
+        FileHelper.TryVerifyFilesExist(_log, values, out var error)
+                  .Should().BeFalse();
+        error.Should().NotBeNull();
+    }
+
+    private string CreateMonitoringHomeCopy()
+    {
+        if (_homeDirectory is not null)
+        {
+            return _homeDirectory;
+        }
+
+        // create a copy of monitoring home, so that we can mess with it
+        var original = EnvironmentHelper.GetMonitoringHomePath();
+        var homeDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        output.WriteLine("Copying {original} to {homeDirectory}");
+
+        CopyDirectory(original, homeDirectory);
+        _homeDirectory = homeDirectory;
+        return homeDirectory;
+
+        // I can't believe there's no built in API for this...
+        static void CopyDirectory(string source, string destination)
+        {
+            var dir = new DirectoryInfo(source);
+            dir.Exists.Should().BeTrue();
+            var dirs = dir.GetDirectories();
+
+            Directory.CreateDirectory(destination);
+
+            foreach (var file in dir.GetFiles())
+            {
+                file.CopyTo(Path.Combine(destination, file.Name));
+            }
+
+            foreach (var subDir in dirs)
+            {
+                var newDestinationDir = Path.Combine(destination, subDir.Name);
+                CopyDirectory(subDir.FullName, newDestinationDir);
+            }
+        }
+    }
+
+    public static class Data
+    {
+        public static IEnumerable<object[]> IndexesOfFilesToGac
+            => Enumerable.Range(0, new TracerValues(Path.GetTempPath()).FilesToAddToGac.Count)
+                         .Select(i => new object[] { i });
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FileHelperTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FileHelperTests.cs
@@ -13,7 +13,8 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.IntegrationTests.FleetInstaller;
 
 [Trait("RunOnWindows", "True")]
-[Trait("IIS", "True")]
+[Trait("IIS", "True")] // these are to stop the tests being run in other stages
+[Trait("MSI", "True")] // these are to stop the tests being run in other stages
 [Trait("FleetInstaller", "True")]
 public class FileHelperTests(ITestOutputHelper output)
 {

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FileHelperTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FileHelperTests.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="FileHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if NETFRAMEWORK
+
+using System.IO;
+using Datadog.FleetInstaller;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests.FleetInstaller;
+
+[Trait("RunOnWindows", "True")]
+[Trait("IIS", "True")]
+[Trait("FleetInstaller", "True")]
+public class FileHelperTests(ITestOutputHelper output)
+{
+    private readonly FleetInstallerLogger _log = new(output);
+
+    [SkippableFact]
+    public void CreateLogDirectory_WhenDirectoryDoesntExist_CreatesDirectory()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.Exists(tempDirectory).Should().BeFalse();
+
+        FileHelper.CreateLogDirectory(_log, tempDirectory).Should().BeTrue();
+        Directory.Exists(tempDirectory).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public void CreateLogDirectory_WhenManyParentDirectoryDoesntExist_CreatesDirectory()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), Path.GetRandomFileName(), Path.GetRandomFileName());
+        Directory.Exists(tempDirectory).Should().BeFalse();
+
+        FileHelper.CreateLogDirectory(_log, tempDirectory).Should().BeTrue();
+        Directory.Exists(tempDirectory).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public void CreateLogDirectory_WhenDirectoryExists_ReturnsTrue()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), Path.GetRandomFileName(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+        Directory.Exists(tempDirectory).Should().BeTrue();
+
+        FileHelper.CreateLogDirectory(_log, tempDirectory).Should().BeTrue();
+        Directory.Exists(tempDirectory).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public void CreateLogDirectory_WhenInvalidPath_ReturnsFalse()
+    {
+        var tempDirectory = Path.Combine("X:", "-1");
+        FileHelper.CreateLogDirectory(_log, tempDirectory).Should().BeFalse();
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FleetInstallerLogger.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FleetInstallerLogger.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="FleetInstallerLogger.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if NETFRAMEWORK
+
+using System;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests.FleetInstaller;
+
+public class FleetInstallerLogger(ITestOutputHelper output) : Datadog.FleetInstaller.ILogger
+{
+    private readonly ITestOutputHelper _output = output;
+
+    public void WriteInfo(string message) => _output.WriteLine("INFO: " + message);
+
+    public void WriteError(string message) => _output.WriteLine("ERROR: " + message);
+
+    public void WriteError(Exception ex, string message)
+    {
+        _output.WriteLine("ERROR: " + message + Environment.NewLine + ex);
+    }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FleetInstallerTestsBase.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/FleetInstallerTestsBase.cs
@@ -1,0 +1,95 @@
+﻿// <copyright file="FleetInstallerTestsBase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Principal;
+using Datadog.FleetInstaller;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests.FleetInstaller;
+
+public abstract class FleetInstallerTestsBase : IDisposable
+{
+    private static bool? _isElevated;
+    private readonly ITestOutputHelper _output;
+    private List<string> _homeDirectory;
+
+    protected FleetInstallerTestsBase(ITestOutputHelper output)
+    {
+        Log = new(output);
+        _output = output;
+    }
+
+    public static bool IsRunningAsAdministrator
+    {
+        get
+        {
+            _isElevated ??= new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
+            return _isElevated.Value;
+        }
+    }
+
+    protected FleetInstallerLogger Log { get; }
+
+    public void Dispose()
+    {
+        if (_homeDirectory is { } list)
+        {
+            foreach (var dir in list)
+            {
+                try
+                {
+                    Directory.Delete(dir, recursive: true);
+                    GacInstaller.TryGacUninstall(Log, new TracerValues(dir));
+                }
+                catch
+                {
+                    // Ignore, something is locking it
+                }
+            }
+        }
+    }
+
+    protected string CreateMonitoringHomeCopy()
+    {
+        // create a copy of monitoring home, so that we can mess with it
+        var original = EnvironmentHelper.GetMonitoringHomePath();
+        var homeDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        _output.WriteLine($"Copying {original} to {homeDirectory}");
+
+        CopyDirectory(original, homeDirectory);
+        _homeDirectory ??= new();
+        _homeDirectory.Add(homeDirectory);
+        return homeDirectory;
+
+        // I can't believe there's no built in API for this...
+        static void CopyDirectory(string source, string destination)
+        {
+            var dir = new DirectoryInfo(source);
+            dir.Exists.Should().BeTrue();
+            var dirs = dir.GetDirectories();
+
+            Directory.CreateDirectory(destination);
+
+            foreach (var file in dir.GetFiles())
+            {
+                file.CopyTo(Path.Combine(destination, file.Name));
+            }
+
+            foreach (var subDir in dirs)
+            {
+                var newDestinationDir = Path.Combine(destination, subDir.Name);
+                CopyDirectory(subDir.FullName, newDestinationDir);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/GacInstallerTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/GacInstallerTests.cs
@@ -1,0 +1,187 @@
+﻿// <copyright file="GacInstallerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System.IO;
+using System.Reflection;
+using Datadog.FleetInstaller;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests.FleetInstaller;
+
+public class GacInstallerTests(ITestOutputHelper output) : FleetInstallerTestsBase(output)
+{
+    private readonly ITestOutputHelper _output = output;
+
+    [SkippableFact]
+    public void FullInstallUninstall_WhenLoaderIsRemovedFromDisk_CanInstallAndUninstall()
+    {
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var homeDirectory = CreateMonitoringHomeCopy();
+        var values = new TracerValues(homeDirectory);
+        // Verify prerequistes
+        AssertFilesAreInGac(values, isInGac: false);
+
+        GacInstaller.TryGacInstall(Log, values).Should().BeTrue();
+        AssertFilesAreInGac(values, isInGac: true);
+
+        // delete the native loader files
+        File.Delete(values.NativeLoaderX64Path);
+        File.Delete(values.NativeLoaderX86Path);
+
+        GacInstaller.TryGacUninstall(Log, values).Should().BeTrue();
+        AssertFilesAreInGac(values, isInGac: false);
+    }
+
+    [SkippableFact]
+    public void FullInstallUninstall_WhenX64LoaderIsStillOnDisk_CanNotUninstall()
+    {
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var homeDirectory = CreateMonitoringHomeCopy();
+        var values = new TracerValues(homeDirectory);
+        // Verify prerequistes
+        AssertFilesAreInGac(values, isInGac: false);
+
+        GacInstaller.TryGacInstall(Log, values).Should().BeTrue();
+        AssertFilesAreInGac(values, isInGac: true);
+
+        File.Delete(values.NativeLoaderX86Path);
+
+        // Should fail and not be removed
+        GacInstaller.TryGacUninstall(Log, values).Should().BeFalse();
+        AssertFilesAreInGac(values, isInGac: true);
+    }
+
+    [SkippableFact]
+    public void FullInstallUninstall_WhenX86LoaderIsStillOnDisk_CanNotUninstall()
+    {
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var homeDirectory = CreateMonitoringHomeCopy();
+        var values = new TracerValues(homeDirectory);
+        // Verify prerequistes
+        AssertFilesAreInGac(values, isInGac: false);
+
+        GacInstaller.TryGacInstall(Log, values).Should().BeTrue();
+        AssertFilesAreInGac(values, isInGac: true);
+
+        File.Delete(values.NativeLoaderX64Path);
+
+        // Should fail and not be removed
+        GacInstaller.TryGacUninstall(Log, values).Should().BeFalse();
+        AssertFilesAreInGac(values, isInGac: true);
+    }
+
+    [SkippableFact]
+    public void FullInstallUninstall_WhenExistingVersionIsInGac_CanAddAndInstallSameVersionMultipleTimes()
+    {
+        // This scenario should _only_ happen in testing, but it's a "safe" one to handle
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        // download the old version
+
+        var homeDirectory1 = CreateMonitoringHomeCopy();
+        var homeDirectory2 = CreateMonitoringHomeCopy();
+        var values1 = new TracerValues(homeDirectory1);
+        var values2 = new TracerValues(homeDirectory2);
+
+        // Verify prerequistes
+        AssertFilesAreInGac(values1, isInGac: false);
+
+        GacInstaller.TryGacInstall(Log, values1).Should().BeTrue();
+        AssertFilesAreInGac(values1, isInGac: true);
+        AssertFilesAreInGac(values2, isInGac: true);
+
+        GacInstaller.TryGacInstall(Log, values2).Should().BeTrue();
+        AssertFilesAreInGac(values2, isInGac: true);
+
+        // delete the native loader files from 1
+        File.Delete(values1.NativeLoaderX64Path);
+        File.Delete(values1.NativeLoaderX86Path);
+
+        // Should succeed, but will still be in the gac
+        GacInstaller.TryGacUninstall(Log, values1).Should().BeTrue();
+        AssertFilesAreInGac(values1, isInGac: true);
+
+        // delete the native loader files from 2
+        File.Delete(values2.NativeLoaderX64Path);
+        File.Delete(values2.NativeLoaderX86Path);
+
+        // Should succeed, and now the values are gone
+        GacInstaller.TryGacUninstall(Log, values2).Should().BeTrue();
+        AssertFilesAreInGac(values1, isInGac: false);
+    }
+
+    // [SkippableFact]
+    // public void FullInstallUninstall_WhenExistingVersionIsInGac_CanAddAndUninstallNewVersion()
+    // {
+    //     Skip.IfNot(IsRunningAsAdministrator);
+    //
+    //     // download the old version
+    //
+    //     var homeDirectory = CreateMonitoringHomeCopy();
+    //     var values = new TracerValues(homeDirectory);
+    //     // Verify prerequistes
+    //     AssertFilesAreInGac(values, isInGac: false);
+    //
+    //     GacInstaller.TryGacInstall(Log, values).Should().BeTrue();
+    //     AssertFilesAreInGac(values, isInGac: true);
+    //
+    //     File.Delete(values.NativeLoaderX64Path);
+    //
+    //     // Should fail and not be removed
+    //     GacInstaller.TryGacUninstall(Log, values).Should().BeFalse();
+    //     AssertFilesAreInGac(values, isInGac: false);
+    // }
+
+    private void AssertFilesAreInGac(TracerValues values, bool isInGac, string version = TracerConstants.AssemblyVersion)
+    {
+        foreach (var gacFile in values.FilesToAddToGac)
+        {
+            var assemblyName = $"{Path.GetFileNameWithoutExtension(gacFile)}, Version={version}";
+            IsAssemblyInGac(assemblyName).Should().Be(isInGac);
+        }
+
+        return;
+
+        bool IsAssemblyInGac(string assemblyName)
+        {
+            _output.WriteLine("Checking if assembly is in GAC: {0}", assemblyName);
+            var gacUtilPath = @"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\gacutil.exe";
+            var result = ProcessHelpers.RunCommand(new ProcessHelpers.Command(gacUtilPath, "/l Datadog.Trace"));
+
+            _output.WriteLine($"ExitCode: {result?.ExitCode}, Error: {result?.Error}");
+            _output.WriteLine(result?.Output);
+            if (result.Output.Contains("Number of items = 0"))
+            {
+                return false;
+            }
+
+            if (result.Output.Contains("Number of items = "))
+            {
+                return true;
+            }
+
+            _output.WriteLine("Unexpected output");
+            return false;
+        }
+    }
+
+    // private string DownloadPreviousVersion()
+    // {
+    //     var previousVersionUrl =
+    //     var homeDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    //     _output.WriteLine($"Copying {original} to {homeDirectory}");
+    // }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/RegistryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/RegistryHelperTests.cs
@@ -1,0 +1,188 @@
+﻿// <copyright file="RegistryHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if NETFRAMEWORK
+
+using System;
+using Datadog.FleetInstaller;
+using FluentAssertions;
+using Microsoft.Win32;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests.FleetInstaller;
+
+public class RegistryHelperTests(ITestOutputHelper output) : FleetInstallerTestsBase(output)
+{
+    [SkippableFact]
+    public void AddCrashTrackingKey_AddsKeyIfItDoesntExist()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key = $@"SOFTWARE\Datadog\Datadog .NET Tracer\{Guid.NewGuid():N}";
+
+        RegistryHelper.AddCrashTrackingKey(Log, values, key)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is there with expected value
+        Registry.LocalMachine.OpenSubKey(key)
+               ?.GetValue(values.NativeLoaderX64Path)
+                .Should()
+                .Be(1);
+    }
+
+    [SkippableFact]
+    public void AddCrashTrackingKey_AddsKeyIfItAlreadyExists()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key = $@"SOFTWARE\Datadog\Datadog .NET Tracer\{Guid.NewGuid():N}";
+        Registry.LocalMachine.CreateSubKey(key).Should().NotBeNull();
+
+        RegistryHelper.AddCrashTrackingKey(Log, values, key)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is there with expected value
+        Registry.LocalMachine.OpenSubKey(key)
+               ?.GetValue(values.NativeLoaderX64Path)
+                .Should()
+                .Be(1);
+    }
+
+    [SkippableFact]
+    public void AddCrashTrackingKey_OverwritesExistingValueIfSet()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key = $@"SOFTWARE\Datadog\Datadog .NET Tracer\{Guid.NewGuid():N}";
+        var regKey = Registry.LocalMachine.CreateSubKey(key);
+        regKey.Should().NotBeNull();
+        regKey!.SetValue(values.NativeLoaderX64Path, 0, RegistryValueKind.DWord);
+
+        RegistryHelper.AddCrashTrackingKey(Log, values, key)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is there with expected value
+        Registry.LocalMachine.OpenSubKey(key)
+               ?.GetValue(values.NativeLoaderX64Path)
+                .Should()
+                .Be(1);
+    }
+
+    [SkippableFact]
+    public void AddCrashTrackingKey_DoesNotAffectOtherValues()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key = $@"SOFTWARE\Datadog\Datadog .NET Tracer\{Guid.NewGuid():N}";
+        var otherValueName = "some-other-value";
+        var otherValueValue = 0;
+        var regKey = Registry.LocalMachine.CreateSubKey(key);
+        regKey.Should().NotBeNull();
+        regKey!.SetValue(otherValueName, otherValueValue, RegistryValueKind.DWord);
+
+        RegistryHelper.AddCrashTrackingKey(Log, values, key)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is there with expected value
+        Registry.LocalMachine.OpenSubKey(key)
+               ?.GetValue(values.NativeLoaderX64Path)
+                .Should()
+                .Be(1);
+
+        // verify existing key is untouched
+        Registry.LocalMachine.OpenSubKey(key)
+               ?.GetValue(otherValueName)
+                .Should()
+                .Be(otherValueValue);
+    }
+
+    [SkippableFact]
+    public void RemoveCrashTrackingKey_RemovesValueIfSet()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key = $@"SOFTWARE\Datadog\Datadog .NET Tracer\{Guid.NewGuid():N}";
+        var keyValue = values.NativeLoaderX64Path;
+        Registry.LocalMachine.CreateSubKey(key)
+                !.SetValue(keyValue, 0, RegistryValueKind.DWord);
+
+        RegistryHelper.RemoveCrashTrackingKey(Log, values, key)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is no longer there
+        Registry.LocalMachine.OpenSubKey(key)?.GetValue(keyValue).Should().BeNull();
+    }
+
+    [SkippableFact]
+    public void RemoveCrashTrackingKey_ReturnsTrueIfKeyDoesntExist()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key = $@"SOFTWARE\Datadog\Datadog .NET Tracer\{Guid.NewGuid():N}";
+        var keyValue = values.NativeLoaderX64Path;
+        Registry.LocalMachine.CreateSubKey(key).Should().NotBeNull();
+
+        RegistryHelper.RemoveCrashTrackingKey(Log, values, key)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is no longer there
+        Registry.LocalMachine.OpenSubKey(key)?.GetValue(keyValue).Should().BeNull();
+    }
+
+    [SkippableFact]
+    public void RemoveCrashTrackingKey_ReturnsTrueIfKeyIsNotThere()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key = $@"SOFTWARE\Datadog\Datadog .NET Tracer\{Guid.NewGuid():N}";
+        Registry.LocalMachine.OpenSubKey(key).Should().BeNull();
+
+        RegistryHelper.RemoveCrashTrackingKey(Log, values, key)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is still not there
+        Registry.LocalMachine.OpenSubKey(key).Should().BeNull();
+    }
+
+    [SkippableFact]
+    public void TryGetIisVersion_ReturnsTrue()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        // Needs to be run on a machine that has IIS installed
+        RegistryHelper.TryGetIisVersion(Log, out var version).Should().BeTrue();
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes

Adds some "integration" tests for the fleet installer component

## Reason for change

We don't have a lot of in-repo tests for the installer currently. Creating sub-cutaneous and integration tests allow more fine-grained testing, particularly of edge cases.

## Implementation details

The fleet installer messes with fundamental components like the GAC so running these tests in a specific separate job (in the MSI installer tests stage, seemed like the right place for it)

Currently these tests are focusing on the lower-level components like the `GacHelper` and `RegistryHelper` etc. I want to add similar levels of testing for the IIS integration (`AppHostHelper`) as well as some full/subcutaneous tests for the install/uninstall commands, I just ran out of time.

## Test coverage

More coverage now, but we could still do more.

## Other details

One aspect that this flagged, is that currently the GAC uninstall does _not_ behave as we originally believed (based on initial testing and `gacutil`'s behaviour). Currently we're failing to remove entries when there's already an entry with the same name (i.e. everytime we do an upgrade...)

We're currently treating the error `IASSEMBLYCACHE_UNINSTALL_DISPOSITION_REFERENCE_NOT_FOUND` as a "success" case, as it looks like the file has already been removed. But in reality, we're actually not finding the assembly to remove it when we should. 

When there's a _single_ assembly in the GAC, there's no issue, and we can use the "simple" name, e.g. `Datadog.Trace` to uninstall the library. But AFAICT when there's multiple, we need the "full" name, e.g. `Datadog.Trace, Version=3.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL`

(None of this is documented, just what I'm observing in my tests)
(Also note that `gacutil.exe` behaves differently - it will happily use just a `Datadog.Trace` and (AFAICT) enumerates the assemblies and tries to remove each of them)


