### PR TITLE
use built-in `System` types instead of vendored types when possible

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -133,6 +133,9 @@
    <assembly fullname="StackExchange.Redis" />
    <assembly fullname="StackExchange.Redis.StrongName" />
    <assembly fullname="System" />
+   <assembly fullname="System.Buffers">
+      <type fullname="System.Buffers.ArrayPool`1" />
+   </assembly>
    <assembly fullname="System.Collections">
       <type fullname="System.Collections.BitArray" />
       <type fullname="System.Collections.Generic.Comparer`1" />
@@ -352,6 +355,7 @@
    <assembly fullname="System.Memory">
       <type fullname="System.Buffers.Binary.BinaryPrimitives" />
       <type fullname="System.Buffers.StandardFormat" />
+      <type fullname="System.Buffers.Text.Base64" />
       <type fullname="System.Buffers.Text.Utf8Formatter" />
       <type fullname="System.Buffers.Text.Utf8Parser" />
       <type fullname="System.MemoryExtensions" />
@@ -498,6 +502,8 @@
       <type fullname="System.BitConverter" />
       <type fullname="System.Boolean" />
       <type fullname="System.Buffer" />
+      <type fullname="System.Buffers.ArrayPool`1" />
+      <type fullname="System.Buffers.OperationStatus" />
       <type fullname="System.Buffers.SpanAction`2" />
       <type fullname="System.Byte" />
       <type fullname="System.Char" />

