### PR TITLE
[Profiler] Little improvement

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -95,8 +95,8 @@ public:
 
         if (rawSample.LocalRootSpanId != 0 && rawSample.SpanId != 0)
         {
-            sample->AddNumericLabel(SpanLabel{Sample::LocalRootSpanIdLabel, rawSample.LocalRootSpanId});
-            sample->AddNumericLabel(SpanLabel{Sample::SpanIdLabel, rawSample.SpanId});
+            sample->AddLabel(NumericLabel{Sample::LocalRootSpanIdLabel, rawSample.LocalRootSpanId});
+            sample->AddLabel(NumericLabel{Sample::SpanIdLabel, rawSample.SpanId});
         }
 
         // compute thread/appdomain details

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCBaseRawSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCBaseRawSample.h
@@ -42,7 +42,7 @@ public:
 
         sample->AddValue(GetValue(), durationIndex);
 
-        sample->AddNumericLabel(NumericLabel(Sample::GarbageCollectionNumberLabel, Number));
+        sample->AddLabel(NumericLabel(Sample::GarbageCollectionNumberLabel, Number));
         AddGenerationLabel(sample, Generation);
 
         BuildCallStack(sample, Generation);
@@ -74,19 +74,19 @@ private:
         switch (generation)
         {
             case 0:
-                sample->AddLabel(Label(Sample::GarbageCollectionGenerationLabel, Gen0Value));
+                sample->AddLabel(StringLabel(Sample::GarbageCollectionGenerationLabel, Gen0Value));
                 break;
 
             case 1:
-                sample->AddLabel(Label(Sample::GarbageCollectionGenerationLabel, Gen1Value));
+                sample->AddLabel(StringLabel(Sample::GarbageCollectionGenerationLabel, Gen1Value));
                 break;
 
             case 2:
-                sample->AddLabel(Label(Sample::GarbageCollectionGenerationLabel, Gen2Value));
+                sample->AddLabel(StringLabel(Sample::GarbageCollectionGenerationLabel, Gen2Value));
                 break;
 
             default: // this should never happen (only gen0, gen1 or gen2 collections)
-                sample->AddLabel(Label(Sample::GarbageCollectionGenerationLabel, std::to_string(generation)));
+                sample->AddLabel(StringLabel(Sample::GarbageCollectionGenerationLabel, std::to_string(generation)));
                 break;
         }
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
@@ -61,7 +61,7 @@ std::vector<std::shared_ptr<IThreadInfo>> const& GCThreadsCpuProvider::GetThread
 
 Labels GCThreadsCpuProvider::GetLabels()
 {
-    return Labels{Label{"gc_cpu_sample", "true"}};
+    return Labels{StringLabel{"gc_cpu_sample", "true"}};
 }
 
 std::vector<FrameInfoView> GCThreadsCpuProvider::GetFrames()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
@@ -14,10 +14,10 @@ LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address
     _gcCount(0)
 {
     auto id = s_nextObjectId++;
-    sample->AddLabel(Label{Sample::ObjectIdLabel, std::to_string(id)});
+    sample->AddLabel(StringLabel{Sample::ObjectIdLabel, std::to_string(id)});
 
-    sample->AddLabel(Label{Sample::ObjectGenerationLabel, std::to_string(0)});
-    sample->AddLabel(Label{Sample::ObjectLifetimeLabel, std::to_string(0)});
+    sample->AddLabel(StringLabel{Sample::ObjectGenerationLabel, std::to_string(0)});
+    sample->AddLabel(StringLabel{Sample::ObjectLifetimeLabel, std::to_string(0)});
     _sample = sample;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -152,8 +152,8 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
         auto sample = info.GetSample();
 
         // update samples lifetime
-        sample->ReplaceLabel(Label{Sample::ObjectLifetimeLabel, std::to_string((sample->GetTimeStamp() - currentTimestamp).count())});
-        sample->ReplaceLabel(Label{Sample::ObjectGenerationLabel, info.IsGen2() ? Gen2 : Gen1});
+        sample->ReplaceLabel(StringLabel{Sample::ObjectLifetimeLabel, std::to_string((sample->GetTimeStamp() - currentTimestamp).count())});
+        sample->ReplaceLabel(StringLabel{Sample::ObjectGenerationLabel, info.IsGen2() ? Gen2 : Gen1});
 
         samples->Add(sample);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -96,9 +96,9 @@ std::unique_ptr<SamplesEnumerator> NativeThreadsCpuProviderBase::GetSamples()
         sample->AddFrame(frame);
     }
 
