### PR TITLE
fix: container ID prefix in metadata and related tests

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.PlatformHelpers
         /// Gets the unique identifier of the container executing the code.
         /// Return values may be:
         /// <list type="bullet">
-        /// <item>"cid-&lt;containerID&gt;" if the container id is available.</item>
+        /// <item>"ci-&lt;containerID&gt;" if the container id is available.</item>
         /// <item>"in-&lt;inode&gt;" if the cgroup node controller's inode is available.
         ///        We use the memory controller on cgroupv1 and the root cgroup on cgroupv2.</item>
         /// <item><c>null</c> if neither are available.</item>
@@ -65,7 +65,7 @@ namespace Datadog.Trace.PlatformHelpers
         {
             if (ContainerId.Value is string containerId)
             {
-                return $"cid-{containerId}";
+                return $"ci-{containerId}";
             }
             else if (CgroupInode.Value is string cgroupInode)
             {

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.IntegrationTests
 
                 if (expectedContainedId is not null && expectedEntitydId is not null)
                 {
-                    expectedEntitydId.Should().Be($"cid-{expectedContainedId}");
+                    expectedEntitydId.Should().Be($"ci-{expectedContainedId}");
                 }
                 else if (expectedEntitydId is not null)
                 {


### PR DESCRIPTION
## Summary of changes

Prefix update and tests.

## Reason for change

per spec 

| Container ID Available | Inode Available     | `Datadog-Container-Id` | `Datadog-Entity-Id` |
|------------------------|---------------------|--------------------------|----------------------|
| ✅ Yes (`123`)         | —                   | `123`                    | `ci-123`             |
| ❌ No                  | ✅ Yes (`456`)       | _(skipped)_              | `in-456`             |
| ❌ No                  | ❌ No                | _(skipped)_              | _(skipped)_          |


- ✅ = available / known  
- ❌ = not available / unknown  
- `ci-` prefix stands for "container ID"  
- `in-` prefix stands for "inode ID"

## Implementation details

Prefix update

## Test coverage

- Updated tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
