### PR TITLE
Refactor RabbitMQ test sample

### DIFF
--- a/tracer/test/snapshots/RabbitMQTests.3_x.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.3_x.SchemaV0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -98,65 +98,8 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_12,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_14,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_16,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -173,7 +116,7 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_17,
+    SpanId: Id_11,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -194,8 +137,104 @@
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_18,
+    TraceId: Id_9,
+    SpanId: Id_12,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_14,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_16,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -207,25 +246,48 @@
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 80,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
     SpanId: Id_19,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_18,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -238,21 +300,24 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_17,
     SpanId: Id_20,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 79,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -260,24 +325,22 @@
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_17,
     SpanId: Id_21,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: queue.declare,
+      amqp.queue: ,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -285,445 +348,53 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_17,
     SpanId: Id_22,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_20,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
+      message.size: 79,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_24,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_23,
     SpanId: Id_25,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_26,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_27,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_28,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_29,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_30,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_31,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_32,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_33,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_34,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_35,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_36,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_37,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_21,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_38,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_22,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_39,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_23,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_40,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -735,7 +406,125 @@
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_28,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_29,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_30,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_26,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -748,10 +537,10 @@
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_42,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_31,
+    SpanId: Id_32,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -767,16 +556,256 @@
     }
   },
   {
-    TraceId: Id_43,
-    SpanId: Id_44,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_31,
+    SpanId: Id_33,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_34,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 79,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_35,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_36,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 79,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
       version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_39,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_40,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 84,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_43,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 84,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -788,8 +817,8 @@
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -805,35 +834,16 @@
     }
   },
   {
-    TraceId: Id_47,
-    SpanId: Id_48,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_49,
+    TraceId: Id_45,
+    SpanId: Id_47,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_46,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.queue: AmqQueue_7
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -846,90 +856,114 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_45,
+    SpanId: Id_48,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
     SpanId: Id_50,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_52,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
     ParentId: Id_48,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_7
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
+    SpanId: Id_52,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
     SpanId: Id_53,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_1
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -937,21 +971,21 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_54,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_44,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_2
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       out.host: rabbitmq,
       runtime-id: Guid_1,
       span.kind: producer,
@@ -962,24 +996,22 @@
     }
   },
   {
-    TraceId: Id_45,
+    TraceId: Id_51,
     SpanId: Id_55,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_46,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_3
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -987,24 +1019,24 @@
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_51,
     SpanId: Id_56,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_48,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_4
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -1012,16 +1044,16 @@
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_57,
     Name: amqp.command,
     Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
       amqp.command: queue.declare,
-      amqp.queue: ,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1035,115 +1067,20 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_58,
     Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_59,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_60,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_61,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_53,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_43,
-    SpanId: Id_62,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_54,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -1156,46 +1093,109 @@
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_63,
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_61,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_55,
+    ParentId: Id_60,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_59,
+    SpanId: Id_62,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_63,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
     SpanId: Id_64,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_56,
+    ParentId: Id_62,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 82,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -1210,217 +1210,8 @@
   {
     TraceId: Id_65,
     SpanId: Id_66,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_68,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_70,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_72,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_74,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_76,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_77,
-    SpanId: Id_78,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_79,
-    SpanId: Id_80,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_82,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_84,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_86,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_88,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
+    Name: PublishToConsumer(ExternalExplicit, i: 0),
+    Resource: PublishToConsumer(ExternalExplicit, i: 0),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -1437,7 +1228,7 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_89,
+    SpanId: Id_67,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1461,13 +1252,80 @@
     }
   },
   {
-    TraceId: Id_67,
-    SpanId: Id_90,
+    TraceId: Id_65,
+    SpanId: Id_68,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_67,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_69,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_67,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_71,
+    Name: PublishToConsumer(ExternalExplicit, i: 1),
+    Resource: PublishToConsumer(ExternalExplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_72,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_68,
+    ParentId: Id_71,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1486,83 +1344,75 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_91,
+    TraceId: Id_70,
+    SpanId: Id_73,
     Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_70,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_92,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_93,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_74,
+    TraceId: Id_70,
+    SpanId: Id_74,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_75,
-    SpanId: Id_94,
+    SpanId: Id_76,
+    Name: PublishToConsumer(ExternalExplicit, i: 2),
+    Resource: PublishToConsumer(ExternalExplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_77,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1586,13 +1436,80 @@
     }
   },
   {
-    TraceId: Id_77,
-    SpanId: Id_95,
+    TraceId: Id_75,
+    SpanId: Id_78,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_77,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_79,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_77,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_81,
+    Name: PublishToConsumer(ExternalImplicit, i: 0),
+    Resource: PublishToConsumer(ExternalImplicit, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_82,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_78,
+    ParentId: Id_81,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1611,83 +1528,75 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_96,
+    TraceId: Id_80,
+    SpanId: Id_83,
     Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_80,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_97,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_83,
-    SpanId: Id_98,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_84,
+    TraceId: Id_80,
+    SpanId: Id_84,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_85,
-    SpanId: Id_99,
+    SpanId: Id_86,
+    Name: PublishToConsumer(ExternalImplicit, i: 1),
+    Resource: PublishToConsumer(ExternalImplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_87,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1711,13 +1620,80 @@
     }
   },
   {
-    TraceId: Id_87,
-    SpanId: Id_100,
+    TraceId: Id_85,
+    SpanId: Id_88,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_89,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_91,
+    Name: PublishToConsumer(ExternalImplicit, i: 2),
+    Resource: PublishToConsumer(ExternalImplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_92,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_88,
+    ParentId: Id_91,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1736,13 +1712,13 @@
     }
   },
   {
-    TraceId: Id_65,
-    SpanId: Id_101,
+    TraceId: Id_90,
+    SpanId: Id_93,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_89,
+    ParentId: Id_92,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1764,41 +1740,169 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_90,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_96,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_97,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_96,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_98,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_97,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_99,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_97,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
+    SpanId: Id_101,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
     SpanId: Id_102,
     Name: amqp.command,
-    Resource: basic.deliver,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_90,
+    ParentId: Id_101,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_69,
+    TraceId: Id_100,
     SpanId: Id_103,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_91,
+    ParentId: Id_102,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1820,25 +1924,17 @@
     }
   },
   {
-    TraceId: Id_71,
+    TraceId: Id_100,
     SpanId: Id_104,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_92,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_102,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -1848,53 +1944,16 @@
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_105,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_93,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
+    TraceId: Id_105,
     SpanId: Id_106,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_94,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Service: Samples.RabbitMQ,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -1904,41 +1963,38 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_105,
     SpanId: Id_107,
     Name: amqp.command,
-    Resource: basic.deliver,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_95,
+    ParentId: Id_106,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_79,
+    TraceId: Id_105,
     SpanId: Id_108,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_96,
+    ParentId: Id_107,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1960,124 +2016,12 @@
     }
   },
   {
-    TraceId: Id_81,
+    TraceId: Id_105,
     SpanId: Id_109,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_97,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_110,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_98,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_111,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_99,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_112,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_100,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_113,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_89,
+    ParentId: Id_107,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2092,12 +2036,84 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_110,
+    SpanId: Id_111,
+    Name: PublishToConsumer(InternalSyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_112,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_111,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_113,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_112,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
     SpanId: Id_114,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_90,
+    ParentId: Id_112,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2112,32 +2128,11 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_115,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_91,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
+    TraceId: Id_115,
     SpanId: Id_116,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    ParentId: Id_92,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2152,37 +2147,50 @@
     }
   },
   {
-    TraceId: Id_73,
+    TraceId: Id_115,
     SpanId: Id_117,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_93,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_116,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_75,
+    TraceId: Id_115,
     SpanId: Id_118,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_94,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_117,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -2192,12 +2200,12 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_115,
     SpanId: Id_119,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_95,
+    ParentId: Id_117,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2212,32 +2220,11 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_120,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_96,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
+    TraceId: Id_120,
     SpanId: Id_121,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    ParentId: Id_97,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2252,37 +2239,50 @@
     }
   },
   {
-    TraceId: Id_83,
+    TraceId: Id_120,
     SpanId: Id_122,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_98,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_121,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_85,
+    TraceId: Id_120,
     SpanId: Id_123,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_99,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_122,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -2292,12 +2292,12 @@
     }
   },
   {
-    TraceId: Id_87,
+    TraceId: Id_120,
     SpanId: Id_124,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_100,
+    ParentId: Id_122,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/RabbitMQTests.3_x.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.3_x.SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -98,65 +98,8 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_12,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_14,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_16,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -173,7 +116,7 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_17,
+    SpanId: Id_11,
     Name: amqp.command,
     Resource: exchange.declare,
     Service: Samples.RabbitMQ,
@@ -193,16 +136,18 @@
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_18,
+    TraceId: Id_9,
+    SpanId: Id_12,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_10,
     Tags: {
-      amqp.command: exchange.declare,
+      amqp.command: queue.bind,
       amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -214,16 +159,123 @@
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_9,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_14,
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_15,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_16,
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_15,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
     SpanId: Id_19,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: queue.declare,
+      amqp.queue: ,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -235,129 +287,102 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_17,
     SpanId: Id_20,
-    Name: amqp.command,
-    Resource: exchange.declare,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      span.kind: consumer,
+      version: 1.0.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_17,
     SpanId: Id_21,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 79,
       out.host: rabbitmq,
       peer.service: rabbitmq,
-      span.kind: client,
+      span.kind: producer,
       version: 1.0.0,
       _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_17,
     SpanId: Id_22,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_21,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      message.size: 79,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_24,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_23,
     SpanId: Id_25,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_24,
     Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -369,16 +394,18 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_23,
     SpanId: Id_26,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_24,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
       amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -390,13 +417,13 @@
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_23,
     SpanId: Id_27,
     Name: amqp.command,
     Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_24,
     Tags: {
       amqp.command: queue.declare,
       amqp.queue: test-queue-name,
@@ -411,34 +438,13 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_28,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_29,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_24,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -450,52 +456,105 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_23,
+    SpanId: Id_29,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_23,
     SpanId: Id_30,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_29,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 80,
+      runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_31,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_31,
     SpanId: Id_32,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_33,
+    Name: amqp.command,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_34,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_32,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -504,67 +563,21 @@
     }
   },
   {
-    TraceId: Id_9,
-    SpanId: Id_33,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_34,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_13,
+    TraceId: Id_31,
     SpanId: Id_35,
     Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_32,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      message.size: 79,
       out.host: rabbitmq,
       peer.service: rabbitmq,
       span.kind: producer,
@@ -573,95 +586,20 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_31,
     SpanId: Id_36,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_37,
     Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_33,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_38,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_34,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_39,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_35,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      message.size: 79,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -674,60 +612,147 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_39,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
     SpanId: Id_40,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_42,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_36,
+    ParentId: Id_38,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_42,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_37,
+    SpanId: Id_43,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 84,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_37,
     SpanId: Id_44,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_43,
     Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 84,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -740,8 +765,8 @@
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -757,10 +782,98 @@
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_45,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_45,
     SpanId: Id_48,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_49,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_50,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_49,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
+    SpanId: Id_52,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -776,154 +889,81 @@
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_49,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_42,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_43,
-    SpanId: Id_50,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_52,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_53,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_54,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_44,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_45,
+    TraceId: Id_51,
     SpanId: Id_55,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_46,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_51,
     SpanId: Id_56,
     Name: amqp.process,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_48,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -932,21 +972,21 @@
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_57,
     Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_1
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       out.host: rabbitmq,
       peer.service: rabbitmq,
       span.kind: producer,
@@ -955,89 +995,20 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_58,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_59,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_60,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_4
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_61,
     Name: amqp.process,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_57,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -1050,60 +1021,48 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_61,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_59,
     SpanId: Id_62,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_58,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_63,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_59,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_64,
     Name: amqp.process,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
@@ -1111,11 +1070,52 @@
     ParentId: Id_60,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_63,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_64,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_63,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -1130,217 +1130,8 @@
   {
     TraceId: Id_65,
     SpanId: Id_66,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_68,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_70,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_72,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_74,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_76,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_77,
-    SpanId: Id_78,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_79,
-    SpanId: Id_80,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_82,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_84,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_86,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_88,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
+    Name: PublishToConsumer(ExternalExplicit, i: 0),
+    Resource: PublishToConsumer(ExternalExplicit, i: 0),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -1357,7 +1148,7 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_89,
+    SpanId: Id_67,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1379,13 +1170,80 @@
     }
   },
   {
-    TraceId: Id_67,
-    SpanId: Id_90,
+    TraceId: Id_65,
+    SpanId: Id_68,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_67,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_69,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_67,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_71,
+    Name: PublishToConsumer(ExternalExplicit, i: 1),
+    Resource: PublishToConsumer(ExternalExplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_72,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_68,
+    ParentId: Id_71,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1402,77 +1260,75 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_91,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_70,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_92,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_70,
+    SpanId: Id_73,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_93,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_70,
+    SpanId: Id_74,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_74,
+    ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_75,
-    SpanId: Id_94,
+    SpanId: Id_76,
+    Name: PublishToConsumer(ExternalExplicit, i: 2),
+    Resource: PublishToConsumer(ExternalExplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_77,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1494,13 +1350,80 @@
     }
   },
   {
-    TraceId: Id_77,
-    SpanId: Id_95,
+    TraceId: Id_75,
+    SpanId: Id_78,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_77,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_79,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_77,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_81,
+    Name: PublishToConsumer(ExternalImplicit, i: 0),
+    Resource: PublishToConsumer(ExternalImplicit, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_82,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_78,
+    ParentId: Id_81,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1517,77 +1440,75 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_96,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_80,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_97,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_80,
+    SpanId: Id_83,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_83,
-    SpanId: Id_98,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_80,
+    SpanId: Id_84,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_84,
+    ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_85,
-    SpanId: Id_99,
+    SpanId: Id_86,
+    Name: PublishToConsumer(ExternalImplicit, i: 1),
+    Resource: PublishToConsumer(ExternalImplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_87,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1609,13 +1530,80 @@
     }
   },
   {
-    TraceId: Id_87,
-    SpanId: Id_100,
+    TraceId: Id_85,
+    SpanId: Id_88,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_89,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_91,
+    Name: PublishToConsumer(ExternalImplicit, i: 2),
+    Resource: PublishToConsumer(ExternalImplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_92,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_88,
+    ParentId: Id_91,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1632,24 +1620,153 @@
     }
   },
   {
-    TraceId: Id_65,
+    TraceId: Id_90,
+    SpanId: Id_93,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_92,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_96,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_97,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_96,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_98,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_97,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_99,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_97,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
     SpanId: Id_101,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_89,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1660,41 +1777,36 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_100,
     SpanId: Id_102,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_90,
+    ParentId: Id_101,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_69,
+    TraceId: Id_100,
     SpanId: Id_103,
     Name: amqp.process,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_91,
+    ParentId: Id_102,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1716,24 +1828,16 @@
     }
   },
   {
-    TraceId: Id_71,
+    TraceId: Id_100,
     SpanId: Id_104,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_92,
+    ParentId: Id_102,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1744,52 +1848,15 @@
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_105,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_93,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
+    TraceId: Id_105,
     SpanId: Id_106,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_94,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1800,41 +1867,36 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_105,
     SpanId: Id_107,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_95,
+    ParentId: Id_106,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_79,
+    TraceId: Id_105,
     SpanId: Id_108,
     Name: amqp.process,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_96,
+    ParentId: Id_107,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1856,124 +1918,12 @@
     }
   },
   {
-    TraceId: Id_81,
+    TraceId: Id_105,
     SpanId: Id_109,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_97,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_110,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_98,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_111,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_99,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_112,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_100,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_113,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_89,
+    ParentId: Id_107,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -1988,12 +1938,82 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_110,
+    SpanId: Id_111,
+    Name: PublishToConsumer(InternalSyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_112,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_111,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_113,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_112,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
     SpanId: Id_114,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_90,
+    ParentId: Id_112,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2008,32 +2028,11 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_115,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_91,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
+    TraceId: Id_115,
     SpanId: Id_116,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    ParentId: Id_92,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2048,36 +2047,47 @@
     }
   },
   {
-    TraceId: Id_73,
+    TraceId: Id_115,
     SpanId: Id_117,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
-    ParentId: Id_93,
+    Type: queue,
+    ParentId: Id_116,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_75,
+    TraceId: Id_115,
     SpanId: Id_118,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
-    ParentId: Id_94,
+    Type: queue,
+    ParentId: Id_117,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -2088,12 +2098,12 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_115,
     SpanId: Id_119,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_95,
+    ParentId: Id_117,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2108,32 +2118,11 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_120,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_96,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
+    TraceId: Id_120,
     SpanId: Id_121,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    ParentId: Id_97,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2148,36 +2137,47 @@
     }
   },
   {
-    TraceId: Id_83,
+    TraceId: Id_120,
     SpanId: Id_122,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
-    ParentId: Id_98,
+    Type: queue,
+    ParentId: Id_121,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_85,
+    TraceId: Id_120,
     SpanId: Id_123,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
-    ParentId: Id_99,
+    Type: queue,
+    ParentId: Id_122,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -2188,12 +2188,12 @@
     }
   },
   {
-    TraceId: Id_87,
+    TraceId: Id_120,
     SpanId: Id_124,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_100,
+    ParentId: Id_122,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/RabbitMQTests.5_x.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.5_x.SchemaV0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -98,65 +98,8 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_12,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_14,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_16,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -173,7 +116,7 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_17,
+    SpanId: Id_11,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -194,8 +137,104 @@
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_18,
+    TraceId: Id_9,
+    SpanId: Id_12,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_14,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_16,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -207,25 +246,48 @@
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 80,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
     SpanId: Id_19,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_18,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -238,21 +300,24 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_17,
     SpanId: Id_20,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 79,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -260,24 +325,22 @@
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_17,
     SpanId: Id_21,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: queue.declare,
+      amqp.queue: ,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -285,445 +348,53 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_17,
     SpanId: Id_22,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_20,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
+      message.size: 79,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_24,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_23,
     SpanId: Id_25,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_26,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_27,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_28,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_29,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_30,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_31,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_32,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_33,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_34,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_35,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_36,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_37,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_21,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_38,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_22,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_39,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_23,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_40,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -735,7 +406,125 @@
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_28,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_29,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_30,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_26,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -748,10 +537,10 @@
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_42,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_31,
+    SpanId: Id_32,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -767,16 +556,256 @@
     }
   },
   {
-    TraceId: Id_43,
-    SpanId: Id_44,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_31,
+    SpanId: Id_33,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_34,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 79,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_35,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_36,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 79,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
       version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_39,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_40,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 84,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_43,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 84,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -788,8 +817,8 @@
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -805,35 +834,16 @@
     }
   },
   {
-    TraceId: Id_47,
-    SpanId: Id_48,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_49,
+    TraceId: Id_45,
+    SpanId: Id_47,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_46,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.queue: AmqQueue_7
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -846,90 +856,114 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_45,
+    SpanId: Id_48,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
     SpanId: Id_50,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_52,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
     ParentId: Id_48,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_7
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
+    SpanId: Id_52,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
     SpanId: Id_53,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_1
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -937,21 +971,21 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_54,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_44,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_2
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       out.host: rabbitmq,
       runtime-id: Guid_1,
       span.kind: producer,
@@ -962,24 +996,22 @@
     }
   },
   {
-    TraceId: Id_45,
+    TraceId: Id_51,
     SpanId: Id_55,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_46,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_3
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -987,24 +1019,24 @@
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_51,
     SpanId: Id_56,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_48,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_4
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -1012,16 +1044,16 @@
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_57,
     Name: amqp.command,
     Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
       amqp.command: queue.declare,
-      amqp.queue: ,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1035,115 +1067,20 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_58,
     Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_59,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_60,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_61,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_53,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_43,
-    SpanId: Id_62,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_54,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -1156,46 +1093,109 @@
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_63,
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_61,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_55,
+    ParentId: Id_60,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_59,
+    SpanId: Id_62,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_63,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
     SpanId: Id_64,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_56,
+    ParentId: Id_62,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 82,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -1210,217 +1210,8 @@
   {
     TraceId: Id_65,
     SpanId: Id_66,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_68,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_70,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_72,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_74,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_76,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_77,
-    SpanId: Id_78,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_79,
-    SpanId: Id_80,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_82,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_84,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_86,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_88,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
+    Name: PublishToConsumer(ExternalExplicit, i: 0),
+    Resource: PublishToConsumer(ExternalExplicit, i: 0),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -1437,7 +1228,7 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_89,
+    SpanId: Id_67,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1461,13 +1252,80 @@
     }
   },
   {
-    TraceId: Id_67,
-    SpanId: Id_90,
+    TraceId: Id_65,
+    SpanId: Id_68,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_67,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_69,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_67,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_71,
+    Name: PublishToConsumer(ExternalExplicit, i: 1),
+    Resource: PublishToConsumer(ExternalExplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_72,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_68,
+    ParentId: Id_71,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1486,83 +1344,75 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_91,
+    TraceId: Id_70,
+    SpanId: Id_73,
     Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_70,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_92,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_93,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_74,
+    TraceId: Id_70,
+    SpanId: Id_74,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_75,
-    SpanId: Id_94,
+    SpanId: Id_76,
+    Name: PublishToConsumer(ExternalExplicit, i: 2),
+    Resource: PublishToConsumer(ExternalExplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_77,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1586,13 +1436,80 @@
     }
   },
   {
-    TraceId: Id_77,
-    SpanId: Id_95,
+    TraceId: Id_75,
+    SpanId: Id_78,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_77,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_79,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_77,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_81,
+    Name: PublishToConsumer(ExternalImplicit, i: 0),
+    Resource: PublishToConsumer(ExternalImplicit, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_82,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_78,
+    ParentId: Id_81,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1611,83 +1528,75 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_96,
+    TraceId: Id_80,
+    SpanId: Id_83,
     Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_80,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_97,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_83,
-    SpanId: Id_98,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_84,
+    TraceId: Id_80,
+    SpanId: Id_84,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_85,
-    SpanId: Id_99,
+    SpanId: Id_86,
+    Name: PublishToConsumer(ExternalImplicit, i: 1),
+    Resource: PublishToConsumer(ExternalImplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_87,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1711,13 +1620,80 @@
     }
   },
   {
-    TraceId: Id_87,
-    SpanId: Id_100,
+    TraceId: Id_85,
+    SpanId: Id_88,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_89,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_91,
+    Name: PublishToConsumer(ExternalImplicit, i: 2),
+    Resource: PublishToConsumer(ExternalImplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_92,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_88,
+    ParentId: Id_91,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1736,13 +1712,13 @@
     }
   },
   {
-    TraceId: Id_65,
-    SpanId: Id_101,
+    TraceId: Id_90,
+    SpanId: Id_93,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_89,
+    ParentId: Id_92,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1764,41 +1740,169 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_90,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_96,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_97,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_96,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_98,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_97,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_99,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_97,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
+    SpanId: Id_101,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
     SpanId: Id_102,
     Name: amqp.command,
-    Resource: basic.deliver,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_90,
+    ParentId: Id_101,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_69,
+    TraceId: Id_100,
     SpanId: Id_103,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_91,
+    ParentId: Id_102,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1820,25 +1924,17 @@
     }
   },
   {
-    TraceId: Id_71,
+    TraceId: Id_100,
     SpanId: Id_104,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_92,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_102,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -1848,53 +1944,16 @@
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_105,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_93,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
+    TraceId: Id_105,
     SpanId: Id_106,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_94,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Service: Samples.RabbitMQ,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -1904,41 +1963,38 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_105,
     SpanId: Id_107,
     Name: amqp.command,
-    Resource: basic.deliver,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_95,
+    ParentId: Id_106,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_79,
+    TraceId: Id_105,
     SpanId: Id_108,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_96,
+    ParentId: Id_107,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1960,124 +2016,12 @@
     }
   },
   {
-    TraceId: Id_81,
+    TraceId: Id_105,
     SpanId: Id_109,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_97,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_110,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_98,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_111,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_99,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_112,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_100,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_113,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_89,
+    ParentId: Id_107,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2092,12 +2036,84 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_110,
+    SpanId: Id_111,
+    Name: PublishToConsumer(InternalSyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_112,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_111,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_113,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_112,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
     SpanId: Id_114,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_90,
+    ParentId: Id_112,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2112,32 +2128,11 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_115,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_91,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
+    TraceId: Id_115,
     SpanId: Id_116,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    ParentId: Id_92,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2152,37 +2147,50 @@
     }
   },
   {
-    TraceId: Id_73,
+    TraceId: Id_115,
     SpanId: Id_117,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_93,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_116,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_75,
+    TraceId: Id_115,
     SpanId: Id_118,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_94,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_117,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -2192,12 +2200,12 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_115,
     SpanId: Id_119,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_95,
+    ParentId: Id_117,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2212,32 +2220,11 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_120,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_96,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
+    TraceId: Id_120,
     SpanId: Id_121,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    ParentId: Id_97,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2252,37 +2239,50 @@
     }
   },
   {
-    TraceId: Id_83,
+    TraceId: Id_120,
     SpanId: Id_122,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_98,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_121,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_85,
+    TraceId: Id_120,
     SpanId: Id_123,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_99,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_122,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -2292,12 +2292,12 @@
     }
   },
   {
-    TraceId: Id_87,
+    TraceId: Id_120,
     SpanId: Id_124,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_100,
+    ParentId: Id_122,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/RabbitMQTests.5_x.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.5_x.SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -98,65 +98,8 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_12,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_14,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_16,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -173,7 +116,7 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_17,
+    SpanId: Id_11,
     Name: amqp.command,
     Resource: exchange.declare,
     Service: Samples.RabbitMQ,
@@ -193,16 +136,18 @@
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_18,
+    TraceId: Id_9,
+    SpanId: Id_12,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_10,
     Tags: {
-      amqp.command: exchange.declare,
+      amqp.command: queue.bind,
       amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -214,16 +159,123 @@
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_9,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_14,
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_15,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_16,
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_15,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
     SpanId: Id_19,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: queue.declare,
+      amqp.queue: ,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -235,129 +287,102 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_17,
     SpanId: Id_20,
-    Name: amqp.command,
-    Resource: exchange.declare,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      span.kind: consumer,
+      version: 1.0.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_17,
     SpanId: Id_21,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 79,
       out.host: rabbitmq,
       peer.service: rabbitmq,
-      span.kind: client,
+      span.kind: producer,
       version: 1.0.0,
       _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_17,
     SpanId: Id_22,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_21,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      message.size: 79,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_24,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_23,
     SpanId: Id_25,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_24,
     Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -369,16 +394,18 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_23,
     SpanId: Id_26,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_24,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
       amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -390,13 +417,13 @@
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_23,
     SpanId: Id_27,
     Name: amqp.command,
     Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_24,
     Tags: {
       amqp.command: queue.declare,
       amqp.queue: test-queue-name,
@@ -411,34 +438,13 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_28,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_29,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_24,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -450,52 +456,105 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_23,
+    SpanId: Id_29,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_23,
     SpanId: Id_30,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_29,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 80,
+      runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_31,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_31,
     SpanId: Id_32,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_33,
+    Name: amqp.command,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_34,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_32,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -504,67 +563,21 @@
     }
   },
   {
-    TraceId: Id_9,
-    SpanId: Id_33,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_34,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_13,
+    TraceId: Id_31,
     SpanId: Id_35,
     Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_32,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      message.size: 79,
       out.host: rabbitmq,
       peer.service: rabbitmq,
       span.kind: producer,
@@ -573,95 +586,20 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_31,
     SpanId: Id_36,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_37,
     Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_33,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_38,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_34,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_39,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_35,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      message.size: 79,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -674,60 +612,147 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_39,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
     SpanId: Id_40,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_42,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_36,
+    ParentId: Id_38,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_42,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_37,
+    SpanId: Id_43,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 84,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_37,
     SpanId: Id_44,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_43,
     Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 84,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -740,8 +765,8 @@
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -757,10 +782,98 @@
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_45,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_45,
     SpanId: Id_48,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_49,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_50,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_49,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
+    SpanId: Id_52,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -776,154 +889,81 @@
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_49,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_42,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_43,
-    SpanId: Id_50,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_52,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_53,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_54,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_44,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_45,
+    TraceId: Id_51,
     SpanId: Id_55,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_46,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_51,
     SpanId: Id_56,
     Name: amqp.process,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_48,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -932,21 +972,21 @@
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_57,
     Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_1
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       out.host: rabbitmq,
       peer.service: rabbitmq,
       span.kind: producer,
@@ -955,89 +995,20 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_58,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_59,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_60,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_4
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_61,
     Name: amqp.process,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_57,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -1050,60 +1021,48 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_61,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_59,
     SpanId: Id_62,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_58,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_63,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_59,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_64,
     Name: amqp.process,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
@@ -1111,11 +1070,52 @@
     ParentId: Id_60,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_63,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_64,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_63,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -1130,217 +1130,8 @@
   {
     TraceId: Id_65,
     SpanId: Id_66,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_68,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_70,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_72,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_74,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_76,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_77,
-    SpanId: Id_78,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_79,
-    SpanId: Id_80,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_82,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_84,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_86,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_88,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
+    Name: PublishToConsumer(ExternalExplicit, i: 0),
+    Resource: PublishToConsumer(ExternalExplicit, i: 0),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -1357,7 +1148,7 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_89,
+    SpanId: Id_67,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1379,13 +1170,80 @@
     }
   },
   {
-    TraceId: Id_67,
-    SpanId: Id_90,
+    TraceId: Id_65,
+    SpanId: Id_68,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_67,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_69,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_67,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_71,
+    Name: PublishToConsumer(ExternalExplicit, i: 1),
+    Resource: PublishToConsumer(ExternalExplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_72,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_68,
+    ParentId: Id_71,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1402,77 +1260,75 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_91,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_70,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_92,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_70,
+    SpanId: Id_73,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_93,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_70,
+    SpanId: Id_74,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_74,
+    ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_75,
-    SpanId: Id_94,
+    SpanId: Id_76,
+    Name: PublishToConsumer(ExternalExplicit, i: 2),
+    Resource: PublishToConsumer(ExternalExplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_77,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1494,13 +1350,80 @@
     }
   },
   {
-    TraceId: Id_77,
-    SpanId: Id_95,
+    TraceId: Id_75,
+    SpanId: Id_78,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_77,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_79,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_77,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_81,
+    Name: PublishToConsumer(ExternalImplicit, i: 0),
+    Resource: PublishToConsumer(ExternalImplicit, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_82,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_78,
+    ParentId: Id_81,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1517,77 +1440,75 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_96,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_80,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_97,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_80,
+    SpanId: Id_83,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_83,
-    SpanId: Id_98,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_80,
+    SpanId: Id_84,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_84,
+    ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_85,
-    SpanId: Id_99,
+    SpanId: Id_86,
+    Name: PublishToConsumer(ExternalImplicit, i: 1),
+    Resource: PublishToConsumer(ExternalImplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_87,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1609,13 +1530,80 @@
     }
   },
   {
-    TraceId: Id_87,
-    SpanId: Id_100,
+    TraceId: Id_85,
+    SpanId: Id_88,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_89,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_91,
+    Name: PublishToConsumer(ExternalImplicit, i: 2),
+    Resource: PublishToConsumer(ExternalImplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_92,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_88,
+    ParentId: Id_91,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1632,24 +1620,153 @@
     }
   },
   {
-    TraceId: Id_65,
+    TraceId: Id_90,
+    SpanId: Id_93,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_92,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_96,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_97,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_96,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_98,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_97,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_99,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_97,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
     SpanId: Id_101,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_89,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1660,41 +1777,36 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_100,
     SpanId: Id_102,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_90,
+    ParentId: Id_101,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_69,
+    TraceId: Id_100,
     SpanId: Id_103,
     Name: amqp.process,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_91,
+    ParentId: Id_102,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1716,24 +1828,16 @@
     }
   },
   {
-    TraceId: Id_71,
+    TraceId: Id_100,
     SpanId: Id_104,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_92,
+    ParentId: Id_102,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1744,52 +1848,15 @@
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_105,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_93,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
+    TraceId: Id_105,
     SpanId: Id_106,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_94,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1800,41 +1867,36 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_105,
     SpanId: Id_107,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_95,
+    ParentId: Id_106,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_79,
+    TraceId: Id_105,
     SpanId: Id_108,
     Name: amqp.process,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_96,
+    ParentId: Id_107,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1856,124 +1918,12 @@
     }
   },
   {
-    TraceId: Id_81,
+    TraceId: Id_105,
     SpanId: Id_109,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_97,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_110,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_98,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_111,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_99,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_112,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_100,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_113,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_89,
+    ParentId: Id_107,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -1988,12 +1938,82 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_110,
+    SpanId: Id_111,
+    Name: PublishToConsumer(InternalSyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_112,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_111,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_113,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_112,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
     SpanId: Id_114,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_90,
+    ParentId: Id_112,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2008,32 +2028,11 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_115,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_91,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
+    TraceId: Id_115,
     SpanId: Id_116,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    ParentId: Id_92,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2048,36 +2047,47 @@
     }
   },
   {
-    TraceId: Id_73,
+    TraceId: Id_115,
     SpanId: Id_117,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
-    ParentId: Id_93,
+    Type: queue,
+    ParentId: Id_116,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_75,
+    TraceId: Id_115,
     SpanId: Id_118,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
-    ParentId: Id_94,
+    Type: queue,
+    ParentId: Id_117,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -2088,12 +2098,12 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_115,
     SpanId: Id_119,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_95,
+    ParentId: Id_117,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2108,32 +2118,11 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_120,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_96,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
+    TraceId: Id_120,
     SpanId: Id_121,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    ParentId: Id_97,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2148,36 +2137,47 @@
     }
   },
   {
-    TraceId: Id_83,
+    TraceId: Id_120,
     SpanId: Id_122,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
-    ParentId: Id_98,
+    Type: queue,
+    ParentId: Id_121,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_85,
+    TraceId: Id_120,
     SpanId: Id_123,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
-    ParentId: Id_99,
+    Type: queue,
+    ParentId: Id_122,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -2188,12 +2188,12 @@
     }
   },
   {
-    TraceId: Id_87,
+    TraceId: Id_120,
     SpanId: Id_124,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_100,
+    ParentId: Id_122,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/RabbitMQTests.6_x.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.6_x.SchemaV0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -98,65 +98,8 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_12,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_14,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_16,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -173,7 +116,7 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_17,
+    SpanId: Id_11,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -194,8 +137,104 @@
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_18,
+    TraceId: Id_9,
+    SpanId: Id_12,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_14,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_16,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -207,25 +246,48 @@
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 80,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
     SpanId: Id_19,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_18,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -238,21 +300,24 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_17,
     SpanId: Id_20,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 79,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -260,24 +325,22 @@
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_17,
     SpanId: Id_21,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: queue.declare,
+      amqp.queue: ,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -285,445 +348,53 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_17,
     SpanId: Id_22,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_20,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
+      message.size: 79,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_24,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_23,
     SpanId: Id_25,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_26,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_27,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_28,
-    Name: amqp.command,
-    Resource: exchange.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_29,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_30,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_31,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_32,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_33,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_34,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_35,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_36,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_37,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_21,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_38,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_22,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_39,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_23,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_40,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -735,7 +406,125 @@
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_28,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_29,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_30,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_26,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -748,10 +537,10 @@
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_42,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_31,
+    SpanId: Id_32,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -767,16 +556,256 @@
     }
   },
   {
-    TraceId: Id_43,
-    SpanId: Id_44,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_31,
+    SpanId: Id_33,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_34,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 79,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_35,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_36,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 79,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
       version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_39,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_40,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 84,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_43,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 84,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -788,8 +817,8 @@
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -805,35 +834,16 @@
     }
   },
   {
-    TraceId: Id_47,
-    SpanId: Id_48,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_49,
+    TraceId: Id_45,
+    SpanId: Id_47,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_46,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.queue: AmqQueue_7
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -846,90 +856,114 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_45,
+    SpanId: Id_48,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
     SpanId: Id_50,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_52,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
     ParentId: Id_48,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_7
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
+    SpanId: Id_52,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
     SpanId: Id_53,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_1
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -937,21 +971,21 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_54,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_44,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_2
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       out.host: rabbitmq,
       runtime-id: Guid_1,
       span.kind: producer,
@@ -962,24 +996,22 @@
     }
   },
   {
-    TraceId: Id_45,
+    TraceId: Id_51,
     SpanId: Id_55,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_46,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_3
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -987,24 +1019,24 @@
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_51,
     SpanId: Id_56,
     Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_48,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_4
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: client,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
@@ -1012,16 +1044,16 @@
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_57,
     Name: amqp.command,
     Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
       amqp.command: queue.declare,
-      amqp.queue: ,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1035,115 +1067,20 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_58,
     Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_59,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_60,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: client,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_61,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_53,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_43,
-    SpanId: Id_62,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_54,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -1156,46 +1093,109 @@
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_63,
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_61,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_55,
+    ParentId: Id_60,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_59,
+    SpanId: Id_62,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_63,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
     SpanId: Id_64,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_56,
+    ParentId: Id_62,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 82,
       runtime-id: Guid_1,
       span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
@@ -1210,217 +1210,8 @@
   {
     TraceId: Id_65,
     SpanId: Id_66,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_68,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_70,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_72,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_74,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_76,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_77,
-    SpanId: Id_78,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_79,
-    SpanId: Id_80,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_82,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_84,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_86,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_88,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
+    Name: PublishToConsumer(ExternalExplicit, i: 0),
+    Resource: PublishToConsumer(ExternalExplicit, i: 0),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -1437,7 +1228,7 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_89,
+    SpanId: Id_67,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1461,13 +1252,80 @@
     }
   },
   {
-    TraceId: Id_67,
-    SpanId: Id_90,
+    TraceId: Id_65,
+    SpanId: Id_68,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_67,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_69,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_67,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_71,
+    Name: PublishToConsumer(ExternalExplicit, i: 1),
+    Resource: PublishToConsumer(ExternalExplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_72,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_68,
+    ParentId: Id_71,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1486,83 +1344,75 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_91,
+    TraceId: Id_70,
+    SpanId: Id_73,
     Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_70,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_92,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_93,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_74,
+    TraceId: Id_70,
+    SpanId: Id_74,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_75,
-    SpanId: Id_94,
+    SpanId: Id_76,
+    Name: PublishToConsumer(ExternalExplicit, i: 2),
+    Resource: PublishToConsumer(ExternalExplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_77,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1586,13 +1436,80 @@
     }
   },
   {
-    TraceId: Id_77,
-    SpanId: Id_95,
+    TraceId: Id_75,
+    SpanId: Id_78,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_77,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_79,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_77,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_81,
+    Name: PublishToConsumer(ExternalImplicit, i: 0),
+    Resource: PublishToConsumer(ExternalImplicit, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_82,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_78,
+    ParentId: Id_81,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1611,83 +1528,75 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_96,
+    TraceId: Id_80,
+    SpanId: Id_83,
     Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_80,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_97,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
+      span.kind: consumer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_83,
-    SpanId: Id_98,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_84,
+    TraceId: Id_80,
+    SpanId: Id_84,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: producer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
-      _dd.top_level: 1.0
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_85,
-    SpanId: Id_99,
+    SpanId: Id_86,
+    Name: PublishToConsumer(ExternalImplicit, i: 1),
+    Resource: PublishToConsumer(ExternalImplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_87,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -1711,13 +1620,80 @@
     }
   },
   {
-    TraceId: Id_87,
-    SpanId: Id_100,
+    TraceId: Id_85,
+    SpanId: Id_88,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_89,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_91,
+    Name: PublishToConsumer(ExternalImplicit, i: 2),
+    Resource: PublishToConsumer(ExternalImplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_92,
     Name: amqp.command,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_88,
+    ParentId: Id_91,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1736,13 +1712,13 @@
     }
   },
   {
-    TraceId: Id_65,
-    SpanId: Id_101,
+    TraceId: Id_90,
+    SpanId: Id_93,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_89,
+    ParentId: Id_92,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1764,41 +1740,169 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_90,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_96,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_97,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_96,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_98,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_97,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_99,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_97,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
+    SpanId: Id_101,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
     SpanId: Id_102,
     Name: amqp.command,
-    Resource: basic.deliver,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_90,
+    ParentId: Id_101,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_69,
+    TraceId: Id_100,
     SpanId: Id_103,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_91,
+    ParentId: Id_102,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1820,25 +1924,17 @@
     }
   },
   {
-    TraceId: Id_71,
+    TraceId: Id_100,
     SpanId: Id_104,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_92,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_102,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -1848,53 +1944,16 @@
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_105,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_93,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
+    TraceId: Id_105,
     SpanId: Id_106,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_94,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Service: Samples.RabbitMQ,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -1904,41 +1963,38 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_105,
     SpanId: Id_107,
     Name: amqp.command,
-    Resource: basic.deliver,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_95,
+    ParentId: Id_106,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      span.kind: consumer,
+      span.kind: producer,
       _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_79,
+    TraceId: Id_105,
     SpanId: Id_108,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_96,
+    ParentId: Id_107,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1960,124 +2016,12 @@
     }
   },
   {
-    TraceId: Id_81,
+    TraceId: Id_105,
     SpanId: Id_109,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_97,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_110,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_98,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_111,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_99,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_112,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_100,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.base_service: Samples.RabbitMQ
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_113,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_89,
+    ParentId: Id_107,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2092,12 +2036,84 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_110,
+    SpanId: Id_111,
+    Name: PublishToConsumer(InternalSyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_112,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_111,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      runtime-id: Guid_1,
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_113,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_112,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
     SpanId: Id_114,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_90,
+    ParentId: Id_112,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2112,32 +2128,11 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_115,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_91,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
+    TraceId: Id_115,
     SpanId: Id_116,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    ParentId: Id_92,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2152,37 +2147,50 @@
     }
   },
   {
-    TraceId: Id_73,
+    TraceId: Id_115,
     SpanId: Id_117,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_93,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_116,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_75,
+    TraceId: Id_115,
     SpanId: Id_118,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_94,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_117,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -2192,12 +2200,12 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_115,
     SpanId: Id_119,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_95,
+    ParentId: Id_117,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2212,32 +2220,11 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_120,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_96,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
+    TraceId: Id_120,
     SpanId: Id_121,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    ParentId: Id_97,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2252,37 +2239,50 @@
     }
   },
   {
-    TraceId: Id_83,
+    TraceId: Id_120,
     SpanId: Id_122,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_98,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_121,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: producer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_85,
+    TraceId: Id_120,
     SpanId: Id_123,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_99,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_122,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0
+      span.kind: consumer,
+      _dd.base_service: Samples.RabbitMQ
     },
     Metrics: {
       process_id: 0,
@@ -2292,12 +2292,12 @@
     }
   },
   {
-    TraceId: Id_87,
+    TraceId: Id_120,
     SpanId: Id_124,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_100,
+    ParentId: Id_122,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/RabbitMQTests.6_x.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.6_x.SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -98,65 +98,8 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_12,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_14,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_15,
-    SpanId: Id_16,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -173,7 +116,7 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_17,
+    SpanId: Id_11,
     Name: amqp.command,
     Resource: exchange.declare,
     Service: Samples.RabbitMQ,
@@ -193,16 +136,18 @@
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_18,
+    TraceId: Id_9,
+    SpanId: Id_12,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_10,
     Tags: {
-      amqp.command: exchange.declare,
+      amqp.command: queue.bind,
       amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -214,16 +159,123 @@
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_9,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_14,
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_15,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_10,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_16,
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_15,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalExplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
     SpanId: Id_19,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: queue.declare,
+      amqp.queue: ,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -235,129 +287,102 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_17,
     SpanId: Id_20,
-    Name: amqp.command,
-    Resource: exchange.declare,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      span.kind: consumer,
+      version: 1.0.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_17,
     SpanId: Id_21,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_18,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 79,
       out.host: rabbitmq,
       peer.service: rabbitmq,
-      span.kind: client,
+      span.kind: producer,
       version: 1.0.0,
       _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_17,
     SpanId: Id_22,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_21,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      message.size: 79,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_24,
-    Name: amqp.command,
-    Resource: queue.bind,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_23,
     SpanId: Id_25,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_24,
     Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -369,16 +394,18 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_23,
     SpanId: Id_26,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_24,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
       amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -390,13 +417,13 @@
     }
   },
   {
-    TraceId: Id_13,
+    TraceId: Id_23,
     SpanId: Id_27,
     Name: amqp.command,
     Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_24,
     Tags: {
       amqp.command: queue.declare,
       amqp.queue: test-queue-name,
@@ -411,34 +438,13 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_23,
     SpanId: Id_28,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_29,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_10,
+    ParentId: Id_24,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -450,52 +456,105 @@
     }
   },
   {
-    TraceId: Id_11,
+    TraceId: Id_23,
+    SpanId: Id_29,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_24,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 80,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_23,
     SpanId: Id_30,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_12,
+    ParentId: Id_29,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 80,
+      runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_31,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_14,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_15,
+    TraceId: Id_31,
     SpanId: Id_32,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
+    Name: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(ExternalImplicit, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_33,
+    Name: amqp.command,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_16,
+    ParentId: Id_32,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_34,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_32,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -504,67 +563,21 @@
     }
   },
   {
-    TraceId: Id_9,
-    SpanId: Id_33,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_10,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_34,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_12,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_13,
+    TraceId: Id_31,
     SpanId: Id_35,
     Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_14,
+    ParentId: Id_32,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      message.size: 79,
       out.host: rabbitmq,
       peer.service: rabbitmq,
       span.kind: producer,
@@ -573,95 +586,20 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_31,
     SpanId: Id_36,
-    Name: amqp.send,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_16,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_37,
     Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_33,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_11,
-    SpanId: Id_38,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_34,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_13,
-    SpanId: Id_39,
-    Name: amqp.process,
-    Resource: basic.get test-queue-name,
+    Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_35,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: test-queue-name,
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
+      message.size: 79,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -674,60 +612,147 @@
     }
   },
   {
-    TraceId: Id_15,
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_39,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
     SpanId: Id_40,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_42,
     Name: amqp.process,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_36,
+    ParentId: Id_38,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 62,
-      runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_42,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    TraceId: Id_37,
+    SpanId: Id_43,
+    Name: amqp.send,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_38,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 84,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_37,
     SpanId: Id_44,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: amqp.process,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_43,
     Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 84,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -740,8 +765,8 @@
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalAsyncDerived, useDefaultQueue: True),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -757,10 +782,98 @@
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_45,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_45,
     SpanId: Id_48,
