### PR TITLE
[Test Optimization] Add missing impacted test code in runner

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
@@ -120,6 +120,7 @@ internal static class CiUtils
         var testSkippingEnabled = testOptimizationSettings.TestsSkippingEnabled == true;
         var earlyFlakeDetectionEnabled = testOptimizationSettings.EarlyFlakeDetectionEnabled == true;
         var flakyRetryEnabled = testOptimizationSettings.FlakyRetryEnabled == true;
+        var impactedTestsDetectionEnabled = testOptimizationSettings.ImpactedTestsDetectionEnabled == true;
 
         var hasEvpProxy = !string.IsNullOrEmpty(agentConfiguration?.EventPlatformProxyEndpoint);
         if (agentless || hasEvpProxy)
@@ -187,7 +188,8 @@ internal static class CiUtils
              && (testOptimizationSettings.CodeCoverageEnabled == null ||
                  testOptimizationSettings.TestsSkippingEnabled == null ||
                  testOptimizationSettings.EarlyFlakeDetectionEnabled == null ||
-                 testOptimizationSettings.FlakyRetryEnabled == null))
+                 testOptimizationSettings.FlakyRetryEnabled == null ||
+                 testOptimizationSettings.ImpactedTestsDetectionEnabled == null))
             {
                 try
                 {
@@ -210,6 +212,7 @@ internal static class CiUtils
                     testSkippingEnabled = itrSettings.TestsSkipping == true;
                     earlyFlakeDetectionEnabled = earlyFlakeDetectionEnabled || itrSettings.EarlyFlakeDetection.Enabled == true;
                     flakyRetryEnabled = flakyRetryEnabled || itrSettings.FlakyTestRetries == true;
+                    impactedTestsDetectionEnabled = impactedTestsDetectionEnabled || itrSettings.ImpactedTestsEnabled == true;
                 }
                 catch (Exception ex)
                 {
@@ -222,12 +225,15 @@ internal static class CiUtils
         Log.Debug("RunCiCommand: TestSkippingEnabled = {Value}", testSkippingEnabled);
         Log.Debug("RunCiCommand: EarlyFlakeDetectionEnabled = {Value}", earlyFlakeDetectionEnabled);
         Log.Debug("RunCiCommand: FlakyRetryEnabled = {Value}", flakyRetryEnabled);
+        Log.Debug("RunCiCommand: ImpactedTestsDetectionEnabled = {Value}", impactedTestsDetectionEnabled);
         testOptimizationSettings.SetCodeCoverageEnabled(codeCoverageEnabled);
         testOptimizationSettings.SetEarlyFlakeDetectionEnabled(earlyFlakeDetectionEnabled);
         testOptimizationSettings.SetFlakyRetryEnabled(flakyRetryEnabled);
+        testOptimizationSettings.SetImpactedTestsEnabled(impactedTestsDetectionEnabled);
         profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.CodeCoverage] = codeCoverageEnabled ? "1" : "0";
         profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.EarlyFlakeDetectionEnabled] = earlyFlakeDetectionEnabled ? "1" : "0";
         profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.FlakyRetryEnabled] = flakyRetryEnabled ? "1" : "0";
+        profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.ImpactedTestsDetectionEnabled] = impactedTestsDetectionEnabled ? "1" : "0";
 
         if (!testSkippingEnabled)
         {


### PR DESCRIPTION
## Summary of changes

This PR adds some missing code in the dd-trace runner related to impacted test feature.

## Reason for change

We can avoid making some requests to the backend if we have all the information we need (calculated in the runner). Impacted tests configuration was missing in the runner, so we had to go to the settings api in every testhost process. This PR fixes that.

## Implementation details

Just add the missing code like the other features.

## Test coverage

This is tested in the `test-environment` repo.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
