### PR TITLE
Fix dependabot update types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,6 @@ updates:
       interval: "monthly"
     groups:
       gh-actions-packages:
-        update-types: ["version-update:semver-patch"]
+        update-types: ["minor"]
         patterns:
           - "*"


### PR DESCRIPTION
## Summary of changes

Fix using an invalid value in `update-types`

## Reason for change

We're getting the following error:

```
The property '#/updates/5/groups/gh-actions-packages/update-types/0' value "version-update:semver-patch" did not match one of the following values: major, minor, patch
```

## Implementation details

The docs are very confusing, in that they specify the `version-update:semver-*` style value for the `ignore` parameter, but `update-types` seems to have [a different set of allowed values](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#update-types-ignore).

Switched it to `minor` 🤞 

## Test coverage

If this PR doesn't flag any errors, then I assume the syntax is good. As for whether it does what we want...
