### PR TITLE
Update Windows to hosted managed DevOps pool

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -253,7 +253,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -280,7 +280,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -326,7 +326,7 @@ stages:
 
   - job: build
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -1067,7 +1067,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-3
+    name: azure-managed-windows-x64-3
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -1130,7 +1130,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -1309,7 +1309,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1364,7 +1364,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-3
+    name: azure-managed-windows-x64-3
 
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -1565,7 +1565,7 @@ stages:
     - job: standalone
       timeoutInMinutes: 60 #default value
       pool:
-        name: azure-windows-scale-set-3
+        name: azure-managed-windows-x64-3
       steps:
         - template: steps/clone-repo.yml
           parameters:
@@ -1611,7 +1611,7 @@ stages:
           net9.0:
             framework: net9.0
       pool:
-        name: azure-windows-scale-set-3
+        name: azure-managed-windows-x64-3
       steps:
         - template: steps/clone-repo.yml
           parameters:
@@ -1637,7 +1637,7 @@ stages:
       dependsOn: [ standalone, multi_version ]
       timeoutInMinutes: 60 #default value
       pool:
-        name: azure-windows-scale-set-3
+        name: azure-managed-windows-x64-3
       steps:
         - checkout: none
         - powershell: |
@@ -1765,7 +1765,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     timeoutInMinutes: 90
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
@@ -1850,7 +1850,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_debugger_matrix'] ]
@@ -1912,7 +1912,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1972,7 +1972,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -2031,7 +2031,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -2161,7 +2161,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     timeoutInMinutes: 60 #default value
 
     steps:
@@ -2240,7 +2240,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_msi_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     variables:
       relativeMsiOutputDirectory: /artifacts/msi/$(targetPlatform)/en-us
 
@@ -2323,7 +2323,7 @@ stages:
   - job: fleet_installer_tests
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
     variables:
       framework: net462
 
@@ -2868,7 +2868,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -3086,7 +3086,7 @@ stages:
     condition: false
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -3473,7 +3473,7 @@ stages:
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_windows_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     # Enable the Datadog Agent service for this job
     services:
@@ -3837,7 +3837,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -4068,7 +4068,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -7150,7 +7150,7 @@ stages:
     timeoutInMinutes: 3
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-managed-windows-x64-3
 
     steps:
     - template: steps/clone-repo.yml


### PR DESCRIPTION
## Summary of changes

- Move the Windows VMs from a VMSS pool to use a Hosted Managed DevOps Pool
- Bump the size of the VMs

## Reason for change

We want to unify the infrastructure hence the move from VMSS to hosted pools. We also want to see if we can improve CI time by using bigger VMs, so this is 

## Implementation details

- Set up a new hosted devops pool (I will document this process in confluence once I'm/we're happy)
- Reused the same image, so should have identical behaviour otherwise
- Update ultimate-pipeline to use the new pool

## Test coverage

This is the test - let's make sure it works, and then compare the speed!

## Other details

Bumped from `Standard_D4ads_v5` to `Standard_D8ads_v5`
