### PR TITLE
[TestOptimization] Fix Impacted Tests line range

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/GitCommandHelper.cs
+++ b/tracer/src/Datadog.Trace/Ci/GitCommandHelper.cs
@@ -27,9 +27,9 @@ internal static class GitCommandHelper
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(GitCommandHelper));
 
     // Regex patterns for parsing the diff output
-    private static readonly Regex DiffHeaderRegex = new Regex(@"^diff --git a/(?<file>.+) b/(?<file2>.+)$");
-    private static readonly Regex LineChangeRegex = new Regex(@"^@@ -\d+(,\d+)? \+(?<start>\d+)(,(?<count>\d+))? @@");
-    private static char[] lineSeparators = { '\n', '\r' };
+    private static readonly Regex DiffHeaderRegex = new(@"^diff --git a/(?<fileA>.+) b/(?<fileB>.+)$", RegexOptions.Compiled);
+    private static readonly Regex LineChangeRegex = new(@"^@@ -\d+(,\d+)? \+(?<start>\d+)(,(?<count>\d+))? @@", RegexOptions.Compiled);
+    private static readonly char[] LineSeparators = ['\n', '\r'];
 
     public static ProcessHelpers.CommandOutput? RunGitCommand(string? workingDirectory, string arguments, MetricTags.CIVisibilityCommands ciVisibilityCommand, string? input = null)
     {
@@ -110,8 +110,8 @@ internal static class GitCommandHelper
         static List<FileCoverageInfo> ParseGitDiff(string diffOutput)
         {
             var fileChanges = new List<FileCoverageInfo>();
+            var modifiedLines = new List<LineRange>(25);
             FileCoverageInfo? currentFile = null;
-            var modifiedLines = new List<Tuple<int, int>>(100);
 
             // Split the diff output into lines for processing
             var lines = SplitLines(diffOutput);
@@ -130,27 +130,31 @@ internal static class GitCommandHelper
                         modifiedLines.Clear();
                     }
 
-                    currentFile = new FileCoverageInfo(headerMatch.Groups["file"].Value);
+                    currentFile = new FileCoverageInfo(headerMatch.Groups["fileB"].Value);
                     Log.Debug("GitCommandHelper:  Processing {File} ...", currentFile.Path);
-
                     continue;
                 }
 
                 // Check for the line change marker (e.g., @@ -1,2 +3,4 @@)
+                // Start tracking new lines
                 var lineChangeMatch = LineChangeRegex.Match(line);
-                if (lineChangeMatch.Success)
+                if (lineChangeMatch.Success &&
+                    int.TryParse(lineChangeMatch.Groups["start"].Value, out var startLine))
                 {
-                    int startLine = int.Parse(lineChangeMatch.Groups["start"].Value); // Start tracking new lines
-                    int lineCount = 0;
-                    if (lineChangeMatch.Groups["count"].Value is string countTxt && countTxt.Length > 0)
+                    var lineCount = 0;
+                    if (lineChangeMatch.Groups["count"].Value is { Length: > 0 } countTxt &&
+                        int.TryParse(countTxt.Trim(), out var lCount))
                     {
-                        lineCount = int.Parse(countTxt); // Start tracking new lines
+                        lineCount = lCount; // Start tracking new lines
+                        if (lineCount > 0)
+                        {
+                            lineCount -= 1; // Adjust for the start line count
+                        }
                     }
 
-                    modifiedLines.Add(new Tuple<int, int>(startLine, startLine + lineCount));
-                    var range = modifiedLines[modifiedLines.Count - 1];
-                    Log.Debug<int, int>("GitCommandHelper:    {From}..{To} ...", range.Item1, range.Item2);
-                    continue;
+                    var range = new LineRange(startLine, startLine + lineCount);
+                    modifiedLines.Add(range);
+                    Log.Debug<int, int>("GitCommandHelper:    {From}..{To} ...", range.Start, range.End);
                 }
             }
 
@@ -163,19 +167,18 @@ internal static class GitCommandHelper
 
             return fileChanges;
 
-            static byte[]? ToFileBitmap(List<Tuple<int, int>> modifiedLines)
+            static byte[]? ToFileBitmap(List<LineRange> modifiedLines)
             {
                 if (modifiedLines.Count == 0)
                 {
                     return null;
                 }
 
-                var maxCount = modifiedLines[modifiedLines.Count - 1].Item2;
-
+                var maxCount = modifiedLines.Max(m => m.End);
                 var bitmap = FileBitmap.FromLineCount(maxCount);
                 foreach (var tuple in modifiedLines)
                 {
-                    for (int i = tuple.Item1; i <= tuple.Item2; i++)
+                    for (var i = tuple.Start; i <= tuple.End; i++)
                     {
                         bitmap.Set(i);
                     }
@@ -189,6 +192,8 @@ internal static class GitCommandHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static string[] SplitLines(string text, StringSplitOptions options = StringSplitOptions.RemoveEmptyEntries)
     {
-        return text.Split(lineSeparators, options);
+        return text.Split(LineSeparators, options);
     }
+
+    private readonly record struct LineRange(int Start, int End);
 }


### PR DESCRIPTION
## Summary of changes

This PR improves the line range calculation on the Impacted Tests feature

## Reason for change

There was an issue where we were counting one line more at the end. Also I've changed all the `int.Parse` with a `int.TryParse` to avoid any exception due to parsing.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
