### PR TITLE
Enable createdump crash reports in CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6783,6 +6783,7 @@ stages:
             COMPlus_DbgEnableMiniDump=1 \
             COMPlus_DbgMiniDumpType=4 \
             DOTNET_DbgMiniDumpName=$(System.DefaultWorkingDirectory)/artifacts/build_data/dumps/coredump.%t.%p \
+            DOTNET_EnableCrashReport=1 \
             DD_INJECTION_ENABLED=tracer \
             DD_INJECT_FORCE=1 \
             DD_TELEMETRY_FORWARDER_PATH=/usr/bin/true \

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2724,7 +2724,7 @@ partial class Build
 
         if (Directory.Exists(TempDirectory))
         {
-            foreach (var dump in GlobFiles(TempDirectory, "coredump*", "*.dmp"))
+            foreach (var dump in GlobFiles(TempDirectory, "coredump*", "*.dmp", "*.crashreport.json"))
             {
                 Logger.Information("Moving file '{Dump}' to '{Root}'", dump, dumpFolder);
 

--- a/tracer/build/_build/BuildVariables.cs
+++ b/tracer/build/_build/BuildVariables.cs
@@ -25,6 +25,7 @@ partial class Build
 
         envVars.Add("COMPlus_DbgEnableMiniDump", "1");
         envVars.Add("COMPlus_DbgMiniDumpType", "4");
+        envVars.Add("COMPlus_EnableCrashReport", "1");
         envVars.Add("VSTEST_CONNECTION_TIMEOUT", "200");
 
         if (EnableFaultTolerantInstrumentation)

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -105,7 +105,8 @@ internal static partial class DotNetSettingsExtensions
         {
             return settings
                 .SetProcessEnvironmentVariable("COMPlus_DbgEnableMiniDump", "1")
-                .SetProcessEnvironmentVariable("COMPlus_DbgMiniDumpType", ((int) dumpType).ToString());
+                .SetProcessEnvironmentVariable("COMPlus_DbgMiniDumpType", ((int) dumpType).ToString())
+                .SetProcessEnvironmentVariable("COMPlus_EnableCrashReport", "1");
         }
 
         return settings;

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -58,6 +58,7 @@ ENV DD_TRACE_DEBUG=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 ## SSI variables
 ENV DD_INJECTION_ENABLED=tracer

--- a/tracer/build/_build/docker/smoke.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.dd-dotnet.dockerfile
@@ -38,6 +38,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 ## SSI variables
 ENV DD_INJECTION_ENABLED=tracer

--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -52,6 +52,7 @@ ENV ASPNETCORE_URLS=http://localhost:5000
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.

--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -41,6 +41,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 ## SSI variables
 ENV DD_INJECTION_ENABLED=tracer

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -42,6 +42,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 ## SSI variables
 ENV DD_INJECTION_ENABLED=tracer

--- a/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
@@ -50,6 +50,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 ## SSI variables
 ENV DD_INJECTION_ENABLED=tracer

--- a/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
@@ -37,6 +37,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 ## SSI variables
 ENV DD_INJECTION_ENABLED=tracer

--- a/tracer/build/_build/docker/smoke.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dockerfile
@@ -55,6 +55,6 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
-
+ENV DOTNET_EnableCrashReport=1
 
 ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]

--- a/tracer/build/_build/docker/smoke.trimming.dockerfile
+++ b/tracer/build/_build/docker/smoke.trimming.dockerfile
@@ -61,6 +61,7 @@ ENV ASPNETCORE_URLS=http://localhost:5000
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
 ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_EnableCrashReport=1
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.


### PR DESCRIPTION
## Summary of changes

Createdump has a feature where it generate a crash report alongside the crash dump. The crash report contains the stacktraces in json format. This PR enables it.

## Reason for change

Coredumps on Alpine are painful to open because Windbg can't unwind Alpine signals, so they have to be opened on an Alpine distro. Fortunately, WSL works.
Coredumps on Alpine ARM64 are **extremely** painful because they have to be opened on an Alpine ARM64 distro, which WSL doesn't support.

Hopefully, this change should help us identify a crash without having to open the coredump.

## Implementation details

Just set `DOTNET_EnableCrashReport=1`. This will generate a `*.crashreport.json` file, which we can then copy at the same time as the dumps.

