### PR TITLE
Skip slow debugger exploration test runs 

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3417,7 +3417,7 @@ stages:
 
     # Enable the Datadog Agent service for this job
     services:
-      dd_agent: dd_agent_no_pull
+      dd_agent: dd_agent
 
     steps:
     - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3417,7 +3417,7 @@ stages:
 
     # Enable the Datadog Agent service for this job
     services:
-      dd_agent: dd_agent
+      dd_agent: dd_agent_no_pull
 
     steps:
     - template: steps/clone-repo.yml

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -364,27 +364,27 @@ partial class Build : NukeBuild
                 var isDebuggerChanged = bool.Parse(EnvironmentInfo.GetVariable<string>("isDebuggerChanged") ?? "false");
                 var isProfilerChanged = bool.Parse(EnvironmentInfo.GetVariable<string>("isProfilerChanged") ?? "false");
 
-                var useCases = new List<string>();
+                var useCases = new List<global::ExplorationTestUseCase>();
                 if (isTracerChanged)
                 {
-                    useCases.Add(global::ExplorationTestUseCase.Tracer.ToString());
+                    useCases.Add(global::ExplorationTestUseCase.Tracer);
                 }
 
                 if (isDebuggerChanged)
                 {
-                    useCases.Add(global::ExplorationTestUseCase.Debugger.ToString());
+                    useCases.Add(global::ExplorationTestUseCase.Debugger);
                 }
 
                 if (isProfilerChanged)
                 {
-                    useCases.Add(global::ExplorationTestUseCase.ContinuousProfiler.ToString());
+                    useCases.Add(global::ExplorationTestUseCase.ContinuousProfiler);
                 }
 
                 GenerateExplorationTestsWindowsMatrix(useCases);
                 GenerateExplorationTestsLinuxMatrix(useCases);
             }
 
-            void GenerateExplorationTestsWindowsMatrix(IEnumerable<string> useCases)
+            void GenerateExplorationTestsWindowsMatrix(IEnumerable<global::ExplorationTestUseCase> useCases)
             {
                 var testDescriptions = ExplorationTestDescription.GetAllExplorationTestDescriptions();
                 var matrix = new Dictionary<string, object>();
@@ -392,9 +392,17 @@ partial class Build : NukeBuild
                 {
                     foreach (var testDescription in testDescriptions)
                     {
+                        if (explorationTestUseCase == global::ExplorationTestUseCase.Debugger
+                            && (testDescription.Name is global::ExplorationTestName.cake or global::ExplorationTestName.protobuf))
+                        {
+                            // Debugger tests are very slow on Windows only on cake and protobuf tests,
+                            //  so exclude them for now, pending investigation by debugger team
+                            continue;
+                        }
+
                         matrix.Add(
                             $"{explorationTestUseCase}_{testDescription.Name.ToString()}",
-                            new { explorationTestUseCase = explorationTestUseCase, explorationTestName = testDescription.Name.ToString() });
+                            new { explorationTestUseCase = explorationTestUseCase.ToString(), explorationTestName = testDescription.Name.ToString() });
                     }
                 }
 
@@ -403,7 +411,7 @@ partial class Build : NukeBuild
                 AzurePipelines.Instance.SetOutputVariable("exploration_tests_windows_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
             }
 
-            void GenerateExplorationTestsLinuxMatrix(IEnumerable<string> useCases)
+            void GenerateExplorationTestsLinuxMatrix(IEnumerable<global::ExplorationTestUseCase> useCases)
             {
                 var testDescriptions = ExplorationTestDescription.GetAllExplorationTestDescriptions();
                 var targetFrameworks = TargetFramework.GetFrameworks(except: new[] { TargetFramework.NET461, TargetFramework.NET462, TargetFramework.NETSTANDARD2_0, });
@@ -428,7 +436,7 @@ partial class Build : NukeBuild
                                 {
                                     matrix.Add(
                                         $"{baseImage}_{targetFramework}_{explorationTestUseCase}_{testDescription.Name}",
-                                        new { baseImage = baseImage, publishTargetFramework = targetFramework, explorationTestUseCase = explorationTestUseCase, explorationTestName = testDescription.Name, artifactSuffix = artifactSuffix });
+                                        new { baseImage = baseImage, publishTargetFramework = targetFramework, explorationTestUseCase = explorationTestUseCase.ToString(), explorationTestName = testDescription.Name, artifactSuffix = artifactSuffix });
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary of changes

Skip Debugger exploration tests on Windows for `Cake` and `Protobuf` tests

## Reason for change

For some reason, the debugger exploration tests for cake and protobuf on Windows are _extremely_ slow:

protobuf
- Tracer: 9mins
- Profiler: 9mins
- Debugger: 38 mins
  - A big chunk of this is "SetupExplorationTests" Creating line probes file finished. Took 17 minutes and 06 seconds.
  - Running the tests also takes 12 minutes though, vs 8s for the other cases :grimacing:

cake
- Tracer: 10mins
- Profiler: 10mins
- Debugger: 76 mins :scream:
  - The difference here is almost entirely in test run time - 66mins vs 39s

## Implementation details

Stop running these tests on Windows for now, until the Debugger team figure out what's going on in these cases

## Test coverage

Less now

