### PR TITLE
[fleet installer] Update logging for fleet installer

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/Log.cs
+++ b/tracer/src/Datadog.FleetInstaller/Log.cs
@@ -25,7 +25,7 @@ internal static class Log
 
         public void WriteError(string message)
         {
-            Console.WriteLine($"ERROR: {message}");
+            Console.Error.WriteLine($"ERROR: {message}");
         }
 
         public void WriteError(Exception ex, string message)

--- a/tracer/src/Datadog.FleetInstaller/Program.cs
+++ b/tracer/src/Datadog.FleetInstaller/Program.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using Datadog.FleetInstaller;
 using Datadog.FleetInstaller.Commands;
 
 // TEMP: For easy local testing
@@ -19,7 +21,7 @@ var rootCommand = new CommandWithExamples(CommandWithExamples.Command);
 
 var builder = new CommandLineBuilder(rootCommand)
     .UseHelp()
-    .UseParseErrorReporting()
+    .UseCustomErrorReporting()
     .CancelOnProcessTermination();
 
 rootCommand.AddExample("""
@@ -41,3 +43,43 @@ rootCommand.AddCommand(new EnableIisInstrumentationCommand());
 rootCommand.AddCommand(new RemoveIisInstrumentation());
 
 return builder.Build().Invoke(args);
+
+#pragma warning disable SA1649 // File name should match first type name
+internal static class CustomErrorHandling
+{
+    public static CommandLineBuilder UseCustomErrorReporting(this CommandLineBuilder builder)
+    {
+        builder.AddMiddleware(
+            async (context, next) =>
+            {
+                if (context.ParseResult.Errors.Count > 0)
+                {
+                    context.InvocationResult = new ParseErrorInvocationResult();
+                }
+                else
+                {
+                    await next(context).ConfigureAwait(true);
+                }
+            },
+            (MiddlewareOrder)1000); // To match MiddlewareOrderInternal.ParseErrorReporting
+
+        return builder;
+    }
+
+    /// <summary>
+    /// A custom parse error reporter that prints the error message but does not print the help text.
+    /// </summary>
+    internal class ParseErrorInvocationResult : IInvocationResult
+    {
+        public void Apply(InvocationContext context)
+        {
+            var log = Log.Instance;
+            foreach (var error in context.ParseResult.Errors)
+            {
+                log.WriteError(error.Message);
+            }
+
+            context.ExitCode = 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Write error logs to stderr instead of stdout
- Don't print the help message when validation checks fail

## Reason for change

Gives a better user experience in the logs given that this will be run programatically rather than directly by a user. You can still see the help information by running with the arg `/?` or `--help` etc

## Implementation details

- Switch to stderr for `Error` (should `Warning` go here too)
- Use a custom error reporting middleware implementation instead of the built in one which prints the logs

## Test coverage

Manual testing at this stage
