### PR TITLE
[Debugger] Allow double interval for diagnostics uploads

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Debugger
 
         private const int DefaultUploadBatchSize = 100;
         public const int DefaultSymbolBatchSizeInBytes = 100000;
-        private const int DefaultDiagnosticsIntervalSeconds = 60 * 60; // 1 hour
+        private const double DefaultDiagnosticsIntervalSeconds = 60 * 60; // 1 hour
         private const int DefaultUploadFlushIntervalMilliseconds = 0;
         public const int DefaultCodeOriginExitSpanFrames = 8;
 
@@ -93,7 +93,7 @@ namespace Datadog.Trace.Debugger
 
             DiagnosticsIntervalSeconds = config
                                         .WithKeys(ConfigurationKeys.Debugger.DiagnosticsInterval)
-                                        .AsInt32(DefaultDiagnosticsIntervalSeconds, interval => interval > 0)
+                                        .AsDouble(DefaultDiagnosticsIntervalSeconds, interval => interval > 0)
                                         .Value;
 
             UploadFlushIntervalMilliseconds = config
@@ -163,7 +163,7 @@ namespace Datadog.Trace.Debugger
 
         public ImmutableHashSet<string> SymDbThirdPartyDetectionExcludes { get; }
 
-        public int DiagnosticsIntervalSeconds { get; }
+        public double DiagnosticsIntervalSeconds { get; }
 
         public int UploadFlushIntervalMilliseconds { get; }
 


### PR DESCRIPTION
## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
