### PR TITLE
[AWS][Lambda] send placeholder span to the extension

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -18,8 +18,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Lambda;
 
 internal abstract class LambdaCommon
 {
-    private const string PlaceholderServiceName = "placeholder-service";
-    private const string PlaceholderOperationName = "placeholder-operation";
+    // Name of the placeholder span sent which will be filtered out by the Lambda Extension,
+    // required so we can get correct span metadata, tags, and more.
+    private const string InvocationSpanResource = "dd-tracer-serverless-span";
     private const double ServerlessMaxWaitingFlushTime = 3;
     private const string LogLevelEnvName = "DD_LOG_LEVEL";
 
@@ -28,11 +29,11 @@ internal abstract class LambdaCommon
         var context = tracer.TracerManager.SpanContextPropagator.Extract(headers).MergeBaggageInto(Baggage.Current);
 
         var span = tracer.StartSpan(
-            PlaceholderOperationName,
+            operationName: InvocationSpanResource,
             tags: null,
             parent: context.SpanContext,
-            serviceName: PlaceholderServiceName,
-            addToTraceContext: false);
+            serviceName: InvocationSpanResource,
+            addToTraceContext: true);
 
         TelemetryFactory.Metrics.RecordCountSpanCreated(MetricTags.IntegrationName.AwsLambda);
         return tracer.TracerManager.ScopeManager.Activate(span, false);


### PR DESCRIPTION
## Summary of changes

Updated the AWS Lambda instrumentation to send the top level placeholder span.

## Reason for change

So telemetry in the span created by the AWS Lambda extension is more accurate.
We would get metrics, metadata, and tags (probably other stuff I'm missing here) easily.

## Implementation details

Just updating the name to what the Extension expects and appending it to the context.

## Test coverage

- [ ] Integration Tests
- [ ] Manual testing

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
