### PR TITLE
Avoid IAST SqlLite tests flakyness

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
-using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -11,6 +10,9 @@ namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 
 public abstract class EFCoreBaseTests: InstrumentationTestsBase, IDisposable
 {
+    [CollectionDefinition("Non-Parallel Collection", DisableParallelization = true)]
+    public class NonParallelCollectionDefinition { }
+
     protected string taintedTitle = "Think_Python";
     protected string notTaintedValue = "nottainted";
     protected string commandUnsafe;

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
@@ -11,7 +11,7 @@ namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 
 public abstract class EFCoreBaseTests: InstrumentationTestsBase, IDisposable
 {
-    [CollectionDefinition("Non-Parallel Collection", DisableParallelization = true)]
+    [CollectionDefinition("IastEfCoreSqliteTests", DisableParallelization = true)]
     public class NonParallelCollectionDefinition { }
 
     protected string taintedTitle = "Think_Python";

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreSqliteTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreSqliteTests.cs
@@ -9,7 +9,7 @@ namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 #if !NET6_0_OR_GREATER
 [Xunit.Trait("Category", "AlpineArmUnsupported")] // sqlite isn't supported in .NET 5 on Alpine
 #endif
-[Collection("Non-Parallel Collection")]
+[Collection("IastEfCoreSqliteTests")]
 public class EFCoreSqliteTests : EFCoreBaseTests
 {
     public EFCoreSqliteTests()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreSqliteTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreSqliteTests.cs
@@ -2,12 +2,14 @@
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Xunit;
 
 namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 
 #if !NET6_0_OR_GREATER
 [Xunit.Trait("Category", "AlpineArmUnsupported")] // sqlite isn't supported in .NET 5 on Alpine
 #endif
+[Collection("Non-Parallel Collection")]
 public class EFCoreSqliteTests : EFCoreBaseTests
 {
     public EFCoreSqliteTests()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreTests.cs
@@ -8,6 +8,7 @@ namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 
 // We cannot use localDB on linux and these calls cannot be mocked
 [Trait("Category", "LinuxUnsupported")]
+[Collection("Non-Parallel Collection")]
 public class EFCoreTests : EFCoreBaseTests
 {
     public EFCoreTests()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreTests.cs
@@ -8,7 +8,7 @@ namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 
 // We cannot use localDB on linux and these calls cannot be mocked
 [Trait("Category", "LinuxUnsupported")]
-[Collection("Non-Parallel Collection")]
+[Collection("IastEfCoreSqliteTests")]
 public class EFCoreTests : EFCoreBaseTests
 {
     public EFCoreTests()


### PR DESCRIPTION
## Summary of changes

The IAST instrumented tests are randomly failing in the CI. These are the tests that have been failing lately:

```
Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.EFCoreSqliteTests.GivenACoreDatabase_WhenCallingFromSqlRawWithTainted_VulnerabilityIsReported 
Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.EFCoreTests.GivenACoreDatabase_WhenCallingFromSqlRawWithTainted_VulnerabilityIsReported 
Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.EFCoreSqliteTests.GivenACoreDatabase_WhenCallingFromSqlRawWithTainted_VulnerabilityIsReported2
Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.EFCoreTests.GivenACoreDatabase_WhenCallingExecuteSqlRawAsyncyWithTainted_VulnerabilityIsReported5
```

The latest fails can be accessed [here](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.status%3Afail%20%40test.full_name%3ADatadog.Trace.Security.IntegrationTests.Datadog.Trace.Security.IntegrationTests.Iast.IastInstrumentationUnitTests.TestInstrumentedUnitTests%20%40os.platform%3AWindows&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1742127474534&end=1743423474534&paused=false).

All of them are SqlLite tests. The tests are only run on Windows. Failures has been detected under .NET 5,6,8,9.

The issue could be reproduced locally. The tests would pass if run separately per class (EFCoreTests and EFCoreSqliteTests). They would only fail when run in parallel. Both classes inherit from the same base class EFCoreBaseTests and this class is referenced only by these two classes.

The underlying problem seems to be that, when running these tests in parallel, sometimes the EntityFrameworkCoreAspect method is not called. The native tracer seems to correctly modify the testing method IL though before actually running the tests. It's interesting to note that both classes share the same method code but, when flakiness occurs, only the first test fails. It has never been observed that both tests fail in the same run. It seems that tests are not totally independent and, in this case, one can affect the other. 

Avoiding parallelization between EFCoreTests and EFCoreSqliteTests fixes the problem locally and is expected to fix it in the CI. 

While this fix fixes the flakiness, it could be good opportunity to investigate further why these particular tests interfere each other, something that has never been observed in other IAST unit tests.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
