### PR TITLE
Add reference to DiffPlex and use for Verify test comparisons.

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Datadog.Trace.Debugger.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Datadog.Trace.Debugger.IntegrationTests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
@@ -79,6 +79,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
     <PackageReference Include="AWSSDK.SimpleEmail" Version="3.7.402.28" />
     <PackageReference Include="MailKit" Version="4.10.0" />
   </ItemGroup>

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -372,17 +372,16 @@ namespace Datadog.Trace.TestHelpers
         // Based on https://github.com/VerifyTests/Verify.DiffPlex/blob/9f9f2a18f35074680be47c9043e95d1857e457e0/src/Verify.DiffPlex/VerifyDiffPlex.cs
         public static class VerifyDiffPlex
         {
+            public enum OutputType
+            {
+                Full,
+                Compact,
+                Minimal
+            }
+
             public static bool Initialized { get; private set; }
 
             public static void Initialize() => Initialize(OutputType.Full);
-
-            private static Func<string, string, StringBuilder> GetCompareFunc(OutputType outputType) =>
-                outputType switch
-                {
-                    OutputType.Compact => CompactCompare,
-                    OutputType.Minimal => MinimalCompare,
-                    _ => VerboseCompare
-                };
 
             public static void Initialize(OutputType outputType)
             {
@@ -402,6 +401,14 @@ namespace Datadog.Trace.TestHelpers
             public static SettingsTask UseDiffPlex(SettingsTask settings, OutputType outputType = OutputType.Full) =>
                 settings.UseStringComparer(
                     (received, verified, _) => GetResult(outputType, received, verified));
+
+            private static Func<string, string, StringBuilder> GetCompareFunc(OutputType outputType) =>
+                outputType switch
+                {
+                    OutputType.Compact => CompactCompare,
+                    OutputType.Minimal => MinimalCompare,
+                    _ => VerboseCompare
+                };
 
             private static Task<CompareResult> GetResult(OutputType outputType, string received, string verified)
             {
@@ -542,13 +549,6 @@ namespace Datadog.Trace.TestHelpers
                 {
                     builder.Length = i + 1;
                 }
-            }
-
-            public enum OutputType
-            {
-                Full,
-                Compact,
-                Minimal
             }
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -11,9 +11,12 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers.Ci;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+using DiffPlex.DiffBuilder;
+using DiffPlex.DiffBuilder.Model;
 using VerifyTests;
 using VerifyXunit;
 
@@ -123,6 +126,7 @@ namespace Datadog.Trace.TestHelpers
 
             settings.ScrubInlineGuids();
             settings.ScrubEmptyLines();
+            VerifyDiffPlex.UseDiffPlex(settings);
             return settings;
         }
 
@@ -363,6 +367,189 @@ namespace Datadog.Trace.TestHelpers
             }
 
             return sb.ToString();
