### PR TITLE
Fix: Rabbitmq7 header injection overwrites user supplied basic properties

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/CachedBasicPropertiesHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/CachedBasicPropertiesHelper.cs
@@ -27,12 +27,13 @@ internal static class CachedBasicPropertiesHelper<TBasicProperties>
         var createBasicPropertiesMethod = new DynamicMethod(
             $"TypeActivator_{targetType.Name}_{parameterType.Name}",
             targetType,
-            [parameterType],
+            [typeof(object)],
             typeof(DuckType).Module,
             true);
 
         var il = createBasicPropertiesMethod.GetILGenerator();
-        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_0); // Load first argument (object).
+        il.Emit(OpCodes.Castclass, parameterType); // Cast to IReadOnlyBasicProperties
         il.Emit(OpCodes.Newobj, constructor);
         il.Emit(OpCodes.Ret);
         Activator = (Func<object, object>)createBasicPropertiesMethod.CreateDelegate(typeof(Func<object, object>), targetType);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/CachedBasicPropertiesHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/CachedBasicPropertiesHelper.cs
@@ -1,9 +1,13 @@
-﻿// <copyright file="CachedBasicPropertiesHelper.cs" company="Datadog">
+// <copyright file="CachedBasicPropertiesHelper.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 #nullable enable
+using System;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
@@ -11,13 +15,29 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
 internal static class CachedBasicPropertiesHelper<TBasicProperties>
 {
     // ReSharper disable once StaticMemberInGenericType
-    private static readonly ActivatorHelper Activator;
+    private static readonly Func<object, object> Activator;
 
     static CachedBasicPropertiesHelper()
     {
-        Activator = new ActivatorHelper(typeof(TBasicProperties).Assembly.GetType("RabbitMQ.Client.BasicProperties")!);
+        var targetType = typeof(TBasicProperties).Assembly.GetType("RabbitMQ.Client.BasicProperties")!;
+        var parameterType = typeof(TBasicProperties).Assembly.GetType("RabbitMQ.Client.IReadOnlyBasicProperties")!;
+
+        var constructor = targetType.GetConstructor([parameterType])!;
+
+        var createBasicPropertiesMethod = new DynamicMethod(
+            $"TypeActivator_{targetType.Name}_{parameterType.Name}",
+            targetType,
+            [parameterType],
+            typeof(DuckType).Module,
+            true);
+
+        var il = createBasicPropertiesMethod.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Ret);
+        Activator = (Func<object, object>)createBasicPropertiesMethod.CreateDelegate(typeof(Func<object, object>), targetType);
     }
 
-    public static TBasicProperties CreateHeaders()
-        => (TBasicProperties)Activator.CreateInstance();
+    public static TBasicProperties CreateHeaders(object readonlyBasicProperties)
+        => (TBasicProperties)Activator(readonlyBasicProperties);
 }


### PR DESCRIPTION
Note: Created as draft as I have not actually run or tested the changes 😶

## Summary of changes
Fixes the header injection so that basic properties are preserved from the supplied argument list in case `PopulateBasicPropertiesHeaders` returns null which happens if the basic properties argument is writable or if no changes had to be made to it.

## Reason for change
Fixes a bug that would remove all user supplied basic properties.

## Implementation details
Stores the basicproperties argument in the active scope and retrieves it a null return value is encountered. Changed `CachedBasicPropertiesHelper` to call the copy constructor that takes a `IReadOnlyBasicProperties` as argument.

## Test coverage
Added basic properties to one of the rabbitmq7 test methods as well as assertions.

## Other details
Fixes #6723 
