### PR TITLE
[Tracer] update sampling formula

### DIFF
--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -11,10 +11,6 @@ namespace Datadog.Trace.Util
     {
         private const ulong KnuthFactor = 1_111_111_111_111_111_111;
 
-        // This needs to be 2^64-1 to match sampling in other tracing libraries and logs,
-        // regardless of the maximum trace id (which is currently 2^63-1 when 128-bit ids is disabled).
-        private const ulong Modulo = ulong.MaxValue;
-
         /// <summary>
         /// Determines if a trace should be kept based on its trace id and the given sampling rate.
         /// </summary>
@@ -32,8 +28,20 @@ namespace Datadog.Trace.Util
         /// <param name="id">The 64-bit id of the object. For example, a span id.</param>
         /// <param name="rate">The sampling rate to apply.</param>
         /// <returns><c>true</c> if the object should be sampled (kept), <c>false</c> otherwise.</returns>
-        internal static bool SampleByRate(ulong id, double rate) =>
-            ((id * KnuthFactor) % Modulo) <= (rate * Modulo);
+        internal static bool SampleByRate(ulong id, double rate)
+        {
+            if (rate == 1.0)
+            {
+                return true;
+            }
+
+            if (rate == 0.0)
+            {
+                return false;
+            }
+
+            return (id * KnuthFactor) <= (rate * ulong.MaxValue);
+        }
 
         internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace)
         {

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SamplingHelpersTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SamplingHelpersTests.cs
@@ -36,6 +36,9 @@ public class SamplingHelpersTests
     [InlineData(12078589664685934330, 0.5, false)] // random traceIDs
     [InlineData(13794769880582338323, 0.5, true)]  // random traceIDs
     [InlineData(14629469446186818297, 0.5, false)] // random traceIDs
+    [InlineData(5826373039044427785, 0.5, true)]   // traceID 8 KnuthFactor = 0.5 * MaxUint64
+    [InlineData(5826373039044427785, 1, true)]     // 1 rate
+    [InlineData(5826373039044427785, 0, false)]    // 0 rate
     public void SampleByRate(ulong traceId, double rate, bool expected)
     {
         SamplingHelpers.SampleByRate(traceId, rate).Should().Be(expected);


### PR DESCRIPTION
## Summary of changes

This PR changes the current formula of the sampler to have the same one as other tracers.

A system test related to sampling disabled for dotnet will also be enabled [here](https://github.com/DataDog/system-tests/pull/4340/files#diff-033a5695a9b33e605ab499457e172333100b31c5fb7bf4d24834d14d76bf684cR618) as it has been [fixed](https://github.com/DataDog/system-tests/pull/4340/files#diff-87d5cf61d21df44e8b2276bbd6c96e943933cee8b0bd61772bad8238737ecf10R169-R174).

## Reason for change

All tracers should use the same formula in order to have a consistent and deterministic sampling.

## Implementation details

* Removal of ` % Modulo` with `Modulo = 2^64-1` that had no impact used as the `ulong` overflows already applies `% 2^64` 
* Fast path for `0` and `1`

## Test coverage

* New tests for `0`, `1` and `0.5` rates

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
