### PR TITLE
[Tracing] Update the default value of DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED to true 

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -792,9 +792,12 @@ namespace Datadog.Trace.Configuration
 
             /// <summary>
             /// Enables injecting 128-bit trace ids into logs as a hexadecimal string.
+            /// If enabled, 64-bit trace ids will continue to be injected as decimal strings.
             /// If disabled, 128-bit trace ids will be truncated to the lower 64 bits,
-            /// and all trace ids will be injected as decimal strings
-            /// Default value is <c>false</c> (disabled).
+            /// and all trace ids will be injected as decimal strings.
+            /// Default value is <c>true</c> (enabled).
+            /// If <see cref="ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled"/> is set to <c>false</c>,
+            /// this setting will also be set to <c>false</c>.
             /// </summary>
             public const string TraceId128BitLoggingEnabled = "DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED";
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -792,9 +792,10 @@ namespace Datadog.Trace.Configuration
 
             /// <summary>
             /// Enables injecting 128-bit trace ids into logs as a hexadecimal string.
-            /// If enabled, 64-bit trace ids will continue to be injected as decimal strings.
+            /// Enables injecting 128-bit trace ids into logs as a hexadecimal string.
             /// If disabled, 128-bit trace ids will be truncated to the lower 64 bits,
-            /// and all trace ids will be injected as decimal strings.
+            /// and injected as decimal strings. 64-bit trace ids are
+            /// always injected as decimal strings, regardless of this setting.
             /// Default value is <c>true</c> (enabled).
             /// If <see cref="ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled"/> is set to <c>false</c>,
             /// this setting will also be set to <c>false</c>.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -792,7 +792,6 @@ namespace Datadog.Trace.Configuration
 
             /// <summary>
             /// Enables injecting 128-bit trace ids into logs as a hexadecimal string.
-            /// Enables injecting 128-bit trace ids into logs as a hexadecimal string.
             /// If disabled, 128-bit trace ids will be truncated to the lower 64 bits,
             /// and injected as decimal strings. 64-bit trace ids are
             /// always injected as decimal strings, regardless of this setting.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -664,7 +664,7 @@ namespace Datadog.Trace.Configuration
                                             .AsBool(true);
             TraceId128BitLoggingEnabled = config
                                          .WithKeys(ConfigurationKeys.FeatureFlags.TraceId128BitLoggingEnabled)
-                                         .AsBool(false);
+                                         .AsBool(TraceId128BitGenerationEnabled);
 
             CommandsCollectionEnabled = config
                                        .WithKeys(ConfigurationKeys.FeatureFlags.CommandsCollectionEnabled)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             string packageVersion = "",
             bool disableLogCorrelation = false,
             Func<string, bool> additionalInjectedLogFilter = null,
-            bool use128Bits = false)
+            bool use128Bits = true)
         {
             foreach (var test in logFileTestCases)
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DatadogLoggingScopeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DatadogLoggingScopeTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DatadogLoggingScopeTests.cs" company="Datadog">
+// <copyright file="DatadogLoggingScopeTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
 
             var actual = scope.ToString();
 
-            var expected = @$"dd_service:""TestService"", dd_env:""test"", dd_version:""1.2.3"", dd_trace_id:""{spanScope.Span.TraceId}"", dd_span_id:""{spanScope.Span.SpanId}""";
+            var expected = @$"dd_service:""TestService"", dd_env:""test"", dd_version:""1.2.3"", dd_trace_id:""{((Span)spanScope.Span).TraceId128}"", dd_span_id:""{spanScope.Span.SpanId}""";
             actual.Should().Be(expected);
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return (s => s.ServiceNameMappings, new string[0]);
 
             yield return (s => s.TraceId128BitGenerationEnabled, true);
-            yield return (s => s.TraceId128BitLoggingEnabled, false);
+            yield return (s => s.TraceId128BitLoggingEnabled, true);
         }
 
         public static IEnumerable<(string Key, string Value, Func<TracerSettings, object> Getter, object Expected)> GetBreakingChangeTestData()

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1050,10 +1050,13 @@ namespace Datadog.Trace.Tests.Configuration
             var settings = new TracerSettings(source);
 
             settings.TraceId128BitGenerationEnabled.Should().Be(expected);
+
+            // Additional behavior: Ensure that TraceId128BitLoggingEnabled is configured to the same value as TraceId128BitGenerationEnabled
+            settings.TraceId128BitLoggingEnabled.Should().Be(expected);
         }
 
         [Theory]
