### PR TITLE
Disable inlining in Samples.InstrumentedTests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -48,6 +48,12 @@ public class IastInstrumentationUnitTests : TestHelper
     public IastInstrumentationUnitTests(ITestOutputHelper output)
         : base("InstrumentedTests", output)
     {
+        // We have seen crashes in CI for these tests which seem to be due to
+        // https://github.com/dotnet/runtime/issues/95653
+        // In the past, we have solved it by setting this variable,
+        // e.g. https://github.com/DataDog/dd-trace-dotnet/pull/5004
+        // so trying the same thing here: 
+        SetEnvironmentVariable("DD_CLR_ENABLE_INLINING", "0");
     }
 
     public List<string> GetAspects()

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -52,7 +52,7 @@ public class IastInstrumentationUnitTests : TestHelper
         // https://github.com/dotnet/runtime/issues/95653
         // In the past, we have solved it by setting this variable,
         // e.g. https://github.com/DataDog/dd-trace-dotnet/pull/5004
-        // so trying the same thing here: 
+        // so trying the same thing here:
         SetEnvironmentVariable("DD_CLR_ENABLE_INLINING", "0");
     }
 


### PR DESCRIPTION
## Summary of changes

Set `DD_CLR_ENABLE_INLINING=0` in Samples.InstrumentedTests

## Reason for change

We have seen crashes in CI for these tests which seem to be due to https://github.com/dotnet/runtime/issues/95653. In the past (e.g. https://github.com/DataDog/dd-trace-dotnet/pull/5004), we have solved it by setting `DD_CLR_ENABLE_INLINING=0`, so trying the same thing here.

## Implementation details

Set `DD_CLR_ENABLE_INLINING=0` in the instrumentation tests

## Test coverage

As this is flaky, we really just have to merge it and see
