### PR TITLE
Decouple Security and Tracer integration tests

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1298,6 +1298,25 @@ partial class Build
         .DependsOn(RunProfilerNativeUnitTestsLinux)
         .After(CompileProfilerNativeTests);
 
+    Target CompileSecurityIntegrationTests => _ => _
+    .Unlisted()
+    .After(CompileManagedSrc)
+    .After(CompileManagedTestHelpers)
+    .After(PublishIisSamples)
+    .After(BuildRunnerTool)
+    .Requires(() => Framework)
+    .Requires(() => MonitoringHomeDirectory != null)
+    .Executes(() =>
+    {
+        var projects = TracerDirectory
+                .GlobFiles("test/*.IntegrationTests/*.IntegrationTests.csproj")
+                .Where(path => ((string)path).Contains(Projects.AppSecIntegrationTests))
+                .Where(project => Solution.GetProject(project).GetTargetFrameworks().Contains(Framework))
+            ;
+
+        DotnetBuild(projects, framework: Framework);
+    });
+
     Target CompileIntegrationTests => _ => _
         .Unlisted()
         .After(CompileManagedSrc)
@@ -1318,6 +1337,7 @@ partial class Build
             var projects = TracerDirectory
                     .GlobFiles("test/*.IntegrationTests/*.IntegrationTests.csproj")
                     .Where(path => !((string)path).Contains(Projects.DebuggerIntegrationTests))
+                    .Where(path => !((string)path).Contains(Projects.AppSecIntegrationTests))
                     .Where(project => Solution.GetProject(project).GetTargetFrameworks().Contains(Framework))
                 ;
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1776,7 +1776,7 @@ partial class Build
 
     Target RunWindowsSecurityIisIntegrationTests => _ => _
         .After(BuildTracerHome)
-        .After(CompileIntegrationTests)
+        .After(CompileSecurityIntegrationTests)
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -274,6 +274,7 @@ partial class Build : NukeBuild
         .Description("Builds the integration tests for Windows")
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CompileIntegrationTests)
+        .DependsOn(CompileSecurityIntegrationTests)
         .DependsOn(BuildRunnerTool);
 
     Target BuildAspNetIntegrationTests => _ => _
@@ -282,7 +283,8 @@ partial class Build : NukeBuild
         .Description("Builds the ASP.NET integration tests for Windows")
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(PublishIisSamples)
-        .DependsOn(CompileIntegrationTests);
+        .DependsOn(CompileIntegrationTests)
+        .DependsOn(CompileSecurityIntegrationTests);
 
     Target BuildWindowsRegressionTests => _ => _
         .Unlisted()


### PR DESCRIPTION
## Summary of changes

This PR decouples security and tracer integration tests compilation under Windows.

## Reason for change

Tasks that don't require security integration tests compilation will no longer compile them:
* BuildAndRunWindowsAzureFunctionsTests
* BuildWindowsRegressionTests

Tasks that do not require the tracer integration tests will no longer compile them:
* RunWindowsSecurityIisIntegrationTests 

This change will also help decoupling security and tracer integration tests compilation and execution if we decide to tackle that in the future.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