-    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
-    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_49,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_50,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_49,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 83,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
+    SpanId: Id_52,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: False),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -776,154 +889,81 @@
     }
   },
   {
-    TraceId: Id_41,
-    SpanId: Id_49,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_42,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_43,
-    SpanId: Id_50,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_52,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: client,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_53,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_54,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_44,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_45,
+    TraceId: Id_51,
     SpanId: Id_55,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
+    Name: amqp.command,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_46,
+    ParentId: Id_52,
     Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      span.kind: consumer,
-      version: 1.0.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_47,
+    TraceId: Id_51,
     SpanId: Id_56,
     Name: amqp.process,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_48,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -932,21 +972,21 @@
     }
   },
   {
-    TraceId: Id_41,
+    TraceId: Id_51,
     SpanId: Id_57,
     Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_42,
+    ParentId: Id_52,
     Tags: {
       amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_1
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       out.host: rabbitmq,
       peer.service: rabbitmq,
       span.kind: producer,
@@ -955,89 +995,20 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_51,
     SpanId: Id_58,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_44,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_59,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_46,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_60,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_48,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_4
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_41,
-    SpanId: Id_61,
     Name: amqp.process,
-    Resource: basic.get <generated>,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_57,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_1
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      message.size: 83,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -1050,60 +1021,48 @@
     }
   },
   {
-    TraceId: Id_43,
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(InternalSyncDerived, useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_61,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_59,
     SpanId: Id_62,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_58,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_2
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_45,
-    SpanId: Id_63,
-    Name: amqp.process,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_59,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_47,
-    SpanId: Id_64,
     Name: amqp.process,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ,
@@ -1111,11 +1070,52 @@
     ParentId: Id_60,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_4
+      amqp.queue: AmqQueue_10
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 61,
+      span.kind: consumer,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_63,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_64,
+    Name: amqp.process,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_63,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_10
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 82,
       runtime-id: Guid_1,
       span.kind: consumer,
       version: 1.0.0
@@ -1130,217 +1130,8 @@
   {
     TraceId: Id_65,
     SpanId: Id_66,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_68,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_70,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_72,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_74,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_76,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_77,
-    SpanId: Id_78,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_79,
-    SpanId: Id_80,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_82,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_84,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_86,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
-    Service: Samples.RabbitMQ,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_88,
-    Name: PublishToConsumer(),
-    Resource: PublishToConsumer(),
+    Name: PublishToConsumer(ExternalExplicit, i: 0),
+    Resource: PublishToConsumer(ExternalExplicit, i: 0),
     Service: Samples.RabbitMQ,
     Tags: {
       env: integration_tests,
@@ -1357,7 +1148,7 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_89,
+    SpanId: Id_67,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1379,13 +1170,80 @@
     }
   },
   {
-    TraceId: Id_67,
-    SpanId: Id_90,
+    TraceId: Id_65,
+    SpanId: Id_68,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_67,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_69,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_67,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_71,
+    Name: PublishToConsumer(ExternalExplicit, i: 1),
+    Resource: PublishToConsumer(ExternalExplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_70,
+    SpanId: Id_72,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_68,
+    ParentId: Id_71,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1402,77 +1260,75 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_91,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_70,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_92,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_70,
+    SpanId: Id_73,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_93,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_70,
+    SpanId: Id_74,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_74,
+    ParentId: Id_72,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_75,
-    SpanId: Id_94,
+    SpanId: Id_76,
+    Name: PublishToConsumer(ExternalExplicit, i: 2),
+    Resource: PublishToConsumer(ExternalExplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_77,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1494,13 +1350,80 @@
     }
   },
   {
-    TraceId: Id_77,
-    SpanId: Id_95,
+    TraceId: Id_75,
+    SpanId: Id_78,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_77,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_79,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_77,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_81,
+    Name: PublishToConsumer(ExternalImplicit, i: 0),
+    Resource: PublishToConsumer(ExternalImplicit, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_80,
+    SpanId: Id_82,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_78,
+    ParentId: Id_81,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1517,77 +1440,75 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_96,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_80,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
-    }
-  },
-  {
-    TraceId: Id_81,
-    SpanId: Id_97,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_80,
+    SpanId: Id_83,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
     ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: basic.deliver,
       amqp.exchange: ,
+      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_83,
-    SpanId: Id_98,
-    Name: amqp.send,
-    Resource: basic.publish <default> -> hello,
+    TraceId: Id_80,
+    SpanId: Id_84,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_84,
+    ParentId: Id_82,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
-      out.host: rabbitmq,
-      peer.service: rabbitmq,
-      span.kind: producer,
-      version: 1.0.0,
-      _dd.peer.service.source: out.host
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_85,
-    SpanId: Id_99,
+    SpanId: Id_86,
+    Name: PublishToConsumer(ExternalImplicit, i: 1),
+    Resource: PublishToConsumer(ExternalImplicit, i: 1),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_87,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
@@ -1609,13 +1530,80 @@
     }
   },
   {
-    TraceId: Id_87,
-    SpanId: Id_100,
+    TraceId: Id_85,
+    SpanId: Id_88,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_85,
+    SpanId: Id_89,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_91,
+    Name: PublishToConsumer(ExternalImplicit, i: 2),
+    Resource: PublishToConsumer(ExternalImplicit, i: 2),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_92,
     Name: amqp.send,
     Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_88,
+    ParentId: Id_91,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -1632,24 +1620,153 @@
     }
   },
   {
-    TraceId: Id_65,
+    TraceId: Id_90,
+    SpanId: Id_93,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_92,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_90,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_96,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_97,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_96,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_98,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_97,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_95,
+    SpanId: Id_99,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_97,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_100,
     SpanId: Id_101,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_89,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1660,41 +1777,36 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_100,
     SpanId: Id_102,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_90,
+    ParentId: Id_101,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_69,
+    TraceId: Id_100,
     SpanId: Id_103,
     Name: amqp.process,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_91,
+    ParentId: Id_102,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1716,24 +1828,16 @@
     }
   },
   {
-    TraceId: Id_71,
+    TraceId: Id_100,
     SpanId: Id_104,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_92,
+    ParentId: Id_102,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1744,52 +1848,15 @@
     }
   },
   {
-    TraceId: Id_73,
-    SpanId: Id_105,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_93,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
+    TraceId: Id_105,
     SpanId: Id_106,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: PublishToConsumer(InternalAsyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalAsyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_94,
     Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      message.size: 17,
       runtime-id: Guid_1,
-      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -1800,41 +1867,36 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_105,
     SpanId: Id_107,
-    Name: amqp.process,
-    Resource: basic.deliver,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_95,
+    ParentId: Id_106,
     Tags: {
-      amqp.command: basic.deliver,
+      amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.queue: hello,
       amqp.routing_key: hello,
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
       message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_79,
+    TraceId: Id_105,
     SpanId: Id_108,
     Name: amqp.process,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ,
     Type: queue,
-    ParentId: Id_96,
+    ParentId: Id_107,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1856,124 +1918,12 @@
     }
   },
   {
-    TraceId: Id_81,
+    TraceId: Id_105,
     SpanId: Id_109,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_97,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_83,
-    SpanId: Id_110,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_98,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_85,
-    SpanId: Id_111,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_99,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_87,
-    SpanId: Id_112,
-    Name: amqp.process,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ,
-    Type: queue,
-    ParentId: Id_100,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.queue: hello,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_113,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_89,
+    ParentId: Id_107,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -1988,12 +1938,82 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_110,
+    SpanId: Id_111,
+    Name: PublishToConsumer(InternalSyncDerived, i: 0),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 0),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_112,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_111,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
+    }
+  },
+  {
+    TraceId: Id_110,
+    SpanId: Id_113,
+    Name: amqp.process,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ,
+    Type: queue,
+    ParentId: Id_112,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_110,
     SpanId: Id_114,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_90,
+    ParentId: Id_112,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2008,32 +2028,11 @@
     }
   },
   {
-    TraceId: Id_69,
-    SpanId: Id_115,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_91,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
+    TraceId: Id_115,
     SpanId: Id_116,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 1),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 1),
     Service: Samples.RabbitMQ,
