### PR TITLE
[Profiler] Add tag GC CPU samples

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
@@ -59,6 +59,11 @@ std::vector<std::shared_ptr<IThreadInfo>> const& GCThreadsCpuProvider::GetThread
     return _gcThreads;
 }
 
+Labels GCThreadsCpuProvider::GetLabels()
+{
+    return Labels{Label{"internal", "true"}};
+}
+
 std::vector<FrameInfoView> GCThreadsCpuProvider::GetFrames()
 {
     return

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
@@ -61,7 +61,7 @@ std::vector<std::shared_ptr<IThreadInfo>> const& GCThreadsCpuProvider::GetThread
 
 Labels GCThreadsCpuProvider::GetLabels()
 {
-    return Labels{Label{"internal", "true"}};
+    return Labels{Label{"gc_cpu_sample", "true"}};
 }
 
 std::vector<FrameInfoView> GCThreadsCpuProvider::GetFrames()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.h
@@ -24,6 +24,7 @@ protected:
 private:
     bool IsGcThread(std::shared_ptr<IThreadInfo> const& thread);
     std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() override;
+    Labels GetLabels() override;
     std::vector<FrameInfoView> GetFrames() override;
 
     std::vector<std::shared_ptr<IThreadInfo>> _gcThreads;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -96,6 +96,11 @@ std::unique_ptr<SamplesEnumerator> NativeThreadsCpuProviderBase::GetSamples()
         sample->AddFrame(frame);
     }
 
+    for (auto const& label : GetLabels())
+    {
+        sample->AddLabel(Label{label.first,label.second});
+    }
+
     enumerator->Set(sample);
 
     return enumerator;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
@@ -8,6 +8,7 @@
 #include "IFrameStore.h"
 #include "ISamplesProvider.h"
 #include "IThreadInfo.h"
+#include "Sample.h"
 
 #include <vector>
 
@@ -26,6 +27,7 @@ private:
     std::unique_ptr<SamplesEnumerator> GetSamples() override;
     virtual std::vector<FrameInfoView> GetFrames() = 0;
     virtual std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() = 0;
+    virtual Labels GetLabels() = 0;
 
     CpuTimeProvider* _cpuTimeProvider;
     std::chrono::milliseconds _previousTotalCpuTime;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
@@ -170,7 +170,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
 
         private static bool IsGcCpuSample((StackTrace StackTrace, PprofHelper.Label[] Labels, long[] Values) sample)
         {
-            return sample.StackTrace.Equals(GcStack) && sample.Labels.Any(label => label.Name == "internal" && label.Value == "true");
+            return sample.StackTrace.Equals(GcStack) && sample.Labels.Any(label => label.Name == "gc_cpu_sample" && label.Value == "true");
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Add a label on GC CPU sample .

## Reason for change

Give information on the sample so the backend can filter in/out .

## Implementation details

- Add a purely virtual `GetLabels` function in `NativeThreadsCpuProviderBase` and call it when building the sample.
- Implements `GetLabels` in `GcThreadsCpuProvider class

## Test coverage
- Improve already existing tests.
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
