### PR TITLE
Send sampling priority to lambda extension

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaRequestBuilder.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaRequestBuilder.cs
@@ -47,8 +47,11 @@ internal class LambdaRequestBuilder : ILambdaExtensionRequest
             request.Headers.Set(HttpHeaderNames.TraceId, span.TraceId128.Lower.ToString(CultureInfo.InvariantCulture));
             request.Headers.Set(HttpHeaderNames.SpanId, span.SpanId.ToString(CultureInfo.InvariantCulture));
 
-            var samplingPriority = span.Context.TraceContext?.GetOrMakeSamplingDecision();
-            request.Headers.Set(HttpHeaderNames.SamplingPriority, SamplingPriorityValues.ToString(samplingPriority));
+            if (span.Context.TraceContext is { } traceContext)
+            {
+                var samplingPriority = traceContext.GetOrMakeSamplingDecision(span);
+                request.Headers.Set(HttpHeaderNames.SamplingPriority, SamplingPriorityValues.ToString(samplingPriority));
+            }
 
             var errorMessage = span.GetTag("error.msg");
             if (errorMessage != null)

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -430,7 +430,7 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// If <see cref="TraceContext"/> is not null, returns <see cref="Trace.TraceContext.GetOrMakeSamplingDecision"/>.
+        /// If <see cref="TraceContext"/> is not null, returns <see cref="Trace.TraceContext.GetOrMakeSamplingDecision()"/>.
         /// Otherwise, returns <see cref="SamplingPriority"/>.
         /// </summary>
         internal int? GetOrMakeSamplingDecision() =>

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -250,12 +250,12 @@ namespace Datadog.Trace
                 return samplingPriority;
             }
 
-            return GetOrMakeSamplingDecisionSlow();
+            return GetOrMakeSamplingDecision(_rootSpan);
         }
 
-        private int GetOrMakeSamplingDecisionSlow()
+        public int GetOrMakeSamplingDecision(Span? span)
         {
-            if (_rootSpan is null)
+            if (span is null)
             {
                 // we can't make a sampling decision without a root span because:
                 // - we need a trace id, and for now trace id lives in SpanContext, not in TraceContext
@@ -267,7 +267,7 @@ namespace Datadog.Trace
             }
 
             var samplingDecision = CurrentTraceSettings?.TraceSampler is { } sampler
-                                       ? sampler.MakeSamplingDecision(_rootSpan)
+                                       ? sampler.MakeSamplingDecision(span)
                                        : SamplingDecision.Default;
 
             SetSamplingPriority(samplingDecision.Priority, samplingDecision.Mechanism);

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -55,14 +55,14 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithScope()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" }, { HttpHeaderNames.SamplingPriority, "-1" } }.Wrap();
+            var headers = new WebHeaderCollection { { HttpHeaderNames.TraceId, "1234" } }.Wrap();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, headers);
 
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, isError: false);
             request.Headers.Get("x-datadog-invocation-error").Should().BeNull();
             request.Headers.Get("x-datadog-tracing-enabled").Should().Be("false");
-            request.Headers.Get("x-datadog-sampling-priority").Should().Be("-1");
+            request.Headers.Get("x-datadog-sampling-priority").Should().Be("1");
             request.Headers.Get("x-datadog-trace-id").Should().Be("1234");
             request.Headers.Get("x-datadog-span-id").Should().NotBeNull();
         }


### PR DESCRIPTION
## Summary of changes

The issue here was that in Lambda, the `_rootSpan` in TraceContext.cs was never defined, so `GetOrMakeSamplingDecision` always returned 1 regardless of the tracer's sampling rules (e.g. the `DD_TRACE_SAMPLING_RULES` env var).

This change simply updates the function to take in `span` rather than hardcoding `_rootSpan`. 

We send this sampling decision to the Lambda extension via the `"x-datadog-sampling-priority"` header in the `/lambda/end-invocation` request. 

## Reason for change

Fix sampling rules in .NET lambdas. Before this change, 100% of traces were sampled regardless of sampling rules.

## Implementation details

## Test coverage

Manual: 
<img width="290" alt="Screenshot 2025-02-26 at 1 34 41 PM" src="https://github.com/user-attachments/assets/36d814db-640e-4396-ace3-317c1402528b" />

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