-        [MemberData(nameof(BooleanTestCases), false)]
+        [MemberData(nameof(BooleanTestCases), true)]
         public void TraceId128BitLoggingEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.TraceId128BitLoggingEnabled, value));

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LoggingMethods.cs
@@ -17,56 +17,68 @@ namespace LogsInjectionHelper.VersionConflict
         {
             try
             {
-                logAction($"{ExcludeMessagePrefix}Starting manual1 Datadog scope.");
-                using (Tracer.Instance.StartActive("manual1"))
+                logAction($"{ExcludeMessagePrefix}Starting scopes.");
+
+                // Start a trace using the latest automatic tracer so that we
+                // automatically create a 128-bit trace-id and properly set the _dd.p.tid tag.
+                // This is only done to make the testing logic easier, since all of the trace-id's
+                // will have 128-bit trace-id's.
+                //
+                // Note: This is not necessary for real applications, as the backend will still be able to
+                // correlate the 64-bit trace-id's from the manual side and the 128-bit trace-id's
+                // from the automatic side.
+                using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic0"))
                 {
-                    logAction($"Trace: manual1");
-                    using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic2"))
+                    using (Tracer.Instance.StartActive("manual1"))
                     {
-                        logAction($"Trace: manual1-automatic2");
-                        using (Tracer.Instance.StartActive("manual3"))
+                        logAction($"Trace: manual1");
+                        using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic2"))
                         {
-                            logAction($"Trace: manual1-automatic2-manual3");
-                            using (Tracer.Instance.StartActive("manual4"))
+                            logAction($"Trace: manual1-automatic2");
+                            using (Tracer.Instance.StartActive("manual3"))
                             {
-                                logAction($"Trace: manual1-automatic2-manual3-manual4");
-
-                                using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic5"))
+                                logAction($"Trace: manual1-automatic2-manual3");
+                                using (Tracer.Instance.StartActive("manual4"))
                                 {
-                                    logAction($"Trace: manual1-automatic2-manual3-manual4-automatic5");
-                                }
+                                    logAction($"Trace: manual1-automatic2-manual3-manual4");
 
-                                logAction($"Trace: manual1-automatic2-manual3-manual4");
-                            }
-
-                            logAction($"Trace: manual1-automatic2-manual3");
-
-                            using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic4"))
-                            {
-                                logAction($"Trace: manual1-automatic2-manual3-automatic4");
-                                using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic5"))
-                                {
-                                    logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5");
-                                    using (Tracer.Instance.StartActive("manual6"))
+                                    using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic5"))
                                     {
-                                        logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5-manual6");
+                                        logAction($"Trace: manual1-automatic2-manual3-manual4-automatic5");
                                     }
 
-                                    logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5");
+                                    logAction($"Trace: manual1-automatic2-manual3-manual4");
                                 }
 
-                                logAction($"Trace: manual1-automatic2-manual3-automatic4");
+                                logAction($"Trace: manual1-automatic2-manual3");
+
+                                using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic4"))
+                                {
+                                    logAction($"Trace: manual1-automatic2-manual3-automatic4");
+                                    using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic5"))
+                                    {
+                                        logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5");
+                                        using (Tracer.Instance.StartActive("manual6"))
+                                        {
+                                            logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5-manual6");
+                                        }
+
+                                        logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5");
+                                    }
+
+                                    logAction($"Trace: manual1-automatic2-manual3-automatic4");
+                                }
+
+                                logAction($"Trace: manual1-automatic2-manual3");
                             }
-
-                            logAction($"Trace: manual1-automatic2-manual3");
+                            logAction($"Trace: manual1-automatic2");
                         }
-                        logAction($"Trace: manual1-automatic2");
-                    }
 
-                    logAction($"Trace: manual1");
+                        logAction($"Trace: manual1");
+                    }
                 }
 
-                logAction($"{ExcludeMessagePrefix}Exited manual1 Datadog scope.");
+                logAction($"{ExcludeMessagePrefix}Exited scopes.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary of changes
Updates the default value of the `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED` configuration from `false` to `true`.

_Before_: Automatic logs injection, by default, injects the trace-id as a decimal number representing the lower 64-bits of the trace-id, regardless if the trace-id had a 128-bit or 64-bit value.

_Now_: Automatic logs injection, by default, injects the trace-id as a 32-character hexadecimal number representing the 128-bit value when the trace-id is a 128-bit value and as a decimal number when the trace-id is a 64-bit value.

This also implements a new behavior so when `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=false`, then `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED` will default to `false`, unless overridden by user configuration.

## Reason for change
We have long supported the correlation of 128-bit trace-ids in logs to their respective spans. Now we are standardizing the behavior of the tracing libraries to consistently inject 128-bit trace-ids as their full hexadecimal values.

## Implementation details
At a technical level, this only changes the default value of the `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED` flag. This changes the value from a constant `false` to the value of the `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`.

## Test coverage
Unit tests have been updated to account for the new configuration default value.

End-to-end tests have been conducted locally with the `LogsInjection.Serilog` test application and logs correlation continues to work as expected.

## Other details
