### PR TITLE
remove `obj` folder(s) on clean

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -341,7 +341,11 @@ partial class Build
             var buildDirectory = NativeBuildDirectory + "_" + finalArchs.Replace(';', '_');
             EnsureExistingDirectory(buildDirectory);
 
-            var envVariables = new Dictionary<string, string> { ["CMAKE_OSX_ARCHITECTURES"] = finalArchs };
+            var envVariables = new Dictionary<string, string>
+            {
+                ["CMAKE_OSX_ARCHITECTURES"] = finalArchs,
+                ["PATH"] = Environment.GetEnvironmentVariable("PATH")
+            };
 
             // Build native
             CMake.Value(

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -143,6 +143,8 @@ partial class Build : NukeBuild
                 DeleteReparsePoints(SourceDirectory);
                 DeleteReparsePoints(TestsDirectory);
             }
+
+            RootDirectory.GlobDirectories("obj*").ForEach(x => DeleteDirectory(x));
             SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => DeleteDirectory(x));
             TestsDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => DeleteDirectory(x));
             BundleHomeDirectory.GlobFiles("**").ForEach(x => DeleteFile(x));


### PR DESCRIPTION
## Summary of changes

the `Clean` command didn't really clean everything, especially native artifacts in the root obj folders (there can be several ones depending on the arch targeted). This can cause different kinds of issues, so I think we should make sure `Clean` actually cleans all files generated by `Build`.

Also added the `PATH` to CMake env variables when `CompileNativeSrcMacOs`. Without it, I get the following errors:
```
[ERR] CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
[ERR] CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
[ERR] CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
```
the alternative is to set those env variables one by one, but I find it easier and more intuitive to just add `PATH`, that way the run of CMake inside Nuke is consistent with what it'd do if ran from the terminal directly.

## Reason for change

make sure we don't have to deal with lingering artifact files issues after a `Clean`

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
