### PR TITLE
[Tracing] Add configuration key DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key to enable experimental features.
         /// </summary>
-        public const string ExperimentalFeaturesEnabled = "DD_TRACE_EXPERIMENTAL_ENABLED";
+        public const string ExperimentalFeaturesEnabled = "DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED";
 
         /// <summary>
         /// Configuration key for the path to the configuration file.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -15,6 +15,11 @@ namespace Datadog.Trace.Configuration
     internal static partial class ConfigurationKeys
     {
         /// <summary>
+        /// Configuration key to enable experimental features.
+        /// </summary>
+        public const string ExperimentalFeaturesEnabled = "DD_TRACE_EXPERIMENTAL_ENABLED";
+
+        /// <summary>
         /// Configuration key for the path to the configuration file.
         /// Can only be set with an environment variable
         /// or in the <c>app.config</c>/<c>web.config</c> file.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -100,8 +100,8 @@ namespace Datadog.Trace.Configuration
                     .WithKeys(ConfigurationKeys.ExperimentalFeaturesEnabled)
                     .AsString()?.Trim() switch
                     {
-                        null or "false" => new HashSet<string>(),
-                        "true" => DefaultExperimentalFeatures,
+                        null or "none" => new HashSet<string>(),
+                        "all" => DefaultExperimentalFeatures,
                         string s => new HashSet<string>(s.Split([','], StringSplitOptions.RemoveEmptyEntries)),
                     };
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -37,6 +37,7 @@ namespace Datadog.Trace.Configuration
     public record TracerSettings
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerSettings>();
+        private static readonly HashSet<string> DefaultExperimentalFeatures = new HashSet<string>();
 
         private readonly IConfigurationTelemetry _telemetry;
         // we cached the static instance here, because is being used in the hotpath
@@ -94,6 +95,15 @@ namespace Datadog.Trace.Configuration
             _telemetry = telemetry;
             ErrorLog = errorLog;
             var config = new ConfigurationBuilder(source, _telemetry);
+
+            ExperimentalFeaturesEnabled = config
+                    .WithKeys(ConfigurationKeys.ExperimentalFeaturesEnabled)
+                    .AsString()?.Trim() switch
+                    {
+                        null or "false" => new HashSet<string>(),
+                        "true" => DefaultExperimentalFeatures,
+                        string s => new HashSet<string>(s.Split([','], StringSplitOptions.RemoveEmptyEntries)),
+                    };
 
             GCPFunctionSettings = new ImmutableGCPFunctionSettings(source, _telemetry);
             IsRunningInGCPFunctions = GCPFunctionSettings.IsGCPFunction;
@@ -622,6 +632,8 @@ namespace Datadog.Trace.Configuration
                 telemetry.Record(ConfigurationKeys.DisabledIntegrations, value, recordValue: true, ConfigurationOrigins.Calculated);
             }
         }
+
+        internal HashSet<string> ExperimentalFeaturesEnabled { get; }
 
         internal OverrideErrorLog ErrorLog { get; }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -351,6 +351,7 @@
   "DD_TRACE_CLIENT_IP_ENABLED": "trace_client_ip_enabled",
   "DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED": "trace_kafka_create_consumer_scope_enabled",
   "DD_TRACE_EXPAND_ROUTE_TEMPLATES_ENABLED": "trace_route_template_expansion_enabled",
+  "DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": "trace_experimental_features_enabled",
   "DD_TRACE_STATS_COMPUTATION_ENABLED": "trace_stats_computation_enabled",
   "_DD_TRACE_STATS_COMPUTATION_INTERVAL": "trace_stats_computation_interval",
   "DD_TRACE_PROPAGATION_STYLE_INJECT": "trace_propagation_style_inject",


### PR DESCRIPTION
## Summary of changes
Adds a configuration flag for enabling experimental behaviors in the tracing library, primarily targeting changes that would require a major version bump.

Configuration key: `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED`
Configuration type: string
Configuration accepted values:
- `"all"` to enable all experimental behaviors
- `"none"` to disable all experimental behaviors
- Or a comma-separated list of case-sensitive configurations for which to apply their experimental behaviors
  - Example: `DD_TAGS,DD_SOME_OTHER_CONFIG`

## Reason for change
As part of our cross-tracer efforts to consolidate behaviors, some of them result in breaking changes to data we produce. If considered a breaking change, we will hide them behind this common flag so that we can properly implement and track their new behaviors.

## Implementation details
See code, changes are relatively small.

## Test coverage
Tests will be added for individual features in subsequent PRs (e.g. `DD_TAGS`)

## Other details
N/A