### PR TITLE
[ASM][ATO] Fix : remove ISession for trimming file, and ducktype

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -48,12 +48,10 @@
    </assembly>
    <assembly fullname="Microsoft.AspNetCore.Http.Features">
       <type fullname="Microsoft.AspNetCore.Http.Features.IFeatureCollection" />
-      <type fullname="Microsoft.AspNetCore.Http.Features.ISessionFeature" />
       <type fullname="Microsoft.AspNetCore.Http.IHeaderDictionary" />
       <type fullname="Microsoft.AspNetCore.Http.IQueryCollection" />
       <type fullname="Microsoft.AspNetCore.Http.IRequestCookieCollection" />
       <type fullname="Microsoft.AspNetCore.Http.IResponseCookies" />
-      <type fullname="Microsoft.AspNetCore.Http.ISession" />
    </assembly>
    <assembly fullname="Microsoft.AspNetCore.Identity" />
    <assembly fullname="Microsoft.AspNetCore.Mvc.Abstractions">

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -16,7 +16,6 @@ using Datadog.Trace.Headers;
 using Datadog.Trace.Util.Http;
 using Datadog.Trace.Vendors.Serilog.Events;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/ISession.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/ISession.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="ISession.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETFRAMEWORK
+#nullable enable
+using System.ComponentModel;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents;
+
+/// <summary>
+/// Duck type of the SignInManager aspnet core type
+/// </summary>
+[Browsable(false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ISession
+{
+    /// <summary>
+    /// Gets a value indicating whether the session is available
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets the session id
+    /// </summary>
+    string Id { get; }
+}
+#endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/ISessionFeature.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/ISessionFeature.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="ISessionFeature.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETFRAMEWORK
+#nullable enable
+using System.ComponentModel;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents;
+
+/// <summary>
+/// Duck type of the ISessionFeature aspnet core type in Microsoft.AspNetCore.Http.Features assembly
+/// </summary>
+[Browsable(false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ISessionFeature
+{
+    /// <summary>
+    /// Gets the Session object, can be null
+    /// </summary>
+    public ISession Session { get; }
+}
+#endif

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/SessionController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/SessionController.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.AspNetCore.Routing;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Datadog.Trace;
+
+namespace weblog
+{
+    [ApiController]
+    [Route("session")]
+    public class SessionController : Controller
+    {
+	    [HttpGet("new")]
+        public IActionResult New()
+        {
+            return Content(HttpContext.Session.Id);
+        }
+
+        [HttpGet("user")]
+        public IActionResult User(string sdk_user)
+        {
+            if (sdk_user != null)
+            {
+                Samples.SampleHelpers.TrackUserLoginSuccessEvent(sdk_user, null);
+            }
+
+            return Content($"Hello, set the user to {sdk_user}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Replace direct access to type `ISessionFeature` and `ISession` with their ducktype counterparts

## Reason for change

A customer is getting 
```
Error : Event Exception: {EventName}
System.MissingMethodException
   
at Datadog.Trace.AppSec.Coordinator.SecurityCoordinatorHelpers.CheckPathParamsAndSessionId(Security security, HttpContext context, Span span, IDictionary`2 pathParams)
   
at Datadog.Trace.DiagnosticListeners.AspNetCoreDiagnosticObserver.OnRoutingEndpointMatched(Object arg)
   
at Datadog.Trace.DiagnosticListeners.DiagnosticObserver.System.IObserver<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.OnNext(KeyValuePair`2 value)
```

We suspect it's a trimmed app, without the right Trimming.xml file version, latest has added ISession.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
