### PR TITLE
[ASM] WAF error span tags

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -54,12 +54,12 @@ internal partial class AppSecRequestContext
 
             if (_wafError != null)
             {
-                tags.SetTag(Tags.WAFError, _wafError.ToString());
+                tags.SetTag(Tags.WafError, _wafError.ToString());
             }
 
             if (_wafRaspError != null)
             {
-                tags.SetTag(Tags.RaspWAFError, _wafRaspError.ToString());
+                tags.SetTag(Tags.RaspWafError, _wafRaspError.ToString());
             }
 
             _raspTelemetryHelper?.GenerateRaspSpanMetricTags(span.Tags);

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -64,10 +64,10 @@ internal class AppSecRequestContext
         }
     }
 
-    internal void AddWAFError(int code, bool isRasp)
+    internal void CheckWAFError(int code, bool isRasp)
     {
         int? existingValue = isRasp ? _wafRaspError : _wafError;
-        if (existingValue == null || existingValue < code)
+        if (code < 0 && (existingValue == null || existingValue < code))
         {
             if (isRasp)
             {

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -26,7 +26,6 @@ internal partial class AppSecRequestContext
     private readonly List<object> _wafSecurityEvents = new();
     private int? _wafError = null;
     private int? _wafRaspError = null;
-    private RaspTelemetryHelper? _raspTelemetryHelper = Security.Instance.RaspEnabled ? new RaspTelemetryHelper() : null;
     private Dictionary<string, List<Dictionary<string, object>>>? _raspStackTraces;
 
     internal void CloseWebSpan(TraceTagCollection tags, Span span)

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -77,6 +77,7 @@ internal readonly partial struct SecurityCoordinator
                          : additiveContext.Run(args, _security.Settings.WafTimeoutMicroSeconds);
 
             SetErrorInformation(isRasp, result);
+            _localRootSpan.Context.TraceContext.AppSecRequestContext.CheckWAFError((int)result.ReturnCode, isRasp);
 
             SecurityReporter.RecordTelemetry(result);
         }
@@ -101,9 +102,9 @@ internal readonly partial struct SecurityCoordinator
 
     private void SetErrorInformation(bool isRasp, IResult? result)
     {
-        if (result?.ReturnCode < 0)
+        if (result is not null)
         {
-            _localRootSpan.Context.TraceContext.AppSecRequestContext.AddWAFError((int)result.ReturnCode, isRasp);
+            _localRootSpan.Context.TraceContext.AppSecRequestContext.CheckWAFError((int)result.ReturnCode, isRasp);
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -74,8 +74,6 @@ internal readonly partial struct SecurityCoordinator
                          : additiveContext.Run(args, _security.Settings.WafTimeoutMicroSeconds);
 
             SetErrorInformation(isRasp, result);
-            _localRootSpan.Context.TraceContext.AppSecRequestContext.CheckWAFError((int)result.ReturnCode, isRasp);
-
             SecurityReporter.RecordTelemetry(result);
         }
         catch (Exception ex) when (ex is not BlockException)

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -76,6 +76,8 @@ internal readonly partial struct SecurityCoordinator
                          ? additiveContext.RunWithEphemeral(args, _security.Settings.WafTimeoutMicroSeconds, isRasp)
                          : additiveContext.Run(args, _security.Settings.WafTimeoutMicroSeconds);
 
+            SetErrorInformation(isRasp, result);
+
             SecurityReporter.RecordTelemetry(result);
         }
         catch (Exception ex) when (ex is not BlockException)
@@ -95,6 +97,14 @@ internal readonly partial struct SecurityCoordinator
         }
 
         return result;
+    }
+
+    private void SetErrorInformation(bool isRasp, IResult? result)
+    {
+        if (result?.ReturnCode < 0)
+        {
+            _localRootSpan.Context.TraceContext.AppSecRequestContext.AddWAFError((int)result.ReturnCode, isRasp);
+        }
     }
 
     internal static Span TryGetRoot(Span span) => span.Context.TraceContext?.RootSpan ?? span;
@@ -132,6 +142,7 @@ internal readonly partial struct SecurityCoordinator
 
                 // run the WAF and execute the results
                 result = additiveContext.Run(userAddresses, _security.Settings.WafTimeoutMicroSeconds);
+                SetErrorInformation(false, result);
                 additiveContext.CommitUserRuns(userAddresses, fromSdk);
                 RecordTelemetry(result);
 

--- a/tracer/src/Datadog.Trace/Metrics.cs
+++ b/tracer/src/Datadog.Trace/Metrics.cs
@@ -88,6 +88,11 @@ namespace Datadog.Trace
         public const string AppSecWafAndBindingsDuration = "_dd.appsec.waf.duration_ext";
 
         /// <summary>
+        /// Returns the most relevant WAF error code
+        /// </summary>
+        public const string WAFError = "_dd.appsec.waf.error";
+
+        /// <summary>
         /// Total cumulative waf duration for RASP calls across spans for one request
         /// </summary>
         public const string RaspWafDuration = "_dd.appsec.rasp.duration";
