### PR TITLE
Skip StackExchange test on timeout exception

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -32,9 +32,10 @@ namespace Samples.StackExchangeRedis
                 return 0;
             }
             catch (Exception ex)
-                when (ex.GetType().Name == "RedisConnectionException"
+                when ((ex.GetType().Name == "RedisConnectionException"
                    && (ex.Message.Contains("No connection is available to service this operation")
                       || ex.Message.Contains("It was not possible to connect to the redis server")))
+                   || ex.GetType().Name == "RedisTimeoutException")
             {
                 // If the redis server is being too slow in responding, we can end up with timeouts
                 // We could do retries, but then we risk butting up against timeout limits etc


### PR DESCRIPTION
## Summary of changes

Skip the StackExchangeRedis tests when a `RedisTimeoutException` is thrown

## Reason for change

We have [seen flake](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=175721&view=logs&j=f6ea8a86-8f60-58a8-769a-78d1e6d785f3&t=76e02f81-b0a5-5745-ca2d-1bffe345502c) in this method, which is likely due to overloading. Skipping to reduce flake.

## Implementation details

Skip if we see a `RedisTimeoutException`. Obviously it's bad if we get _loads_ of these and don't notice, but it's all trade offs. We record metrics whenever we skip, so we have the data separately too.

## Test coverage

Can't easily test this, as it's flake, so see what happenes.
