### PR TITLE
Don't build in MSI stage

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2187,7 +2187,7 @@ partial class Build
 
     Target CreateTrimmingFile => _ => _
        .Description("Create Datadog.Trace.Trimming.xml file")
-       .DependsOn(CompileManagedSrc)
+       .After(CompileManagedSrc)
        .Executes(() =>
         {
             var loaderTypes = GetTypeReferences(SourceDirectory / "bin" / "ProfilerResources" / "netcoreapp2.0" / "Datadog.Trace.ClrProfiler.Managed.Loader.dll");


### PR DESCRIPTION
## Summary of changes

Make `CreateTrimmingFile` not automatically rebuild the tracer

## Reason for change

Previously `CreateTrimmingFile` was _depending_ on `CompileManagedSrc` which means it calls it if not otherwise called, whereas `After` means it just runs after that.

This was causing the build part of the `package_windows` stage to take ~4mins. With this change, it should take ~30s

## Implementation details

`DependsOn` -> `After`

## Test coverage

This is the test, but also ran one [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=176352&view=results)
