### PR TITLE
Replace AWS ARM64 graviton images with Azure Managed DevOps pools

### DIFF
--- a/.azure-pipelines/steps/make-artifacts-uploadable.yml
+++ b/.azure-pipelines/steps/make-artifacts-uploadable.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
   - script: |
-      sudo chmod -R 755 ${{ parameters.artifact }} || true
-    displayName: Make ${{ parameters.artifact }} uploadable to AzDo
+      sudo chmod -R 755 ${{ parameters.path }} || true
+    displayName: Make ${{ parameters.path }} uploadable to AzDo
     condition: always()
 

--- a/.azure-pipelines/steps/make-artifacts-uploadable.yml
+++ b/.azure-pipelines/steps/make-artifacts-uploadable.yml
@@ -1,0 +1,11 @@
+parameters:
+  - name: 'path'
+    type: 'string'
+    default: 'artifacts/build_data/*'
+
+steps:
+  - script: |
+      sudo chmod -R 755 ${{ parameters.artifact }} || true
+    displayName: Make ${{ parameters.artifact }} uploadable to AzDo
+    condition: always()
+

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -182,4 +182,4 @@ steps:
   condition: succeededOrFailed()
   continueOnError: true
 
-    
+- template: ./make-artifacts-uploadable.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3252,15 +3252,7 @@ stages:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
             baseImage: $(baseImage) # for interpolation in the docker-compose file
 
-        - script: |
-            # Attempting to copy somewhere else to see what the errors are and avoid permissions issues
-            mkdir -p $(Agent.TempDirectory)/build_data
-            cp -r artifacts/build_data $(Agent.TempDirectory)/build_data
-          displayName: Copy data
-          condition: always()
-          continueOnError: true
-
-        - publish: $(Agent.TempDirectory)/build_data
+        - publish: artifacts/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
           continueOnError: true
@@ -3356,15 +3348,7 @@ stages:
           condition: succeededOrFailed()
           continueOnError: true
 
-        - script: |
-            # Attempting to copy somewhere else to see what the errors are and avoid permissions issues
-            mkdir -p $(Agent.TempDirectory)/build_data
-            cp -r artifacts/build_data $(Agent.TempDirectory)/build_data
-          displayName: Copy data
-          condition: always()
-          continueOnError: true
-
-        - publish: $(Agent.TempDirectory)/build_data
+        - publish: artifacts/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
           continueOnError: true

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1489,6 +1489,7 @@ stages:
         command: "BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()
@@ -1538,6 +1539,7 @@ stages:
             command: "BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
+        - template: steps/make-artifacts-uploadable.yml
         - publish: artifacts/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
@@ -2432,11 +2434,7 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         baseImage: $(baseImage) # for interpolation in the docker-compose file
 
