### PR TITLE
Add notification channel for build pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ include:
 variables:
   DOTNET_PACKAGE_VERSION:
     description: "Used by the package stage when triggered manually"
+  REPO_NOTIFICATION_CHANNEL: "#apm-dotnet-error-bots"
 
 build:
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ include:
 variables:
   DOTNET_PACKAGE_VERSION:
     description: "Used by the package stage when triggered manually"
-  REPO_NOTIFICATION_CHANNEL: "#apm-dotnet-error-bots"
+  REPO_NOTIFICATION_CHANNEL: "#apm-dotnet-bots"
 
 build:
   except:


### PR DESCRIPTION
## Summary of changes

This PR adds a channel for notifications for pipeline failures

## Reason for change

The shared pipeline has added notifications for failures during a release pipeline. More notifications may be added in the future.

## Implementation details
Of the channels available, I chose `#apm-dotnet-bots`