--- a/tracer/src/Datadog.Trace/Agent/MultipartFormItem.cs
+++ b/tracer/src/Datadog.Trace/Agent/MultipartFormItem.cs
@@ -6,9 +6,9 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Datadog.Trace.Logging;
-using Datadog.Trace.VendoredMicrosoftCode.System.Diagnostics.CodeAnalysis;
 
 namespace Datadog.Trace.Agent
 {

--- a/tracer/src/Datadog.Trace/Ci/Coverage/ModuleValue.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/ModuleValue.cs
@@ -9,7 +9,10 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Datadog.Trace.Ci.Coverage.Metadata;
+
+#if !NETCOREAPP3_1_OR_GREATER
 using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
+#endif
 
 namespace Datadog.Trace.Ci.Coverage;
 

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
@@ -7,27 +7,28 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NETCOREAPP3_0_OR_GREATER
+using System.Text;
+
+#if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+#else
+using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
 #endif
+
 #if NET6_0
 using System.Runtime.Intrinsics.Arm;
 #endif
-using System.Text;
-using Datadog.Trace.Util;
-using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
 
 namespace Datadog.Trace.Ci.Coverage.Util;
 
 /// <summary>
 /// Represents a memory-efficient, modifiable file bitmap, optimized for high performance using unsafe code and SIMD instructions when available.
 /// </summary>
-internal unsafe ref struct FileBitmap
+internal readonly unsafe ref struct FileBitmap
 {
     /// <summary>
     /// Size of the bitmap in bytes.

--- a/tracer/src/Datadog.Trace/Ci/Ipc/CircularChannel.Reader.cs
+++ b/tracer/src/Datadog.Trace/Ci/Ipc/CircularChannel.Reader.cs
@@ -9,7 +9,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.Logging;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 namespace Datadog.Trace.Ci.Ipc;
 

--- a/tracer/src/Datadog.Trace/Ci/Ipc/IpcDualChannel.cs
+++ b/tracer/src/Datadog.Trace/Ci/Ipc/IpcDualChannel.cs
@@ -6,9 +6,14 @@
 
 using System;
 using System.IO;
-using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 namespace Datadog.Trace.Ci.Ipc;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHeadersAdapter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHeadersAdapter.cs
@@ -9,7 +9,12 @@ using System.Collections.Generic;
 using System.Text;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Util;
-using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Runtime.CompilerServices;
+#else
+using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
+#endif
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.IbmMq;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/V3/XUnitTestMethodRunnerBaseRunTestCaseV3Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/V3/XUnitTestMethodRunnerBaseRunTestCaseV3Integration.cs
@@ -14,7 +14,12 @@ using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
-using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Runtime.CompilerServices;
+#else
+using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
+#endif
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.V3;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
@@ -8,7 +8,10 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging;
-using VendoredUnsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
+
+#if !NETCOREAPP3_1_OR_GREATER
+using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
+#endif
 
 namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations;
 
@@ -25,21 +28,13 @@ internal abstract class ContinuationGenerator<TTarget, TReturn>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static TReturn ToTReturn<TFrom>(TFrom returnValue)
     {
-#if NETCOREAPP3_1_OR_GREATER
         return Unsafe.As<TFrom, TReturn>(ref returnValue);
-#else
-            return VendoredUnsafe.As<TFrom, TReturn>(ref returnValue);
-#endif
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static TTo FromTReturn<TTo>(TReturn returnValue)
     {
-#if NETCOREAPP3_1_OR_GREATER
         return Unsafe.As<TReturn, TTo>(ref returnValue);
-#else
-            return VendoredUnsafe.As<TReturn, TTo>(ref returnValue);
-#endif
     }
 
     internal abstract class CallbackHandler

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
@@ -4,12 +4,16 @@
 // </copyright>
 #nullable enable
 using System;
-using System.Text;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Util;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+using System.Buffers.Text;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text;
+#endif
 
 namespace Datadog.Trace.DataStreamsMonitoring;
 

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -11,8 +11,13 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
-using Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Binary;
 using Datadog.Trace.Vendors.Serilog.Events;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers.Binary;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Binary;
+#endif
 
 #nullable enable
 
@@ -224,7 +229,7 @@ namespace Datadog.Trace.DatabaseMonitoring
             var versionAndSampling = (byte)(((version << 4) & 0b1111_0000) | (sampled & 0b0000_0001));
             var contextBytes = new byte[1 + sizeof(ulong) + TraceId.Size];
 
-            var span = new VendoredMicrosoftCode.System.Span<byte>(contextBytes) { [0] = versionAndSampling };
+            var span = new Span<byte>(contextBytes) { [0] = versionAndSampling };
             BinaryPrimitives.WriteUInt64BigEndian(span.Slice(1), spanId);
             BinaryPrimitives.WriteUInt64BigEndian(span.Slice(1 + sizeof(ulong)), traceId.Upper);
             BinaryPrimitives.WriteUInt64BigEndian(span.Slice(1 + sizeof(ulong) + sizeof(ulong)), traceId.Lower);

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -83,6 +83,23 @@
     <None Remove="AppSec\Waf\ConfigFiles\apisecurity-config.json" />
   </ItemGroup>
 
+  <!-- we don't need the vendored .NET runtime code when targetting .NET Core 3.1+ -->
+  <!-- but keep Vendors/System.Reflection.Metadata/** for now because we use it to access internal members -->
+  <PropertyGroup>
+    <DotNetRuntimeFiles>
+      Vendors/System.Collections.Immutable/**;
+      Vendors/System.Memory/**;
+      Vendors/System.Private.CoreLib/**;
+      Vendors/System.Runtime.CompilerServices.Unsafe/**;
+    </DotNetRuntimeFiles>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0' ">
+    <Compile Remove="$(DotNetRuntimeFiles)" />
+    <EmbeddedResource Remove="$(DotNetRuntimeFiles)" />
+    <None Include="$(DotNetRuntimeFiles)" />
+  </ItemGroup>
+
   <!-- Below this point is reserved for vendor items -->
   <!--Newtonsoft.Json-->
   <!-- Modifications: Original condition was only for net45, but we include net461 here so that net45 and net461 generate the same Newtonsoft.Json -->

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -10,7 +10,12 @@ using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Telemetry;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 namespace Datadog.Trace.Debugger
 {

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionCaseInstrumentationManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionCaseInstrumentationManager.cs
@@ -6,24 +6,15 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Threading;
-using System.Threading.Tasks;
-using Datadog.Trace.Debugger.Configurations.Models;
-using Datadog.Trace.Debugger.Expressions;
-using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.PInvoke;
-using Datadog.Trace.Debugger.RateLimiting;
-using Datadog.Trace.Debugger.Sink.Models;
-using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Telemetry.Metrics;
-using Datadog.Trace.Util;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
-using Datadog.Trace.Vendors.Serilog.Events;
+#endif
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -11,21 +11,19 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Helpers;
-using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.PInvoke;
-using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Sink.Models;
-using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Debugger.Symbols;
-using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
-using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
 using Datadog.Trace.Vendors.Serilog.Events;
-using ProbeInfo = Datadog.Trace.Debugger.Expressions.ProbeInfo;
-using ProbeLocation = Datadog.Trace.Debugger.Expressions.ProbeLocation;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/FrameFilter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/FrameFilter.cs
@@ -7,7 +7,12 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 using Datadog.Trace.Debugger.Symbols;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyConfigurationReader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyConfigurationReader.cs
@@ -8,8 +8,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Datadog.Trace.Logging;
-using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyModules.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyModules.cs
@@ -4,7 +4,12 @@
 // </copyright>
 
 using System;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/MethodScopeMembers.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/MethodScopeMembers.cs
@@ -5,7 +5,12 @@
 
 using System;
 using Datadog.Trace.Debugger.Helpers;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 namespace Datadog.Trace.Debugger.Expressions;
 

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryExtensions.cs
@@ -5,7 +5,11 @@
 
 #nullable enable
 
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 namespace Datadog.Trace.Debugger.Helpers
 {
@@ -16,7 +20,7 @@ namespace Datadog.Trace.Debugger.Helpers
         /// </summary>
         internal static IMemoryOwner<T> EnlargeBuffer<T>(this IMemoryOwner<T> memoryOwner, int currentSize)
         {
-            var newMemory = ArrayMemoryPool<T>.Shared.Rent(currentSize * 2);
+            var newMemory = MemoryPool<T>.Shared.Rent(currentSize * 2);
             memoryOwner.Memory.Span.CopyTo(newMemory.Memory.Span);
             memoryOwner.Dispose();
             return newMemory;

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -16,7 +16,12 @@ using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 namespace Datadog.Trace.Debugger
 {

--- a/tracer/src/Datadog.Trace/Debugger/SignatureParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SignatureParser.cs
@@ -7,7 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Logging;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 #nullable enable
 namespace Datadog.Trace.Debugger

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
@@ -8,7 +8,12 @@ using System;
 using System.Diagnostics;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 namespace Datadog.Trace.Debugger.SpanCodeOrigin
 {

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/AssemblyFilter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/AssemblyFilter.cs
@@ -8,7 +8,12 @@ using System;
 using System.Reflection;
 using Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty;
 using Datadog.Trace.Logging;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols
 {

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -10,10 +10,18 @@ using System.Reflection;
 using Datadog.Trace.Debugger.Symbols.Model;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
-using Datadog.Trace.VendoredMicrosoftCode.System;
+
+// keep vendored System.Reflection.Metadata for now because we access non-public members
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
 using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
-using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols
 {
@@ -167,7 +175,7 @@ namespace Datadog.Trace.Debugger.Symbols
                     return false;
                 }
 
-                if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(typeDefinitionHandle.RowId))
+                if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(typeDefinitionHandle))
                 {
                     return false;
                 }
@@ -352,7 +360,7 @@ namespace Datadog.Trace.Debugger.Symbols
                         continue;
                     }
 
-                    if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(typeHandle.RowId))
+                    if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(typeHandle))
                     {
                         continue;
                     }
@@ -407,7 +415,7 @@ namespace Datadog.Trace.Debugger.Symbols
                     continue;
                 }
 
-                var fieldName = Datadog.Trace.VendoredMicrosoftCode.System.MemoryExtensions.AsSpan(MetadataReader.GetString(fieldDef.Name));
+                var fieldName = MetadataReader.GetString(fieldDef.Name).AsSpan();
                 if (fieldName.IsEmpty)
                 {
                     continue;

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsExtensions.cs
@@ -6,14 +6,19 @@
 #nullable enable
 
 using System.Reflection;
-using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Symbols;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Reflection.Metadata;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols;
 
 internal static class SymbolsExtensions
 {
-    private static EntityHandle _nilEntityHandle = new(0);
+    private static readonly EntityHandle _nilEntityHandle = default;
 
     internal static ref readonly EntityHandle NilEntityHandle => ref _nilEntityHandle;
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -21,8 +21,13 @@ using Datadog.Trace.Debugger.Upload;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Util;
-using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols
 {

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/TypeProvider.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/TypeProvider.cs
@@ -4,10 +4,15 @@
 // </copyright>
 #nullable enable
 
-using System.Text;
 using Datadog.Trace.Util;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols
 {

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.Dnlib.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.Dnlib.cs
@@ -8,14 +8,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Datadog.Trace.Debugger.Symbols;
-using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
-using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 using Datadog.Trace.Vendors.dnlib.DotNet;
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb;
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Dss;
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Managed;
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Portable;
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Symbols;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+using System.Collections.Immutable;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
+#endif
 
 #nullable enable
 namespace Datadog.Trace.Pdb
@@ -114,7 +120,7 @@ namespace Datadog.Trace.Pdb
             return DnlibPdbReader?.GetMethod(breakpointMethod.Value.BreakpointMethod, version: 1);
         }
 
-        private ImmutableArray<LocalScope>? GetLocalSymbolsDnlib(int rowId, VendoredMicrosoftCode.System.ReadOnlySpan<DatadogSequencePoint> sequencePoints, bool searchMoveNext)
+        private ImmutableArray<LocalScope>? GetLocalSymbolsDnlib(int rowId, ReadOnlySpan<DatadogSequencePoint> sequencePoints, bool searchMoveNext)
         {
             ImmutableArray<LocalScope>.Builder? localScopes = null;
             var method = GetMethodDefDnlib((uint)rowId);
@@ -130,12 +136,12 @@ namespace Datadog.Trace.Pdb
                 return null;
             }
 
-            localScopes = new ImmutableArray<LocalScope>.Builder();
+            localScopes = ImmutableArray.CreateBuilder<LocalScope>();
 
             for (var k = 0; k < allMethodScopes.Count; k++)
             {
                 var datadogScop = new LocalScope();
-                var scopeLocals = new ImmutableArray<DatadogLocal>.Builder();
+                var scopeLocals = ImmutableArray.CreateBuilder<DatadogLocal>();
                 var currentScope = allMethodScopes[k];
                 DatadogSequencePoint sequencePointForScope = default;
                 for (var l = 0; l < currentScope.Locals.Count; l++)
@@ -248,7 +254,7 @@ namespace Datadog.Trace.Pdb
                 return null;
             }
 
-            var memory = ArrayMemoryPool<DatadogSequencePoint>.Shared.Rent(symbolMethod.SequencePoints.Count);
+            var memory = MemoryPool<DatadogSequencePoint>.Shared.Rent(symbolMethod.SequencePoints.Count);
             var sequencePoints = memory.Memory.Span;
 
             for (int i = 0; i < symbolMethod.SequencePoints.Count; i++)

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -9,7 +9,12 @@ using System.Text;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 #nullable enable
 

--- a/tracer/src/Datadog.Trace/Util/BitConverterShim.cs
+++ b/tracer/src/Datadog.Trace/Util/BitConverterShim.cs
@@ -5,7 +5,7 @@
 
 #nullable enable
 
-#if !NETCOREAPP
+#if !NETCOREAPP3_1_OR_GREATER
 
 using System;
 using System.Runtime.CompilerServices;
@@ -14,7 +14,7 @@ using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServic
 
 namespace Datadog.Trace.Util;
 
-internal class BitConverterShim
+internal static class BitConverterShim
 {
     public static bool IsLittleEndian => BitConverter.IsLittleEndian;
 

--- a/tracer/src/Datadog.Trace/Util/HexString.cs
+++ b/tracer/src/Datadog.Trace/Util/HexString.cs
@@ -8,11 +8,13 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Binary;
-#if NETCOREAPP
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers.Binary;
 using BitConverter = System.BitConverter;
 using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
 #else
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Binary;
 using BitConverter = Datadog.Trace.Util.BitConverterShim;
 using MemoryMarshal = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices.MemoryMarshal;
 #endif

--- a/tracer/src/Datadog.Trace/Util/Streams/InitiallyBufferedStream.cs
+++ b/tracer/src/Datadog.Trace/Util/Streams/InitiallyBufferedStream.cs
@@ -9,7 +9,12 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Buffers;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#endif
 
 namespace Datadog.Trace.Util.Streams;
 

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
@@ -7,6 +7,7 @@ Microsoft.AspNetCore.Routing.Abstractions, Version=2.0.0.0, Culture=neutral, Pub
 Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 Microsoft.Net.Http.Headers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 Microsoft.Win32.Primitives, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 System.Collections, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.Concurrent, Version=4.0.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.NonGeneric, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a


### PR DESCRIPTION
## Summary of changes

When targeting .NET Core 3.1 and .NET 6, do not include the files copied ("vendored") from the .NET runtime. Instead, use the built-in types.

TODO update table

| Runtime         | Before  | After | Before R2R | After R2R |
|-----------------|---------|-------|------------|-----------|
| `netcoreapp3.1` | 7.59 MB | 
| `net6.0`        | 7.62 MB |

## Reason for change

- consistency: we currently have different ways of choosing built-in types vs vendored types
- smaller artifacts for .NET Core 3.1 and .NET 6.0 (important for Serverless)
 
## Implementation details

- Use `#if NETCOREAPP3_1_OR_GREATER` around `using` directives to choose the correct namespaces
- Don't compile `Datadog.Trace/Vendors/System/**` when targetting `netcoreapp3.1` or `net6.0`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
