### PR TITLE
Add traits to exclude tests that will not run anyway

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -68,6 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
+        [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         public async Task NamedPipesSubmitsMetrics()
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -192,7 +192,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #if NETCOREAPP3_1_OR_GREATER
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Category", "LinuxUnsupported")]
         [InlineData(null)]
         [InlineData(true)]
         [InlineData(false)]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -138,6 +138,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("Category", "LinuxUnsupported")]
         [MemberData(nameof(Data))]
         public async Task WhenUsingNamedPipesAgent_UsesNamedPipesTelemetry(bool? enableDependencies)
         {
@@ -191,7 +192,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #if NETCOREAPP3_1_OR_GREATER
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
-        [Trait("RunOnWindows", "True")]
+        [Trait("Category", "LinuxUnsupported")]
         [InlineData(null)]
         [InlineData(true)]
         [InlineData(false)]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     // https://github.com/DataDog/dd-trace-dotnet/pull/4608 you may get
     // struct tearing issues. Bumping the TraceAnnotations.VersionMismatch.AfterFeature project to a version
     // with the issue solves the problem.
-    // _However_ Duck-typing is broken on .NET 8 prior to when we added explicit support, so there will never
+    // However Duck-typing is broken on .NET 8 prior to when we added explicit support, so there will never
     // be an "older" package version we can test with
 #if !NET8_0_OR_GREATER
     public class TraceAnnotationsVersionMismatchBeforeFeatureTests : TraceAnnotationsTests

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -35,23 +35,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
     }
 
+    // The .NET 8 runtime is more aggressive in optimising structs
+    // so if you reference a version of the .NET tracer prior to this fix:
+    // https://github.com/DataDog/dd-trace-dotnet/pull/4608 you may get
+    // struct tearing issues. Bumping the TraceAnnotations.VersionMismatch.AfterFeature project to a version
+    // with the issue solves the problem.
+    // _However_ Duck-typing is broken on .NET 8 prior to when we added explicit support, so there will never
+    // be an "older" package version we can test with
+#if !NET8_0_OR_GREATER
     public class TraceAnnotationsVersionMismatchBeforeFeatureTests : TraceAnnotationsTests
     {
         public TraceAnnotationsVersionMismatchBeforeFeatureTests(ITestOutputHelper output)
             : base("TraceAnnotations.VersionMismatch.BeforeFeature", enableTelemetry: false, output)
         {
-#if NET8_0_OR_GREATER
-            // The .NET 8 runtime is more aggressive in optimising structs
-            // so if you reference a version of the .NET tracer prior to this fix:
-            // https://github.com/DataDog/dd-trace-dotnet/pull/4608 you may get
-            // struct tearing issues. Bumping the TraceAnnotations.VersionMismatch.AfterFeature project to a version
-            // with the issue solves the problem.
-            // _However_ Duck-typing is broken on .NET 8 prior to when we added explicit support, so there will never
-            // be an "older" package version we can test with
-            throw new SkipException("Tracer versions before TraceAnnotations was supported do not support .NET 8");
-#endif
         }
     }
+#endif
 
     public class TraceAnnotationsVersionMismatchNewerNuGetTests : TraceAnnotationsTests
     {

--- a/tracer/test/Datadog.Trace.IntegrationTests/Logging/TracerFlare/TracerFlareApiTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Logging/TracerFlare/TracerFlareApiTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerFlareApiTests.cs" company="Datadog">
+// <copyright file="TracerFlareApiTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -55,6 +55,7 @@ public class TracerFlareApiTests(ITestOutputHelper output)
     [SkippableFact]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
+    [Trait("Category", "LinuxUnsupported")]
     public async Task CanSendToAgent_NamedPipes()
     {
         if (!EnvironmentTools.IsWindows())

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractorTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractorTest.cs
@@ -28,6 +28,7 @@ public class SymbolExtractorTest
         typeof(SymbolExtractorTest).Assembly.GetTypes().Where(t => t.Namespace == TestSamplesNamespace && !t.Name.StartsWith("<") && !t.IsNested).Select(type => new object[] { type });
 
     [SkippableTheory]
+    [Trait("Category", "LinuxUnsupported")]
     [MemberData(nameof(TestSamples))]
     private async Task Test(Type type)
     {

--- a/tracer/test/Datadog.Trace.Tests/MultipartFormTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/MultipartFormTests.cs
@@ -133,6 +133,7 @@ namespace Datadog.Trace.Tests
 
         [Theory]
         [MemberData(nameof(GetTestData))]
+        [Trait("Category", "LinuxUnsupported")]
         public async Task HttpStreamRequest_NamedPipes_MultipartTest(bool useStream, bool useGzip)
         {
             if (!EnvironmentTools.IsWindows())
@@ -169,6 +170,7 @@ namespace Datadog.Trace.Tests
 
         [Theory]
         [MemberData(nameof(GetTestData))]
+        [Trait("Category", "LinuxUnsupported")]
         public async Task HttpStreamRequest_NamedPipes_VerificationTest(bool useStream, bool useGzip)
         {
             if (!EnvironmentTools.IsWindows())

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks;
 
+[Trait("Category", "LinuxUnsupported")]
 public class IisCheckTests : ToolTestHelper
 {
     public IisCheckTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.Tools.dd_dotnet.IntegrationTests.Checks;
 
 [SupportedOSPlatform("windows")]
+[Trait("Category", "LinuxUnsupported")]
 [Collection(nameof(ConsoleTestsCollection))]
 public class IisCheckTests : TestHelper
 {


### PR DESCRIPTION
## Summary of changes

Some tests launch SkipException when run under a certain OS but have no traits to exclude it's execution in the CI.
While the impact of these tests is low, adding these traits is recommended because:
* It avoids launching tests that just throw an exception
* It makes the logs cleaner
* If a class contains no tests that should be run under a certain OS, we avoid calling the class constructor code by using traits.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
