### PR TITLE
Increase the size of the arm64 pool

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -720,7 +720,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -763,7 +763,7 @@ stages:
     dependsOn: []
 
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -813,7 +813,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -855,7 +855,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -903,7 +903,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1222,7 +1222,7 @@ stages:
           artifactSuffix: linux-musl-arm64
 
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1325,7 +1325,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -1520,7 +1520,7 @@ stages:
         matrix:
           $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_arm64_matrix'] ]
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
       workspace:
         clean: all
       steps:
@@ -3133,7 +3133,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -3212,7 +3212,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -3327,7 +3327,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -4111,12 +4111,12 @@ stages:
         arm64:
           baseImage: debian
           artifactSuffix: linux-arm64
-          poolname: azure-managed-linux-arm64-1
+          poolname: azure-managed-linux-arm64-2
           targetArch: arm64
         alpine_arm64:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
-          poolname: azure-managed-linux-arm64-1
+          poolname: azure-managed-linux-arm64-2
           targetArch: arm64
 
     pool:
@@ -5916,7 +5916,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -6000,7 +6000,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -6074,7 +6074,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -6166,7 +6166,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -6890,7 +6890,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml


### PR DESCRIPTION
## Summary of changes

Bump the size of the ARM64 VMs

## Reason for change

Want to understand where the tradeoff is with machine size for the arm64 machines

## Implementation details

Created a new managed devops pool, and used Standard_D8pds_v6, and let's see what happens...

## Test coverage

No change

## Other details

If we go ahead with this, we should scale it up higher, and scale down the other pool