### PR TITLE
[Profiler] Fix missing http profiler in profiler_list tag

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
@@ -271,6 +271,16 @@ std::string ProfileExporter::GetEnabledProfilersTag(IEnabledProfilers* enabledPr
         emptyList = false;
     }
 
+    if (enabledProfilers->IsEnabled(RuntimeProfiler::Network))
+    {
+        if (!emptyList)
+        {
+            buffer << separator;
+        }
+        buffer << "http";
+        emptyList = false;
+    }
+
     return buffer.str();
 }
 


### PR DESCRIPTION
## Summary of changes
Add "http" to profiler_list tag when HTTP profiling is enabled

## Reason for change
It was missing

## Implementation details
Update the string generation in the exporter

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