-    ParentId: Id_92,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2048,36 +2047,47 @@
     }
   },
   {
-    TraceId: Id_73,
+    TraceId: Id_115,
     SpanId: Id_117,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
-    ParentId: Id_93,
+    Type: queue,
+    ParentId: Id_116,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_75,
+    TraceId: Id_115,
     SpanId: Id_118,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
-    ParentId: Id_94,
+    Type: queue,
+    ParentId: Id_117,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -2088,12 +2098,12 @@
     }
   },
   {
-    TraceId: Id_77,
+    TraceId: Id_115,
     SpanId: Id_119,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_95,
+    ParentId: Id_117,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2108,32 +2118,11 @@
     }
   },
   {
-    TraceId: Id_79,
-    SpanId: Id_120,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_96,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_81,
+    TraceId: Id_120,
     SpanId: Id_121,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: PublishToConsumer(InternalSyncDerived, i: 2),
+    Resource: PublishToConsumer(InternalSyncDerived, i: 2),
     Service: Samples.RabbitMQ,
-    ParentId: Id_97,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -2148,36 +2137,47 @@
     }
   },
   {
-    TraceId: Id_83,
+    TraceId: Id_120,
     SpanId: Id_122,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.send,
+    Resource: basic.publish <default> -> hello,
     Service: Samples.RabbitMQ,
-    ParentId: Id_98,
+    Type: queue,
+    ParentId: Id_121,
     Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      message.size: 17,
+      out.host: rabbitmq,
+      peer.service: rabbitmq,
+      span.kind: producer,
+      version: 1.0.0,
+      _dd.peer.service.source: out.host
     }
   },
   {
-    TraceId: Id_85,
+    TraceId: Id_120,
     SpanId: Id_123,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
+    Name: amqp.process,
+    Resource: basic.deliver,
     Service: Samples.RabbitMQ,
-    ParentId: Id_99,
+    Type: queue,
+    ParentId: Id_122,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.queue: hello,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
+      span.kind: consumer,
       version: 1.0.0
     },
     Metrics: {
@@ -2188,12 +2188,12 @@
     }
   },
   {
-    TraceId: Id_87,
+    TraceId: Id_120,
     SpanId: Id_124,
     Name: consumer.Received event,
     Resource: consumer.Received event,
     Service: Samples.RabbitMQ,
-    ParentId: Id_100,
+    ParentId: Id_122,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -55,7 +55,12 @@ namespace Samples.RabbitMQ
             var sendTask = Task.Run(() => Send(consumerType.ToString()));
             var receiveTask = Task.Run(() => Receive(useQueue, consumerType, isAsyncConsumer));
 
-            await Task.WhenAll(sendTask, receiveTask);
+            var allTasks = Task.WhenAll(sendTask, receiveTask);
+            var completed = await Task.WhenAny(allTasks, Task.Delay(TimeSpan.FromMinutes(3))); // Intentionally very big
+            if (completed != allTasks)
+            {
+                throw new TimeoutException("Timeout waiting for the Send and receive tasks to complete");
+            }
 
             _sendFinished.Reset();
         }

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -49,10 +49,10 @@ namespace Samples.RabbitMQ
 
         private static async Task RunProducersAndConsumers(bool useQueue, ConsumerType consumerType, bool isAsyncConsumer)
         {
-            await PublishAndGet(useDefaultQueue: false);
-            await PublishAndGet(useDefaultQueue: true);
+            await PublishAndGet(consumerType.ToString(), useDefaultQueue: false);
+            await PublishAndGet(consumerType.ToString(), useDefaultQueue: true);
 
-            var sendTask = Task.Run(Send);
+            var sendTask = Task.Run(() => Send(consumerType.ToString()));
             var receiveTask = Task.Run(() => Receive(useQueue, consumerType, isAsyncConsumer));
 
             await Task.WhenAll(sendTask, receiveTask);
@@ -60,9 +60,9 @@ namespace Samples.RabbitMQ
             _sendFinished.Reset();
         }
 
