### PR TITLE
Analyze CI crashes on Windows

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/CrashReport.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/CrashReport.cs
@@ -1,0 +1,146 @@
+// <copyright file="CrashReport.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation;
+
+internal class CrashReport
+{
+    private readonly string _pdbSymbolsFolder;
+    private readonly Dictionary<string, List<(ulong Offset, uint Size, string Symbol)>> _pdbSymbols = new();
+    private readonly JObject _json;
+    private readonly ITestOutputHelper _output;
+
+    public CrashReport(string pathToCrashReport, ITestOutputHelper output)
+    {
+        _output = output;
+        _pdbSymbolsFolder = Path.Combine(Path.GetTempPath(), "symbols");
+        _json = JObject.Parse(File.ReadAllText(pathToCrashReport));
+    }
+
+    public async Task<IReadOnlyList<string>> ResolveCrashStackTrace()
+    {
+        var result = new List<string>();
+        var stackTrace = (JArray)_json["error"]["stack"]["frames"];
+
+        foreach (var frame in stackTrace)
+        {
+            result.Add(await ResolveSymbol(frame));
+        }
+
+        return result;
+    }
+
+    private async Task<string> ResolveSymbol(JToken frame)
+    {
+        var name = frame["function"].ToString();
+
+        if (frame["build_id_type"]?.ToString() == "PDB")
+        {
+            var buildId = frame["build_id"].ToString();
+            var pdbName = $"{Path.GetFileNameWithoutExtension(name)}.pdb";
+
+            var moduleAddress = ulong.Parse(frame["module_base_address"].ToString().Replace("0x", string.Empty), NumberStyles.HexNumber);
+            var address = ulong.Parse(frame["ip"].ToString().Replace("0x", string.Empty), NumberStyles.HexNumber);
+
+            var resolvedName = await ResolvePdbSymbol(pdbName, buildId, moduleAddress, address);
+
+            if (resolvedName != null)
+            {
+                var modulePath = name.Split('!')[0];
+                var module = Path.GetFileNameWithoutExtension(modulePath);
+
+                name = $"{module}!{resolvedName}";
+            }
+        }
+
+        return name;
+    }
+
+    private async Task<string> ResolvePdbSymbol(string pdbName, string pdbHash, ulong moduleAddress, ulong address)
+    {
+        var pdbFolder = Path.Combine(_pdbSymbolsFolder, pdbName, pdbHash);
+        var pdbPath = Path.Combine(pdbFolder, pdbName);
+
+        if (!_pdbSymbols.TryGetValue(pdbPath, out var symbols))
+        {
+            var fileExists = File.Exists(pdbPath);
+
+            if (!fileExists)
+            {
+                fileExists = await DownloadSymbol(pdbName, pdbHash, pdbFolder);
+            }
+
+            if (fileExists)
+            {
+                using var reader = new SharpPdb.Native.PdbFileReader(pdbPath);
+
+                symbols = reader.Functions
+                                .OrderBy(f => f.RelativeVirtualAddress)
+                                .Select(f => (f.RelativeVirtualAddress, f.CodeSize, f.GetUndecoratedName()))
+                                .ToList();
+            }
+            else
+            {
+                symbols = new();
+            }
+
+            _pdbSymbols.Add(pdbPath, symbols);
+        }
+
+        string name = null;
+
+        foreach (var symbol in symbols)
+        {
+            if (symbol.Offset > address - moduleAddress)
+            {
+                break;
+            }
+
+            name = $"{symbol.Symbol}+{address - moduleAddress - symbol.Offset:x2}";
+
+            if (symbol.Offset + symbol.Size < address - moduleAddress)
+            {
+                name = $"<unknown> ({name})";
+            }
+        }
+
+        return name;
+    }
+
+    private async Task<bool> DownloadSymbol(string pdbName, string pdbHash, string destinationFolder)
+    {
+        var serverUrl = "https://msdl.microsoft.com/download/symbols";
+        var url = $"{serverUrl}/{pdbName}/{pdbHash}/{pdbName}";
+
+        _output.WriteLine($"Downloading symbol from {url} to {destinationFolder}");
+
+        using var client = new HttpClient();
+
+        var response = await client.GetAsync(url);
+
+        if (response.StatusCode != System.Net.HttpStatusCode.OK)
+        {
+            return false;
+        }
+
+        var content = await response.Content.ReadAsStreamAsync();
+
+        Directory.CreateDirectory(destinationFolder);
+
+        using var file = File.Create(Path.Combine(destinationFolder, pdbName));
+        await content.CopyToAsync(file);
+
+        return true;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Datadog.Trace.TestHelpers.AutoInstrumentation.csproj
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Datadog.Trace.TestHelpers.AutoInstrumentation.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="SharpPdb" Version="1.0.4" />
     <PackageReference Include="Testcontainers" Version="3.6.0" />
   </ItemGroup>
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -123,16 +123,23 @@ public static class ErrorHelpers
             return;
         }
 
-        var crashReport = new CrashReport(pathToCrashReport, output);
-        var stacktrace = await crashReport.ResolveCrashStackTrace();
-
-        output.WriteLine("Crash stacktrace:");
-
-        foreach (var frame in stacktrace)
+        try
         {
-            output.WriteLine(frame);
-        }
+            var crashReport = new CrashReport(pathToCrashReport, output);
+            var stacktrace = await crashReport.ResolveCrashStackTrace();
 
-        // TODO: Add logic to throw SkipException on known crashes
+            output.WriteLine("Crash stacktrace:");
+
+            foreach (var frame in stacktrace)
+            {
+                output.WriteLine(frame);
+            }
+
+            // TODO: Add logic to throw SkipException on known crashes
+        }
+        catch (Exception ex) when (ex is not SkipException)
+        {
+            output.WriteLine($"Unexpected exception while analyzing the crash report: {ex}");
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -125,7 +125,7 @@ public static class ErrorHelpers
 
         try
         {
-            var crashReport = new CrashReport(pathToCrashReport, output);
+            using var crashReport = new CrashReport(pathToCrashReport, output);
             var stacktrace = await crashReport.ResolveCrashStackTrace();
 
             output.WriteLine("Crash stacktrace:");

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -1,17 +1,18 @@
-﻿// <copyright file="ErrorHelpers.cs" company="Datadog">
+// <copyright file="ErrorHelpers.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.TestHelpers.AutoInstrumentation;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -51,6 +52,8 @@ public static class ErrorHelpers
             SendMetric(output, "dd_trace_dotnet.ci.tests.skipped_due_to_flake", environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
             throw new SkipException("Exit code (13) - anticipated flake");
         }
+
+        SkipKnownCrashes(environmentHelper.PathToCrashReport, output).Wait();
     }
 
     public static async Task SendMetric(ITestOutputHelper outputHelper, string metricName, EnvironmentHelper environmentHelper)
@@ -111,5 +114,25 @@ public static class ErrorHelpers
     {
         SpanTagHelper.TryNormalizeTagName(tag, normalizeSpaces: true, out var normalizedTag);
         return normalizedTag;
+    }
+
+    private static async Task SkipKnownCrashes(string pathToCrashReport, ITestOutputHelper output)
+    {
+        if (pathToCrashReport == null || !File.Exists(pathToCrashReport))
+        {
+            return;
+        }
+
+        var crashReport = new CrashReport(pathToCrashReport, output);
+        var stacktrace = await crashReport.ResolveCrashStackTrace();
+
+        output.WriteLine("Crash stacktrace:");
+
+        foreach (var frame in stacktrace)
+        {
+            output.WriteLine(frame);
+        }
+
+        // TODO: Add logic to throw SkipException on known crashes
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -64,6 +64,8 @@ namespace Datadog.Trace.TestHelpers
                           : string.Empty;
         }
 
+        public string PathToCrashReport { get; private set; }
+
         public bool AutomaticInstrumentationEnabled { get; private set; } = true;
 
         public bool DebugModeEnabled { get; set; }
@@ -295,6 +297,10 @@ namespace Datadog.Trace.TestHelpers
             {
                 environmentVariables[ConfigurationKeys.Telemetry.AgentlessEnabled] = "0";
             }
+
+            PathToCrashReport = Path.Combine(LogDirectory, $"{SampleName}-{Guid.NewGuid()}.crash.json");
+            environmentVariables["DD_INTERNAL_CRASHTRACKING_OUTPUT"] = $"file://{PathToCrashReport}";
+            environmentVariables["DD_CRASHTRACKING_FILTERING_ENABLED"] = "0";
 
             ConfigureTransportVariables(environmentVariables, agent);
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -80,6 +80,8 @@ namespace Datadog.Trace.TestHelpers
 
         public string FullSampleName => $"{_appNamePrepend}{SampleName}";
 
+        public bool UseCrashTracking { get; set; } = true;
+
         public static bool IsNet5()
         {
             return Environment.Version.Major >= 5;
@@ -298,9 +300,12 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables[ConfigurationKeys.Telemetry.AgentlessEnabled] = "0";
             }
 
-            PathToCrashReport = Path.Combine(LogDirectory, $"{SampleName}-{Guid.NewGuid()}.crash.json");
-            environmentVariables["DD_INTERNAL_CRASHTRACKING_OUTPUT"] = $"file://{PathToCrashReport}";
-            environmentVariables["DD_CRASHTRACKING_FILTERING_ENABLED"] = "0";
+            if (UseCrashTracking)
+            {
+                PathToCrashReport = Path.Combine(LogDirectory, $"{SampleName}-{Guid.NewGuid()}.crash.json");
+                environmentVariables["DD_INTERNAL_CRASHTRACKING_OUTPUT"] = $"file://{PathToCrashReport}";
+                environmentVariables["DD_CRASHTRACKING_FILTERING_ENABLED"] = "0";
+            }
 
             ConfigureTransportVariables(environmentVariables, agent);
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -41,6 +41,9 @@ public class CreatedumpTests : ConsoleTestHelper
         SetEnvironmentVariable("COMPlus_DbgMiniDumpType", string.Empty);
         SetEnvironmentVariable("COMPlus_DbgEnableMiniDump", string.Empty);
         SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", string.Empty);
+
+        // Don't let the EnvironmentHelper override our environment variables
+        EnvironmentHelper.UseCrashTracking = false;
     }
 
     private static (string Key, string Value) LdPreloadConfig


### PR DESCRIPTION
## Summary of changes

Automatically analyze crashes in integration tests on Windows, and display the crashing stacktrace in the test output.

## Reason for change

First step to be able to skip known crashes causes by bugs in the .NET runtime.

## Implementation details

When running a sample, we set two more environment variables:
 - `DD_CRASHTRACKING_FILTERING_ENABLED=0`: tells crashtracking to process all crashes, not just those that are caused by our instrumentation
 - `DD_INTERNAL_CRASHTRACKING_OUTPUT=...`: tells crashtracking to store the crash report in a file instead of sending it by telemetry (it's much easier this way because we don't have to deal with the mock agent)

When a crash happens, the `ErrorHelpers.CheckForKnownSkipConditions` is called as usual. There is now additional logic to check if a crash report exists. If it finds one, it resolves the symbols and display the stacktrace. In the future, we need to add logic to check for known frames in the resolved stacktrace and throw a `SkipException` when appropriate.

## Test coverage

I don't think we need to add a test for a test helper?

## Other details
Next steps are:
 - Implement the same thing for Linux (a bit harder to fetch/process the symbols)
 - Add the relevant rules
 - Add support for ARM64 (either very simple or very difficult)
