### PR TITLE
Update critical path analyzer

### DIFF
--- a/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
+++ b/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
@@ -12,6 +12,9 @@ using Logger = Serilog.Log;
 
 namespace CriticalPathAnalysis;
 
+/// <summary>
+/// Implements the Critical Path Method
+/// </summary>
 public static class CriticalPathAnalyzer
 {
     // These checks are required for merging
@@ -38,10 +41,38 @@ public static class CriticalPathAnalyzer
         "verify_app_trimming_descriptor_generator",
     };
 
-    public static Task AnalyzeCriticalPath(AbsolutePath rootDirectory)
+    // These stages are ignored from the analysis, primarily because they are not going to be around for much longer
+    static readonly string[] AlwaysIgnoreStages =
     {
+        "throughput",
+        "benchmarks",
+        "coverage", // optional, basically never run
+        "integration_tests_windows_iis_security", // removed recently
+    };
+
+    // These stages don't run on PRs, but do run on master, so exclude from the analysis for PRs only
+    static readonly string[] MasterOnlyStages =
+    {
+        "upload_container_images",
+        "nuget_installer_smoke_tests",
+        "nuget_installer_smoke_tests_arm64",
+        "nuget_installer_smoke_tests_windows",
+        "dotnet_tool_nuget_smoke_tests_linux",
+        "dotnet_tool_nuget_smoke_tests_macos",
+        "dotnet_tool_smoke_tests_linux",
+        "dotnet_tool_self_instrument_smoke_tests_linux",
+        "dotnet_tool_smoke_tests_arm64",
+        "dotnet_tool_smoke_tests_windows",
+        "dd_dotnet_msi_installer_smoke_tests",
+        "dd_dotnet_installer_failure_tests_linux_arm64",
+        "msi_installer_smoke_tests",
+    };
+
+    public static Task AnalyzeCriticalPath(AbsolutePath rootDirectory, bool isMasterRun)
+    {
+        var ignoreStages = isMasterRun ? AlwaysIgnoreStages : MasterOnlyStages.Concat(AlwaysIgnoreStages).ToArray();
         var pipeline = PipelineParser.GetPipelineDefinition(rootDirectory);
-        var stages = GetStages(rootDirectory, pipeline);
+        var stages = GetStages(rootDirectory, pipeline, ignoreStages);
         stages = OrderByDependencies(stages);
         UpdateEarliestValues(stages);
         UpdateLatestValues(stages);
@@ -49,7 +80,7 @@ public static class CriticalPathAnalyzer
         var stageOrder = pipeline.Stages.Select((x, i) => (x.Stage, Index: i)).ToDictionary(x => x.Stage, x => x.Index);
         var ordered = stages.OrderBy(x => stageOrder[x.Id]);
         var mermaidDiagram = GenerateMermaidDiagram(ordered);
-        var outputPath = rootDirectory / "tracer" / "build_data" / "pipeline_critical_path.md";
+        var outputPath = rootDirectory / "artifacts" / "build_data" / "pipeline_critical_path.md";
         File.WriteAllText(outputPath, $"""
                                        ```mermaid
                                        {mermaidDiagram}
@@ -59,17 +90,22 @@ public static class CriticalPathAnalyzer
         return Task.CompletedTask;
     }
 
-    static List<PipelineStage> GetStages(AbsolutePath rootDirectory, PipelineDefinition pipeline)
+    static List<PipelineStage> GetStages(AbsolutePath rootDirectory, PipelineDefinition pipeline, string[] IgnoreStages)
     {
         var stages = new List<PipelineStage>(pipeline.Stages.Length);
 
-        // Export the data from the widget here by clicking "Download as csv" and moving to tracer/build_data/stages.csv
-        // https://ddstaging.datadoghq.com/dashboard/74k-me3-y2z?from_ts=1689611447016&to_ts=1692289847016&live=true
-        var stagesCsv = rootDirectory / "tracer" / "build_data" / "stages.csv";
+        // Export the data from the widget here by clicking "Download as csv" and moving to artifacts/build_data/stages.csv
+        // https://app.datadoghq.com/dashboard/49i-n6n-9jq
+        var stagesCsv = rootDirectory / "artifacts" / "build_data" / "stages.csv";
         using var reader = Sep.New(',').Reader().FromFile(stagesCsv);
         foreach (var row in reader)
         {
             var stageName = row[0].ToString();
+            if (IgnoreStages.Contains(stageName))
+            {
+                continue;
+            }
+
             var durationInNanosecond = row[1].Parse<decimal>();
             var durationInMilliSeconds = (long)(durationInNanosecond / 1_000_000m);
             var requiredForMerging = RequiredStagesForMerging.Contains(stageName);
@@ -82,11 +118,24 @@ public static class CriticalPathAnalyzer
         // the successors (stages that depend on us)
         foreach (var currentStage in stages)
         {
-            var stageDefinition = pipeline.Stages.First(x => x.Stage == currentStage.Id);
+            var stageDefinition = pipeline.Stages.FirstOrDefault(x => x.Stage == currentStage.Id);
+            if (stageDefinition is null)
+            {
+                throw new Exception("Could not find stage called " + currentStage.Id);
+            }
 
             foreach (var dependency in stageDefinition.DependsOn)
             {
-                var predecessor = stages.First(x => x.Id == dependency);
+                if (IgnoreStages.Contains(dependency))
+                {
+                    continue;
+                }
+
+                var predecessor = stages.FirstOrDefault(x => x.Id == dependency);
+                if (predecessor is null)
+                {
+                    throw new Exception(stageDefinition.Stage + " depends on stage '" + dependency + "' that could not be found in output results");
+                }
                 currentStage.Predecessors.Add(predecessor);
                 predecessor.Successors.Add(currentStage);
             }

--- a/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
+++ b/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
@@ -121,7 +121,7 @@ public static class CriticalPathAnalyzer
             var stageDefinition = pipeline.Stages.FirstOrDefault(x => x.Stage == currentStage.Id);
             if (stageDefinition is null)
             {
-                throw new Exception("Could not find stage called " + currentStage.Id);
+                throw new Exception($"Could not find stage called {currentStage.Id}. " );
             }
 
             foreach (var dependency in stageDefinition.DependsOn)
@@ -134,7 +134,7 @@ public static class CriticalPathAnalyzer
                 var predecessor = stages.FirstOrDefault(x => x.Id == dependency);
                 if (predecessor is null)
                 {
-                    throw new Exception(stageDefinition.Stage + " depends on stage '" + dependency + "' that could not be found in output results");
+                    throw new Exception($"{stageDefinition.Stage} depends on stage '{dependency}' that could not be found in output results");
                 }
                 currentStage.Predecessors.Add(predecessor);
                 predecessor.Successors.Add(currentStage);

--- a/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
+++ b/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
@@ -79,7 +79,7 @@ public static class CriticalPathAnalyzer
         // displaying in original (pipeline) order
         var stageOrder = pipeline.Stages.Select((x, i) => (x.Stage, Index: i)).ToDictionary(x => x.Stage, x => x.Index);
         var ordered = stages.OrderBy(x => stageOrder[x.Id]);
-        var mermaidDiagram = GenerateMermaidDiagram(ordered);
+        var mermaidDiagram = GenerateMermaidDiagram(ordered, isMasterRun);
         var outputPath = rootDirectory / "artifacts" / "build_data" / "pipeline_critical_path.md";
         File.WriteAllText(outputPath, $"""
                                        ```mermaid
@@ -213,14 +213,17 @@ public static class CriticalPathAnalyzer
         return ordered;
     }
 
-    static string GenerateMermaidDiagram(IEnumerable<PipelineStage> stages)
+    static string GenerateMermaidDiagram(IEnumerable<PipelineStage> stages, bool isMaster)
     {
         // can't easily show flex in the diagram, so display using earliest start/end
         // and mark critical tasks
         var sb = new StringBuilder();
-        sb.AppendLine("""
+        sb.Append("""
              gantt
                  title Consolidated pipeline critical path analysis
+             """);
+        sb.AppendLine(isMaster ? " for master" : " for branches");
+        sb.AppendLine("""
                  dateFormat s
                  axisFormat %H:%M
                  todayMarker off


### PR DESCRIPTION
## Summary of changes

- Add documentation to the `AnalyzePipelineCriticalPath` target
- Handle changes to the pipeline
- Work with both main and branch results
- Update dashboard

## Reason for change

The existing analyzer had some issues due to changes to the pipeline. It also didn't handle the fact that we've moved the CI data to prod from staging and 

## Implementation details

- Add some docs
- Allow "ignoring" stages for the analysis (stages we don't care about because they're _going_ to be removed or because they have been removed but still show in the data)
- Make errors more explicit
- Allow handling `master` and "other" branches

## Test coverage

Ran locally, for "branches" we have:

```mermaid
gantt
    title Consolidated pipeline critical path analysis for branches
    dateFormat s
    axisFormat %H:%M
    todayMarker off
    merge_commit_id (29s)  : done, crit, merge_commit_id, 0, 29s
    generate_variables (2mins)  : done, generate_variables, after merge_commit_id , 155s
    build_windows_tracer (18mins)  : done, build_windows_tracer, after merge_commit_id , 1083s
    build_windows_profiler (13mins)  : done, build_windows_profiler, after merge_commit_id , 835s
    build_linux_tracer (14mins)  : done, build_linux_tracer, after merge_commit_id , 852s
    build_linux_tracer_r2r (14mins)  : done, build_linux_tracer_r2r, after merge_commit_id , 852s
    build_linux_universal (4mins)  : done, build_linux_universal, after merge_commit_id , 277s
    build_linux_profiler (12mins)  : done, build_linux_profiler, after merge_commit_id , 755s
    package_linux (2mins)  : done, package_linux, after merge_commit_id build_linux_tracer build_linux_profiler build_dd_dotnet_linux build_linux_universal , 149s
    build_arm64_tracer (15mins)  : done, crit, build_arm64_tracer, after merge_commit_id , 941s
    build_arm64_tracer_r2r (16mins)  : done, build_arm64_tracer_r2r, after merge_commit_id , 980s
    build_arm64_profiler (9mins)  : done, build_arm64_profiler, after merge_commit_id , 571s
    build_arm64_universal (7mins)  : done, build_arm64_universal, after merge_commit_id , 431s
    package_arm64 (4mins)  : done, crit, package_arm64, after merge_commit_id build_arm64_tracer build_arm64_profiler build_dd_dotnet_linux_arm64 build_arm64_universal , 267s
    build_macos (18mins)  : done, build_macos, after merge_commit_id , 1083s
    package_windows (8mins)  : done, package_windows, after build_windows_tracer build_windows_profiler build_dd_dotnet_windows merge_commit_id , 506s
    build_dd_dotnet_windows (3mins)  : done, build_dd_dotnet_windows, after merge_commit_id , 232s
    build_dd_dotnet_linux (3mins)  : done, build_dd_dotnet_linux, after merge_commit_id , 182s
    build_dd_dotnet_linux_arm64 (5mins)  : done, build_dd_dotnet_linux_arm64, after merge_commit_id , 339s
    debug_builds (12mins)  : done, debug_builds, after merge_commit_id , 740s
    unit_tests_windows (10mins)  : unit_tests_windows, after build_windows_tracer merge_commit_id generate_variables , 656s
    unit_tests_macos (19mins)  : done, unit_tests_macos, after build_macos merge_commit_id generate_variables , 1150s
    unit_tests_linux (9mins)  : unit_tests_linux, after build_linux_tracer build_linux_profiler merge_commit_id generate_variables , 582s
    unit_tests_arm64 (19mins)  : unit_tests_arm64, after build_arm64_tracer merge_commit_id generate_variables , 1150s
    build_samples (14mins)  : done, build_samples, after merge_commit_id , 869s
    build_samples_macos (8mins)  : done, build_samples_macos, after merge_commit_id , 496s
    integration_tests_windows (54mins)  : integration_tests_windows, after build_windows_tracer generate_variables merge_commit_id build_samples , 3254s
    integration_tests_windows_debugger (16mins)  : done, integration_tests_windows_debugger, after build_windows_tracer generate_variables merge_commit_id , 960s
    integration_tests_windows_iis (19mins)  : integration_tests_windows_iis, after build_windows_tracer generate_variables merge_commit_id , 1150s
    integration_tests_azure_functions (11mins)  : done, integration_tests_azure_functions, after build_windows_tracer generate_variables merge_commit_id , 697s
    static_analysis_checks_tracer (7mins)  : done, static_analysis_checks_tracer, after merge_commit_id , 467s
    static_analysis_tests_profiler (24mins)  : done, static_analysis_tests_profiler, after merge_commit_id generate_variables , 1462s
    msi_integration_tests_windows (17mins)  : msi_integration_tests_windows, after build_windows_tracer package_windows generate_variables merge_commit_id , 1061s
    integration_tests_linux (43mins)  : integration_tests_linux, after package_linux generate_variables merge_commit_id build_samples , 2611s
    integration_tests_linux_debugger (28mins)  : done, integration_tests_linux_debugger, after package_linux generate_variables merge_commit_id , 1715s
    profiler_integration_tests_windows (33mins)  : done, profiler_integration_tests_windows, after package_windows generate_variables merge_commit_id , 2013s
    profiler_integration_tests_linux (37mins)  : profiler_integration_tests_linux, after package_linux generate_variables merge_commit_id , 2225s
    asan_profiler_tests (17mins)  : done, asan_profiler_tests, after merge_commit_id generate_variables , 1020s
    ubsan_profiler_tests (17mins)  : done, ubsan_profiler_tests, after merge_commit_id generate_variables , 1040s
    integration_tests_arm64 (58mins)  : crit, integration_tests_arm64, after package_arm64 generate_variables merge_commit_id build_samples , 3525s
    integration_tests_arm64_debugger (40mins)  : done, integration_tests_arm64_debugger, after package_arm64 generate_variables merge_commit_id , 2459s
    exploration_tests_windows (11mins)  : done, exploration_tests_windows, after build_windows_tracer generate_variables merge_commit_id , 711s
    exploration_tests_linux (7mins)  : done, exploration_tests_linux, after package_linux generate_variables merge_commit_id , 467s
    appsec_benchmarks (40mins)  : done, appsec_benchmarks, after build_windows_tracer build_windows_profiler generate_variables merge_commit_id , 2410s
    dotnet_tool (14mins)  : dotnet_tool, after build_windows_tracer build_windows_profiler build_linux_tracer build_linux_profiler build_arm64_tracer build_arm64_profiler build_linux_universal build_arm64_universal build_macos build_dd_dotnet_windows build_dd_dotnet_linux build_dd_dotnet_linux_arm64 merge_commit_id , 852s
    tool_artifacts_tests_windows (10mins)  : tool_artifacts_tests_windows, after dotnet_tool merge_commit_id , 643s
    tool_artifacts_tests_linux (14mins)  : tool_artifacts_tests_linux, after dotnet_tool merge_commit_id , 886s
    store_ssi_artifacts (43s)  : done, store_ssi_artifacts, after package_linux package_arm64 merge_commit_id , 43s
    store_serverless_artifacts (42s)  : done, store_serverless_artifacts, after build_linux_tracer_r2r build_arm64_tracer_r2r build_linux_universal build_arm64_universal , 42s
    upload_to_azure (5mins)  : done, upload_to_azure, after package_windows package_linux package_arm64 dotnet_tool merge_commit_id store_serverless_artifacts , 346s
    throughput_profiler (26mins)  : done, throughput_profiler, after package_linux generate_variables build_windows_tracer merge_commit_id , 1615s
    execution_benchmarks (18mins)  : done, execution_benchmarks, after build_windows_tracer merge_commit_id , 1083s
    profiler_execution_benchmarks (10mins)  : done, profiler_execution_benchmarks, after merge_commit_id build_windows_profiler build_linux_profiler , 606s
    system_tests (43mins)  : done, system_tests, after package_linux merge_commit_id , 2611s
    installer_smoke_tests (8mins)  : installer_smoke_tests, after package_linux generate_variables merge_commit_id , 496s
    installer_chiseled_smoke_tests (3mins)  : done, installer_chiseled_smoke_tests, after package_linux generate_variables merge_commit_id , 193s
    trimmed_installer_smoke_tests (3mins)  : done, trimmed_installer_smoke_tests, after package_windows package_linux generate_variables merge_commit_id , 190s
    installer_smoke_tests_arm64 (8mins)  : installer_smoke_tests_arm64, after package_arm64 generate_variables merge_commit_id , 516s
    tracer_home_smoke_tests (21mins)  : tracer_home_smoke_tests, after package_windows generate_variables merge_commit_id , 1296s
    fleet_installer_smoke_tests (29mins)  : done, fleet_installer_smoke_tests, after package_windows generate_variables merge_commit_id , 1750s
    dd_dotnet_installer_failure_tests_linux (2mins)  : done, dd_dotnet_installer_failure_tests_linux, after generate_variables merge_commit_id , 120s
    compare_throughput (2mins)  : done, compare_throughput, after merge_commit_id , 149s
    trace_pipeline (2mins)  : done, crit, trace_pipeline, after merge_commit_id unit_tests_linux unit_tests_macos unit_tests_windows unit_tests_arm64 integration_tests_windows integration_tests_windows_debugger integration_tests_windows_iis integration_tests_azure_functions msi_integration_tests_windows integration_tests_linux integration_tests_linux_debugger integration_tests_arm64 integration_tests_arm64_debugger static_analysis_checks_tracer exploration_tests_windows exploration_tests_linux tool_artifacts_tests_windows tool_artifacts_tests_linux upload_to_azure execution_benchmarks installer_smoke_tests installer_smoke_tests_arm64 dd_dotnet_installer_failure_tests_linux tracer_home_smoke_tests compare_throughput system_tests , 149s

```


and for `master` we have:

```mermaid
gantt
    title Consolidated pipeline critical path analysis for master
    dateFormat s
    axisFormat %H:%M
    todayMarker off
    merge_commit_id (29s)  : done, crit, merge_commit_id, 0, 29s
    generate_variables (2mins)  : done, generate_variables, after merge_commit_id , 155s
    build_windows_tracer (18mins)  : done, crit, build_windows_tracer, after merge_commit_id , 1127s
    build_windows_profiler (13mins)  : done, build_windows_profiler, after merge_commit_id , 835s
    build_linux_tracer (14mins)  : done, build_linux_tracer, after merge_commit_id , 852s
    build_linux_tracer_r2r (13mins)  : done, build_linux_tracer_r2r, after merge_commit_id , 835s
    build_linux_universal (4mins)  : done, build_linux_universal, after merge_commit_id , 277s
    build_linux_profiler (12mins)  : done, build_linux_profiler, after merge_commit_id , 755s
    package_linux (2mins)  : done, package_linux, after merge_commit_id build_linux_tracer build_linux_profiler build_dd_dotnet_linux build_linux_universal , 158s
    build_arm64_tracer (15mins)  : done, build_arm64_tracer, after merge_commit_id , 904s
    build_arm64_tracer_r2r (16mins)  : done, build_arm64_tracer_r2r, after merge_commit_id , 960s
    build_arm64_profiler (9mins)  : done, build_arm64_profiler, after merge_commit_id , 571s
    build_arm64_universal (7mins)  : done, build_arm64_universal, after merge_commit_id , 440s
    package_arm64 (5mins)  : done, package_arm64, after merge_commit_id build_arm64_tracer build_arm64_profiler build_dd_dotnet_linux_arm64 build_arm64_universal , 301s
    build_macos (17mins)  : done, build_macos, after merge_commit_id , 1040s
    package_windows (9mins)  : done, package_windows, after build_windows_tracer build_windows_profiler build_dd_dotnet_windows merge_commit_id , 548s
    build_dd_dotnet_windows (3mins)  : done, build_dd_dotnet_windows, after merge_commit_id , 227s
    build_dd_dotnet_linux (3mins)  : done, build_dd_dotnet_linux, after merge_commit_id , 190s
    build_dd_dotnet_linux_arm64 (5mins)  : done, build_dd_dotnet_linux_arm64, after merge_commit_id , 326s
    debug_builds (12mins)  : done, debug_builds, after merge_commit_id , 726s
    unit_tests_windows (12mins)  : unit_tests_windows, after build_windows_tracer merge_commit_id generate_variables , 770s
    unit_tests_macos (19mins)  : done, unit_tests_macos, after build_macos merge_commit_id generate_variables , 1150s
    unit_tests_linux (10mins)  : unit_tests_linux, after build_linux_tracer build_linux_profiler merge_commit_id generate_variables , 618s
    unit_tests_arm64 (19mins)  : unit_tests_arm64, after build_arm64_tracer merge_commit_id generate_variables , 1197s
    build_samples (14mins)  : done, build_samples, after merge_commit_id , 869s
    build_samples_macos (8mins)  : done, build_samples_macos, after merge_commit_id , 516s
    integration_tests_windows (57mins)  : integration_tests_windows, after build_windows_tracer generate_variables merge_commit_id build_samples , 3455s
    integration_tests_windows_debugger (17mins)  : done, integration_tests_windows_debugger, after build_windows_tracer generate_variables merge_commit_id , 1061s
    integration_tests_windows_iis (19mins)  : integration_tests_windows_iis, after build_windows_tracer generate_variables merge_commit_id , 1173s
    integration_tests_azure_functions (11mins)  : done, integration_tests_azure_functions, after build_windows_tracer generate_variables merge_commit_id , 711s
    static_analysis_checks_tracer (7mins)  : done, static_analysis_checks_tracer, after merge_commit_id , 477s
    static_analysis_tests_profiler (25mins)  : done, static_analysis_tests_profiler, after merge_commit_id generate_variables , 1521s
    msi_integration_tests_windows (25mins)  : msi_integration_tests_windows, after build_windows_tracer package_windows generate_variables merge_commit_id , 1521s
    integration_tests_linux (47mins)  : integration_tests_linux, after package_linux generate_variables merge_commit_id build_samples , 2828s
    integration_tests_linux_debugger (27mins)  : done, integration_tests_linux_debugger, after package_linux generate_variables merge_commit_id , 1648s
    profiler_integration_tests_windows (43mins)  : done, profiler_integration_tests_windows, after package_windows generate_variables merge_commit_id , 2611s
    profiler_integration_tests_linux (37mins)  : profiler_integration_tests_linux, after package_linux generate_variables merge_commit_id , 2225s
    asan_profiler_tests (17mins)  : done, asan_profiler_tests, after merge_commit_id generate_variables , 1040s
    ubsan_profiler_tests (17mins)  : done, ubsan_profiler_tests, after merge_commit_id generate_variables , 1061s
    integration_tests_arm64 (1h 1mins)  : integration_tests_arm64, after package_arm64 generate_variables merge_commit_id build_samples , 3668s
    integration_tests_arm64_debugger (37mins)  : done, integration_tests_arm64_debugger, after package_arm64 generate_variables merge_commit_id , 2225s
    exploration_tests_windows (1h 17mins)  : done, crit, exploration_tests_windows, after build_windows_tracer generate_variables merge_commit_id , 4664s
    exploration_tests_linux (17mins)  : done, exploration_tests_linux, after package_linux generate_variables merge_commit_id , 1040s
    appsec_benchmarks (40mins)  : done, appsec_benchmarks, after build_windows_tracer build_windows_profiler generate_variables merge_commit_id , 2459s
    dotnet_tool (16mins)  : dotnet_tool, after build_windows_tracer build_windows_profiler build_linux_tracer build_linux_profiler build_arm64_tracer build_arm64_profiler build_linux_universal build_arm64_universal build_macos build_dd_dotnet_windows build_dd_dotnet_linux build_dd_dotnet_linux_arm64 merge_commit_id , 999s
    tool_artifacts_tests_windows (11mins)  : tool_artifacts_tests_windows, after dotnet_tool merge_commit_id , 683s
    tool_artifacts_tests_linux (13mins)  : tool_artifacts_tests_linux, after dotnet_tool merge_commit_id , 835s
    store_ssi_artifacts (52s)  : done, store_ssi_artifacts, after package_linux package_arm64 merge_commit_id , 52s
    store_serverless_artifacts (53s)  : done, store_serverless_artifacts, after build_linux_tracer_r2r build_arm64_tracer_r2r build_linux_universal build_arm64_universal , 53s
    upload_to_azure (7mins)  : done, upload_to_azure, after package_windows package_linux package_arm64 dotnet_tool merge_commit_id store_serverless_artifacts , 458s
    upload_container_images (9s)  : done, upload_container_images, after upload_to_azure , 9s
    throughput_profiler (27mins)  : done, throughput_profiler, after package_linux generate_variables build_windows_tracer merge_commit_id , 1648s
    execution_benchmarks (29mins)  : done, execution_benchmarks, after build_windows_tracer merge_commit_id , 1785s
    profiler_execution_benchmarks (14mins)  : done, profiler_execution_benchmarks, after merge_commit_id build_windows_profiler build_linux_profiler , 886s
    system_tests (43mins)  : done, system_tests, after package_linux merge_commit_id , 2611s
    installer_smoke_tests (10mins)  : installer_smoke_tests, after package_linux generate_variables merge_commit_id , 631s
    installer_chiseled_smoke_tests (3mins)  : done, installer_chiseled_smoke_tests, after package_linux generate_variables merge_commit_id , 223s
    nuget_installer_smoke_tests (6mins)  : done, nuget_installer_smoke_tests, after dotnet_tool package_windows generate_variables merge_commit_id , 382s
    trimmed_installer_smoke_tests (3mins)  : done, trimmed_installer_smoke_tests, after package_windows package_linux generate_variables merge_commit_id , 205s
    dotnet_tool_nuget_smoke_tests_linux (3mins)  : done, dotnet_tool_nuget_smoke_tests_linux, after dotnet_tool generate_variables merge_commit_id , 186s
    dotnet_tool_smoke_tests_linux (3mins)  : done, dotnet_tool_smoke_tests_linux, after dotnet_tool generate_variables merge_commit_id , 227s
    dotnet_tool_self_instrument_smoke_tests_linux (2mins)  : done, dotnet_tool_self_instrument_smoke_tests_linux, after dotnet_tool generate_variables merge_commit_id , 161s
    installer_smoke_tests_arm64 (9mins)  : installer_smoke_tests_arm64, after package_arm64 generate_variables merge_commit_id , 582s
    installer_chiseled_smoke_tests_arm64 (5mins)  : done, installer_chiseled_smoke_tests_arm64, after package_arm64 generate_variables merge_commit_id , 353s
    nuget_installer_smoke_tests_arm64 (10mins)  : done, nuget_installer_smoke_tests_arm64, after dotnet_tool package_windows generate_variables merge_commit_id , 631s
    dotnet_tool_smoke_tests_arm64 (7mins)  : done, dotnet_tool_smoke_tests_arm64, after dotnet_tool generate_variables merge_commit_id , 440s
    nuget_installer_smoke_tests_windows (32mins)  : done, nuget_installer_smoke_tests_windows, after dotnet_tool package_windows generate_variables merge_commit_id , 1973s
    dotnet_tool_smoke_tests_windows (28mins)  : done, dotnet_tool_smoke_tests_windows, after dotnet_tool package_windows generate_variables merge_commit_id , 1715s
    msi_installer_smoke_tests (29mins)  : done, msi_installer_smoke_tests, after package_windows generate_variables merge_commit_id , 1750s
    dd_dotnet_msi_installer_smoke_tests (29mins)  : done, dd_dotnet_msi_installer_smoke_tests, after package_windows generate_variables merge_commit_id , 1750s
    tracer_home_smoke_tests (22mins)  : tracer_home_smoke_tests, after package_windows generate_variables merge_commit_id , 1322s
    fleet_installer_smoke_tests (28mins)  : done, fleet_installer_smoke_tests, after package_windows generate_variables merge_commit_id , 1715s
    dotnet_tool_nuget_smoke_tests_macos (6mins)  : done, dotnet_tool_nuget_smoke_tests_macos, after dotnet_tool generate_variables merge_commit_id , 382s
    dd_dotnet_installer_failure_tests_linux (2mins)  : done, dd_dotnet_installer_failure_tests_linux, after generate_variables merge_commit_id , 152s
    dd_dotnet_installer_failure_tests_linux_arm64 (3mins)  : done, dd_dotnet_installer_failure_tests_linux_arm64, after generate_variables merge_commit_id , 193s
    compare_throughput (2mins)  : done, compare_throughput, after merge_commit_id , 155s
    trace_pipeline (2mins)  : done, crit, trace_pipeline, after merge_commit_id unit_tests_linux unit_tests_macos unit_tests_windows unit_tests_arm64 integration_tests_windows integration_tests_windows_debugger integration_tests_windows_iis integration_tests_azure_functions msi_integration_tests_windows integration_tests_linux integration_tests_linux_debugger integration_tests_arm64 integration_tests_arm64_debugger static_analysis_checks_tracer exploration_tests_windows exploration_tests_linux tool_artifacts_tests_windows tool_artifacts_tests_linux upload_to_azure upload_container_images execution_benchmarks installer_smoke_tests installer_smoke_tests_arm64 nuget_installer_smoke_tests nuget_installer_smoke_tests_arm64 nuget_installer_smoke_tests_windows dotnet_tool_nuget_smoke_tests_linux dotnet_tool_nuget_smoke_tests_macos dotnet_tool_smoke_tests_linux dotnet_tool_self_instrument_smoke_tests_linux dotnet_tool_smoke_tests_arm64 dotnet_tool_smoke_tests_windows dd_dotnet_msi_installer_smoke_tests dd_dotnet_installer_failure_tests_linux dd_dotnet_installer_failure_tests_linux_arm64 msi_installer_smoke_tests tracer_home_smoke_tests compare_throughput system_tests , 161s
    notify_slack_on_failures (9s)  : done, crit, notify_slack_on_failures, after trace_pipeline , 9s


```

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
