### PR TITLE
Parallel Linux integration tests in the CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2368,6 +2368,7 @@ stages:
           -e IncludeTestsRequiringDocker=false  \
           -e Filter=$(IntegrationTestFilter) \
           -e SampleName=$(IntegrationTestSampleName) \
+          -e Area=$(area) \
           IntegrationTests
       displayName: docker-compose run IntegrationTests
       env:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2403,7 +2403,7 @@ stages:
   - job: DockerTest
     timeoutInMinutes: 60 #default value
     strategy:
-      matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_matrix']]
+      matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_docker_matrix']]
 
     variables:
       TestAllPackageVersions: true
@@ -3209,7 +3209,7 @@ stages:
     - job: DockerTest
       timeoutInMinutes: 60 #default value
       strategy:
-        matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_arm64_matrix']]
+        matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_arm64_docker_matrix']]
       workspace:
         clean: all
       pool:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2464,6 +2464,7 @@ stages:
           -e IncludeTestsRequiringDocker=true \
           -e Filter=$(IntegrationTestFilter) \
           -e SampleName=$(IntegrationTestSampleName) \
+          -e Area=$(area) \
           IntegrationTests
       displayName: docker-compose run IntegrationTests
       env:
@@ -3173,6 +3174,7 @@ stages:
               -e IncludeTestsRequiringDocker=false \
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
+              -e Area=$(area) \
               IntegrationTests.ARM64
           displayName: docker-compose run --no-deps IntegrationTests
           env:
@@ -3263,6 +3265,7 @@ stages:
               -e IncludeTestsRequiringDocker=true \
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
+              -e Area=$(area) \
               IntegrationTests.ARM64 \
           displayName: docker-compose run IntegrationTests
           env:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3174,7 +3174,6 @@ stages:
               -e IncludeTestsRequiringDocker=false \
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
-              -e Area=$(area) \
               IntegrationTests.ARM64
           displayName: docker-compose run --no-deps IntegrationTests
           env:
@@ -3209,7 +3208,7 @@ stages:
     - job: DockerTest
       timeoutInMinutes: 60 #default value
       strategy:
-        matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_arm64_docker_matrix']]
+        matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_arm64_matrix']]
       workspace:
         clean: all
       pool:
@@ -3265,7 +3264,6 @@ stages:
               -e IncludeTestsRequiringDocker=true \
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
-              -e Area=$(area) \
               IntegrationTests.ARM64 \
           displayName: docker-compose run IntegrationTests
           env:

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1693,14 +1693,13 @@ partial class Build
 
                 var armFilter = IsArm64 ? "&(Category!=ArmUnsupported)" : string.Empty;
 
-                var filterData = Filter?.StartsWith("Area=") is true ? Filter : $"({Filter})";
                 var filter = (string.IsNullOrWhiteSpace(Filter), IsWin) switch
                 {
-                    (false, _) => $"{filterData}{dockerFilter}{armFilter}",
+                    (false, _) => $"({Filter}){dockerFilter}{armFilter}",
                     (true, false) => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
                     // TODO: I think we should change this filter to run on Windows by default, e.g.
                     // (RunOnWindows!=False|Category=Smoke)&LoadFromGAC!=True&IIS!=True
-                    (true, true) => "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
+                    (true, true) => $"(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
                 };
 
                 return filter;

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1631,8 +1631,6 @@ partial class Build
         {
             var isDebugRun = IsDebugRun();
 
-            Logger.Information("Running integration tests with area: {Area}", Area);
-
             var filter = AddAreaFilter(GetFilter());
 
             try
@@ -1658,8 +1656,6 @@ partial class Build
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .WithDatadogLogger()
                         .SetProjectFile(project)), degreeOfParallelism: 4);
