### PR TITLE
Fix HttpListener.GetContext leak in tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
@@ -35,7 +35,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Clear any existing log path values, as these take precedence over DD_TRACE_LOG_PATH
             SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, string.Empty);
 
-            using ProcessResult processResult = await RunSampleAndWaitForExit(MockTracerAgent.Create(Output, 9696, doNotBindPorts: true));
+            using var agent = MockTracerAgent.Create(Output, 9696, doNotBindPorts: true);
+            using ProcessResult processResult = await RunSampleAndWaitForExit(agent);
             string[] logFileContent = File.ReadAllLines(tmpFile);
             int numOfLoadersLoad = logFileContent.Count(line => line.Contains("Datadog.Trace.ClrProfiler.Managed.Loader loaded"));
             Assert.Equal(1, numOfLoadersLoad);

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MockTelemetryAgent.cs" company="Datadog">
+// <copyright file="MockTelemetryAgent.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -28,7 +28,7 @@ namespace Datadog.Trace.TestHelpers
     internal class MockTelemetryAgent : IDisposable
     {
         private readonly HttpListener _listener;
-        private readonly Thread _listenerThread;
+        private readonly Task _listenerTask;
 
         public MockTelemetryAgent(int port = 8524, int retries = 5)
         {
@@ -49,8 +49,7 @@ namespace Datadog.Trace.TestHelpers
                     Port = port;
                     _listener = listener;
 
-                    _listenerThread = new Thread(HandleHttpRequests);
-                    _listenerThread.Start();
+                    _listenerTask = HandleHttpRequests();
 
                     return;
                 }
@@ -188,13 +187,13 @@ namespace Datadog.Trace.TestHelpers
             ctx.Response.Close();
         }
 
-        private void HandleHttpRequests()
+        private async Task HandleHttpRequests()
         {
             while (_listener.IsListening)
             {
                 try
                 {
-                    var ctx = _listener.GetContext();
+                    var ctx = await _listener.GetContextAsync();
                     HandleHttpRequest(ctx);
                 }
                 catch (HttpListenerException)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1126,7 +1126,7 @@ namespace Datadog.Trace.TestHelpers
                         _listener = listener;
 
                         listeners.Add($"Traces at port {Port}");
-                        _tracesListenerTask = Task.Factory.StartNew(HandleHttpRequests, TaskCreationOptions.LongRunning);
+                        _tracesListenerTask = HandleHttpRequests();
 
                         return;
                     }
@@ -1165,13 +1165,13 @@ namespace Datadog.Trace.TestHelpers
                 _udpClient?.Close();
             }
 
-            private void HandleHttpRequests()
+            private async Task HandleHttpRequests()
             {
                 while (_listener.IsListening)
                 {
                     try
                     {
-                        var ctx = _listener.GetContext();
+                        var ctx = await _listener.GetContextAsync();
                         try
                         {
                             if (Version != null)


### PR DESCRIPTION
## Summary of changes

Replace calls to `HttpListener.GetContext` with `HttpListener.GetContextAsync`

## Reason for change

On .NET Core 3.1, the tests were leaking threads because of an issue in `HttpListener.GetContext`, where the call to `GetContext` doesn't end even after disposing the listener: https://github.com/dotnet/runtime/issues/25497

Apparently, the async APIs is not affected by this bug.

## Test coverage

Tested on my machine. I observed the thread increase and the OOM before the change. Everything seems fine after the change.

## Other details

Also fixed a missing dispose for one `MockTracerAgent`.