-    - script: |
-        sudo chmod -R 644 artifacts/build_data/dumps/* || true
-      displayName: Make dumps uploadable to AzDo
-      condition: succeededOrFailed()
-
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()
@@ -2538,11 +2536,7 @@ stages:
       condition: succeededOrFailed()
       continueOnError: true
 
-    - script: |
-        sudo chmod -R 644 artifacts/build_data/dumps/* || true
-      displayName: Make dumps uploadable to AzDo
-      condition: succeededOrFailed()
-
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()
@@ -2727,11 +2721,7 @@ stages:
       condition: succeededOrFailed()
       continueOnError: true
 
-    - script: |
-        sudo chmod -R 644 artifacts/build_data/dumps/* || true
-      displayName: Make dumps uploadable to AzDo
-      condition: succeededOrFailed()
-
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()
@@ -2821,11 +2811,7 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         baseImage: $(baseImage) # for interpolation in the docker-compose file
 
-    - script: |
-        sudo chmod -R 644 artifacts/build_data/dumps/* || true
-      displayName: Make dumps uploadable to AzDo
-      condition: succeededOrFailed()
-
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()
@@ -3252,6 +3238,7 @@ stages:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
             baseImage: $(baseImage) # for interpolation in the docker-compose file
 
+        - template: steps/make-artifacts-uploadable.yml
         - publish: artifacts/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
@@ -3348,6 +3335,7 @@ stages:
           condition: succeededOrFailed()
           continueOnError: true
 
+        - template: steps/make-artifacts-uploadable.yml
         - publish: artifacts/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
@@ -3434,6 +3422,7 @@ stages:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
             baseImage: $(baseImage) # for interpolation in the docker-compose file
 
+        - template: steps/make-artifacts-uploadable.yml
         - publish: artifacts/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
@@ -3614,6 +3603,7 @@ stages:
       condition: succeededOrFailed()
       continueOnError: true
 
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()
@@ -4136,6 +4126,7 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         enable_crash_dumps: true
 
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       displayName: Uploading tool_artifacts_tests_windows logs
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -4260,11 +4251,7 @@ stages:
         baseImage: $(baseImage)
         command: "BuildAndRunDdDotnetArtifactTests --framework net7.0"
 
-    - script: |
-        sudo chmod -R 644 artifacts/build_data/dumps/* || true
-      displayName: Make dumps uploadable to AzDo
-      condition: succeededOrFailed()
-
+    - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: always()

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -720,7 +720,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
     workspace:
       clean: all
     steps:
@@ -763,7 +763,7 @@ stages:
     dependsOn: []
 
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
     workspace:
       clean: all
     steps:
@@ -813,7 +813,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
     workspace:
       clean: all
     steps:
@@ -855,7 +855,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
     workspace:
       clean: all
     steps:
@@ -903,7 +903,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1222,7 +1222,7 @@ stages:
           artifactSuffix: linux-musl-arm64
 
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1325,7 +1325,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
     workspace:
       clean: all
     steps:
@@ -1519,7 +1519,7 @@ stages:
         matrix:
           $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_arm64_matrix'] ]
       pool:
-        name: aws-arm64-auto-scaling
+        name: azure-managed-linux-arm64-1
       workspace:
         clean: all
       steps:
@@ -3205,7 +3205,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: aws-arm64-auto-scaling
+        name: azure-managed-linux-arm64-1
 
       steps:
         - template: steps/clone-repo.yml
@@ -3283,7 +3283,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: aws-arm64-auto-scaling
+        name: azure-managed-linux-arm64-1
 
       steps:
         - template: steps/clone-repo.yml
@@ -3397,7 +3397,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: aws-arm64-auto-scaling
+        name: azure-managed-linux-arm64-1
 
       steps:
         - template: steps/clone-repo.yml
@@ -4178,12 +4178,12 @@ stages:
         arm64:
           baseImage: debian
           artifactSuffix: linux-arm64
-          poolname: aws-arm64-auto-scaling
+          poolname: azure-managed-linux-arm64-1
           targetArch: arm64
         alpine_arm64:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
-          poolname: aws-arm64-auto-scaling
+          poolname: azure-managed-linux-arm64-1
           targetArch: arm64
 
     pool:
@@ -5990,7 +5990,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: aws-arm64-auto-scaling
+        name: azure-managed-linux-arm64-1
 
       steps:
         - template: steps/clone-repo.yml
@@ -6074,7 +6074,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: aws-arm64-auto-scaling
+        name: azure-managed-linux-arm64-1
 
       steps:
         - template: steps/clone-repo.yml
@@ -6148,7 +6148,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -6240,7 +6240,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: aws-arm64-auto-scaling
+      name: azure-managed-linux-arm64-1
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -6964,7 +6964,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: aws-arm64-auto-scaling
+        name: azure-managed-linux-arm64-1
 
       steps:
         - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3252,7 +3252,15 @@ stages:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
             baseImage: $(baseImage) # for interpolation in the docker-compose file
 
-        - publish: artifacts/build_data
+        - script: |
+            # Attempting to copy somewhere else to see what the errors are and avoid permissions issues
+            mkdir -p $(Agent.TempDirectory)/build_data
+            cp -r artifacts/build_data $(Agent.TempDirectory)/build_data
+          displayName: Copy data
+          condition: always()
+          continueOnError: true
+
+        - publish: $(Agent.TempDirectory)/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
           continueOnError: true
@@ -3348,7 +3356,15 @@ stages:
           condition: succeededOrFailed()
           continueOnError: true
 
-        - publish: artifacts/build_data
+        - script: |
+            # Attempting to copy somewhere else to see what the errors are and avoid permissions issues
+            mkdir -p $(Agent.TempDirectory)/build_data
+            cp -r artifacts/build_data $(Agent.TempDirectory)/build_data
+          displayName: Copy data
+          condition: always()
+          continueOnError: true
+
+        - publish: $(Agent.TempDirectory)/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: always()
           continueOnError: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - DEFAULT_REGION=us-east-1
     ports:
       - "4566:4566"
-    volumes:
-      - "./artifacts/build_data/localstack:/tmp"
 
   elasticsearch7_arm64:
     image: elasticsearch:7.10.1


### PR DESCRIPTION
## Summary of changes

Replaces our previous ARM64 auto-scaling graviton agents with Azure Managed DevOps pool images

## Reason for change

The AWS sandbox is being retired, which we means we would have to rebuild the somewhat hacky "VMSS emulator" that we built there, because Microsoft have refused to support ARM64 VMSS pools with Azure DevOps

This will hopefully bring a number of additional benefits, in that it supports more dynamic (and greater) scaling, allows dynamic scaling up and down (e.g. scale all the images off at night) and still allows us to use custom images.

## Implementation details

Followed [the documentation](https://learn.microsoft.com/en-us/azure/devops/managed-devops-pools/?view=azure-devops) to perform all the preliminary configuration to enable Managed DevOps pools. Adding a new pool needs to be done from Azure, but should be relatively simple. 

It still requires that create new VM images in certain circumstances, but now the process of creating an image is identical for x64 and arm64. 

Currently the x64 Linux and Windows images are still using VMSS instead of Managed DevOps pools, but we can consider migrating those across in the future.

## Test coverage

Ran some manual tests, and once the initial configuration was done, worked like a charm with one exception - the Docker tests were failing to upload the logs, because localstack was locking the directory. I don't _think_ we actually need to report this temp file, so removed the binding for simplicity.

However we also realised that the same permissions issue was preventing crashdump uploads too, so fixed that "everywhere" by creating a small template to do the permissions fix.