-
-                Logger.Information("Running integration tests with filter: {Filter}", filter);
 
                 DotNetTest(config => config
                     .SetDotnetPath(TargetPlatform)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1693,13 +1693,12 @@ partial class Build
 
                 var armFilter = IsArm64 ? "&(Category!=ArmUnsupported)" : string.Empty;
 
-                var filter = (string.IsNullOrWhiteSpace(Filter), IsWin) switch
+                var filter = (string.IsNullOrWhiteSpace(Filter), IsWin, Filter?.StartsWith("Area=")) switch
                 {
-                    (false, _) => $"({Filter}){dockerFilter}{armFilter}",
-                    (true, false) => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
-                    // TODO: I think we should change this filter to run on Windows by default, e.g.
-                    // (RunOnWindows!=False|Category=Smoke)&LoadFromGAC!=True&IIS!=True
-                    (true, true) => "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
+                    (false, _, true) => $"{Filter}{dockerFilter}{armFilter}", // No parentheses for area=
+                    (false, _, false) => $"({Filter}){dockerFilter}{armFilter}", // Parentheses for other filters
+                    (true, false, _) => "(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True)" + $"{dockerFilter}{armFilter}",
+                    (true, true, _) => "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
                 };
 
                 return filter;

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1693,12 +1693,14 @@ partial class Build
 
                 var armFilter = IsArm64 ? "&(Category!=ArmUnsupported)" : string.Empty;
 
-                var filter = (string.IsNullOrWhiteSpace(Filter), IsWin, Filter?.StartsWith("Area=")) switch
+                var filterData = Filter?.StartsWith("Area=") is true ? Filter : $"({Filter})";
+                var filter = (string.IsNullOrWhiteSpace(Filter), IsWin) switch
                 {
-                    (false, _, true) => $"{Filter}{dockerFilter}{armFilter}", // No parentheses for area=
-                    (false, _, false) => $"({Filter}){dockerFilter}{armFilter}", // Parentheses for other filters
-                    (true, false, _) => "(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True)" + $"{dockerFilter}{armFilter}",
-                    (true, true, _) => "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
+                    (false, _) => $"{filterData}{dockerFilter}{armFilter}",
+                    (true, false) => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
+                    // TODO: I think we should change this filter to run on Windows by default, e.g.
+                    // (RunOnWindows!=False|Category=Smoke)&LoadFromGAC!=True&IIS!=True
+                    (true, true) => "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
                 };
 
                 return filter;

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1630,7 +1630,6 @@ partial class Build
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
-
             var filter = AddAreaFilter(GetFilter());
 
             try

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1630,6 +1630,9 @@ partial class Build
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
+
+            Logger.Information("Running integration tests with area: {Area}", Area);
+
             var filter = AddAreaFilter(GetFilter());
 
             try
@@ -1655,6 +1658,8 @@ partial class Build
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .WithDatadogLogger()
                         .SetProjectFile(project)), degreeOfParallelism: 4);
+
+                Logger.Information("Running integration tests with filter: {Filter}", filter);
 
                 DotNetTest(config => config
                     .SetDotnetPath(TargetPlatform)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1699,7 +1699,7 @@ partial class Build
                     (true, false) => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
                     // TODO: I think we should change this filter to run on Windows by default, e.g.
                     // (RunOnWindows!=False|Category=Smoke)&LoadFromGAC!=True&IIS!=True
-                    (true, true) => $"(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
+                    (true, true) => "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)",
                 };
 
                 return filter;

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -274,8 +274,7 @@ partial class Build : NukeBuild
             {
                 GenerateIntegrationTestsLinuxMatrix(true);
                 GenerateIntegrationTestsLinuxMatrix(false);
-                GenerateIntegrationTestsLinuxArm64Matrix(true);
-                GenerateIntegrationTestsLinuxArm64Matrix(false);
+                GenerateIntegrationTestsLinuxArm64Matrix();
                 GenerateIntegrationTestsDebuggerLinuxMatrix();
             }
 

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -272,12 +272,14 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsLinuxMatrices()
             {
-                GenerateIntegrationTestsLinuxMatrix();
-                GenerateIntegrationTestsLinuxArm64Matrix();
+                GenerateIntegrationTestsLinuxMatrix(true);
+                GenerateIntegrationTestsLinuxArm64Matrix(false);
+                GenerateIntegrationTestsLinuxMatrix(true);
+                GenerateIntegrationTestsLinuxArm64Matrix(false);
                 GenerateIntegrationTestsDebuggerLinuxMatrix();
             }
 
-            void GenerateIntegrationTestsLinuxMatrix()
+            void GenerateIntegrationTestsLinuxMatrix(bool dockerTest)
             {
                 var baseImages = new []
                 {
@@ -292,16 +294,28 @@ partial class Build : NukeBuild
                 {
                     foreach (var (baseImage, artifactSuffix) in baseImages)
                     {
-                        matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix });
+                        if (dockerTest)
+                        {
+                            matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix });
+                        }
+                        else
+                        {
+                            var areas = new[] { TracerArea, AsmArea };
+                            foreach (var area in areas)
+                            {
+                                matrix.Add($"{baseImage}_{framework}_{area}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix, area = area });
+                            }
+                        }
                     }
                 }
 
                 Logger.Information($"Integration test Linux matrix");
                 Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
-                AzurePipelines.Instance.SetOutputVariable("integration_tests_linux_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                var outputVariableName = dockerTest ? "integration_tests_linux_docker_matrix" : "integration_tests_linux_matrix";
+                AzurePipelines.Instance.SetOutputVariable(outputVariableName, JsonConvert.SerializeObject(matrix, Formatting.None));
             }
 
