### PR TITLE
use full name for protobuf schema.name tag

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/SchemaExtractor.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Protobuf/SchemaExtractor.cs
@@ -54,7 +54,7 @@ internal class SchemaExtractor
         }
 
         activeSpan.SetTag(Tags.SchemaType, "protobuf");
-        activeSpan.SetTag(Tags.SchemaName, descriptor.Value.Name);
+        activeSpan.SetTag(Tags.SchemaName, descriptor.Value.FullName);
         activeSpan.SetTag(Tags.SchemaOperation, operationName);
 
         // check rate limit

--- a/tracer/test/snapshots/GoogleProtobufTests.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GoogleProtobufTests.SchemaV0.verified.txt
@@ -11,7 +11,7 @@
       runtime-id: Guid_1,
       schema.definition: {"openapi":"3.0.4","info":{},"paths":{},"components":{"schemas":{"sample.AddressBook":{"type":"object","properties":{"people":{"type":"array","items":{"$ref":"#/components/schemas/PeopleEntry"},"x-protobuf-number":1}}},"sample.AddressBook.PeopleEntry":{"type":"object","properties":{"key":{"type":"integer","format":"int32","x-protobuf-number":1},"value":{"$ref":"#/components/schemas/Person"}}},"sample.Person":{"type":"object","properties":{"name":{"type":"string","x-protobuf-number":1},"email":{"type":"string","x-protobuf-number":3},"phones":{"type":"array","items":{"$ref":"#/components/schemas/PhoneNumber"},"x-protobuf-number":4},"created":{"$ref":"#/components/schemas/Timestamp"},"last_updated":{"$ref":"#/components/schemas/Timestamp"}}},"sample.Person.PhoneNumber":{"type":"object","properties":{"number":{"type":"string","x-protobuf-number":1},"type":{"enum":["UNSPECIFIED","MOBILE","HOME","WORK"],"type":"string","x-protobuf-number":2}}},"google.protobuf.Timestamp":{"type":"object","properties":{"seconds":{"type":"integer","format":"int64","x-protobuf-number":1},"nanos":{"type":"integer","format":"int32","x-protobuf-number":2}}}}}},
       schema.id: 11125159909443644813,
-      schema.name: AddressBook,
+      schema.name: sample.AddressBook,
       schema.operation: deserialization,
       schema.type: protobuf,
       schema.weight: 1
@@ -35,7 +35,7 @@
       runtime-id: Guid_1,
       schema.definition: {"openapi":"3.0.4","info":{},"paths":{},"components":{"schemas":{"sample.AddressBook":{"type":"object","properties":{"people":{"type":"array","items":{"$ref":"#/components/schemas/PeopleEntry"},"x-protobuf-number":1}}},"sample.AddressBook.PeopleEntry":{"type":"object","properties":{"key":{"type":"integer","format":"int32","x-protobuf-number":1},"value":{"$ref":"#/components/schemas/Person"}}},"sample.Person":{"type":"object","properties":{"name":{"type":"string","x-protobuf-number":1},"email":{"type":"string","x-protobuf-number":3},"phones":{"type":"array","items":{"$ref":"#/components/schemas/PhoneNumber"},"x-protobuf-number":4},"created":{"$ref":"#/components/schemas/Timestamp"},"last_updated":{"$ref":"#/components/schemas/Timestamp"}}},"sample.Person.PhoneNumber":{"type":"object","properties":{"number":{"type":"string","x-protobuf-number":1},"type":{"enum":["UNSPECIFIED","MOBILE","HOME","WORK"],"type":"string","x-protobuf-number":2}}},"google.protobuf.Timestamp":{"type":"object","properties":{"seconds":{"type":"integer","format":"int64","x-protobuf-number":1},"nanos":{"type":"integer","format":"int32","x-protobuf-number":2}}}}}},
       schema.id: 11125159909443644813,
-      schema.name: AddressBook,
+      schema.name: sample.AddressBook,
       schema.operation: serialization,
       schema.type: protobuf,
       schema.weight: 1

--- a/tracer/test/snapshots/GoogleProtobufTests.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GoogleProtobufTests.SchemaV1.verified.txt
@@ -11,7 +11,7 @@
       runtime-id: Guid_1,
       schema.definition: {"openapi":"3.0.4","info":{},"paths":{},"components":{"schemas":{"sample.AddressBook":{"type":"object","properties":{"people":{"type":"array","items":{"$ref":"#/components/schemas/PeopleEntry"},"x-protobuf-number":1}}},"sample.AddressBook.PeopleEntry":{"type":"object","properties":{"key":{"type":"integer","format":"int32","x-protobuf-number":1},"value":{"$ref":"#/components/schemas/Person"}}},"sample.Person":{"type":"object","properties":{"name":{"type":"string","x-protobuf-number":1},"email":{"type":"string","x-protobuf-number":3},"phones":{"type":"array","items":{"$ref":"#/components/schemas/PhoneNumber"},"x-protobuf-number":4},"created":{"$ref":"#/components/schemas/Timestamp"},"last_updated":{"$ref":"#/components/schemas/Timestamp"}}},"sample.Person.PhoneNumber":{"type":"object","properties":{"number":{"type":"string","x-protobuf-number":1},"type":{"enum":["UNSPECIFIED","MOBILE","HOME","WORK"],"type":"string","x-protobuf-number":2}}},"google.protobuf.Timestamp":{"type":"object","properties":{"seconds":{"type":"integer","format":"int64","x-protobuf-number":1},"nanos":{"type":"integer","format":"int32","x-protobuf-number":2}}}}}},
       schema.id: 11125159909443644813,
-      schema.name: AddressBook,
+      schema.name: sample.AddressBook,
       schema.operation: deserialization,
       schema.type: protobuf,
       schema.weight: 1
@@ -35,7 +35,7 @@
       runtime-id: Guid_1,
       schema.definition: {"openapi":"3.0.4","info":{},"paths":{},"components":{"schemas":{"sample.AddressBook":{"type":"object","properties":{"people":{"type":"array","items":{"$ref":"#/components/schemas/PeopleEntry"},"x-protobuf-number":1}}},"sample.AddressBook.PeopleEntry":{"type":"object","properties":{"key":{"type":"integer","format":"int32","x-protobuf-number":1},"value":{"$ref":"#/components/schemas/Person"}}},"sample.Person":{"type":"object","properties":{"name":{"type":"string","x-protobuf-number":1},"email":{"type":"string","x-protobuf-number":3},"phones":{"type":"array","items":{"$ref":"#/components/schemas/PhoneNumber"},"x-protobuf-number":4},"created":{"$ref":"#/components/schemas/Timestamp"},"last_updated":{"$ref":"#/components/schemas/Timestamp"}}},"sample.Person.PhoneNumber":{"type":"object","properties":{"number":{"type":"string","x-protobuf-number":1},"type":{"enum":["UNSPECIFIED","MOBILE","HOME","WORK"],"type":"string","x-protobuf-number":2}}},"google.protobuf.Timestamp":{"type":"object","properties":{"seconds":{"type":"integer","format":"int64","x-protobuf-number":1},"nanos":{"type":"integer","format":"int32","x-protobuf-number":2}}}}}},
       schema.id: 11125159909443644813,
-      schema.name: AddressBook,
+      schema.name: sample.AddressBook,
       schema.operation: serialization,
       schema.type: protobuf,
       schema.weight: 1


### PR DESCRIPTION
## Summary of changes

Use the full name of the Schema instead of the "short name". The full name has the package name in front.

## Reason for change

match what's done in Java because otherwise the same schema would appear twice.

## Implementation details

## Test coverage

updated snapshots

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