+        }
+
+        // Based on https://github.com/VerifyTests/Verify.DiffPlex/blob/9f9f2a18f35074680be47c9043e95d1857e457e0/src/Verify.DiffPlex/VerifyDiffPlex.cs
+        public static class VerifyDiffPlex
+        {
+            public static bool Initialized { get; private set; }
+
+            public static void Initialize() => Initialize(OutputType.Full);
+
+            private static Func<string, string, StringBuilder> GetCompareFunc(OutputType outputType) =>
+                outputType switch
+                {
+                    OutputType.Compact => CompactCompare,
+                    OutputType.Minimal => MinimalCompare,
+                    _ => VerboseCompare
+                };
+
+            public static void Initialize(OutputType outputType)
+            {
+                if (Initialized)
+                {
+                    throw new("Already Initialized");
+                }
+
+                Initialized = true;
+                VerifierSettings.SetDefaultStringComparer((received, verified, _) => GetResult(outputType, received, verified));
+            }
+
+            public static void UseDiffPlex(VerifySettings settings, OutputType outputType = OutputType.Full) =>
+                settings.UseStringComparer(
+                    (received, verified, _) => GetResult(outputType, received, verified));
+
+            public static SettingsTask UseDiffPlex(SettingsTask settings, OutputType outputType = OutputType.Full) =>
+                settings.UseStringComparer(
+                    (received, verified, _) => GetResult(outputType, received, verified));
+
+            private static Task<CompareResult> GetResult(OutputType outputType, string received, string verified)
+            {
+                var compare = GetCompareFunc(outputType);
+                var builder = compare(received, verified);
+                TrimEnd(builder);
+                var message = builder.ToString();
+                var result = CompareResult.NotEqual(message);
+                return Task.FromResult(result);
+            }
+
+            private static StringBuilder VerboseCompare(string received, string verified)
+            {
+                var diff = InlineDiffBuilder.Diff(verified, received);
+
+                var builder = new StringBuilder();
+                foreach (var line in diff.Lines)
+                {
+                    switch (line.Type)
+                    {
+                        case ChangeType.Inserted:
+                            builder.Append("+ ");
+                            break;
+                        case ChangeType.Deleted:
+                            builder.Append("- ");
+                            break;
+                        default:
+                            builder.Append("  ");
+                            break;
+                    }
+
+                    builder.AppendLine(line.Text);
+                }
+
+                return builder;
+            }
+
+            private static StringBuilder MinimalCompare(string received, string verified)
+            {
+                var diff = InlineDiffBuilder.Diff(verified, received);
+
+                var builder = new StringBuilder();
+                foreach (var line in diff.Lines)
+                {
+                    switch (line.Type)
+                    {
+                        case ChangeType.Inserted:
+                            builder.Append("+ ");
+                            break;
+                        case ChangeType.Deleted:
+                            builder.Append("- ");
+                            break;
+                        default:
+                            // omit unchanged files
+                            continue;
+                    }
+
+                    builder.AppendLine(line.Text);
+                }
+
+                return builder;
+            }
+
+            private static StringBuilder CompactCompare(string received, string verified)
+            {
+                var diff = InlineDiffBuilder.Diff(verified, received);
+                var builder = new StringBuilder();
+
+                // ReSharper disable once RedundantSuppressNullableWarningExpression
+                var prefixLength = diff.Lines.Max(_ => _.Position).ToString()!.Length;
+                var spacePrefix = new string(' ', prefixLength - 1);
+
+                static bool IsChanged(DiffPiece? line) => line?.Type is ChangeType.Inserted or ChangeType.Deleted;
+
+                void AddDiffLine(int? lineNumber, string symbol, string text)
+                {
+                    var prefix = lineNumber?.ToString("D" + prefixLength) ?? spacePrefix + symbol;
+                    builder.AppendLine($"{prefix} {text}");
+                }
+
+                DiffPiece? prevLine = null;
+                var lastIndex = diff.Lines.Count - 1;
+
+                for (var i = 0; i <= lastIndex; i++)
+                {
+                    var currentLine = diff.Lines[i];
+                    var nextLine = i < lastIndex
+                        ? diff.Lines[i + 1]
+                        : null;
+
+                    if (IsChanged(currentLine))
+                    {
+                        if (i == 0)
+                        {
+                            AddDiffLine(null, " ", "[BOF]");
+                        }
+
+                        var symbol = currentLine.Type == ChangeType.Inserted ? "+" : "-";
+                        AddDiffLine(null, symbol, currentLine.Text);
+
+                        if (i == lastIndex)
+                        {
+                            AddDiffLine(null, " ", "[EOF]");
+                        }
+                    }
+                    else if (IsChanged(prevLine) || IsChanged(nextLine))
+                    {
+                        AddDiffLine(currentLine.Position, " ", currentLine.Text);
+                        if (!IsChanged(nextLine))
+                        {
+                            builder.AppendLine();
+                        }
+                    }
+
+                    prevLine = currentLine;
+                }
+
+                return builder;
+            }
+
+            private static void TrimEnd(StringBuilder builder)
+            {
+                if (builder.Length == 0)
+                {
+                    return;
+                }
+
+                var i = builder.Length - 1;
+                for (; i >= 0; i--)
+                {
+                    if (!char.IsWhiteSpace(builder[i]))
+                    {
+                        break;
+                    }
+                }
+
+                if (i < builder.Length - 1)
+                {
+                    builder.Length = i + 1;
+                }
+            }
+
+            public enum OutputType
+            {
+                Full,
+                Compact,
+                Minimal
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="..\Datadog.Trace.TestHelpers.SharedSource\VerifyHelper.cs" Link="Helpers\VerifyHelper.cs" />
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/Datadog.Trace.Tools.Runner.ArtifactTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/Datadog.Trace.Tools.Runner.ArtifactTests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <PackageReference Include="ELFSharp" Version="2.17.3" />
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Datadog.Trace.Tools.dd_dotnet.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Datadog.Trace.Tools.dd_dotnet.IntegrationTests.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.Tests/Datadog.Trace.Tools.dd_dotnet.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.Tests/Datadog.Trace.Tools.dd_dotnet.Tests.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Verify.Xunit" Version="14.13.1" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

Use [DiffPlex](https://github.com/VerifyTests/Verify.DiffPlex?tab=readme-ov-file#diff-results) to compare verify snapshots

## Reason for change

Currently, when snapshots fail in CI, verify dumps the full diff to the console. This makes it very hard to see what's changed, and generally requires grabbing the full snapshots or manually diffing the contents. Using Diffplex should make it easier to see what's changed

## Implementation details.

_Ideally_ we would just add a reference to `Verify.DiffPlex`. But as they only support .NET FX 4.8+ and .NET 6+, we can't. So instead, add a reference to `DiffPlex` directly, and then vendor + tweak the verify integration.

## Test coverage

I expect something will flake in this PR, so we can see an example 😅 

## Other details
