### PR TITLE
Fix accidentally using the wrong scale set

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6446,7 +6446,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-windows-scale-set-3
 
     steps:
     - template: steps/install-docker-compose-v1.yml


### PR DESCRIPTION
## Summary of changes

Fix the scale set used for tracer-home tests

## Reason for change

This must have been missed during an update from 2->3

## Implementation details

Switch to the correct scaleset

## Test coverage

This is the test

## Other details
