### PR TITLE
[Benchmarks] Add Micro-benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,4 +214,17 @@ macrobenchmarks:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $BENCHMARK_RUN == "true"'
       when: always
     - when: manual
+
+microbenchmarks:
+  stage: benchmarks
+  needs: [ ]
+  trigger:
+    include: .gitlab/benchmarks/microbenchmarks.yml
+  allow_failure: true
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"'
+      when: always
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $BENCHMARK_RUN == "true"'
+      when: always
+    - when: manual
     

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -17,7 +17,7 @@ run-benchmarks:
     # - ./platform/steps/upload-to-bp-ui.sh
     
   rules:
-    - when: manual
+    - when: on_success
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     AWS_REGION: "us-east-1"

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -26,3 +26,29 @@ run-benchmarks:
     AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
     AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
     AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
+
+upload-tp-bp-ui:
+  stage: benchmarks
+  tags: ["arch:amd64"]
+  interruptible: true
+  timeout: 1h
+  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks
+
+  script:
+    - git clone --branch fayssal/test-micro-delivery https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    # - ./platform/steps/launch-instance.sh
+    # - ./platform/steps/post-pr-comment.sh
+    # Temporarely commented out pending issue resolution with sending files to backend
+    - ./platform/steps/upload-to-bp-ui.sh
+    
+  rules:
+    - when: manual
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    AWS_REGION: "us-east-1"
+    CLEANUP: "false"
+    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -6,8 +6,8 @@ run-benchmarks:
   tags: ["arch:amd64"]
   interruptible: true
   timeout: 1h
-  # Image based on earlier version of tooling
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet0
+  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks
 
   script:
     - git clone --branch fayssal/migrate-micros-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -11,7 +11,7 @@ run-benchmarks:
 
   script:
     - git clone --branch fayssal/test-micro-delivery https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-    # - ./platform/steps/launch-instance.sh
+    - ./platform/steps/launch-instance.sh
     - ./platform/steps/post-pr-comment.sh
     # Temporarely commented out pending issue resolution with sending files to backend
     # - ./platform/steps/upload-to-bp-ui.sh

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -1,0 +1,33 @@
+stages:
+  - benchmarks
+
+run-benchmarks:
+  stage: benchmarks
+  tags: ["arch:amd64"]
+  interruptible: true
+  timeout: 1h
+  # Image based on earlier version of tooling
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet0
+
+  script:
+    - git clone --branch fayssal/migrate-micros-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - ./platform/launch-instance.sh
+    - ./platform/post-pr-comment.sh
+    # - ./platform/steps/upload-to-bp-ui.sh
+    
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
+  rules:
+    - when: manual
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    AWS_REGION: "us-east-1"
+    CLEANUP: "false"
+    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -16,12 +16,6 @@ run-benchmarks:
     # Temporarely commented out pending issue resolution with sending files to backend
     # - ./platform/steps/upload-to-bp-ui.sh
     
-  artifacts:
-    name: "artifacts"
-    when: always
-    paths:
-      - artifacts/
-    expire_in: 3 months
   rules:
     - when: manual
   variables:

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -46,7 +46,7 @@ upload-to-bp-ui:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - candidate-results/
     expire_in: 3 months
     
   rules:

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -27,7 +27,7 @@ run-benchmarks:
     AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
     AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
-upload-tp-bp-ui:
+upload-to-bp-ui:
   stage: benchmarks
   tags: ["arch:amd64"]
   interruptible: true
@@ -41,6 +41,13 @@ upload-tp-bp-ui:
     # - ./platform/steps/post-pr-comment.sh
     # Temporarely commented out pending issue resolution with sending files to backend
     - ./platform/steps/upload-to-bp-ui.sh
+
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
     
   rules:
     - when: manual

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -13,6 +13,7 @@ run-benchmarks:
     - git clone --branch fayssal/migrate-micros-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
     - ./platform/launch-instance.sh
     - ./platform/post-pr-comment.sh
+    # Temporarely commented out pending issue resolution with sending files to backend
     # - ./platform/steps/upload-to-bp-ui.sh
     
   artifacts:

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -11,7 +11,7 @@ run-benchmarks:
 
   script:
     - git clone --branch fayssal/test-micro-delivery https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-    - ./platform/steps/launch-instance.sh
+    # - ./platform/steps/launch-instance.sh
     - ./platform/steps/post-pr-comment.sh
     # Temporarely commented out pending issue resolution with sending files to backend
     # - ./platform/steps/upload-to-bp-ui.sh

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -10,9 +10,9 @@ run-benchmarks:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks
 
   script:
