### PR TITLE
[Test Optimization] Add missing `test_session` metric

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/AWSCodePipelineEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/AWSCodePipelineEnvironmentValues.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -17,6 +18,7 @@ internal sealed class AWSCodePipelineEnvironmentValues<TValueProvider>(TValuePro
 
         IsCI = true;
         Provider = "awscodepipeline";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.AwsCodePipeline;
         PipelineId = ValueProvider.GetValue(Constants.AWSCodePipelineId);
 
         VariablesToBypass = new Dictionary<string, string?>();

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/AppveyorEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/AppveyorEnvironmentValues.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Telemetry.Metrics;
+
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class AppveyorEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
@@ -15,6 +17,7 @@ internal sealed class AppveyorEnvironmentValues<TValueProvider>(TValueProvider v
 
         IsCI = true;
         Provider = "appveyor";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.AppVeyor;
         var repoProvider = ValueProvider.GetValue(Constants.AppveyorRepoProvider);
         if (repoProvider == "github")
         {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/AzurePipelinesEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/AzurePipelinesEnvironmentValues.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -17,6 +18,7 @@ internal sealed class AzurePipelinesEnvironmentValues<TValueProvider>(TValueProv
 
         IsCI = true;
         Provider = "azurepipelines";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.AzurePipelines;
         SourceRoot = ValueProvider.GetValue(Constants.AzureBuildSourcesDirectory);
         WorkspacePath = ValueProvider.GetValue(Constants.AzureBuildSourcesDirectory);
         PipelineId = ValueProvider.GetValue(Constants.AzureBuildBuildId);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitbucketEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitbucketEnvironmentValues.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Telemetry.Metrics;
+
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class BitbucketEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
@@ -15,6 +17,7 @@ internal sealed class BitbucketEnvironmentValues<TValueProvider>(TValueProvider 
 
         IsCI = true;
         Provider = "bitbucket";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.BitBucket;
         Repository = ValueProvider.GetValue(Constants.BitBucketGitSshOrigin);
         if (string.IsNullOrEmpty(Repository))
         {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitriseEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BitriseEnvironmentValues.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Telemetry.Metrics;
+
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class BitriseEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
@@ -15,6 +17,7 @@ internal sealed class BitriseEnvironmentValues<TValueProvider>(TValueProvider va
 
         IsCI = true;
         Provider = "bitrise";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.Bitrise;
         Repository = ValueProvider.GetValue(Constants.BitriseGitRepositoryUrl);
 
         var prCommit = ValueProvider.GetValue(Constants.BitriseGitCommit);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuddyEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuddyEnvironmentValues.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Telemetry.Metrics;
+
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class BuddyEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
@@ -15,6 +17,7 @@ internal sealed class BuddyEnvironmentValues<TValueProvider>(TValueProvider valu
 
         IsCI = true;
         Provider = "buddy";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.BuddyCi;
         Repository = ValueProvider.GetValue(Constants.BuddyScmUrl);
         Commit = ValueProvider.GetValue(Constants.BuddyExecutionRevision);
         Branch = ValueProvider.GetValue(Constants.BuddyExecutionBranch);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuildkiteEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/BuildkiteEnvironmentValues.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -19,6 +20,7 @@ internal sealed class BuildkiteEnvironmentValues<TValueProvider>(TValueProvider 
 
         IsCI = true;
         Provider = "buildkite";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.BuildKite;
         Repository = ValueProvider.GetValue(Constants.BuildKiteRepo);
         Commit = ValueProvider.GetValue(Constants.BuildKiteCommit);
         Branch = ValueProvider.GetValue(Constants.BuildKiteBranch);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -94,6 +95,8 @@ internal abstract class CIEnvironmentValues
     public CodeOwners? CodeOwners { get; protected set; }
 
     public Dictionary<string, string?>? VariablesToBypass { get; protected set; }
+
+    public MetricTags.CIVisibilityTestSessionProvider MetricTag { get; protected set; } = MetricTags.CIVisibilityTestSessionProvider.Unsupported;
 
     public static CIEnvironmentValues Create()
     {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CircleCiEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CircleCiEnvironmentValues.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -17,6 +18,7 @@ internal sealed class CircleCiEnvironmentValues<TValueProvider>(TValueProvider v
 
         IsCI = true;
         Provider = "circleci";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.CircleCI;
         Repository = ValueProvider.GetValue(Constants.CircleCIRepositoryUrl);
         Commit = ValueProvider.GetValue(Constants.CircleCISha);
         Tag = ValueProvider.GetValue(Constants.CircleCITag);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CodefreshEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CodefreshEnvironmentValues.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -17,6 +18,7 @@ internal sealed class CodefreshEnvironmentValues<TValueProvider>(TValueProvider 
 
         IsCI = true;
         Provider = "codefresh";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.Codefresh;
         PipelineId = ValueProvider.GetValue(Constants.CodefreshBuildId);
         PipelineName = ValueProvider.GetValue(Constants.CodefreshPipelineName);
         PipelineUrl = ValueProvider.GetValue(Constants.CodefreshBuildUrl);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
@@ -20,6 +21,7 @@ internal sealed class GithubActionsEnvironmentValues<TValueProvider>(TValueProvi
 
         IsCI = true;
         Provider = "github";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.GithubActions;
 
         var serverUrl = ValueProvider.GetValue(Constants.GitHubServerUrl);
         if (string.IsNullOrWhiteSpace(serverUrl))

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitlabEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitlabEnvironmentValues.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -18,6 +19,7 @@ internal sealed class GitlabEnvironmentValues<TValueProvider>(TValueProvider val
 
         IsCI = true;
         Provider = "gitlab";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.Gitlab;
         Repository = ValueProvider.GetValue(Constants.GitlabRepositoryUrl);
         Commit = ValueProvider.GetValue(Constants.GitlabCommitSha);
         Branch = ValueProvider.GetValue(Constants.GitlabCommitBranch);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/JenkinsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/JenkinsEnvironmentValues.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -18,6 +19,7 @@ internal sealed class JenkinsEnvironmentValues<TValueProvider>(TValueProvider va
 
         IsCI = true;
         Provider = "jenkins";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.Jenkins;
         Repository = ValueProvider.GetValue(Constants.JenkinsGitUrl);
         if (string.IsNullOrEmpty(Repository))
         {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/TeamcityEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/TeamcityEnvironmentValues.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Telemetry.Metrics;
+
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class TeamcityEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
@@ -15,6 +17,7 @@ internal sealed class TeamcityEnvironmentValues<TValueProvider>(TValueProvider v
 
         IsCI = true;
         Provider = "teamcity";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.Teamcity;
         JobName = ValueProvider.GetValue(Constants.TeamCityBuildConfName);
         JobUrl = ValueProvider.GetValue(Constants.TeamCityBuildUrl);
     }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/TravisEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/TravisEnvironmentValues.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Telemetry.Metrics;
+
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class TravisEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
@@ -15,6 +17,7 @@ internal sealed class TravisEnvironmentValues<TValueProvider>(TValueProvider val
 
         IsCI = true;
         Provider = "travisci";
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.TravisCi;
 
         var prSlug = ValueProvider.GetValue(Constants.TravisPullRequestSlug);
         var repoSlug = !string.IsNullOrEmpty(prSlug) ? prSlug : ValueProvider.GetValue(Constants.TravisRepoSlug);

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
@@ -7,6 +7,7 @@
 using System;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Pdb;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Ci.CiEnvironment;
 
@@ -16,6 +17,7 @@ internal sealed class UnsupportedCIEnvironmentValues<TValueProvider>(TValueProvi
     protected override void OnInitialize(IGitInfo gitInfo)
     {
         Log.Information("CIEnvironmentValues: CI could not be detected, using the git folder: {GitFolder}", gitInfo.SourceRoot);
+        MetricTag = MetricTags.CIVisibilityTestSessionProvider.Unsupported;
         Branch = gitInfo.Branch;
         Commit = gitInfo.Commit;
         Repository = gitInfo.Repository;

--- a/tracer/src/Datadog.Trace/Ci/Tags/TestSuiteVisibilityTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/TestSuiteVisibilityTags.cs
@@ -32,4 +32,9 @@ internal static class TestSuiteVisibilityTags
     /// Test session working directory environment variable
     /// </summary>
     public const string TestSessionWorkingDirectoryEnvironmentVariable = "DD_TESTSESSION_WORKINGDIRECTORY";
+
+    /// <summary>
+    /// Test session auto injected environment variable
+    /// </summary>
+    public const string TestSessionAutoInjectedEnvironmentVariable = "DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER";
 }

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -102,20 +102,25 @@ public sealed class TestSession
             OpenedTestSessions.Add(this);
         }
 
-        _testOptimization.Log.Debug("### Test Session Created: {Command}", command);
-
-        if (startDate is null)
-        {
-            // If a module doesn't have a fixed start time we reset it before running code
-            span.ResetStartTime();
-        }
-
         // Record EventCreate telemetry metric
         if (TelemetryHelper.GetEventTypeWithCodeOwnerAndSupportedCiAndBenchmark(
                 MetricTags.CIVisibilityTestingEventType.Session,
                 framework == CommonTags.TestingFrameworkNameBenchmarkDotNet) is { } eventTypeWithMetadata)
         {
             TelemetryFactory.Metrics.RecordCountCIVisibilityEventCreated(TelemetryHelper.GetTelemetryTestingFrameworkEnum(framework), eventTypeWithMetadata);
+        }
+
+        TelemetryFactory.Metrics.RecordCountCIVisibilityTestSession(
+            _testOptimization.CIValues.MetricTag,
+            EnvironmentHelpers.GetEnvironmentVariable(TestSuiteVisibilityTags.TestSessionAutoInjectedEnvironmentVariable)?.ToBoolean() is true ? MetricTags.CIVisibilityTestSessionType.AutoInjected : MetricTags.CIVisibilityTestSessionType.NotAutoInjected,
+            _testOptimization.Settings.Logs ? MetricTags.CIVisibilityTestSessionAgentlessLogSubmission.Enabled : MetricTags.CIVisibilityTestSessionAgentlessLogSubmission.NotEnabled);
+
+        _testOptimization.Log.Debug("### Test Session Created: {Command}", command);
+
+        if (startDate is null)
+        {
+            // If a module doesn't have a fixed start time we reset it before running code
+            span.ResetStartTime();
         }
     }
 

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -110,9 +110,13 @@ public sealed class TestSession
             TelemetryFactory.Metrics.RecordCountCIVisibilityEventCreated(TelemetryHelper.GetTelemetryTestingFrameworkEnum(framework), eventTypeWithMetadata);
         }
 
+        var sessionTypeTag = EnvironmentHelpers.GetEnvironmentVariable(TestSuiteVisibilityTags.TestSessionAutoInjectedEnvironmentVariable)?.ToBoolean() is true ?
+                                 MetricTags.CIVisibilityTestSessionType.AutoInjected :
+                                 MetricTags.CIVisibilityTestSessionType.NotAutoInjected;
+
         TelemetryFactory.Metrics.RecordCountCIVisibilityTestSession(
             _testOptimization.CIValues.MetricTag,
-            EnvironmentHelpers.GetEnvironmentVariable(TestSuiteVisibilityTags.TestSessionAutoInjectedEnvironmentVariable)?.ToBoolean() is true ? MetricTags.CIVisibilityTestSessionType.AutoInjected : MetricTags.CIVisibilityTestSessionType.NotAutoInjected,
+            sessionTypeTag,
             _testOptimization.Settings.Logs ? MetricTags.CIVisibilityTestSessionAgentlessLogSubmission.Enabled : MetricTags.CIVisibilityTestSessionAgentlessLogSubmission.NotEnabled);
 
         _testOptimization.Log.Debug("### Test Session Created: {Command}", command);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3055;
+    private const int CountCIVisibilityLength = 3115;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -2761,7 +2761,68 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true", "has_failed_all_retries:true" }),
-            // code_coverage_started, index = 2740
+            // test_session, index = 2740
+            new(new[] { "provider:unsupported" }),
+            new(new[] { "provider:unsupported", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor" }),
+            new(new[] { "provider:appveyor", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp" }),
+            new(new[] { "provider:azp", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp", "auto_injected:true" }),
+            new(new[] { "provider:azp", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket" }),
+            new(new[] { "provider:bitbucket", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise" }),
+            new(new[] { "provider:bitrise", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite" }),
+            new(new[] { "provider:buildkite", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci" }),
+            new(new[] { "provider:circleci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh" }),
+            new(new[] { "provider:codefresh", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions" }),
+            new(new[] { "provider:githubactions", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab" }),
+            new(new[] { "provider:gitlab", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins" }),
+            new(new[] { "provider:jenkins", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity" }),
+            new(new[] { "provider:teamcity", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci" }),
+            new(new[] { "provider:travisci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci" }),
+            new(new[] { "provider:buddyci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws" }),
+            new(new[] { "provider:aws", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws", "auto_injected:true" }),
+            new(new[] { "provider:aws", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            // code_coverage_started, index = 2800
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2772,7 +2833,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // code_coverage_finished, index = 2750
+            // code_coverage_finished, index = 2810
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2783,19 +2844,19 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // manual_api_events, index = 2760
+            // manual_api_events, index = 2820
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // events_enqueued_for_serialization, index = 2764
+            // events_enqueued_for_serialization, index = 2824
             new(null),
-            // endpoint_payload.requests, index = 2765
+            // endpoint_payload.requests, index = 2825
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:test_cycle", "rq_compressed:true" }),
             new(new[] { "endpoint:code_coverage" }),
             new(new[] { "endpoint:code_coverage", "rq_compressed:true" }),
-            // endpoint_payload.requests_errors, index = 2769
+            // endpoint_payload.requests_errors, index = 2829
             new(new[] { "endpoint:test_cycle", "error_type:timeout" }),
             new(new[] { "endpoint:test_cycle", "error_type:network" }),
             new(new[] { "endpoint:test_cycle", "error_type:status_code" }),
@@ -2818,10 +2879,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:429" }),
-            // endpoint_payload.dropped, index = 2791
+            // endpoint_payload.dropped, index = 2851
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:code_coverage" }),
-            // git.command, index = 2793
+            // git.command, index = 2853
             new(new[] { "command:get_repository" }),
             new(new[] { "command:get_branch" }),
             new(new[] { "command:get_remote" }),
@@ -2832,7 +2893,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
             new(new[] { "command:diff" }),
-            // git.command_errors, index = 2803
+            // git.command_errors, index = 2863
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -2913,10 +2974,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:diff", "exit_code:127" }),
             new(new[] { "command:diff", "exit_code:128" }),
             new(new[] { "command:diff", "exit_code:129" }),
-            // git_requests.search_commits, index = 2883
+            // git_requests.search_commits, index = 2943
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 2885
+            // git_requests.search_commits_errors, index = 2945
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2928,10 +2989,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 2896
+            // git_requests.objects_pack, index = 2956
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 2898
+            // git_requests.objects_pack_errors, index = 2958
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2943,10 +3004,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 2909
+            // git_requests.settings, index = 2969
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 2911
+            // git_requests.settings_errors, index = 2971
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2958,7 +3019,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 2922
+            // git_requests.settings_response, index = 2982
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
@@ -3023,10 +3084,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:false" }),
-            // itr_skippable_tests.request, index = 2986
+            // itr_skippable_tests.request, index = 3046
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 2988
+            // itr_skippable_tests.request_errors, index = 3048
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3038,33 +3099,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 2999
+            // itr_skippable_tests.response_tests, index = 3059
             new(null),
-            // itr_skippable_tests.response_suites, index = 3000
+            // itr_skippable_tests.response_suites, index = 3060
             new(null),
-            // itr_skipped, index = 3001
+            // itr_skipped, index = 3061
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 3005
+            // itr_unskippable, index = 3065
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 3009
+            // itr_forced_run, index = 3069
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 3013
+            // code_coverage.is_empty, index = 3073
             new(null),
-            // code_coverage.errors, index = 3014
+            // code_coverage.errors, index = 3074
             new(null),
-            // known_tests.request, index = 3015
+            // known_tests.request, index = 3075
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // known_tests.request_errors, index = 3017
+            // known_tests.request_errors, index = 3077
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3076,10 +3137,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.request, index = 3028
+            // impacted_tests_detection.request, index = 3088
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // impacted_tests_detection.request_errors, index = 3030
+            // impacted_tests_detection.request_errors, index = 3090
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3091,12 +3152,12 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.is_modified, index = 3041
+            // impacted_tests_detection.is_modified, index = 3101
             new(null),
-            // test_management_tests.request, index = 3042
+            // test_management_tests.request, index = 3102
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // test_management_tests.request_errors, index = 3044
+            // test_management_tests.request_errors, index = 3104
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3116,7 +3177,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 60, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3130,189 +3191,195 @@ internal partial class CiVisibilityMetricsTelemetryCollector
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+        var index = 2740 + ((int)tag1 * 4) + ((int)tag2 * 2) + (int)tag3;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2740 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2800 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2750 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2810 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 2760 + (int)tag;
+        var index = 2820 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2764], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[2824], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpointAndCompression tag, int increment = 1)
     {
-        var index = 2765 + (int)tag;
+        var index = 2825 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
-        var index = 2769 + ((int)tag1 * 11) + (int)tag2;
+        var index = 2829 + ((int)tag1 * 11) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
-        var index = 2791 + (int)tag;
+        var index = 2851 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
-        var index = 2793 + (int)tag;
+        var index = 2853 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 2803 + ((int)tag1 * 8) + (int)tag2;
+        var index = 2863 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2883 + (int)tag;
+        var index = 2943 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2885 + (int)tag;
+        var index = 2945 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2896 + (int)tag;
+        var index = 2956 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2898 + (int)tag;
+        var index = 2958 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2909 + (int)tag;
+        var index = 2969 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2911 + (int)tag;
+        var index = 2971 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_CoverageFeature tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_ItrSkippingFeature tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_KnownTestsFeature tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_EarlyFlakeDetectionFeature tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_FlakyTestRetriesFeature tag5, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_TestManagementFeature tag6, int increment = 1)
     {
-        var index = 2922 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
+        var index = 2982 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2986 + (int)tag;
+        var index = 3046 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2988 + (int)tag;
+        var index = 3048 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2999], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3059], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3000], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3060], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3001 + (int)tag;
+        var index = 3061 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3005 + (int)tag;
+        var index = 3065 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3009 + (int)tag;
+        var index = 3069 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3013], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3073], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3014], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3074], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3015 + (int)tag;
+        var index = 3075 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3017 + (int)tag;
+        var index = 3077 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3028 + (int)tag;
+        var index = 3088 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3030 + (int)tag;
+        var index = 3090 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3041], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3101], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3042 + (int)tag;
+        var index = 3102 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3044 + (int)tag;
+        var index = 3104 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -24,6 +24,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "event_created",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "event_finished",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "test_session",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "code_coverage_started",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "code_coverage_finished",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "manual_api_events",
@@ -80,6 +81,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "civisibility",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -13,6 +13,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmarkAndEarlyFlakeDetectionAndRum tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeRetryReason tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementQuarantinedOrDisabled tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementAttemptToFix tag5, int increment = 1);
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1);
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class MetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3055;
+    private const int CountCIVisibilityLength = 3115;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -2761,7 +2761,68 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true", "has_failed_all_retries:true" }),
-            // code_coverage_started, index = 2740
+            // test_session, index = 2740
+            new(new[] { "provider:unsupported" }),
+            new(new[] { "provider:unsupported", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor" }),
+            new(new[] { "provider:appveyor", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp" }),
+            new(new[] { "provider:azp", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp", "auto_injected:true" }),
+            new(new[] { "provider:azp", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket" }),
+            new(new[] { "provider:bitbucket", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise" }),
+            new(new[] { "provider:bitrise", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite" }),
+            new(new[] { "provider:buildkite", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci" }),
+            new(new[] { "provider:circleci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh" }),
+            new(new[] { "provider:codefresh", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions" }),
+            new(new[] { "provider:githubactions", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab" }),
+            new(new[] { "provider:gitlab", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins" }),
+            new(new[] { "provider:jenkins", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity" }),
+            new(new[] { "provider:teamcity", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci" }),
+            new(new[] { "provider:travisci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci" }),
+            new(new[] { "provider:buddyci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws" }),
+            new(new[] { "provider:aws", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws", "auto_injected:true" }),
+            new(new[] { "provider:aws", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            // code_coverage_started, index = 2800
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2772,7 +2833,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // code_coverage_finished, index = 2750
+            // code_coverage_finished, index = 2810
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2783,19 +2844,19 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // manual_api_events, index = 2760
+            // manual_api_events, index = 2820
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // events_enqueued_for_serialization, index = 2764
+            // events_enqueued_for_serialization, index = 2824
             new(null),
-            // endpoint_payload.requests, index = 2765
+            // endpoint_payload.requests, index = 2825
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:test_cycle", "rq_compressed:true" }),
             new(new[] { "endpoint:code_coverage" }),
             new(new[] { "endpoint:code_coverage", "rq_compressed:true" }),
-            // endpoint_payload.requests_errors, index = 2769
+            // endpoint_payload.requests_errors, index = 2829
             new(new[] { "endpoint:test_cycle", "error_type:timeout" }),
             new(new[] { "endpoint:test_cycle", "error_type:network" }),
             new(new[] { "endpoint:test_cycle", "error_type:status_code" }),
@@ -2818,10 +2879,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:429" }),
-            // endpoint_payload.dropped, index = 2791
+            // endpoint_payload.dropped, index = 2851
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:code_coverage" }),
-            // git.command, index = 2793
+            // git.command, index = 2853
             new(new[] { "command:get_repository" }),
             new(new[] { "command:get_branch" }),
             new(new[] { "command:get_remote" }),
@@ -2832,7 +2893,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
             new(new[] { "command:diff" }),
-            // git.command_errors, index = 2803
+            // git.command_errors, index = 2863
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -2913,10 +2974,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:diff", "exit_code:127" }),
             new(new[] { "command:diff", "exit_code:128" }),
             new(new[] { "command:diff", "exit_code:129" }),
-            // git_requests.search_commits, index = 2883
+            // git_requests.search_commits, index = 2943
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 2885
+            // git_requests.search_commits_errors, index = 2945
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2928,10 +2989,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 2896
+            // git_requests.objects_pack, index = 2956
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 2898
+            // git_requests.objects_pack_errors, index = 2958
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2943,10 +3004,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 2909
+            // git_requests.settings, index = 2969
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 2911
+            // git_requests.settings_errors, index = 2971
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2958,7 +3019,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 2922
+            // git_requests.settings_response, index = 2982
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
@@ -3023,10 +3084,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:false" }),
-            // itr_skippable_tests.request, index = 2986
+            // itr_skippable_tests.request, index = 3046
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 2988
+            // itr_skippable_tests.request_errors, index = 3048
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3038,33 +3099,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 2999
+            // itr_skippable_tests.response_tests, index = 3059
             new(null),
-            // itr_skippable_tests.response_suites, index = 3000
+            // itr_skippable_tests.response_suites, index = 3060
             new(null),
-            // itr_skipped, index = 3001
+            // itr_skipped, index = 3061
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 3005
+            // itr_unskippable, index = 3065
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 3009
+            // itr_forced_run, index = 3069
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 3013
+            // code_coverage.is_empty, index = 3073
             new(null),
-            // code_coverage.errors, index = 3014
+            // code_coverage.errors, index = 3074
             new(null),
-            // known_tests.request, index = 3015
+            // known_tests.request, index = 3075
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // known_tests.request_errors, index = 3017
+            // known_tests.request_errors, index = 3077
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3076,10 +3137,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.request, index = 3028
+            // impacted_tests_detection.request, index = 3088
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // impacted_tests_detection.request_errors, index = 3030
+            // impacted_tests_detection.request_errors, index = 3090
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3091,12 +3152,12 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.is_modified, index = 3041
+            // impacted_tests_detection.is_modified, index = 3101
             new(null),
-            // test_management_tests.request, index = 3042
+            // test_management_tests.request, index = 3102
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // test_management_tests.request_errors, index = 3044
+            // test_management_tests.request_errors, index = 3104
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3116,7 +3177,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 60, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3130,189 +3191,195 @@ internal partial class CiVisibilityMetricsTelemetryCollector
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+        var index = 2740 + ((int)tag1 * 4) + ((int)tag2 * 2) + (int)tag3;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2740 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2800 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2750 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2810 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 2760 + (int)tag;
+        var index = 2820 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2764], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[2824], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpointAndCompression tag, int increment = 1)
     {
-        var index = 2765 + (int)tag;
+        var index = 2825 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
-        var index = 2769 + ((int)tag1 * 11) + (int)tag2;
+        var index = 2829 + ((int)tag1 * 11) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
-        var index = 2791 + (int)tag;
+        var index = 2851 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
-        var index = 2793 + (int)tag;
+        var index = 2853 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 2803 + ((int)tag1 * 8) + (int)tag2;
+        var index = 2863 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2883 + (int)tag;
+        var index = 2943 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2885 + (int)tag;
+        var index = 2945 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2896 + (int)tag;
+        var index = 2956 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2898 + (int)tag;
+        var index = 2958 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2909 + (int)tag;
+        var index = 2969 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2911 + (int)tag;
+        var index = 2971 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_CoverageFeature tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_ItrSkippingFeature tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_KnownTestsFeature tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_EarlyFlakeDetectionFeature tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_FlakyTestRetriesFeature tag5, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_TestManagementFeature tag6, int increment = 1)
     {
-        var index = 2922 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
+        var index = 2982 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2986 + (int)tag;
+        var index = 3046 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2988 + (int)tag;
+        var index = 3048 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2999], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3059], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3000], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3060], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3001 + (int)tag;
+        var index = 3061 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3005 + (int)tag;
+        var index = 3065 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3009 + (int)tag;
+        var index = 3069 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3013], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3073], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3014], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3074], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3015 + (int)tag;
+        var index = 3075 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3017 + (int)tag;
+        var index = 3077 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3028 + (int)tag;
+        var index = 3088 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3030 + (int)tag;
+        var index = 3090 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3041], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3101], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3042 + (int)tag;
+        var index = 3102 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3044 + (int)tag;
+        var index = 3104 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -24,6 +24,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "event_created",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "event_finished",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "test_session",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "code_coverage_started",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "code_coverage_finished",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "manual_api_events",
@@ -80,6 +81,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "civisibility",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -13,6 +13,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmarkAndEarlyFlakeDetectionAndRum tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeRetryReason tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementQuarantinedOrDisabled tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementAttemptToFix tag5, int increment = 1);
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1);
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class MetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3055;
+    private const int CountCIVisibilityLength = 3115;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -2761,7 +2761,68 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true", "has_failed_all_retries:true" }),
-            // code_coverage_started, index = 2740
+            // test_session, index = 2740
+            new(new[] { "provider:unsupported" }),
+            new(new[] { "provider:unsupported", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor" }),
+            new(new[] { "provider:appveyor", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp" }),
+            new(new[] { "provider:azp", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp", "auto_injected:true" }),
+            new(new[] { "provider:azp", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket" }),
+            new(new[] { "provider:bitbucket", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise" }),
+            new(new[] { "provider:bitrise", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite" }),
+            new(new[] { "provider:buildkite", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci" }),
+            new(new[] { "provider:circleci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh" }),
+            new(new[] { "provider:codefresh", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions" }),
+            new(new[] { "provider:githubactions", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab" }),
+            new(new[] { "provider:gitlab", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins" }),
+            new(new[] { "provider:jenkins", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity" }),
+            new(new[] { "provider:teamcity", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci" }),
+            new(new[] { "provider:travisci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci" }),
+            new(new[] { "provider:buddyci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws" }),
+            new(new[] { "provider:aws", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws", "auto_injected:true" }),
+            new(new[] { "provider:aws", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            // code_coverage_started, index = 2800
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2772,7 +2833,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // code_coverage_finished, index = 2750
+            // code_coverage_finished, index = 2810
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2783,19 +2844,19 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // manual_api_events, index = 2760
+            // manual_api_events, index = 2820
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // events_enqueued_for_serialization, index = 2764
+            // events_enqueued_for_serialization, index = 2824
             new(null),
-            // endpoint_payload.requests, index = 2765
+            // endpoint_payload.requests, index = 2825
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:test_cycle", "rq_compressed:true" }),
             new(new[] { "endpoint:code_coverage" }),
             new(new[] { "endpoint:code_coverage", "rq_compressed:true" }),
-            // endpoint_payload.requests_errors, index = 2769
+            // endpoint_payload.requests_errors, index = 2829
             new(new[] { "endpoint:test_cycle", "error_type:timeout" }),
             new(new[] { "endpoint:test_cycle", "error_type:network" }),
             new(new[] { "endpoint:test_cycle", "error_type:status_code" }),
@@ -2818,10 +2879,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:429" }),
-            // endpoint_payload.dropped, index = 2791
+            // endpoint_payload.dropped, index = 2851
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:code_coverage" }),
-            // git.command, index = 2793
+            // git.command, index = 2853
             new(new[] { "command:get_repository" }),
             new(new[] { "command:get_branch" }),
             new(new[] { "command:get_remote" }),
@@ -2832,7 +2893,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
             new(new[] { "command:diff" }),
-            // git.command_errors, index = 2803
+            // git.command_errors, index = 2863
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -2913,10 +2974,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:diff", "exit_code:127" }),
             new(new[] { "command:diff", "exit_code:128" }),
             new(new[] { "command:diff", "exit_code:129" }),
-            // git_requests.search_commits, index = 2883
+            // git_requests.search_commits, index = 2943
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 2885
+            // git_requests.search_commits_errors, index = 2945
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2928,10 +2989,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 2896
+            // git_requests.objects_pack, index = 2956
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 2898
+            // git_requests.objects_pack_errors, index = 2958
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2943,10 +3004,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 2909
+            // git_requests.settings, index = 2969
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 2911
+            // git_requests.settings_errors, index = 2971
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2958,7 +3019,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 2922
+            // git_requests.settings_response, index = 2982
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
@@ -3023,10 +3084,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:false" }),
-            // itr_skippable_tests.request, index = 2986
+            // itr_skippable_tests.request, index = 3046
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 2988
+            // itr_skippable_tests.request_errors, index = 3048
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3038,33 +3099,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 2999
+            // itr_skippable_tests.response_tests, index = 3059
             new(null),
-            // itr_skippable_tests.response_suites, index = 3000
+            // itr_skippable_tests.response_suites, index = 3060
             new(null),
-            // itr_skipped, index = 3001
+            // itr_skipped, index = 3061
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 3005
+            // itr_unskippable, index = 3065
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 3009
+            // itr_forced_run, index = 3069
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 3013
+            // code_coverage.is_empty, index = 3073
             new(null),
-            // code_coverage.errors, index = 3014
+            // code_coverage.errors, index = 3074
             new(null),
-            // known_tests.request, index = 3015
+            // known_tests.request, index = 3075
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // known_tests.request_errors, index = 3017
+            // known_tests.request_errors, index = 3077
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3076,10 +3137,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.request, index = 3028
+            // impacted_tests_detection.request, index = 3088
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // impacted_tests_detection.request_errors, index = 3030
+            // impacted_tests_detection.request_errors, index = 3090
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3091,12 +3152,12 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.is_modified, index = 3041
+            // impacted_tests_detection.is_modified, index = 3101
             new(null),
-            // test_management_tests.request, index = 3042
+            // test_management_tests.request, index = 3102
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // test_management_tests.request_errors, index = 3044
+            // test_management_tests.request_errors, index = 3104
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3116,7 +3177,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 60, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3130,189 +3191,195 @@ internal partial class CiVisibilityMetricsTelemetryCollector
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+        var index = 2740 + ((int)tag1 * 4) + ((int)tag2 * 2) + (int)tag3;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2740 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2800 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2750 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2810 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 2760 + (int)tag;
+        var index = 2820 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2764], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[2824], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpointAndCompression tag, int increment = 1)
     {
-        var index = 2765 + (int)tag;
+        var index = 2825 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
-        var index = 2769 + ((int)tag1 * 11) + (int)tag2;
+        var index = 2829 + ((int)tag1 * 11) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
-        var index = 2791 + (int)tag;
+        var index = 2851 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
-        var index = 2793 + (int)tag;
+        var index = 2853 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 2803 + ((int)tag1 * 8) + (int)tag2;
+        var index = 2863 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2883 + (int)tag;
+        var index = 2943 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2885 + (int)tag;
+        var index = 2945 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2896 + (int)tag;
+        var index = 2956 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2898 + (int)tag;
+        var index = 2958 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2909 + (int)tag;
+        var index = 2969 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2911 + (int)tag;
+        var index = 2971 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_CoverageFeature tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_ItrSkippingFeature tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_KnownTestsFeature tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_EarlyFlakeDetectionFeature tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_FlakyTestRetriesFeature tag5, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_TestManagementFeature tag6, int increment = 1)
     {
-        var index = 2922 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
+        var index = 2982 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2986 + (int)tag;
+        var index = 3046 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2988 + (int)tag;
+        var index = 3048 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2999], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3059], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3000], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3060], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3001 + (int)tag;
+        var index = 3061 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3005 + (int)tag;
+        var index = 3065 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3009 + (int)tag;
+        var index = 3069 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3013], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3073], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3014], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3074], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3015 + (int)tag;
+        var index = 3075 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3017 + (int)tag;
+        var index = 3077 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3028 + (int)tag;
+        var index = 3088 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3030 + (int)tag;
+        var index = 3090 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3041], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3101], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3042 + (int)tag;
+        var index = 3102 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3044 + (int)tag;
+        var index = 3104 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -24,6 +24,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "event_created",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "event_finished",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "test_session",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "code_coverage_started",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "code_coverage_finished",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "manual_api_events",
@@ -80,6 +81,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "civisibility",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -13,6 +13,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmarkAndEarlyFlakeDetectionAndRum tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeRetryReason tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementQuarantinedOrDisabled tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementAttemptToFix tag5, int increment = 1);
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1);
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class MetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3055;
+    private const int CountCIVisibilityLength = 3115;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -2761,7 +2761,68 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true" }),
             new(new[] { "test_framework:unknown", "event_type:test", "is_new:true", "early_flake_detection_abort_reason:slow", "browser_driver:selenium", "is_rum:true", "retry_reason:atr", "is_disabled:true", "is_attempt_to_fix:true", "has_failed_all_retries:true" }),
-            // code_coverage_started, index = 2740
+            // test_session, index = 2740
+            new(new[] { "provider:unsupported" }),
+            new(new[] { "provider:unsupported", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true" }),
+            new(new[] { "provider:unsupported", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor" }),
+            new(new[] { "provider:appveyor", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true" }),
+            new(new[] { "provider:appveyor", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp" }),
+            new(new[] { "provider:azp", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:azp", "auto_injected:true" }),
+            new(new[] { "provider:azp", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket" }),
+            new(new[] { "provider:bitbucket", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true" }),
+            new(new[] { "provider:bitbucket", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise" }),
+            new(new[] { "provider:bitrise", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true" }),
+            new(new[] { "provider:bitrise", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite" }),
+            new(new[] { "provider:buildkite", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true" }),
+            new(new[] { "provider:buildkite", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci" }),
+            new(new[] { "provider:circleci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true" }),
+            new(new[] { "provider:circleci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh" }),
+            new(new[] { "provider:codefresh", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true" }),
+            new(new[] { "provider:codefresh", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions" }),
+            new(new[] { "provider:githubactions", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true" }),
+            new(new[] { "provider:githubactions", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab" }),
+            new(new[] { "provider:gitlab", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true" }),
+            new(new[] { "provider:gitlab", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins" }),
+            new(new[] { "provider:jenkins", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true" }),
+            new(new[] { "provider:jenkins", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity" }),
+            new(new[] { "provider:teamcity", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true" }),
+            new(new[] { "provider:teamcity", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci" }),
+            new(new[] { "provider:travisci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true" }),
+            new(new[] { "provider:travisci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci" }),
+            new(new[] { "provider:buddyci", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true" }),
+            new(new[] { "provider:buddyci", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws" }),
+            new(new[] { "provider:aws", "agentless_log_submission_enabled:true" }),
+            new(new[] { "provider:aws", "auto_injected:true" }),
+            new(new[] { "provider:aws", "auto_injected:true", "agentless_log_submission_enabled:true" }),
+            // code_coverage_started, index = 2800
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2772,7 +2833,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // code_coverage_finished, index = 2750
+            // code_coverage_finished, index = 2810
             new(new[] { "test_framework:xunit", "library:custom" }),
             new(new[] { "test_framework:xunit", "library:unknown" }),
             new(new[] { "test_framework:nunit", "library:custom" }),
@@ -2783,19 +2844,19 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "test_framework:benchmarkdotnet", "library:unknown" }),
             new(new[] { "test_framework:unknown", "library:custom" }),
             new(new[] { "test_framework:unknown", "library:unknown" }),
-            // manual_api_events, index = 2760
+            // manual_api_events, index = 2820
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // events_enqueued_for_serialization, index = 2764
+            // events_enqueued_for_serialization, index = 2824
             new(null),
-            // endpoint_payload.requests, index = 2765
+            // endpoint_payload.requests, index = 2825
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:test_cycle", "rq_compressed:true" }),
             new(new[] { "endpoint:code_coverage" }),
             new(new[] { "endpoint:code_coverage", "rq_compressed:true" }),
-            // endpoint_payload.requests_errors, index = 2769
+            // endpoint_payload.requests_errors, index = 2829
             new(new[] { "endpoint:test_cycle", "error_type:timeout" }),
             new(new[] { "endpoint:test_cycle", "error_type:network" }),
             new(new[] { "endpoint:test_cycle", "error_type:status_code" }),
@@ -2818,10 +2879,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "endpoint:code_coverage", "error_type:status_code_4xx_response", "status_code:429" }),
-            // endpoint_payload.dropped, index = 2791
+            // endpoint_payload.dropped, index = 2851
             new(new[] { "endpoint:test_cycle" }),
             new(new[] { "endpoint:code_coverage" }),
-            // git.command, index = 2793
+            // git.command, index = 2853
             new(new[] { "command:get_repository" }),
             new(new[] { "command:get_branch" }),
             new(new[] { "command:get_remote" }),
@@ -2832,7 +2893,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:get_objects" }),
             new(new[] { "command:pack_objects" }),
             new(new[] { "command:diff" }),
-            // git.command_errors, index = 2803
+            // git.command_errors, index = 2863
             new(new[] { "command:get_repository", "exit_code:missing" }),
             new(new[] { "command:get_repository", "exit_code:unknown" }),
             new(new[] { "command:get_repository", "exit_code:-1" }),
@@ -2913,10 +2974,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "command:diff", "exit_code:127" }),
             new(new[] { "command:diff", "exit_code:128" }),
             new(new[] { "command:diff", "exit_code:129" }),
-            // git_requests.search_commits, index = 2883
+            // git_requests.search_commits, index = 2943
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.search_commits_errors, index = 2885
+            // git_requests.search_commits_errors, index = 2945
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2928,10 +2989,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.objects_pack, index = 2896
+            // git_requests.objects_pack, index = 2956
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.objects_pack_errors, index = 2898
+            // git_requests.objects_pack_errors, index = 2958
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2943,10 +3004,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings, index = 2909
+            // git_requests.settings, index = 2969
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // git_requests.settings_errors, index = 2911
+            // git_requests.settings_errors, index = 2971
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -2958,7 +3019,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // git_requests.settings_response, index = 2922
+            // git_requests.settings_response, index = 2982
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:true", "itrskip_enabled:true", "known_tests_enabled:true", "early_flake_detection_enabled:true", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
@@ -3023,10 +3084,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:true", "test_management_enabled:false" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:true" }),
             new(new[] { "coverage_enabled:false", "itrskip_enabled:false", "known_tests_enabled:false", "early_flake_detection_enabled:false", "flaky_test_retries_enabled:false", "test_management_enabled:false" }),
-            // itr_skippable_tests.request, index = 2986
+            // itr_skippable_tests.request, index = 3046
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // itr_skippable_tests.request_errors, index = 2988
+            // itr_skippable_tests.request_errors, index = 3048
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3038,33 +3099,33 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // itr_skippable_tests.response_tests, index = 2999
+            // itr_skippable_tests.response_tests, index = 3059
             new(null),
-            // itr_skippable_tests.response_suites, index = 3000
+            // itr_skippable_tests.response_suites, index = 3060
             new(null),
-            // itr_skipped, index = 3001
+            // itr_skipped, index = 3061
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_unskippable, index = 3005
+            // itr_unskippable, index = 3065
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // itr_forced_run, index = 3009
+            // itr_forced_run, index = 3069
             new(new[] { "event_type:test" }),
             new(new[] { "event_type:suite" }),
             new(new[] { "event_type:module" }),
             new(new[] { "event_type:session" }),
-            // code_coverage.is_empty, index = 3013
+            // code_coverage.is_empty, index = 3073
             new(null),
-            // code_coverage.errors, index = 3014
+            // code_coverage.errors, index = 3074
             new(null),
-            // known_tests.request, index = 3015
+            // known_tests.request, index = 3075
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // known_tests.request_errors, index = 3017
+            // known_tests.request_errors, index = 3077
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3076,10 +3137,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.request, index = 3028
+            // impacted_tests_detection.request, index = 3088
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // impacted_tests_detection.request_errors, index = 3030
+            // impacted_tests_detection.request_errors, index = 3090
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3091,12 +3152,12 @@ internal partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
-            // impacted_tests_detection.is_modified, index = 3041
+            // impacted_tests_detection.is_modified, index = 3101
             new(null),
-            // test_management_tests.request, index = 3042
+            // test_management_tests.request, index = 3102
             new(null),
             new(new[] { "rq_compressed:true" }),
-            // test_management_tests.request_errors, index = 3044
+            // test_management_tests.request_errors, index = 3104
             new(new[] { "error_type:timeout" }),
             new(new[] { "error_type:network" }),
             new(new[] { "error_type:status_code" }),
@@ -3116,7 +3177,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 60, 10, 10, 4, 1, 4, 22, 2, 10, 80, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3130,189 +3191,195 @@ internal partial class CiVisibilityMetricsTelemetryCollector
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+        var index = 2740 + ((int)tag1 * 4) + ((int)tag2 * 2) + (int)tag3;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2740 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2800 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
-        var index = 2750 + ((int)tag1 * 2) + (int)tag2;
+        var index = 2810 + ((int)tag1 * 2) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 2760 + (int)tag;
+        var index = 2820 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2764], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[2824], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpointAndCompression tag, int increment = 1)
     {
-        var index = 2765 + (int)tag;
+        var index = 2825 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
-        var index = 2769 + ((int)tag1 * 11) + (int)tag2;
+        var index = 2829 + ((int)tag1 * 11) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
-        var index = 2791 + (int)tag;
+        var index = 2851 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
-        var index = 2793 + (int)tag;
+        var index = 2853 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
-        var index = 2803 + ((int)tag1 * 8) + (int)tag2;
+        var index = 2863 + ((int)tag1 * 8) + (int)tag2;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2883 + (int)tag;
+        var index = 2943 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2885 + (int)tag;
+        var index = 2945 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2896 + (int)tag;
+        var index = 2956 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2898 + (int)tag;
+        var index = 2958 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2909 + (int)tag;
+        var index = 2969 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2911 + (int)tag;
+        var index = 2971 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_CoverageFeature tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_ItrSkippingFeature tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_KnownTestsFeature tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_EarlyFlakeDetectionFeature tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_FlakyTestRetriesFeature tag5, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilitySettingsResponse_TestManagementFeature tag6, int increment = 1)
     {
-        var index = 2922 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
+        var index = 2982 + ((int)tag1 * 32) + ((int)tag2 * 16) + ((int)tag3 * 8) + ((int)tag4 * 4) + ((int)tag5 * 2) + (int)tag6;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 2986 + (int)tag;
+        var index = 3046 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 2988 + (int)tag;
+        var index = 3048 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[2999], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3059], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3000], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3060], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3001 + (int)tag;
+        var index = 3061 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3005 + (int)tag;
+        var index = 3065 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
-        var index = 3009 + (int)tag;
+        var index = 3069 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3013], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3073], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3014], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3074], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3015 + (int)tag;
+        var index = 3075 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityKnownTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3017 + (int)tag;
+        var index = 3077 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3028 + (int)tag;
+        var index = 3088 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsDetectionRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3030 + (int)tag;
+        var index = 3090 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityImpactedTestsIsModified(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.CountCIVisibility[3041], increment);
+        Interlocked.Add(ref _buffer.CountCIVisibility[3101], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1)
     {
-        var index = 3042 + (int)tag;
+        var index = 3102 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
-        var index = 3044 + (int)tag;
+        var index = 3104 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -24,6 +24,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "event_created",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "event_finished",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "test_session",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "code_coverage_started",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "code_coverage_finished",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "manual_api_events",
@@ -80,6 +81,7 @@ internal static partial class CountCIVisibilityExtensions
         {
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventCreated => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.EventFinished => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestSession => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageStarted => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.CodeCoverageFinished => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ManualApiEvent => "civisibility",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -13,6 +13,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmarkAndEarlyFlakeDetectionAndRum tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeRetryReason tag3, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementQuarantinedOrDisabled tag4, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeTestManagementAttemptToFix tag5, int increment = 1);
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1);
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class MetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -20,6 +20,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountCIVisibilityTestSession(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionProvider tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionType tag2, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestSessionAgentlessLogSubmission tag3, int increment = 1)
+    {
+    }
+
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
@@ -36,6 +36,15 @@ internal enum CountCIVisibility
         ("event_finished", isCommon: true, NS.CIVisibility)] EventFinished,
 
     /// <summary>
+    /// Test session by CI Visibility
+    /// </summary>
+    [TelemetryMetric<
+            MetricTags.CIVisibilityTestSessionProvider,
+            MetricTags.CIVisibilityTestSessionType,
+            MetricTags.CIVisibilityTestSessionAgentlessLogSubmission>
+        ("test_session", isCommon: true, NS.CIVisibility)] TestSession,
+
+    /// <summary>
     /// The number of code coverage start calls by CI Visibility
     /// </summary>
     [TelemetryMetric<

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -576,4 +576,35 @@ internal static class MetricTags
         [Description("")] Uncompressed,
         [Description("rs_compressed:true")] Compressed,
     }
+
+    public enum CIVisibilityTestSessionProvider
+    {
+        [Description("provider:unsupported")] Unsupported,
+        [Description("provider:appveyor")] AppVeyor,
+        [Description("provider:azp")] AzurePipelines,
+        [Description("provider:bitbucket")] BitBucket,
+        [Description("provider:bitrise")] Bitrise,
+        [Description("provider:buildkite")] BuildKite,
+        [Description("provider:circleci")] CircleCI,
+        [Description("provider:codefresh")] Codefresh,
+        [Description("provider:githubactions")] GithubActions,
+        [Description("provider:gitlab")] Gitlab,
+        [Description("provider:jenkins")] Jenkins,
+        [Description("provider:teamcity")] Teamcity,
+        [Description("provider:travisci")] TravisCi,
+        [Description("provider:buddyci")] BuddyCi,
+        [Description("provider:aws")] AwsCodePipeline,
+    }
+
+    public enum CIVisibilityTestSessionType
+    {
+        [Description("")] NotAutoInjected,
+        [Description("auto_injected:true")] AutoInjected,
+    }
+
+    public enum CIVisibilityTestSessionAgentlessLogSubmission
+    {
+        [Description("")] NotEnabled,
+        [Description("agentless_log_submission_enabled:true")] Enabled,
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
@@ -46,6 +46,7 @@ public class ConfigurationTests
         "DD_TESTSESSION_COMMAND",
         "DD_TESTSESSION_WORKINGDIRECTORY",
         "DD_CIVISIBILITY_CODE_COVERAGE_MODE",
+        "DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER",
         // Internal env vars that we only ever read from environment
         "DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH",
         "DD_DOTNET_TRACER_HOME",

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
@@ -23,7 +23,7 @@ public class MetricTests
 {
     private static readonly Dictionary<string, string[]> IgnoredTagsByMetricName = new()
     {
-        { "spans_finished", new[] { "integration_name" } }, // this is technically difficult for us, so we don't tag it
+        { "spans_finished", ["integration_name"] }, // this is technically difficult for us, so we don't tag it
         { "trace_chunks_dropped", ["src_library"] }, // this is optional, only added by the rust library
         { "trace_chunks_sent", ["src_library"] }, // this is optional, only added by the rust library
         { "trace_api.requests", ["src_library"] }, // this is optional, only added by the rust library
@@ -34,8 +34,8 @@ public class MetricTests
 
     private static readonly Dictionary<string, string[]> OptionalTagsByMetricName = new()
     {
-        { "event_created", new[] { "has_codeowner", "is_unsupported_ci", "is_benchmark" } },
-        { "event_finished", new[] { "has_codeowner", "is_unsupported_ci", "is_benchmark", "is_new", "early_flake_detection_abort_reason", "browser_driver", "is_rum", "agentless_log_submission_enabled", "retry_reason", "is_quarantined", "is_disabled", "is_attempt_to_fix", "has_failed_all_retries", string.Empty } },
+        { "event_created", ["has_codeowner", "is_unsupported_ci", "is_benchmark"] },
+        { "event_finished", ["has_codeowner", "is_unsupported_ci", "is_benchmark", "is_new", "early_flake_detection_abort_reason", "browser_driver", "is_rum", "agentless_log_submission_enabled", "retry_reason", "is_quarantined", "is_disabled", "is_attempt_to_fix", "has_failed_all_retries", string.Empty] },
         { "endpoint_payload.requests_errors", ["status_code"] },
         { "git_requests.search_commits_errors", ["status_code"] },
         { "git_requests.objects_pack_errors", ["status_code"] },


### PR DESCRIPTION
## Summary of changes

This PR adds the missing `test_session` telemetry metric.

JIRA: https://datadoghq.atlassian.net/browse/SDTEST-1697

## Reason for change

The metric was already in the `common_metrics.json` file but the implementation was missing.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
