### PR TITLE
Pin github actions to sha

### DIFF
--- a/.github/actions/code-freeze/action.yml
+++ b/.github/actions/code-freeze/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: octokit/request-action@v2.x
+    - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
       name: 'Get open PRs'
       id: prs
       with:

--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -33,18 +33,18 @@ runs:
         cp ./tracer/build/_build/docker/system-tests.dockerfile ${{inputs.artifacts_path}}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 #v2.10.0
 
     - name: Login to Docker
       shell: bash
       run: docker login -u publisher -p ${{ inputs.github_token }} ghcr.io
 
     - name: Docker Build linux-x64 and linux-arm64 images
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
       with:
         push: true
         tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot

--- a/.github/actions/publish-debug-symbols/action.yml
+++ b/.github/actions/publish-debug-symbols/action.yml
@@ -19,13 +19,13 @@ runs:
   steps:
     # datadog-ci needs the version 20 (https://github.com/DataDog/profiling-backend/blob/prod/debug-symbol-upload/Dockerfile#L6)
     - name: Install Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: 20
 
     # Use the same go version as in https://github.com/DataDog/profiling-backend/blob/prod/debug-symbol-upload/Dockerfile#L21
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: '^1.22.3'
 

--- a/.github/workflows/create_skip_code_freeze.yml
+++ b/.github/workflows/create_skip_code_freeze.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     
     steps:
-      - uses: octokit/request-action@v2.x
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
         name: 'Open Skip Milestone'
         with:
           route: PATCH /repos/{owner}/{repo}/milestones/2


### PR DESCRIPTION
## Summary of changes

Pins the action used inside our custom actions to sha

## Reason for change

We pinned all the actions that are used in workflows, but we should pin the ones used in actions too

## Implementation details

- Check what the current version is, grab the sha, use it
- Didn't update the version at all, just used whatever we're _currently_ pinned to

## Test coverage

Nope