-            void GenerateIntegrationTestsLinuxArm64Matrix()
+            void GenerateIntegrationTestsLinuxArm64Matrix(bool dockerTest)
             {
                 var baseImages = new []
                 {
@@ -316,13 +330,25 @@ partial class Build : NukeBuild
                 {
                     foreach (var (baseImage, artifactSuffix) in baseImages)
                     {
-                        matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix });
+                        if (dockerTest)
+                        {
+                            matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix });
+                        }
+                        else
+                        {
+                            var areas = new[] { TracerArea, AsmArea };
+                            foreach (var area in areas)
+                            {
+                                matrix.Add($"{baseImage}_{framework}_{area}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix, area = area });
+                            }
+                        }
                     }
                 }
 
                 Logger.Information($"Integration test Linux Arm64 matrix");
                 Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
-                AzurePipelines.Instance.SetOutputVariable("integration_tests_linux_arm64_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                var outputVariableName = dockerTest ? "integration_tests_linux_arm64_docker_matrix" : "integration_tests_linux_arm64_matrix";
+                AzurePipelines.Instance.SetOutputVariable(outputVariableName, JsonConvert.SerializeObject(matrix, Formatting.None));
             }
 
             void GenerateIntegrationTestsDebuggerLinuxMatrix()

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -315,7 +315,7 @@ partial class Build : NukeBuild
                 AzurePipelines.Instance.SetOutputVariable(outputVariableName, JsonConvert.SerializeObject(matrix, Formatting.None));
             }
 
-            void GenerateIntegrationTestsLinuxArm64Matrix(bool dockerTest)
+            void GenerateIntegrationTestsLinuxArm64Matrix()
             {
                 var baseImages = new []
                 {
@@ -330,25 +330,13 @@ partial class Build : NukeBuild
                 {
                     foreach (var (baseImage, artifactSuffix) in baseImages)
                     {
-                        if (dockerTest)
-                        {
-                            matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix });
-                        }
-                        else
-                        {
-                            var areas = new[] { TracerArea, AsmArea };
-                            foreach (var area in areas)
-                            {
-                                matrix.Add($"{baseImage}_{framework}_{area}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix, area = area });
-                            }
-                        }
+                        matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix });
                     }
                 }
 
-                Logger.Information(dockerTest ? "Integration test Linux Arm64 dockerTest matrix": "Integration test Linux Arm64 matrix");
+                Logger.Information($"Integration test Linux Arm64 matrix");
                 Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
-                var outputVariableName = dockerTest ? "integration_tests_linux_arm64_docker_matrix" : "integration_tests_linux_arm64_matrix";
-                AzurePipelines.Instance.SetOutputVariable(outputVariableName, JsonConvert.SerializeObject(matrix, Formatting.None));
+                AzurePipelines.Instance.SetOutputVariable("integration_tests_linux_arm64_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
             }
 
             void GenerateIntegrationTestsDebuggerLinuxMatrix()

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -273,8 +273,8 @@ partial class Build : NukeBuild
             void GenerateIntegrationTestsLinuxMatrices()
             {
                 GenerateIntegrationTestsLinuxMatrix(true);
-                GenerateIntegrationTestsLinuxArm64Matrix(false);
-                GenerateIntegrationTestsLinuxMatrix(true);
+                GenerateIntegrationTestsLinuxMatrix(false);
+                GenerateIntegrationTestsLinuxArm64Matrix(true);
                 GenerateIntegrationTestsLinuxArm64Matrix(false);
                 GenerateIntegrationTestsDebuggerLinuxMatrix();
             }
@@ -309,7 +309,7 @@ partial class Build : NukeBuild
                     }
                 }
 
-                Logger.Information($"Integration test Linux matrix");
+                Logger.Information(dockerTest ? "Integration test Linux dockerTest matrix" : "Integration test Linux matrix");
                 Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                 var outputVariableName = dockerTest ? "integration_tests_linux_docker_matrix" : "integration_tests_linux_matrix";
                 AzurePipelines.Instance.SetOutputVariable(outputVariableName, JsonConvert.SerializeObject(matrix, Formatting.None));
@@ -345,7 +345,7 @@ partial class Build : NukeBuild
                     }
                 }
 
-                Logger.Information($"Integration test Linux Arm64 matrix");
+                Logger.Information(dockerTest ? "Integration test Linux Arm64 dockerTest matrix": "Integration test Linux Arm64 matrix");
                 Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                 var outputVariableName = dockerTest ? "integration_tests_linux_arm64_docker_matrix" : "integration_tests_linux_arm64_matrix";
                 AzurePipelines.Instance.SetOutputVariable(outputVariableName, JsonConvert.SerializeObject(matrix, Formatting.None));


### PR DESCRIPTION
## Summary of changes

This PR is a continuation of this one:
https://github.com/DataDog/dd-trace-dotnet/pull/6820

This PR parallelizes the Linux tracer and ASM tests. The goal is to decrease the total CI running time.

We are using the area traits of the integration tests assemblies and filtering the tests based on that trait when running the integration tests, allowing us to run them in parallel.

We are not including arm_64 tests since the benefits are not so clear.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
