### PR TITLE
Protect against more `NullReferenceExceptions` in `Kafka`

### DIFF
--- a/docs/development/DuckTyping.md
+++ b/docs/development/DuckTyping.md
@@ -687,7 +687,7 @@ In the above example, the `ProxyMyHandlerStruct.Configuration` field is of type 
 What's more, the `[DuckCopy]` `struct` does _not_ implement `IDuckType`. So with the above duck-types, there's no way to detect when `originalObject.Configuration` is `null`! This is a problem, as it could mean accidentally using the `default` value for `MaxConnections` (i.e. `0`) when in practice the `Configuration` property was `null`. 
 
 The solution to this problem is to always define duck-chained `[DuckCopy]` `struct`s as nullable.
-Note though that the underlying type that is being duck-types _must_ NOT be a `struct`, if the underlying type is a `struct` do not mark is as nullable as it cannot be `null`.
+Note though that the underlying type that is being duck-typed _must_ NOT be a `struct`; if the underlying type is a `struct` **do not mark** is as nullable as it cannot be `null` and you will get duck-typing errors at runtime.
 
 ```csharp
 [DuckCopy]

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -476,7 +476,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeInte
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerDisposeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerUnsubscribeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncDeliveryHandlerIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -476,7 +476,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeInte
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerDisposeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerUnsubscribeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncDeliveryHandlerIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/Offset.cs

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -476,6 +476,8 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeInte
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerDisposeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerUnsubscribeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
+src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncDeliveryHandlerIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/Offset.cs

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -467,7 +467,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeaders.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IMessage.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IProduceException.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITimestamp.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITopicPartition.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITypedDeliveryHandlerShimAction.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConstants.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerCloseIntegration.cs
@@ -476,8 +475,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeInte
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerDisposeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerUnsubscribeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncDeliveryHandlerIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/Offset.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IProducerBuilder.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IProducerBuilder.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka;
 
@@ -13,7 +14,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka;
 /// Duck Type for Producer[TKey, TValue]+Config
 /// Interface, as used in generic constraint
 /// </summary>
-internal interface IProducerBuilder
+internal interface IProducerBuilder : IDuckType
 {
     IEnumerable<KeyValuePair<string, string>> Config { get; }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITopicPartition.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITopicPartition.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITopicPartition.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITopicPartition.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// <summary>
         ///     Gets the Kafka topic name.
         /// </summary>
-        public string Topic { get; }
+        public string? Topic { get; }
 
         /// <summary>
         ///     Gets the Kafka partition.

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITopicPartition.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITopicPartition.cs
@@ -3,12 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.DuckTyping;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 {
     /// <summary>
     /// TopicPartition interface for duck-typing
     /// </summary>
-    internal interface ITopicPartition
+    internal interface ITopicPartition : IDuckType
     {
         /// <summary>
         ///     Gets the Kafka topic name.

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -315,7 +315,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         internal static void TryInjectHeaders<TTopicPartitionMarker, TMessage>(
             Span span,
             DataStreamsManager dataStreamsManager,
-            string topic,
+            string? topic,
             TMessage message)
             where TMessage : IMessage
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -363,7 +363,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             }
         }
 
-        internal static void DisableHeadersIfUnsupportedBroker(Exception exception)
+        internal static void DisableHeadersIfUnsupportedBroker(Exception? exception)
         {
             if (_headersInjectionEnabled && exception is not null && exception.Message.IndexOf("Unknown broker error", StringComparison.OrdinalIgnoreCase) != -1)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#nullable enable
-
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -41,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// <param name="message">Message instance</param>
         /// <param name="cancellationToken">CancellationToken instance</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget, TTopicPartition, TMessage>(TTarget instance, TTopicPartition topicPartition, TMessage? message, CancellationToken cancellationToken)
+        internal static CallTargetState OnMethodBegin<TTarget, TTopicPartition, TMessage>(TTarget instance, TTopicPartition topicPartition, TMessage message, CancellationToken cancellationToken)
             where TMessage : IMessage
         {
             if (message.Instance is null
@@ -56,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 Tracer.Instance,
                 instance,
                 partition,
-                isTombstone: message.Value == null,
+                isTombstone: message.Value is null,
                 finishOnClose: true);
 
             if (scope is null)
@@ -83,12 +81,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// <param name="exception">Exception instance in case the original code threw an exception.</param>
         /// <param name="state">Calltarget state value</param>
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-        internal static TResponse? OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse? response, Exception exception, in CallTargetState state)
+        internal static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, in CallTargetState state)
             where TResponse : IDeliveryResult
         {
             if (state.Scope?.Span?.Tags is KafkaTags tags)
             {
-                IDeliveryResult? deliveryResult = null;
+                IDeliveryResult deliveryResult = null;
                 if (exception is not null)
                 {
                     var produceException = exception.DuckAs<IProduceException>();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -44,12 +44,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         internal static CallTargetState OnMethodBegin<TTarget, TTopicPartition, TMessage>(TTarget instance, TTopicPartition topicPartition, TMessage? message, CancellationToken cancellationToken)
             where TMessage : IMessage
         {
-            if (instance is null || topicPartition is null || message is null || message.Instance is null)
-            {
-                return CallTargetState.GetDefault();
-            }
-
-            if (!topicPartition.TryDuckCast<ITopicPartition>(out var partition) || partition?.Instance is null)
+            if (message.Instance is null
+                || !topicPartition.TryDuckCast<ITopicPartition>(out var partition)
+                || partition?.Instance is null)
             {
                 return CallTargetState.GetDefault();
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -29,6 +31,7 @@ public class KafkaProducerConstructorIntegration
         where TProducerBuilder : IProducerBuilder
     {
         if (!Tracer.Instance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId)
+            || instance is null
             || builder.Instance is null
             || builder.Config is null)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
@@ -30,12 +30,11 @@ public class KafkaProducerConstructorIntegration
     internal static CallTargetState OnMethodBegin<TTarget, TProducerBuilder>(TTarget instance, TProducerBuilder? builder)
         where TProducerBuilder : IProducerBuilder
     {
-        if (instance is null || builder is null || builder.Instance is null || builder.Config is null)
-        {
-            return CallTargetState.GetDefault();
-        }
-
-        if (!Tracer.Instance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId))
+        if (!Tracer.Instance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId)
+            || instance is null
+            || builder is null
+            || builder.Instance is null
+            || builder.Config is null)
         {
             return CallTargetState.GetDefault();
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#nullable enable
-
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -27,12 +25,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class KafkaProducerConstructorIntegration
 {
-    internal static CallTargetState OnMethodBegin<TTarget, TProducerBuilder>(TTarget instance, TProducerBuilder? builder)
+    internal static CallTargetState OnMethodBegin<TTarget, TProducerBuilder>(TTarget instance, TProducerBuilder builder)
         where TProducerBuilder : IProducerBuilder
     {
         if (!Tracer.Instance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId)
-            || instance is null
-            || builder is null
             || builder.Instance is null
             || builder.Config is null)
         {
@@ -77,7 +73,7 @@ public class KafkaProducerConstructorIntegration
         return CallTargetState.GetDefault();
     }
 
-    internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception? exception, in CallTargetState state)
+    internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, in CallTargetState state)
     {
         // This method is called in the Producer constructor, so if we have an exception
         // the builder won't be created, so no point recording it.

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Program.cs
@@ -21,7 +21,7 @@ namespace Samples.Kafka
 
                 await TopicHelpers.TryDeleteTopic(topic, config);
 
-                // null message and topic were edge cases where we were throwing in our integrations
+                // null message was an edge case causing us to throw a null reference in the 
                 await TryProduceWithNullMessage(topic, config);
 
                 await ConsumeAgainstNonExistentTopic(topic, config);
@@ -139,9 +139,7 @@ namespace Samples.Kafka
             }
             catch (Exception ex)
             {
-                Console.WriteLine("CAUGHT EXPECTED EXCEPTION!");
-                Console.WriteLine($"Exception in reproduction test: {ex}");
-                Console.WriteLine($"Stack trace: {ex.StackTrace}");
+                Console.WriteLine($"Expected Exception in reproduction test: {ex}");
             }
         }
 

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
@@ -23,7 +23,6 @@ namespace Samples.Kafka
 
                 // null message and topic were edge cases where we were throwing in our integrations
                 await TryProduceWithNullMessage(topic, config);
-                await TryProduceWithNullTopicPartition(topic, config);
 
                 await ConsumeAgainstNonExistentTopic(topic, config);
                 await ConsumeAndProduceMessages(topic, config);
@@ -123,32 +122,6 @@ namespace Samples.Kafka
             await Task.WhenAny(
                 Task.WhenAll(consumeTask1, consumeTask2),
                 Task.Delay(TimeSpan.FromSeconds(5)));
-        }
-
-        private static async Task TryProduceWithNullTopicPartition(string topic, ClientConfig config)
-        {
-            // NOTE: you'll see an Null Ref exception, it is expected, but it shouldn't be in OUR logs
-            try
-            {
-                using var producer = new ProducerBuilder<string, string>(config).Build();
-
-                // Create a message with null values but valid structure
-                var message = new Message<string, string>
-                {
-                    Key = null,
-                    Value = null,
-                };
-
-                // This should pass Kafka validation but might still trigger our issue
-                Console.WriteLine("Attempting to produce message with NULL TopicPartition THIS SHOULD THROW.");
-                await producer.ProduceAsync((TopicPartition)null, message);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("CAUGHT EXPECTED EXCEPTION!");
-                Console.WriteLine($"Exception in reproduction test: {ex}");
-                Console.WriteLine($"Stack trace: {ex.StackTrace}");
-            }
         }
 
         private static async Task TryProduceWithNullMessage(string topic, ClientConfig config)

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Properties/launchSettings.json
@@ -12,7 +12,33 @@
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH": "$(SolutionDir)shared/bin/monitoring-home/osx/Datadog.Trace.ClrProfiler.Native.dylib",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "DD_TRACE_DEBUG": "1"
+        "DD_TRACE_DEBUG": "1",
+        "DD_TRACE_AGENT_PORT": "8136"
+      },
+      "nativeDebugging": true
+    },
+    "Samples.Kafka.Windows": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+        "DD_VERSION": "1.0.0",
+
+        "DD_TRACE_DEBUG": "true",
+        "DD_TRACE_AGENT_PORT": "8136"
+      },
+      "nativeDebugging": true
+    },
+    "Samples.Kafka.Windows.NoDatadog": {
+      "commandName": "Project",
+      "environmentVariables": {
       },
       "nativeDebugging": true
     },

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Properties/launchSettings.json
@@ -11,9 +11,7 @@
         "COR_PROFILER_PATH": "$(SolutionDir)shared/bin/monitoring-home/osx/Datadog.Trace.ClrProfiler.Native.dylib",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH": "$(SolutionDir)shared/bin/monitoring-home/osx/Datadog.Trace.ClrProfiler.Native.dylib",
-        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "DD_TRACE_DEBUG": "1",
-        "DD_TRACE_AGENT_PORT": "8136"
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
       },
       "nativeDebugging": true
     },
@@ -29,10 +27,7 @@
         "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
-        "DD_VERSION": "1.0.0",
-
-        "DD_TRACE_DEBUG": "true",
-        "DD_TRACE_AGENT_PORT": "8136"
+        "DD_VERSION": "1.0.0"
       },
       "nativeDebugging": true
     },


### PR DESCRIPTION
## Summary of changes

This adds more null checking in to the the Kafka integrations that I spotted popping up in Error Tracking recently:
- `KafkaProduceAsyncIntegration`
- `KafkaProducerConstructorIntegration`

There weren't many of these exceptions being thrown by us, but when I looked at the integration code I noticed that it didn't have as much null-checking as I think we should.

The first was easy to reproduce, I couldn't reproduce the second one.

_Most likely the rest of the integration code should get a once over, but only address these as these are what we know are getting hit._

## Reason for change

Integration code was throwing `NullReferenceExceptions`

## Implementation details

More protections against `null`

## Test coverage

Added two calls that reproduced the null reference in `KafkaProduceAsyncIntegration`
I couldn't reproduce the ctor one though.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
