### PR TITLE
ignore entire `baggage` header if malformed

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -264,9 +264,9 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
 
             if (separatorPosition <= 0 || separatorPosition == span.Length - 1)
             {
-                // -1: invalid, no '=' character found, e.g. "foo"
-                // 0: invalid, key is empty, e.g. "=value" or "="
-                // span.Length - 1: invalid, value is empty, e.g. "key=" or "="
+                // separatorPosition == -1: invalid, no '=' character found, e.g. "foo"
+                // separatorPosition == 0: invalid, key is empty, e.g. "=value" or "="
+                // separatorPosition == span.Length - 1: invalid, value is empty, e.g. "key=" or "="
                 continue;
             }
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -86,10 +86,15 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
         }
 
         var baggage = ParseHeader(header!);
-        context = new PropagationContext(spanContext: null, baggage);
-        TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.Baggage);
 
-        return baggage is { Count: > 0 };
+        if (baggage is { Count: > 0 })
+        {
+            context = new PropagationContext(spanContext: null, baggage);
+            TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.Baggage);
+            return true;
+        }
+
+        return false;
     }
 
     internal static void EncodeStringAndAppend(StringBuilder sb, string source, bool isKey)

--- a/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CBaggagePropagator.cs
@@ -264,17 +264,19 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
 
             if (separatorPosition <= 0 || separatorPosition == span.Length - 1)
             {
-                // separatorPosition == -1: invalid, no '=' character found, e.g. "foo"
-                // separatorPosition == 0: invalid, key is empty, e.g. "=value" or "="
-                // separatorPosition == span.Length - 1: invalid, value is empty, e.g. "key=" or "="
-                continue;
+                // invalid format, ignore entire header.
+                // separatorPosition == -1: no '=' character found, e.g. "foo"
+                // separatorPosition == 0: key is empty, e.g. "=value" or "="
+                // separatorPosition == span.Length - 1: value is empty, e.g. "key=" or "="
+                return null;
             }
 
             var key = Decode(span.Slice(0, separatorPosition).Trim());
 
             if (key.Length == 0)
             {
-                continue;
+                // key was whitespace only. invalid format, ignore entire header.
+                return null;
             }
 
             // Ignore everything starting with the first `;` character after the value.
@@ -285,7 +287,8 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
             if (propertiesPosition >= 0 && propertiesPosition < separatorPosition)
             {
                 // invalid, ';' character was found before the value token, e.g. "key;=value" or ";="
-                continue;
+                // invalid format, ignore entire header.
+                return null;
             }
 
             // If no ';' character is found, make sure we parse the remaining string, e.g. "key=value"
@@ -296,7 +299,8 @@ internal class W3CBaggagePropagator : IContextInjector, IContextExtractor
 
             if (value.Length == 0)
             {
-                continue;
+                // value was whitespace only. invalid format, ignore entire header.
+                return null;
             }
 
             baggage ??= new Baggage();

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -171,7 +171,7 @@ public class W3CBaggagePropagatorTests
         }
 
         baggage.Should().NotBeNull();