-    for (auto const& label : GetLabels())
+    for (auto&& label : GetLabels())
     {
-        sample->AddLabel(Label{label.first,label.second});
+        sample->AddLabel(std::move(label));
     }
 
     enumerator->Set(sample);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
@@ -66,7 +66,7 @@ libdatadog::Success Profile::Add(std::shared_ptr<Sample> const& sample)
     for (auto const& label : labels)
     {
         auto ffiLabel = std::visit(
-            overloaded{
+            LabelsVisitor{
                 [](NumericLabel const& l) -> ddog_prof_Label {
                     auto const& [name, value] = l;
                     return ddog_prof_Label {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawAllocationSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawAllocationSample.h
@@ -46,7 +46,7 @@ public:
             sample->AddValue(AllocationSize, allocationSizeIndex);
         }
 
-        sample->AddLabel(Label(Sample::AllocationClassLabel, AllocationClass));
+        sample->AddLabel(StringLabel(Sample::AllocationClassLabel, AllocationClass));
     }
 
     std::string AllocationClass;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -47,15 +47,15 @@ public:
         auto contentionCountIndex = valueOffsets[0];
         auto contentionDurationIndex = valueOffsets[1];
 
-        sample->AddLabel(Label{BucketLabelName, std::move(Bucket)});
+        sample->AddLabel(StringLabel{BucketLabelName, std::move(Bucket)});
         sample->AddValue(1, contentionCountIndex);
-        sample->AddNumericLabel(NumericLabel{RawCountLabelName, 1});
-        sample->AddNumericLabel(NumericLabel{RawDurationLabelName, ContentionDuration.count()});
+        sample->AddLabel(NumericLabel{RawCountLabelName, 1});
+        sample->AddLabel(NumericLabel{RawDurationLabelName, ContentionDuration.count()});
         sample->AddValue(ContentionDuration.count(), contentionDurationIndex);
         if (BlockingThreadId != 0)
         {
-            sample->AddNumericLabel(NumericLabel{BlockingThreadIdLabelName, BlockingThreadId});
-            sample->AddLabel(Label{BlockingThreadNameLabelName, shared::ToString(BlockingThreadName)});
+            sample->AddLabel(NumericLabel{BlockingThreadIdLabelName, BlockingThreadId});
+            sample->AddLabel(StringLabel{BlockingThreadNameLabelName, shared::ToString(BlockingThreadName)});
         }
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawExceptionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawExceptionSample.h
@@ -30,8 +30,8 @@ public:
     {
         assert(valueOffsets.size() == 1);
         sample->AddValue(1, valueOffsets[0]);
-        sample->AddLabel(Label(Sample::ExceptionMessageLabel, ExceptionMessage));
-        sample->AddLabel(Label(Sample::ExceptionTypeLabel, ExceptionType));
+        sample->AddLabel(StringLabel(Sample::ExceptionMessageLabel, ExceptionMessage));
+        sample->AddLabel(StringLabel(Sample::ExceptionTypeLabel, ExceptionType));
     }
 
     std::string ExceptionMessage;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawGarbageCollectionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawGarbageCollectionSample.h
@@ -48,12 +48,12 @@ public:
 
     inline void DoAdditionalTransform(std::shared_ptr<Sample> sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        sample->AddLabel(Label(Sample::GarbageCollectionReasonLabel, GetReasonText()));
-        sample->AddLabel(Label(Sample::GarbageCollectionTypeLabel, GetTypeText()));
-        sample->AddLabel(Label(Sample::GarbageCollectionCompactingLabel, (IsCompacting ? "true" : "false")));
+        sample->AddLabel(StringLabel(Sample::GarbageCollectionReasonLabel, GetReasonText()));
+        sample->AddLabel(StringLabel(Sample::GarbageCollectionTypeLabel, GetTypeText()));
+        sample->AddLabel(StringLabel(Sample::GarbageCollectionCompactingLabel, (IsCompacting ? "true" : "false")));
 
         // set event type
-        sample->AddLabel(Label(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeGarbageCollection));
+        sample->AddLabel(StringLabel(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeGarbageCollection));
     }
 
 public:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawNetworkSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawNetworkSample.h
@@ -69,45 +69,45 @@ public:
         // Note: we don't need to add the start timestamp as a label because it is computed
         // by the backend from the end timestamp and the duration; i.e. the value of this sample
 
-        sample->AddLabel(Label(Sample::RequestUrlLabel, Url));
-        sample->AddNumericLabel(NumericLabel(Sample::RequestStatusCodeLabel, StatusCode));
+        sample->AddLabel(StringLabel(Sample::RequestUrlLabel, Url));
+        sample->AddLabel(NumericLabel(Sample::RequestStatusCodeLabel, StatusCode));
         if (!Error.empty())
         {
-            sample->AddLabel(Label(Sample::RequestErrorLabel, Error));
+            sample->AddLabel(StringLabel(Sample::RequestErrorLabel, Error));
         }
         if (HasBeenRedirected)
         {
-            sample->AddLabel(Label(Sample::RequestRedirectUrlLabel, RedirectUrl));
+            sample->AddLabel(StringLabel(Sample::RequestRedirectUrlLabel, RedirectUrl));
         }
         if (DnsDuration != std::chrono::nanoseconds::zero())
         {
-            sample->AddNumericLabel(NumericLabel(Sample::RequestDnsWaitLabel, DnsWait.count()));
-            sample->AddNumericLabel(NumericLabel(Sample::RequestDnsDurationLabel, DnsDuration.count()));
-            sample->AddLabel(Label(Sample::RequestDnsSuccessLabel, DnsSuccess ? "true" : "false"));
+            sample->AddLabel(NumericLabel(Sample::RequestDnsWaitLabel, DnsWait.count()));
+            sample->AddLabel(NumericLabel(Sample::RequestDnsDurationLabel, DnsDuration.count()));
+            sample->AddLabel(StringLabel(Sample::RequestDnsSuccessLabel, DnsSuccess ? "true" : "false"));
         }
         if (HandshakeDuration != std::chrono::nanoseconds::zero())
         {
-            sample->AddNumericLabel(NumericLabel(Sample::RequestHandshakeWaitLabel, HandshakeWait.count()));
-            sample->AddNumericLabel(NumericLabel(Sample::RequestHandshakeDurationLabel, HandshakeDuration.count()));
+            sample->AddLabel(NumericLabel(Sample::RequestHandshakeWaitLabel, HandshakeWait.count()));
+            sample->AddLabel(NumericLabel(Sample::RequestHandshakeDurationLabel, HandshakeDuration.count()));
         }
         if (!HandshakeError.empty())
         {
-            sample->AddLabel(Label(Sample::RequestHandshakeErrorLabel, HandshakeError));
+            sample->AddLabel(StringLabel(Sample::RequestHandshakeErrorLabel, HandshakeError));
         }
         if (SocketConnectDuration != std::chrono::nanoseconds::zero())
         {
-            sample->AddNumericLabel(NumericLabel(Sample::RequestSocketDurationLabel, SocketConnectDuration.count()));
+            sample->AddLabel(NumericLabel(Sample::RequestSocketDurationLabel, SocketConnectDuration.count()));
         }
         if (RequestDuration != std::chrono::nanoseconds::zero())  // could be 0 in case of connection/handshake error
         {
-            sample->AddNumericLabel(NumericLabel(Sample::RequestDurationLabel, RequestDuration.count()));
+            sample->AddLabel(NumericLabel(Sample::RequestDurationLabel, RequestDuration.count()));
         }
         if (ResponseDuration != std::chrono::nanoseconds::zero())  // could be 0 in case of error
         {
-            sample->AddNumericLabel(NumericLabel(Sample::ResponseContentDurationLabel, ResponseDuration.count()));
+            sample->AddLabel(NumericLabel(Sample::ResponseContentDurationLabel, ResponseDuration.count()));
         }
-        sample->AddLabel(Label(Sample::RequestResponseThreadIdLabel, EndThreadId));
-        sample->AddLabel(Label(Sample::RequestResponseThreadNameLabel, EndThreadName));
+        sample->AddLabel(StringLabel(Sample::RequestResponseThreadIdLabel, EndThreadId));
+        sample->AddLabel(StringLabel(Sample::RequestResponseThreadNameLabel, EndThreadName));
     }
 
     std::string Url;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawStopTheWorldSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawStopTheWorldSample.h
@@ -19,6 +19,6 @@ public:
     void DoAdditionalTransform(std::shared_ptr<Sample> sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
         // set event type
-        sample->AddLabel(Label(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeStopTheWorld));
+        sample->AddLabel(StringLabel(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeStopTheWorld));
     }
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawThreadLifetimeSample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawThreadLifetimeSample.cpp
@@ -13,12 +13,12 @@ void RawThreadLifetimeSample::OnTransform(
     if (Kind == ThreadEventKind::Start)
     {
         sample->AddFrame({EmptyModule, StartFrame, "", 0});
-        sample->AddLabel(Label(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeThreadStart));
+        sample->AddLabel(StringLabel(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeThreadStart));
     }
     else if (Kind == ThreadEventKind::Stop)
     {
         sample->AddFrame({EmptyModule, StopFrame, "", 0});
-        sample->AddLabel(Label(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeThreadStop));
+        sample->AddLabel(StringLabel(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeThreadStop));
     }
 
     // Set an arbitratry value to avoid being discarded by the backend

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
@@ -58,15 +58,13 @@ Sample::Sample(std::chrono::nanoseconds timestamp, std::string_view runtimeId, s
     _timestamp = timestamp;
     _runtimeId = runtimeId;
     _callstack.reserve(framesCount);
-    _labels.reserve(10);
-    _numericLabels.reserve(10);
+    _allLabels.reserve(10);
 }
 
 Sample::Sample(std::string_view runtimeId) :
     _values(ValuesCount),
     _timestamp{0},
-    _labels{},
-    _numericLabels{},
+    _allLabels{},
     _callstack{},
     _runtimeId{runtimeId}
 {
@@ -122,10 +120,5 @@ std::string_view Sample::GetRuntimeId() const
 
 const Labels& Sample::GetLabels() const
 {
-    return _labels;
-}
-
-const NumericLabels& Sample::GetNumericLabels() const
-{
-    return _numericLabels;
+    return _allLabels;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -29,9 +29,9 @@ typedef std::vector<NumericLabel> NumericLabels;
 typedef std::vector<std::variant<StringLabel, NumericLabel>> Labels;
 
 template<class... Ts>
-struct overloaded : Ts... { using Ts::operator()...; };
+struct LabelsVisitor : Ts... { using Ts::operator()...; };
 template<class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
+LabelsVisitor(Ts...) -> LabelsVisitor<Ts...>;
 
 using namespace std::chrono_literals;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -5,6 +5,7 @@
 
 #include "IFrameStore.h"
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <iostream>
@@ -12,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <variant>
 #include <vector>
 
 struct SampleValueType
@@ -20,17 +22,20 @@ struct SampleValueType
     std::string Unit;
 };
 
-
 typedef std::vector<int64_t> Values;
-typedef std::pair<std::string_view, std::string> Label;
-typedef std::vector<Label> Labels;
+typedef std::pair<std::string_view, std::string> StringLabel;
 typedef std::pair<std::string_view, int64_t> NumericLabel;
-typedef std::pair<std::string_view, uint64_t> SpanLabel;
 typedef std::vector<NumericLabel> NumericLabels;
+typedef std::vector<std::variant<StringLabel, NumericLabel>> Labels;
+
+template<class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
 
 using namespace std::chrono_literals;
 
-class Sample
+class Sample final
 {
 public:
     static size_t ValuesCount;
@@ -53,7 +58,6 @@ public:
     const Values& GetValues() const;
     const std::vector<FrameInfoView>& GetCallstack() const;
     const Labels& GetLabels() const;
-    const NumericLabels& GetNumericLabels() const;
     std::string_view GetRuntimeId() const;
 
     // Since this class is not finished, this method is only for test purposes
@@ -65,43 +69,25 @@ public:
     void AddValue(std::int64_t value, size_t index);
     void AddFrame(FrameInfoView const& frame);
 
-    template<typename T>
+    template <typename T>
     void AddLabel(T&& label)
     {
-        _labels.push_back(std::forward<T>(label));
+        _allLabels.push_back(std::forward<T>(label));
     }
 
-    template<typename T>
-    void AddNumericLabel(T&& label)
-    {
-        _numericLabels.push_back(std::forward<T>(label));
-    }
-
-    template<typename T>
+    template <typename T>
     void ReplaceLabel(T&& label)
     {
-        for (auto it = _labels.rbegin(); it != _labels.rend(); it++)
+        auto it = std::find_if(_allLabels.rbegin(), _allLabels.rend(),
+                               [&label](auto& item) {
+                                   T* elt = std::get_if<T>(&item);
+                                   return elt != nullptr && elt->first == label.first;
+                               });
+
+        if (it != _allLabels.rend())
         {
-            if (it->first == label.first)
-            {
-                it->second = label.second;
-
-                return;
-            }
-        }
-    }
-
-    template<typename T>
-    void ReplaceNumericLabel(T&& label)
-    {
-        for (auto it = _numericLabels.rbegin(); it != _numericLabels.rend(); it++)
-        {
-            if (it->first == label.first)
-            {
-                it->second = label.second;
-
-                return;
-            }
+            auto& e = std::get<T>(*it);
+            e.second = label.second;
         }
     }
 
@@ -109,25 +95,25 @@ public:
     template <typename T>
     void SetPid(T&& pid)
     {
-        AddNumericLabel(NumericLabel{ProcessIdLabel, std::forward<T>(pid)});
+        AddLabel(NumericLabel{ProcessIdLabel, std::forward<T>(pid)});
     }
 
     template <typename T>
     void SetAppDomainName(T&& name)
     {
-        AddLabel(Label{AppDomainNameLabel, std::forward<T>(name)});
+        AddLabel(StringLabel{AppDomainNameLabel, std::forward<T>(name)});
     }
 
     template <typename T>
     void SetThreadId(T&& tid)
     {
-        AddLabel(Label{ThreadIdLabel, std::forward<T>(tid)});
+        AddLabel(StringLabel{ThreadIdLabel, std::forward<T>(tid)});
     }
 
     template <typename T>
     void SetThreadName(T&& name)
     {
-        AddLabel(Label{ThreadNameLabel, std::forward<T>(name)});
+        AddLabel(StringLabel{ThreadNameLabel, std::forward<T>(name)});
     }
 
     void SetTimestamp(std::chrono::nanoseconds timestamp)
@@ -145,8 +131,7 @@ public:
         _timestamp = 0ns;
         _callstack.clear();
         _runtimeId = {};
-        _numericLabels.clear();
-        _labels.clear();
+        _allLabels.clear();
         std::fill(_values.begin(), _values.end(), 0);
     }
     // well known labels
@@ -193,7 +178,6 @@ private:
     std::chrono::nanoseconds _timestamp;
     std::vector<FrameInfoView> _callstack;
     Values _values;
-    Labels _labels;
-    NumericLabels _numericLabels;
+    Labels _allLabels;
     std::string_view _runtimeId;
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<Sample> CreateSample(std::string_view runtimeId, const std::vect
 
     for (auto const& [name, value] : labels)
     {
-        sample->AddLabel(Label{name, value});
+        sample->AddLabel(StringLabel{name, value});
     }
 
     sample->SetValue(value);

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -164,32 +164,42 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
         builder << "AD_" << expectedAppDomainId[currentSample];
         std::string expectedAppDomainName(builder.str());
 
-        std::stringstream builder2;
-        builder2 << expectedAppDomainId[currentSample];
-        std::string expectedPid(builder2.str());
+        auto expectedPid = expectedAppDomainId[currentSample];
 
         auto labels = sample->GetLabels();
-        for (const Label& label : labels)
+        for (auto const& label : labels)
         {
-            if (label.first == Sample::AppDomainNameLabel)
-            {
-                ASSERT_EQ(expectedAppDomainName, label.second);
-            }
-            else if (label.first == Sample::ProcessIdLabel)
-            {
-                ASSERT_EQ(expectedPid, label.second);
-            }
-            else if (
-                (label.first == Sample::ThreadIdLabel) ||
-                (label.first == Sample::ThreadNameLabel))
-            {
-                // can't test thread info
-            }
-            else
-            {
-                // unknown label
-                ASSERT_TRUE(false);
-            }
+            std::visit(overloaded{
+                [expectedPid](NumericLabel const& label){
+                    auto const& [name, value] = label;
+                    if(name == Sample::ProcessIdLabel)
+                    {
+                        ASSERT_EQ(expectedPid, value);
+                    }
+                    else
+                    {
+                        ASSERT_TRUE(false) << label.first;
+                    }
+                },
+                [expectedAppDomainName](StringLabel const& label) {
+                    auto const& [name, value] = label;
+                    if (name == Sample::AppDomainNameLabel)
+                    {
+                        ASSERT_EQ(expectedAppDomainName, value);
+                    }
+                    else if (
+                        (name == Sample::ThreadIdLabel) ||
+                        (name == Sample::ThreadNameLabel))
+                    {
+                        // can't test thread info
+                    }
+                    else
+                    {
+                        // unknown label
+                        ASSERT_TRUE(false);
+                    }
+                }, 
+            }, label);
         }
 
         currentSample++;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -169,7 +169,7 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
         auto labels = sample->GetLabels();
         for (auto const& label : labels)
         {
-            std::visit(overloaded{
+            std::visit(LabelsVisitor{
                 [expectedPid](NumericLabel const& label){
                     auto const& [name, value] = label;
                     if(name == Sample::ProcessIdLabel)


### PR DESCRIPTION
## Summary of changes

Use only one container in `Sample` class to store labels.

## Reason for change

There is 2 types of labels: numeric and string. The type is related to the type of the value.
Before that we had 2 containers (one per type of label).

## Implementation details

- Use `std::variant` to store `NumericLabel` and `StringLabel` labels in the same container.
- Use `std::visit` to have a processing per label type.
- Rename `Label` into `StringLabel`
- Remove `SpanLabel` and use `NumericLabel` instead (since it's a Numeric label)

## Test coverage

Current test should be suffice
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
