### PR TITLE
[CI] Stop running windows throughput tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4641,7 +4641,7 @@ stages:
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [Linux64, Windows64, LinuxArm64]
+      jobs: [Linux64, LinuxArm64]
       allowSkipped: true
   #### Throughput Linux 64, Windows 64, Linux arm 64
 
@@ -4697,59 +4697,6 @@ stages:
       # bother trying to upload these in case of failure, which means we can retry the
       # stages without issue
       artifact: crank_linux_x64_1
-
-  - job: Windows64
-    timeoutInMinutes: 60
-    pool: Throughput
-
-    steps:
-    - template: steps/clone-repo.yml
-      parameters:
-        targetShaId: $(targetShaId)
-        targetBranch: $(targetBranch)
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download windows native binary
-      inputs:
-        artifact: windows-tracer-home
-        path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-win
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download Datadog.Trace.Manual
-      inputs:
-        artifact: build-windows-working-directory
-        itemPattern: tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll
-        path: $(Agent.TempDirectory)
-
-    - script: |
-        mkdir -p tracer/bin/netcoreapp3.1
-        cp $(Agent.TempDirectory)/tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll tracer/bin/netcoreapp3.1/
-        test ! -s "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll (native loader) does not exist" && exit 1
-        test ! -s "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll does not exist" && exit 1
-        test ! -s "tracer/tracer-home-win/win-x64/ddwaf.dll" && echo "tracer/tracer-home-win/win-x64/ddwaf.dll does not exist" && exit 1
-        test ! -s "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll" && echo "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll does not exist" && exit 1
-        mkdir -p $(CrankDir)/results/logs
-        cd $(CrankDir)
-        chmod +x ./run.sh
-        ./run.sh "windows" "$(runExtendedThroughputTests)"
-      displayName: Crank tracer
-      env:
-        DD_SERVICE: dd-trace-dotnet
-        DD_ENV: CI
-        DD_CIVISIBILITY_AGENTLESS_ENABLED: true
-        DD_API_KEY: $(ddApiKey)
-
-    - script: |
-        cp $(CrankDir)/*.json $(CrankDir)/results
-      displayName: Copy the results to results dir
-
-    - publish: "$(CrankDir)/results"
-      displayName: Publish results
-      # We don't include the JobAttempt in this case, because we rely on a specific name
-      # and an error in the throughput tests probably means no usable data, so dont
-      # bother trying to upload these in case of failure, which means we can retry the
-      # stages without issue
-      artifact: crank_windows_x64_1
 
   - job: LinuxArm64
     timeoutInMinutes: 60
@@ -7082,13 +7029,6 @@ stages:
       inputs:
         artifact: crank_linux_x64_1
         path: $(System.DefaultWorkingDirectory)/artifacts/build_data/throughput/current/crank_linux_x64_1
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download crank_windows_x64_1
-      continueOnError: true
-      inputs:
-        artifact: crank_windows_x64_1
-        path: $(System.DefaultWorkingDirectory)/artifacts/build_data/throughput/current/crank_windows_x64_1
 
     - script: tracer\build.cmd CompareThroughputResults
       displayName: Compare Crank results


### PR DESCRIPTION
## Summary of changes

Removes the Windows throughput tests

## Reason for change

They've been broken for ~3 weeks, nobody's looking at them, they slow down the pipelines, and we're migrating to the benchmarking platform anyway

## Implementation details

Delete the Windows job from the throughput stage - I've left all the other infra for it, as we will likely remove _all_ of the crank stuff post- benchmarking platform transition

## Test coverage

This is the test

## Other details

Hopefully the compare stage works, this PR will show if it doesn't though