### PR TITLE
Use the correct Skip milestone ID

### DIFF
--- a/.github/workflows/create_skip_code_freeze.yml
+++ b/.github/workflows/create_skip_code_freeze.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
         name: 'Open Skip Milestone'
         with:
-          route: PATCH /repos/{owner}/{repo}/milestones/2
+          route: PATCH /repos/{owner}/{repo}/milestones/183
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           state: open


### PR DESCRIPTION
## Summary of changes

https://github.com/DataDog/dd-trace-dotnet/milestone/183

is the one we want

https://github.com/DataDog/dd-trace-dotnet/milestone/2

was from my testing and I failed to updated it.

## Reason for change

Wrong milestone ID

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
