### PR TITLE
Split sample upload

### DIFF
--- a/.azure-pipelines/steps/download-samples.yml
+++ b/.azure-pipelines/steps/download-samples.yml
@@ -1,0 +1,20 @@
+parameters:
+  - name: 'framework'
+    type: 'string'
+    default: ''
+
+steps:
+- task: DownloadPipelineArtifact@2
+  displayName: Download standalone samples
+  inputs:
+    artifact: samples-standalone
+    path: $(outputDir)/bin
+  retryCountOnTaskFailure: 5
+
+- ${{ if ne(parameters.framework, '') }}:
+  - task: DownloadPipelineArtifact@2
+    displayName: Download multi-version samples
+    inputs:
+      artifact: samples-multi-version-${{ parameters.framework }}
+      path: $(outputDir)/publish
+    retryCountOnTaskFailure: 5

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1624,7 +1624,7 @@ stages:
           retryCountOnTaskFailure: 1
 
         - publish: $(outputDir)/publish
-          displayName: Upload artifact samples (bin only)
+          displayName: Upload artifact samples (publish only)
           artifact: samples-multi-version-$(framework)
 
         - publish: artifacts/build_data
@@ -1694,12 +1694,7 @@ stages:
       parameters:
         includeX86: true
     - template: steps/restore-working-directory.yml
-    - task: DownloadPipelineArtifact@2
-      displayName: Download samples
-      inputs:
-        artifact: samples-standalone
-        path: $(outputDir)
-      retryCountOnTaskFailure: 5
+    - template: steps/download-samples.yml
 
 # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
 #    - powershell: |
@@ -2252,18 +2247,9 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
-    - task: DownloadPipelineArtifact@2
-      displayName: Download standalone samples
-      inputs:
-        artifact: samples-standalone
-        path: $(outputDir)
-      retryCountOnTaskFailure: 5
-    - task: DownloadPipelineArtifact@2
-      displayName: Download multi-version samples
-      inputs:
-        artifact: samples-multi-version-$(publishTargetFramework)
-        path: $(outputDir)
-      retryCountOnTaskFailure: 5
+    - template: steps/download-samples.yml
+      parameters:
+        framework: $(publishTargetFramework)
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -2342,18 +2328,9 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
-    - task: DownloadPipelineArtifact@2
-      displayName: Download standalone samples
-      inputs:
-        artifact: samples-standalone
-        path: $(outputDir)
-      retryCountOnTaskFailure: 5
-    - task: DownloadPipelineArtifact@2
-      displayName: Download multi-version samples
-      inputs:
-        artifact: samples-multi-version-$(publishTargetFramework)
-        path: $(outputDir)
-      retryCountOnTaskFailure: 5
+    - template: steps/download-samples.yml
+      parameters:
+        framework: $(publishTargetFramework)
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -2471,18 +2448,9 @@ stages:
       inputs:
         artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
-    - task: DownloadPipelineArtifact@2
-      displayName: Download samples
-      inputs:
-        artifact: samples-standalone
-        path: $(outputDir)
-      retryCountOnTaskFailure: 5
-    - task: DownloadPipelineArtifact@2
-      displayName: Download multi-version samples
-      inputs:
-        artifact: samples-multi-version-$(publishTargetFramework)
-        path: $(outputDir)
-      retryCountOnTaskFailure: 5
+    - template: steps/download-samples.yml
+      parameters:
+        framework: $(publishTargetFramework)
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3078,18 +3046,9 @@ stages:
           parameters:
             artifact: build-$(artifactSuffix)-working-directory
 
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-standalone
-            path: $(outputDir)
-          retryCountOnTaskFailure: 5
-        - task: DownloadPipelineArtifact@2
-          displayName: Download multi-version samples
-          inputs:
-            artifact: samples-multi-version-$(publishTargetFramework)
-            path: $(outputDir)
-          retryCountOnTaskFailure: 5
+        - template: steps/download-samples.yml
+          parameters:
+            framework: $(publishTargetFramework)
 
         - template: steps/run-in-docker.yml
           parameters:
@@ -3162,18 +3121,9 @@ stages:
         - template: steps/restore-working-directory.yml
           parameters:
             artifact: build-$(artifactSuffix)-working-directory
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-standalone
-            path: $(outputDir)
-          retryCountOnTaskFailure: 5
-        - task: DownloadPipelineArtifact@2
-          displayName: Download multi-version samples
-          inputs:
-            artifact: samples-multi-version-$(publishTargetFramework)
-            path: $(outputDir)
-          retryCountOnTaskFailure: 5
+        - template: steps/download-samples.yml
+          parameters:
+            framework: $(publishTargetFramework)
 
         - template: steps/run-in-docker.yml
           parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1579,7 +1579,7 @@ stages:
 
         - publish: $(outputDir)/bin
           displayName: Upload artifact samples (bin only)
-          artifact: samples-bin-standalone
+          artifact: samples-standalone
 
         - publish: artifacts/build_data
           displayName: Uploading logs
@@ -1632,91 +1632,6 @@ stages:
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: failed()
           continueOnError: true
