### PR TITLE
Add AWS Lamda testing for .NET 9

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2587,6 +2587,9 @@ stages:
         net8:
           publishTargetFramework: "net8.0"
           lambdaBaseImage: "public.ecr.aws/lambda/dotnet:8"
+        net9:
+          publishTargetFramework: "net9.0"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:9"
     pool:
       name: azure-linux-scale-set
 


### PR DESCRIPTION
## Summary of changes

Add testing for .NET 9

## Reason for change

We don't currently test on .NET 9... we should 😄 

## Implementation details

Added an extra dimension

## Test coverage

A bit more now

## Other details

I have a sneaking suspicion we _don't_ currently test on ARM64, and we obviously should...