@@ -106,6 +111,11 @@ namespace Datadog.Trace
         /// Counts the number of times a rule type is evaluated.
         /// </summary>
         public const string RaspRuleEval = "_dd.appsec.rasp.rule.eval";
+
+        /// <summary>
+        /// Returns the most relevant WAF error code when calling RASP
+        /// </summary>
+        public const string RaspWAFError = "_dd.appsec.rasp.error";
 
         /// <summary>
         /// Float representing the number of rules loaded successfully

--- a/tracer/src/Datadog.Trace/Metrics.cs
+++ b/tracer/src/Datadog.Trace/Metrics.cs
@@ -88,11 +88,6 @@ namespace Datadog.Trace
         public const string AppSecWafAndBindingsDuration = "_dd.appsec.waf.duration_ext";
 
         /// <summary>
-        /// Returns the most relevant WAF error code
-        /// </summary>
-        public const string WAFError = "_dd.appsec.waf.error";
-
-        /// <summary>
         /// Total cumulative waf duration for RASP calls across spans for one request
         /// </summary>
         public const string RaspWafDuration = "_dd.appsec.rasp.duration";
@@ -111,11 +106,6 @@ namespace Datadog.Trace
         /// Counts the number of times a rule type is evaluated.
         /// </summary>
         public const string RaspRuleEval = "_dd.appsec.rasp.rule.eval";
-
-        /// <summary>
-        /// Returns the most relevant WAF error code when calling RASP
-        /// </summary>
-        public const string RaspWAFError = "_dd.appsec.rasp.error";
 
         /// <summary>
         /// Float representing the number of rules loaded successfully

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -617,12 +617,12 @@ namespace Datadog.Trace
         /// <summary>
         /// The most relevant WAF error code during a request
         /// </summary>
-        public const string WAFError = "_dd.appsec.waf.error";
+        public const string WafError = "_dd.appsec.waf.error";
 
         /// <summary>
         /// The most relevant WAF error code during a request when using RASP
         /// </summary>
-        public const string RaspWAFError = "_dd.appsec.rasp.error";
+        public const string RaspWafError = "_dd.appsec.rasp.error";
 
         /// <summary>
         ///  String-serialized JSON array, each item being a map containing:

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -615,6 +615,16 @@ namespace Datadog.Trace
         internal const string AppSecWafVersion = "_dd.appsec.waf.version";
 
         /// <summary>
+        /// The most relevant WAF error code during a request
+        /// </summary>
+        public const string WAFError = "_dd.appsec.waf.error";
+
+        /// <summary>
+        /// The most relevant WAF error code during a request when using RASP
+        /// </summary>
+        public const string RaspWAFError = "_dd.appsec.rasp.error";
+
+        /// <summary>
         ///  String-serialized JSON array, each item being a map containing:
         ///  Error(e) - the error string.
         ///  Rules(r) - an array of rules which failed to load with this error.

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -1,0 +1,35 @@
+// <copyright file="AppSecContextTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Tagging;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+public class AppSecContextTests
+{
+    [InlineData(-2, -2, -1, -2, -1)]
+    [InlineData(2, -2, -1, null, -1)]
+    [InlineData(2, 2, 1, null, null)]
+    [Theory]
+    public void GivenAQuery_WhenWAFError_ThenSpanHasErrorTags(int raspErrorCode, int wafErrorCode, int wafErrorCode2, int? expectedRaspErrorCode, int? expectedWafErrorCode)
+    {
+        var settings = TracerSettings.Create(new Dictionary<string, object>());
+        var tracer = new Tracer(settings, null, null, null, null);
+        var rootTestScope = (Scope)tracer.StartActive("test.trace");
+
+        var appSecContext = rootTestScope.Span.Context.TraceContext.AppSecRequestContext;
+        appSecContext.CheckWAFError(raspErrorCode, true);
+        appSecContext.CheckWAFError(wafErrorCode, false);
+        appSecContext.CheckWAFError(wafErrorCode2, false);
+        TraceTagCollection tags = new();
+        appSecContext.CloseWebSpan(tags, rootTestScope.Span);
+        tags.GetTag(Tags.WAFError).Should().Be(expectedWafErrorCode?.ToString());
+        tags.GetTag(Tags.RaspWAFError).Should().Be(expectedRaspErrorCode?.ToString());
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -29,7 +29,7 @@ public class AppSecContextTests
         appSecContext.CheckWAFError(wafErrorCode2, false);
         TraceTagCollection tags = new();
         appSecContext.CloseWebSpan(tags, rootTestScope.Span);
-        tags.GetTag(Tags.WAFError).Should().Be(expectedWafErrorCode?.ToString());
-        tags.GetTag(Tags.RaspWAFError).Should().Be(expectedRaspErrorCode?.ToString());
+        tags.GetTag(Tags.WafError).Should().Be(expectedWafErrorCode?.ToString());
+        tags.GetTag(Tags.RaspWafError).Should().Be(expectedRaspErrorCode?.ToString());
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR adds the new error span tags for ASM. It adds the error tags containing the error returned by the WAF.

These tags are defined in [this RFC](https://docs.google.com/document/d/1D4hkC0jwwUyeo0hEQgyKP54kM1LZU98GL8MaP60tQrA/edit?tab=t.0).

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