-
-    - job: merge
-      dependsOn: [ standalone, multi_version ]
-      timeoutInMinutes: 60 #default value
-      pool:
-        name: azure-windows-scale-set-3
-      steps:
-        - checkout: none
-        - powershell: |
-            mkdir $(Build.ArtifactStagingDirectory)/bin
-            mkdir $(Build.ArtifactStagingDirectory)/publish
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-bin-standalone
-            path: $(Build.ArtifactStagingDirectory)/bin
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-net462
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-netcoreapp2.1
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-netcoreapp3.0
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-netcoreapp3.1
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-net5.0
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-net6.0
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-net7.0
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-net8.0
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download samples
-          inputs:
-            artifact: samples-multi-version-net9.0
-            path: $(Build.ArtifactStagingDirectory)/publish
-          retryCountOnTaskFailure: 5
-
-        - publish: $(Build.ArtifactStagingDirectory)
-          displayName: Upload artifact samples
-          artifact: samples
 
 # This is just to test that we _can_ build the solution on macos
 # It's not used by other stages, and just ensures we don't break the macos build
@@ -1782,7 +1697,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download samples
       inputs:
-        artifact: samples
+        artifact: samples-standalone
         path: $(outputDir)
       retryCountOnTaskFailure: 5
 
@@ -2338,9 +2253,15 @@ stages:
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
     - task: DownloadPipelineArtifact@2
-      displayName: Download samples
+      displayName: Download standalone samples
       inputs:
-        artifact: samples
+        artifact: samples-standalone
+        path: $(outputDir)
+      retryCountOnTaskFailure: 5
+    - task: DownloadPipelineArtifact@2
+      displayName: Download multi-version samples
+      inputs:
+        artifact: samples-multi-version-$(publishTargetFramework)
         path: $(outputDir)
       retryCountOnTaskFailure: 5
 
@@ -2422,9 +2343,15 @@ stages:
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
     - task: DownloadPipelineArtifact@2
-      displayName: Download samples
+      displayName: Download standalone samples
       inputs:
-        artifact: samples
+        artifact: samples-standalone
+        path: $(outputDir)
+      retryCountOnTaskFailure: 5
+    - task: DownloadPipelineArtifact@2
+      displayName: Download multi-version samples
+      inputs:
+        artifact: samples-multi-version-$(publishTargetFramework)
         path: $(outputDir)
       retryCountOnTaskFailure: 5
 
@@ -2547,7 +2474,13 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download samples
       inputs:
-        artifact: samples
+        artifact: samples-standalone
+        path: $(outputDir)
+      retryCountOnTaskFailure: 5
+    - task: DownloadPipelineArtifact@2
+      displayName: Download multi-version samples
+      inputs:
+        artifact: samples-multi-version-$(publishTargetFramework)
         path: $(outputDir)
       retryCountOnTaskFailure: 5
 
@@ -3148,7 +3081,13 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download samples
           inputs:
-            artifact: samples
+            artifact: samples-standalone
+            path: $(outputDir)
+          retryCountOnTaskFailure: 5
+        - task: DownloadPipelineArtifact@2
+          displayName: Download multi-version samples
+          inputs:
+            artifact: samples-multi-version-$(publishTargetFramework)
             path: $(outputDir)
           retryCountOnTaskFailure: 5
 
@@ -3226,7 +3165,13 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download samples
           inputs:
-            artifact: samples
+            artifact: samples-standalone
+            path: $(outputDir)
+          retryCountOnTaskFailure: 5
+        - task: DownloadPipelineArtifact@2
+          displayName: Download multi-version samples
+          inputs:
+            artifact: samples-multi-version-$(publishTargetFramework)
             path: $(outputDir)
           retryCountOnTaskFailure: 5
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1560,7 +1560,7 @@ stages:
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
-        jobs: [standalone, multi_version, merge]
+        jobs: [standalone, multi_version]
 
     - job: standalone
       timeoutInMinutes: 60 #default value


### PR DESCRIPTION
## Summary of changes

Don't bother to "merge" the samples into a single artifact to reduce download size

## Reason for change

When we moved the sample build to a separate stage (to avoid re-work and to run the build in parallel) we added a job that would aggregate all the different TFMs into a single artifact. This was for simplicity on the consuming side.

However, the size of this merged sample artifact was huge, such that it takes ~6 minutes to download again in some cases (the arm64 agents are _much_ slower to do the download). In general, only a single TFM is ever used anyway (because we parallelize our tests by TFM too), so this is mostly unnecessarily wasted time.

## Implementation details

- Remove the `merge` job in the `build_samples` stage
- Add a "helper" `download-samples.yml` script to make sure you download the different samples to the correct folder (standalone goes in `bin`, multi-version goes in `publish` currently)
- Update usages 

## Test coverage

- Ran an "all areas" test [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=176344&view=logs&j=66fb5b47-c134-514a-33bf-1ca485953300)
- Ran an "all TFMs" test [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=176347&view=results)

## Other details

Removing the `merge` job also speeds up the `build_samples` stage which is sometimes a blocker for testing stages, so that's an extra bonus