-        baggage!.Count.Should().Be(expectedPairs.Length);
+        baggage.Should().HaveCount(expectedPairs.Length);
 
         foreach (var pair in expectedPairs)
         {

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -178,7 +178,7 @@ public class W3CBaggagePropagatorTests
     {
         var baggage = W3CBaggagePropagator.ParseHeader(inputHeader)!;
 
-        if (expectedPairs is null || expectedPairs.Length == 0)
+        if (expectedPairs is null)
         {
             baggage.Should().BeNull();
             return;

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -46,9 +46,11 @@ public class W3CBaggagePropagatorTests
         => new()
         {
             // input header ➡️ expected key/value pairs after decoding
+            // empty
             { null, null },
             { string.Empty, null },
             { " ", null },
+            // invalid
             { "invalid", null },
             { "invalid;", null },
             { "invalid=", null },
@@ -73,7 +75,7 @@ public class W3CBaggagePropagatorTests
             { "=value1,key2=value2", null },
             { "=,key2=value2", null },
             { "key1;a=value1,key2=value2", null },
-            // valid headers
+            // valid
             { "valid=%20", [("valid", " ")] },
             { "%20=valid", [(" ", "valid")] },
             { "%20=%20", [(" ", " ")] },

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -59,18 +59,32 @@ public class W3CBaggagePropagatorTests
             { "=", null },
             { " = ", null },
             { ";", null },
+            // valid + invalid
+            { "key1=value1,", null },
+            { "key1=value1,key2", null },
+            { "key1=value1,key2=", null },
+            { "key1=value1,=value", null },
+            { "key1=value1,=", null },
+            { "key1=value1,key2;a=value2", null },
+            // invalid + valid
+            { ",key2=value2", null },
+            { "key1,key2=value2", null },
+            { "key1=,key2=value2", null },
+            { "=value1,key2=value2", null },
+            { "=,key2=value2", null },
+            { "key1;a=value1,key2=value2", null },
+            // valid headers
             { "valid=%20", [("valid", " ")] },
             { "%20=valid", [(" ", "valid")] },
             { "%20=%20", [(" ", " ")] },
             { "key1=value1,key2=value2", [("key1", "value1"), ("key2", "value2")] },
-            { "key1=value1,invalid", [("key1", "value1")] },
             { "key1=value1, key2 = value2;property1;property2, key3=value3; propertyKey=propertyValue", [("key1", "value1"), ("key2", "value2"), ("key3", "value3")] }, // W3C metadata/property not currently supported so the values are discarded
             { "key1=value1%2Cvalid", [("key1", "value1,valid")] },
             { "key1=value1=valid", [("key1", "value1=valid")] },
             { "%20key1%20=%20value%091", [(" key1 ", " value\t1")] },                          // encoded whitespace
             { "key1 = value1, key2 = value\t2 ", [("key1", "value1"), ("key2", "value\t2")] }, // whitespace not encoded
-            { "key%F0%9F%90%B6=value%E6%88%91", [("key🐶", "value我")] },                      // encoded unicode
-            { "key🐶=value我", [("key🐶", "value我")] },                                       // unicode not encoded
+            { "key%F0%9F%90%B6=value%E6%88%91", [("key🐶", "value我")] },                       // encoded unicode
+            { "key🐶=value我", [("key🐶", "value我")] },                                         // unicode not encoded
         };
 
     [Theory]
@@ -263,6 +277,20 @@ public class W3CBaggagePropagatorTests
     [InlineData("")]
     [InlineData("  ")]
     [InlineData(null)]
+    // valid + invalid
+    [InlineData("key1=value1,")]
+    [InlineData("key1=value1,key2")]
+    [InlineData("key1=value1,key2=")]
+    [InlineData("key1=value1,=value2")]
+    [InlineData("key1=value1,=")]
+    [InlineData("key1=value1,key2;a=value2")]
+    // invalid + valid
+    [InlineData(",key2=value2")]
+    [InlineData("key1,key2=value2")]
+    [InlineData("key1=,key2=value2")]
+    [InlineData("=value1,key2=value2")]
+    [InlineData("=,key2=value2")]
+    [InlineData("key1;a=value1,key2=value2")]
     public void Extract_InvalidFormat(string header)
     {
         var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CBaggagePropagatorTests.cs
@@ -162,7 +162,7 @@ public class W3CBaggagePropagatorTests
     [MemberData(nameof(ExtractBaggageData))]
     public void ParseHeader(string inputHeader, (string Key, string Value)[] expectedPairs)
     {
-        var baggage = W3CBaggagePropagator.ParseHeader(inputHeader);
+        var baggage = W3CBaggagePropagator.ParseHeader(inputHeader)!;
 
         if (expectedPairs is null || expectedPairs.Length == 0)
         {


### PR DESCRIPTION
## Summary of changes

When parsing a `baggage` header, if it is malformed in any way, ignore the entire header instead of trying to extract the valid key/value pairs.

## Reason for change

This is the defined behavior in the RFC and how we implement baggage in other tracing libraries.

## Implementation details

Bail our as soon as we find any invalid format in the `baggage` header.

## Test coverage

Fixed existing tests and added more test cases.

## Other details
n/a
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