-        private static async Task PublishAndGet(bool useDefaultQueue)
+        private static async Task PublishAndGet(string consumerType, bool useDefaultQueue)
         {
-            string messagePrefix = $"Program.PublishAndGetDefault(useDefaultQueue: {useDefaultQueue})";
+            string messagePrefix = $"Program.PublishAndGetDefault({consumerType}, useDefaultQueue: {useDefaultQueue})";
 
             // Configure and send to RabbitMQ queue
             var factory = new ConnectionFactory() { HostName = Host() };
@@ -121,7 +121,7 @@ namespace Samples.RabbitMQ
             }
         }
 
-        private static async Task Send()
+        private static async Task Send(string consumerType)
         {
             // Configure and send to RabbitMQ queue
             var factory = new ConnectionFactory() { HostName = Host() };
@@ -133,7 +133,7 @@ namespace Samples.RabbitMQ
 
                 for (int i = 0; i < 3; i++)
                 {
-                    using (SampleHelpers.CreateScope("PublishToConsumer()"))
+                    using (SampleHelpers.CreateScope($"PublishToConsumer({consumerType}, i: {i})"))
                     {
                         string message = $"Send - Message #{i}";
                         var body = Encoding.UTF8.GetBytes(message);

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -8,6 +8,14 @@ using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
+#if RABBITMQ_7_0
+using IRabbitChannel = RabbitMQ.Client.IChannel;
+using IRabbitConsumer = RabbitMQ.Client.IAsyncBasicConsumer;
+#else
+using IRabbitChannel = RabbitMQ.Client.IModel;
+using IRabbitConsumer = RabbitMQ.Client.IBasicConsumer;
+#endif
+
 namespace Samples.RabbitMQ
 {
     public static class Program
@@ -52,15 +60,14 @@ namespace Samples.RabbitMQ
             _sendFinished.Reset();
         }
 
-#if RABBITMQ_7_0
         private static async Task PublishAndGet(bool useDefaultQueue)
         {
             string messagePrefix = $"Program.PublishAndGetDefault(useDefaultQueue: {useDefaultQueue})";
 
             // Configure and send to RabbitMQ queue
             var factory = new ConnectionFactory() { HostName = Host() };
-            using (var connection = await factory.CreateConnectionAsync())
-            using (var channel = await connection.CreateChannelAsync())
+            using (var connection = await Helper.CreateConnectionAsync(factory))
+            using (var channel = await Helper.CreateChannelAsync(connection))
             {
                 string publishExchangeName;
                 string publishQueueName;
@@ -71,7 +78,7 @@ namespace Samples.RabbitMQ
                     if (useDefaultQueue)
                     {
                         publishExchangeName = "";
-                        publishQueueName = (await channel.QueueDeclareAsync()).QueueName;
+                        publishQueueName = (await Helper.QueueDeclareAsync(channel)).QueueName;
                         publishRoutingKey = publishQueueName;
                     }
                     else
@@ -80,35 +87,36 @@ namespace Samples.RabbitMQ
                         publishQueueName = queueName;
                         publishRoutingKey = routingKey;
 
-                        await channel.ExchangeDeclareAsync(publishExchangeName, "direct");
-                        await channel.QueueDeclareAsync(queue: publishQueueName,
-                                             durable: false,
-                                             exclusive: false,
-                                             autoDelete: false,
-                                             arguments: null);
-                        await channel.QueueBindAsync(publishQueueName, publishExchangeName, publishRoutingKey);
+                        await Helper.ExchangeDeclareAsync(channel, publishExchangeName, "direct");
+                        await Helper.QueueDeclareAsync(channel, queue: publishQueueName);
+                        await Helper.QueueBindAsync(channel, publishQueueName, publishExchangeName, publishRoutingKey);
                     }
 
                     // Ensure there are no more messages in this queue
-                    await channel.QueuePurgeAsync(publishQueueName);
+                    await Helper.QueuePurgeAsync(channel, publishQueueName);
 
                     // Test an empty BasicGetResult
-                    await channel.BasicGetAsync(publishQueueName, true);
+                    await Helper.BasicGetAsync(channel, publishQueueName);
 
                     // Send message to the default exchange and use new queue as the routingKey
                     string message = $"{messagePrefix} - Message";
                     var body = Encoding.UTF8.GetBytes(message);
-                    await channel.BasicPublishAsync(exchange: publishExchangeName,
-                                         routingKey: publishRoutingKey,
-                                         body: body);
+
+                    await Helper.BasicPublishAsync(channel, exchange: publishExchangeName,
+                                                   routingKey: publishRoutingKey,
+                                                   body: body);
                     Console.WriteLine($"BasicPublish - Sent message: {message}");
                 }
 
                 // Immediately get a message from the queue
                 // Move this outside of the manual span to ensure that the operation
                 // uses the distributed tracing context
-                var result = await channel.BasicGetAsync(publishQueueName, true);
+                var result = await Helper.BasicGetAsync(channel, publishQueueName);
+#if RABBITMQ_6_0 || RABBITMQ_7_0
                 var resultMessage = Encoding.UTF8.GetString(result.Body.ToArray());
+#else
+                var resultMessage = Encoding.UTF8.GetString(result.Body);
+#endif
                 Console.WriteLine($"[Program.PublishAndGetDefault] BasicGet - Received message: {resultMessage}");
             }
         }
@@ -117,15 +125,11 @@ namespace Samples.RabbitMQ
         {
             // Configure and send to RabbitMQ queue
             var factory = new ConnectionFactory() { HostName = Host() };
-            using (var connection = await factory.CreateConnectionAsync())
-            using (var channel = await connection.CreateChannelAsync())
+            using (var connection = await Helper.CreateConnectionAsync(factory))
+            using (var channel = await Helper.CreateChannelAsync(connection))
             {
-                await channel.QueueDeclareAsync(queue: "hello",
-                                     durable: false,
-                                     exclusive: false,
-                                     autoDelete: false,
-                                     arguments: null);
-                await channel.QueuePurgeAsync("hello"); // Ensure there are no more messages in this queue
+                await Helper.QueueDeclareAsync(channel, queue: "hello");
+                await Helper.QueuePurgeAsync(channel, "hello"); // Ensure there are no more messages in this queue
 
                 for (int i = 0; i < 3; i++)
                 {
@@ -134,7 +138,7 @@ namespace Samples.RabbitMQ
                         string message = $"Send - Message #{i}";
                         var body = Encoding.UTF8.GetBytes(message);
 
-                        await channel.BasicPublishAsync (exchange: "",
+                        await Helper.BasicPublishAsync (channel, exchange: "",
                                              routingKey: "hello",
                                              body: body);
                         Console.WriteLine("[Send] - [x] Sent \"{0}\"", message);
@@ -156,27 +160,27 @@ namespace Samples.RabbitMQ
 
             // Configure and listen to RabbitMQ queue
             var factory = new ConnectionFactory() { HostName = Host() };
+
+#if RABBITMQ_5_0 && !RABBITMQ_7_0
+            factory.DispatchConsumersAsync = isAsyncConsumer;
+#else
             _ = isAsyncConsumer; // not used in v7+
-            using (var connection = await factory.CreateConnectionAsync())
-            using (var channel = await connection.CreateChannelAsync())
+#endif
+            using (var connection = await Helper.CreateConnectionAsync(factory))
+            using (var channel = await Helper.CreateChannelAsync(connection))
 
             {
-                await channel.QueueDeclareAsync(queue: "hello",
-                                     durable: false,
-                                     exclusive: false,
-                                     autoDelete: false,
-                                     arguments: null);
+                await Helper.QueueDeclareAsync(channel, queue: "hello");
 
                 var queue = new BlockingCollection<BasicDeliverEventArgs>();
                 var consumer = CreateConsumer(channel, queue, useQueue: useQueue, consumerType);
-                await channel.BasicConsumeAsync("hello",
-                                     true,
-                                     consumer);
+                await Helper.BasicConsumeAsync(channel, "hello", consumer);
 
                 ProcessReceive(useQueue, queue);
             }
         }
 
+#if RABBITMQ_7_0
         private static IAsyncBasicConsumer CreateConsumer(IChannel channel, BlockingCollection<BasicDeliverEventArgs> queue, bool useQueue, ConsumerType consumerType)
         {
             Task HandleEvent(object sender, BasicDeliverEventArgs ea)
@@ -218,143 +222,6 @@ namespace Samples.RabbitMQ
             return consumer;
         }
 #else
-        private static Task PublishAndGet(bool useDefaultQueue)
-        {
-            string messagePrefix = $"Program.PublishAndGetDefault(useDefaultQueue: {useDefaultQueue})";
-
-            // Configure and send to RabbitMQ queue
-            var factory = new ConnectionFactory() { HostName = Host() };
-            
-            using (var connection = factory.CreateConnection())
-            using (var channel = connection.CreateModel())
-            {
-                string publishExchangeName;
-                string publishQueueName;
-                string publishRoutingKey;
-
-                using (SampleHelpers.CreateScope(messagePrefix))
-                {
-                    if (useDefaultQueue)
-                    {
-                        publishExchangeName = "";
-                        publishQueueName = channel.QueueDeclare().QueueName;
-                        publishRoutingKey = publishQueueName;
-                    }
-                    else
-                    {
-                        publishExchangeName = exchangeName;
-                        publishQueueName = queueName;
-                        publishRoutingKey = routingKey;
-
-                        channel.ExchangeDeclare(publishExchangeName, "direct");
-                        channel.QueueDeclare(queue: publishQueueName,
-                                            durable: false,
-                                            exclusive: false,
-                                            autoDelete: false,
-                                            arguments: null);
-                        channel.QueueBind(publishQueueName, publishExchangeName, publishRoutingKey);
-                    }
-
-                    // Ensure there are no more messages in this queue
-                    channel.QueuePurge(publishQueueName);
-
-                    // Test an empty BasicGetResult
-                    channel.BasicGet(publishQueueName, true);
-
-                    // Send message to the default exchange and use new queue as the routingKey
-                    string message = $"{messagePrefix} - Message";
-                    var body = Encoding.UTF8.GetBytes(message);
-                    channel.BasicPublish(exchange: publishExchangeName,
-                                            routingKey: publishRoutingKey,
-                                            basicProperties: null,
-                                            body: body);
-                    Console.WriteLine($"BasicPublish - Sent message: {message}");
-                }
-
-                // Immediately get a message from the queue
-                // Move this outside of the manual span to ensure that the operation
-                // uses the distributed tracing context
-                var result = channel.BasicGet(publishQueueName, true);
-#if RABBITMQ_6_0
-                var resultMessage = Encoding.UTF8.GetString(result.Body.ToArray());
-#else
-                var resultMessage = Encoding.UTF8.GetString(result.Body);
-#endif
-
-                Console.WriteLine($"[Program.PublishAndGetDefault] BasicGet - Received message: {resultMessage}");
-            }
-
-            return Task.CompletedTask;
-        }
-
-        private static Task Send()
-        {
-            // Configure and send to RabbitMQ queue
-            var factory = new ConnectionFactory() { HostName = Host() };
-            using(var connection = factory.CreateConnection())
-            using(var channel = connection.CreateModel())
-            {
-                channel.QueueDeclare(queue: "hello",
-                                        durable: false,
-                                        exclusive: false,
-                                        autoDelete: false,
-                                        arguments: null);
-                channel.QueuePurge("hello"); // Ensure there are no more messages in this queue
-
-                for (int i = 0; i < 3; i++)
-                {
-                    using (SampleHelpers.CreateScope("PublishToConsumer()"))
-                    {
-                        string message = $"Send - Message #{i}";
-                        var body = Encoding.UTF8.GetBytes(message);
-
-                        channel.BasicPublish(exchange: "",
-                                                routingKey: "hello",
-                                                basicProperties: null,
-                                                body: body);
-                        Console.WriteLine("[Send] - [x] Sent \"{0}\"", message);
-
-
-                        Interlocked.Increment(ref _messageCount);
-                    }
-                }
-            }
-
-            _sendFinished.Set();
-            Console.WriteLine("[Send] Exiting Thread.");
-            return Task.CompletedTask;
-        }
-
-        private static void Receive(bool useQueue, ConsumerType consumerType, bool isAsyncConsumer)
-        {
-            // Let's just wait for all sending activity to finish before doing any work
-            _sendFinished.WaitOne();
-
-            // Configure and listen to RabbitMQ queue
-            var factory = new ConnectionFactory() { HostName = Host() };
-#if RABBITMQ_5_0
-            factory.DispatchConsumersAsync = isAsyncConsumer;
-#endif
-
-            using(var connection = factory.CreateConnection())
-            using(var channel = connection.CreateModel())
-            {
-                channel.QueueDeclare(queue: "hello",
-                                    durable: false,
-                                    exclusive: false,
-                                    autoDelete: false,
-                                    arguments: null);
-
-                var queue = new BlockingCollection<BasicDeliverEventArgs>();
-                var consumer = CreateConsumer(channel, queue, useQueue: useQueue, consumerType);
-                channel.BasicConsume("hello",
-                                    true,
-                                    consumer);
-
-                ProcessReceive(useQueue, queue);
-            }
-        }
-
         private static IBasicConsumer CreateConsumer(IModel channel, BlockingCollection<BasicDeliverEventArgs> queue, bool useQueue, ConsumerType consumerType)
         {
             void HandleEvent(object sender, BasicDeliverEventArgs ea)
@@ -478,6 +345,130 @@ namespace Samples.RabbitMQ
             ExternalImplicit,
             ExternalExplicit,
             InternalAsyncDerived,
+        }
+    }
+
+    /// <summary>
+    /// A wrapper that encapsulates differences in APIs (primarily sync vs async) across RabbitMQ versions
+    /// </summary>
+    internal static class Helper
+    {
+        public static Task<IConnection> CreateConnectionAsync(ConnectionFactory factory)
+        {
+#if RABBITMQ_7_0
+            return factory.CreateConnectionAsync();
+#else
+            return Task.FromResult(factory.CreateConnection());
+#endif
+        }
+
+        public static Task<IRabbitChannel> CreateChannelAsync(IConnection connection)
+        {
+#if RABBITMQ_7_0
+            return connection.CreateChannelAsync();
+#else
+            return Task.FromResult(connection.CreateModel());
+#endif
+        }
+
+        public static Task<QueueDeclareOk> QueueDeclareAsync(IRabbitChannel channel)
+        {
+#if RABBITMQ_7_0
+            return channel.QueueDeclareAsync();
+#else
+            return Task.FromResult(channel.QueueDeclare());
+#endif
+        }
+
+
+        public static Task<QueueDeclareOk> QueueDeclareAsync(IRabbitChannel channel, string queue)
+        {
+#if RABBITMQ_7_0
+            return channel.QueueDeclareAsync(
+                queue: queue,
+                durable: false,
+                exclusive: false,
+                autoDelete: false,
+                arguments: null);
+#else
+            return Task.FromResult(
+                channel.QueueDeclare(
+                    queue: queue,
+                    durable: false,
+                    exclusive: false,
+                    autoDelete: false,
+                    arguments: null));
+#endif
+        }
+
+        public static Task ExchangeDeclareAsync(IRabbitChannel channel, string exchange, string type)
+        {
+#if RABBITMQ_7_0
+            return channel.ExchangeDeclareAsync(exchange, type);
+#else
+            channel.ExchangeDeclare(exchange, type);
+            return Task.CompletedTask;
+#endif
+        }
+
+        public static Task QueueBindAsync(IRabbitChannel channel, string publishQueueName, string publishExchangeName, string publishRoutingKey)
+        {
+#if RABBITMQ_7_0
+            return channel.QueueBindAsync(publishQueueName, publishExchangeName, publishRoutingKey);
+#else
+            channel.QueueBind(publishQueueName, publishExchangeName, publishRoutingKey);
+            return Task.CompletedTask;
+#endif
+        }
+
+        public static Task QueuePurgeAsync(IRabbitChannel channel, string publishQueueName)
+        {
+#if RABBITMQ_7_0
+            return channel.QueuePurgeAsync(publishQueueName);
+#else
+            channel.QueuePurge(publishQueueName);
+            return Task.CompletedTask;
+#endif
+        }
+
+        public static Task<BasicGetResult> BasicGetAsync(IRabbitChannel channel, string publishQueueName)
+        {
+#if RABBITMQ_7_0
+            return channel.BasicGetAsync(publishQueueName, true);
+#else
+            return Task.FromResult(channel.BasicGet(publishQueueName, true));
+#endif
+        }
+
+#if RABBITMQ_6_0 || RABBITMQ_7_0
+        public static Task BasicPublishAsync(IRabbitChannel channel, string exchange, string routingKey, ReadOnlyMemory<byte> body)
+#else
+        public static Task BasicPublishAsync(IRabbitChannel channel, string exchange, string routingKey, byte[] body)
+#endif
+        {
+#if RABBITMQ_7_0
+            return channel.BasicPublishAsync(
+                               exchange: exchange,
+                               routingKey: routingKey,
+                               body: body)
+                          .AsTask();
+#else
+            channel.BasicPublish(exchange: exchange,
+                                 routingKey: routingKey,
+                                 basicProperties: null,
+                                 body: body);
+            return Task.CompletedTask;
+#endif
+        }
+
+        public static Task BasicConsumeAsync(IRabbitChannel channel, string queue, IRabbitConsumer consumer)
+        {
+#if RABBITMQ_7_0
+            return channel.BasicConsumeAsync(queue, autoAck: true, consumer);
+#else
+            channel.BasicConsume(queue, true, consumer);
+            return Task.CompletedTask;
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Refactor RabbitMQ sample to reduce duplication
- Update manual spans to make hierarchy clearer and deterministic in snapshots

## Reason for change

Was trying to debug a failure in #6753 and the snapshots were making it too confusing

## Implementation details

- Created a RabbitMQ "Helper" that wraps the differences in APIs between version
  - The critical thing is that the v7 APIs are all async and the previous version are all sync
  - Previously we duplicated large amounts of code - this creates a helper to encapsulate the differences
  - ✅ Ran the snapshots at this point for all supported versions, and confirmed that they still passed
- Updated the manual spans to make sure each one is unique
- Updated all the snapshots

## Test coverage

The coverage is the same, the samples are just refactored and the snapshots updated.

## Other details

Previously, the top-level spans were all identical, and therefor the sorting in the snapshots was non-deterministic:

![image](https://github.com/user-attachments/assets/e7748d42-af8a-49f3-a5d7-ae98e9d5b159)

After this PR, the manual root spans are all unique

![image](https://github.com/user-attachments/assets/088c1546-1c7e-4618-9ee6-a2b7b73dbde8)


Prerequisite for 
- #6753 