### PR TITLE
Disable the merge queue

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,4 @@
+---
+schema-version: v1
+kind: mergequeue
+enable: false


### PR DESCRIPTION
## Summary of changes

Disables the merge queue

## Reason for change

We don't want it.

It hits our CI very hard and doesn't work very well for us, we prefer to use the manual button to merge the PRs

## Implementation details

Added the file, also saw that https://github.com/DataDog/dd-trace-go/blob/main/repository.datadog.yml has it as well so I think this should be good.

## Test coverage

None

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