-    - git clone --branch fayssal/migrate-micros-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-    - ./platform/launch-instance.sh
-    - ./platform/post-pr-comment.sh
+    - git clone --branch fayssal/test-micro-delivery https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - ./platform/steps/launch-instance.sh
+    - ./platform/steps/post-pr-comment.sh
     # Temporarely commented out pending issue resolution with sending files to backend
     # - ./platform/steps/upload-to-bp-ui.sh
     

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1003,7 +1003,6 @@ partial class Build
              var prDir = BuildDataDirectory / "benchmarks";
 
              var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, "master", GitHubRepositoryName, BenchmarkCategory);
-             string tempFolder = Path.GetTempPath();
              string filePath = Path.Combine(Path.GetTempPath(), "benchmarks_report.md");
              Console.WriteLine($"The file was stored at: {filePath}");
              File.WriteAllText(filePath, markdown);

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -986,6 +986,27 @@ partial class Build
              await ReplaceCommentInPullRequest(prNumber, $"## Benchmarks Report for " + BenchmarkCategory, markdown);
          });
 
+    Target CompareBenchmarksResultsBP => _ => _
+         .Unlisted()
+         .DependsOn(CreateRequiredDirectories)
+         .Requires(() => GitHubRepositoryName)
+         .Requires(() => BenchmarkCategory)
+         .Executes(async () =>
+         {
+             if (!int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var prNumber))
+             {
+                 Logger.Warning("No PR_NUMBER variable found. Skipping benchmark comparison");
+                 return;
+             }
+
+             var masterDir = BuildDataDirectory / "previous_benchmarks";
+             var prDir = BuildDataDirectory / "benchmarks";
+
+             var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, "master", GitHubRepositoryName, BenchmarkCategory);
+             string filePath = "C:\\benchmarks_report.md";
+             File.WriteAllText(filePath, markdown);
+         });
+
     Target CompareThroughputResults => _ => _
          .Unlisted()
          .DependsOn(CreateRequiredDirectories)

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1003,7 +1003,9 @@ partial class Build
              var prDir = BuildDataDirectory / "benchmarks";
 
              var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, "master", GitHubRepositoryName, BenchmarkCategory);
-             string filePath = "C:\\benchmarks_report.md";
+             string tempFolder = Path.GetTempPath();
+             string filePath = Path.Combine(tempFolder, "benchmarks_report.md");
+             Console.WriteLine($"The file was stored at: {filePath}");
              File.WriteAllText(filePath, markdown);
          });
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -991,7 +991,7 @@ partial class Build
          .DependsOn(CreateRequiredDirectories)
          .Requires(() => GitHubRepositoryName)
          .Requires(() => BenchmarkCategory)
-         .Executes(async () =>
+         .Executes(() =>
          {
              if (!int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var prNumber))
              {

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1004,7 +1004,7 @@ partial class Build
 
              var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, "master", GitHubRepositoryName, BenchmarkCategory);
              string tempFolder = Path.GetTempPath();
-             string filePath = Path.Combine(tempFolder, "benchmarks_report.md");
+             string filePath = Path.Combine(Path.GetTempPath(), "benchmarks_report.md");
              Console.WriteLine($"The file was stored at: {filePath}");
              File.WriteAllText(filePath, markdown);
          });

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -566,7 +566,7 @@ partial class Build : NukeBuild
                     .SetFramework(framework)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 20")
+                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 200")
                     .SetProcessEnvironmentVariable("DD_SERVICE", "dd-trace-dotnet")
                     .SetProcessEnvironmentVariable("DD_ENV", "CI")
                     .SetProcessEnvironmentVariable("DD_DOTNET_TRACER_HOME", MonitoringHome)

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -566,7 +566,7 @@ partial class Build : NukeBuild
                     .SetFramework(framework)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 200")
+                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 20")
                     .SetProcessEnvironmentVariable("DD_SERVICE", "dd-trace-dotnet")
                     .SetProcessEnvironmentVariable("DD_ENV", "CI")
                     .SetProcessEnvironmentVariable("DD_DOTNET_TRACER_HOME", MonitoringHome)

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -566,7 +566,7 @@ partial class Build : NukeBuild
                     .SetFramework(framework)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 2000")
+                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 200")
                     .SetProcessEnvironmentVariable("DD_SERVICE", "dd-trace-dotnet")
                     .SetProcessEnvironmentVariable("DD_ENV", "CI")
                     .SetProcessEnvironmentVariable("DD_DOTNET_TRACER_HOME", MonitoringHome)


### PR DESCRIPTION
## Summary of changes
This PR introduces running benchmarks through the Benchmarking-platform all while keeping the current benchmarks running.
The tests are setup to run:

- On commit to the master branch
- On schedule if BENCHMARK_RUN is set to "true" for the scheduled pipeline.
- On manual trigger (keep in mind that it requires build artifacts from the Azure Pipeline)

## Reason for change
Related to efforts to use Gitlab as our main CI Provider.
## Implementation details

## Test coverage

## Other details
Results from the benchmarks report do differ as we do not run on master currently so the comparaison is done against an old seeded run
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
