### PR TITLE
Fix NoWarn for Datadog.Trace and Trimming

### DIFF
--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -12,7 +12,7 @@
 
     <!-- WebClient is obsolete -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <!-- StyleCop -->

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
+    <NoWarn>$(NoWarn);NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == '' ">bin\$(Configuration)\packages</PackageOutputPath>
     <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>
   </PropertyGroup>

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -10,7 +10,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
+    <NoWarn>$(NoWarn);NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == '' ">bin\$(Configuration)\packages</PackageOutputPath>
   </PropertyGroup>
 

--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.props
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.props
@@ -9,7 +9,7 @@ Copyright 2017 Datadog, Inc.
   <PropertyGroup>
     <!-- IL2007: Could not resolve assembly specified in descriptor file -->
     <!-- IL2008: Could not resolve type specified in descriptor file -->
-    <NoWarn>IL2007;IL2008</NoWarn>
+    <NoWarn>$(NoWarn);IL2007;IL2008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.props
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.props
@@ -9,7 +9,7 @@ Copyright 2017 Datadog, Inc.
   <PropertyGroup>
     <!-- IL2007: Could not resolve assembly specified in descriptor file -->
     <!-- IL2008: Could not resolve type specified in descriptor file -->
-    <NoWarn>IL2007;IL2008</NoWarn>
+    <NoWarn>$(NoWarn);IL2007;IL2008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

They were lacking $(NoWarn) and when installed would override any Directory.Build.props that had NoWarn set.

This depended / required on when MSBuild would evaluate the properties.

## Reason for change

We shouldn't overwrite these.

## Implementation details

Added `$(NoWarn)`

## Test coverage

Reproduced locally:

Added a `Directory.Build.props` in a different project then installed `Datadog.Trace` as a NuGet

```xml
<Project>
  <PropertyGroup>
    <NoWarn>$(NoWarn);CA2200</NoWarn>
  </PropertyGroup>
</Project>
```

Created a warning like so

```
            try
            {
                return true;
            }
            catch (Exception e)
            {
                throw e;
            }
```

Warning not ignored.

## Other details
<!-- Fixes #{issue} -->

Fixes #6742

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
