### PR TITLE
[ASM] Fix IAST Grpc DotNet flaky test

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Grpc/GrpcDotNetTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Grpc/GrpcDotNetTests.cs
@@ -47,8 +47,13 @@ public class GrpcDotNetTests : TestHelper
 
         const int expectedSpanCount = 24;
         const string filename = "Iast.GrpcDotNetTests.BodyPropagation.SubmitsTraces";
+
+        // No meta structs support for this test as vulnerabilities can be triggered at the start of the app
+        // The tracer could possibly not have the time to load the mock agent configuration
         using var agent = EnvironmentHelper.GetMockAgent();
+        agent.Configuration.SpanMetaStructs = false;
         using var process = await RunSampleAndWaitForExit(agent);
+
         var spans = agent.WaitForSpans(expectedSpanCount);
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
 

--- a/tracer/test/snapshots/Iast.GrpcDotNetTests.BodyPropagation.SubmitsTraces.verified.txt
+++ b/tracer/test/snapshots/Iast.GrpcDotNetTests.BodyPropagation.SubmitsTraces.verified.txt
@@ -55,9 +55,6 @@
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 2.0
-    },
-    MetaStruct: {
-      iast: 
     }
   },
   {
@@ -116,9 +113,6 @@
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 2.0
-    },
-    MetaStruct: {
-      iast: 
     }
   },
   {
@@ -177,9 +171,6 @@
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 2.0
-    },
-    MetaStruct: {
-      iast: 
     }
   },
   {
@@ -238,9 +229,6 @@
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 2.0
-    },
-    MetaStruct: {
-      iast: 
     }
   }
 ]


### PR DESCRIPTION
## Summary of changes

Disabling SpanMetaStructs from Agent used in related test and snapshot file.

## Reason for change

The test started to be flaky in master.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
