### PR TITLE
Refactor Flag to skip method execution

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegrationV4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegrationV4.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjecti
                 if (DiagnosticContextHelper.Cache<TTarget>.Mdc is { } mdc)
                 {
                     var removeSpanId = DiagnosticContextHelper.SetMdcState(mdc, tracer);
-                    return new CallTargetState(scope: null, (object)removeSpanId);
+                    return new CallTargetState(scope: null, removeSpanId);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetState.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetState.cs
@@ -31,15 +31,14 @@ public readonly struct CallTargetState
     /// Initializes a new instance of the <see cref="CallTargetState"/> struct.
     /// </summary>
     /// <param name="scope">Scope instance</param>
-    /// <param name="skipMethodBody">Flag to skip the original method body execution</param>
-    internal CallTargetState(Scope? scope, bool skipMethodBody = false)
+    internal CallTargetState(Scope? scope)
     {
         _previousScope = null;
         _scope = scope;
         _state = null;
         _startTime = null;
         _previousDistributedSpanContext = null;
-        _skipMethodBody = skipMethodBody;
+        _skipMethodBody = false;
     }
 
     /// <summary>
@@ -64,8 +63,23 @@ public readonly struct CallTargetState
     /// </summary>
     /// <param name="scope">Scope instance</param>
     /// <param name="state">Object state instance</param>
+    internal CallTargetState(Scope? scope, object? state)
+    {
+        _previousScope = null;
+        _scope = scope;
+        _state = state;
+        _startTime = null;
+        _previousDistributedSpanContext = null;
+        _skipMethodBody = false;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CallTargetState"/> struct.
+    /// </summary>
+    /// <param name="scope">Scope instance</param>
+    /// <param name="state">Object state instance</param>
     /// <param name="skipMethodBody">Flag to skip the original method body execution</param>
-    internal CallTargetState(Scope? scope, object? state, bool skipMethodBody = false)
+    internal CallTargetState(Scope? scope, object? state, bool skipMethodBody)
     {
         _previousScope = null;
         _scope = scope;

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -983,7 +983,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
             call_target_bubble_up_exception_function_available = EnsureIsCallTargetBubbleUpExceptionFunctionAvailable(module_metadata, bubbleUpTypeDef);
         }
 
-        call_target_state_skip_method_body_function_available = IsSkipMethodBodyEnabled() && EnsureCallTargetStateSkipMethodBodyFunctionAvailable(module_metadata);
+        call_target_state_skip_method_body_function_available = EnsureCallTargetStateSkipMethodBodyFunctionAvailable(module_metadata);
 
         auto native_loader_library_path = GetNativeLoaderFilePath();
         if (fs::exists(native_loader_library_path))

--- a/tracer/src/Datadog.Tracer.Native/environment_variables.h
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables.h
@@ -135,9 +135,6 @@ namespace environment
 
     // Security Controls config.
     const shared::WSTRING security_controls_configuration = WStr("DD_IAST_SECURITY_CONTROLS_CONFIGURATION");
-
-    // Enables or disables the skip method body feature
-    const shared::WSTRING internal_skip_method_body_enabled = WStr("DD_INTERNAL_SKIP_METHOD_BODY_ENABLED");
 } // namespace environment
 } // namespace trace
 

--- a/tracer/src/Datadog.Tracer.Native/environment_variables_util.cpp
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables_util.cpp
@@ -80,9 +80,5 @@ bool IsEditAndContinueEnabled()
 {
     return IsEditAndContinueEnabledCore() || IsEditAndContinueEnabledNetFx();
 }
-bool IsSkipMethodBodyEnabled()
-{
-    ToBooleanWithDefault(shared::GetEnvironmentValue(environment::internal_skip_method_body_enabled), true);
-}
 
 } // namespace trace

--- a/tracer/src/Datadog.Tracer.Native/environment_variables_util.h
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables_util.h
@@ -61,7 +61,6 @@ bool IsVersionCompatibilityEnabled();
 bool IsIastEnabled();
 bool IsRaspEnabled();
 bool IsEditAndContinueEnabled();
-bool IsSkipMethodBodyEnabled();
 
 } // namespace trace
 


### PR DESCRIPTION
## Summary of changes

- Remove the "kill switch" for the "skip method execution" filter
- Refactor the `CallTargetState` constructors

## Reason for change

https://github.com/DataDog/dd-trace-dotnet/pull/6843 introduced a new flag to allow bypassing the target method. This required introducing a new parameter, `skipMethodBody`, to the `CallTargetState` constructors. However, this was added as an optional parameter, which ultimately resulted in overload confusion and broken NLog tests + the introduction of a "kill switch" env variable to disable the functionality during debugging.

The fact that the overload selection was confusing indicates to me that we should _not_ be using optional parameters here, otherwise we're just asking for the same problem to happen again. Similarly, having the kill switch seems dangerous, as AFAICT there's basically no scenarios where we would want to disable this functionality globally, as it would just break any integration that relied on it.

## Implementation details

- Add additional overloads for the common `CallTargetState` constructors to avoid hitting the optional parameter `skipMethodBody`. It means that if you want to set `skipMethodBody=true`, you have to pass an additional `state` argument too, but that seems a small price to pay for the high level of confusion otherwise
- Remove the `DD_INTERNAL_SKIP_METHOD_BODY_ENABLED` kill-switch key 

## Test coverage

As long as all the existing tests pass, we're ok
