### PR TITLE
Log values of WCF settings on startup

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -530,6 +530,12 @@ namespace Datadog.Trace
                     writer.WritePropertyName("wcf_obfuscation_enabled");
                     writer.WriteValue(instanceSettings.WcfObfuscationEnabled);
 
+                    writer.WritePropertyName("trace_delay_wcf_instrumentation_enabled");
+                    writer.WriteValue(instanceSettings.DelayWcfInstrumentationEnabled);
+
+                    writer.WritePropertyName("trace_wcf_web_http_resource_names_enabled");
+                    writer.WriteValue(instanceSettings.WcfWebHttpResourceNamesEnabled);
+
                     writer.WritePropertyName("bypass_http_request_url_caching_enabled");
                     writer.WriteValue(instanceSettings.BypassHttpRequestUrlCachingEnabled);
 


### PR DESCRIPTION
## Summary of changes

Just logs a couple more settings in the startup.

I think we are probably missing more, but only adding these as `delay` one is commonly used by support to rule out WCF issues, but the value isn't actually logged on startup while another WCF-related one is and could be confusing.

## Reason for change

They weren't there and would have been useful

## Implementation details

Added them

## Test coverage

None

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
