### PR TITLE
[Profiler] Fix integration tests build

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -55,6 +55,18 @@
     <Compile Include="..\..\..\tracer\test\Datadog.Trace.TestHelpers\MockSpanLink.cs">
       <Link>Tracer\MockSpanLink.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tracer\test\Datadog.Trace.TestHelpers\MockSpanEvent.cs">
+      <Link>Tracer\MockSpanEvent.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\tracer\test\Datadog.Trace.TestHelpers\MockAttributeAnyValue.cs">
+      <Link>Tracer\MockAttributeAnyValue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\tracer\test\Datadog.Trace.TestHelpers\MockAttributeArray.cs">
+      <Link>Tracer\MockAttributeArray.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\tracer\test\Datadog.Trace.TestHelpers\MockAttributeArrayValue.cs">
+      <Link>Tracer\MockAttributeArrayValue.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\tracer\src\Datadog.Trace\Tags.cs">
       <Link>Tracer\Tags.cs</Link>
     </Compile>


### PR DESCRIPTION
## Summary of changes
Fix profiler tests build.
## Reason for change

Since https://github.com/DataDog/dd-trace-dotnet/pull/6769, profiler integration tests project cannot be built.
## Implementation details

Add missing C# files.
## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
