### PR TITLE
Point to dd-trace-dotnet/macro instead of development branch

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -408,7 +408,7 @@ profiler_cpu_timer_create-arm64:
 .benchmarks-win:
   stage: benchmarks-win
   needs: ["check_azure_pipeline"]
-  tags: ["arch:amd64"]
+  tags: ["runner:apm-k8s-same-cpu"]
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:test
   interruptible: true
   timeout: 1h

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -446,8 +446,7 @@ profiler_cpu_timer_create-arm64:
   script:
     - source build-id.txt
     - echo "Building for the following build https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId&view=results"
-    # TODO: Remove this once the branch is merged to dd-trace-dotnet/macro
-    - export BP_INFRA_BENCHMARKING_PLATFORM_BRANCH=igoragoli/update-dd-trace-dotnet-macro
+    - export BP_INFRA_BENCHMARKING_PLATFORM_BRANCH=dd-trace-dotnet/macro
     - git clone --branch $BP_INFRA_BENCHMARKING_PLATFORM_BRANCH https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./ephemeral-infra/run-windows-benchmarks.sh
 

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -408,7 +408,7 @@ profiler_cpu_timer_create-arm64:
 .benchmarks-win:
   stage: benchmarks-win
   needs: ["check_azure_pipeline"]
-  tags: ["runner:apm-k8s-same-cpu"]
+  tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:test
   interruptible: true
   timeout: 1h

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -409,7 +409,7 @@ profiler_cpu_timer_create-arm64:
   stage: benchmarks-win
   needs: ["check_azure_pipeline"]
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:test
   interruptible: true
   timeout: 1h
   rules:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -409,7 +409,7 @@ profiler_cpu_timer_create-arm64:
   stage: benchmarks-win
   needs: ["check_azure_pipeline"]
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:test
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
   interruptible: true
   timeout: 1h
   rules:


### PR DESCRIPTION
- Point to `dd-trace-dotnet/macro` instead of `igoragoli/update-dd-trace-dotnet-macro`.