### PR TITLE
Skip the failing debugger tests

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplay.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplay.cs
@@ -113,7 +113,7 @@ public abstract class AspNetCore5ExceptionReplay : AspNetBase, IClassFixture<Asp
         SetHttpPort(Fixture.HttpPort);
     }
 
-    [SkippableTheory]
+    [SkippableTheory(Skip = "This is currently failing on all platforms since #6750 and needs investigating ASAP")]
     [MemberData(nameof(ExceptionReplayTests))]
     [Trait("RunOnWindows", "True")]
     public async Task TestExceptionReplay(ProbeTestDescription testData)


### PR DESCRIPTION
## Summary of changes

Skips the failing exception replay tests

## Reason for change

The exception replay tests are all failing since #6750 and need to be investigated ASAP

## Implementation details

Skip the `AspNetCore5ExceptionReplay.TestExceptionReplay` tests

## Test coverage

This is the test 
