### PR TITLE
Remove check for low memory on macos

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Caching/DefaultMemoryChecker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Caching/DefaultMemoryChecker.cs
@@ -64,7 +64,12 @@ internal class DefaultMemoryChecker : IMemoryChecker
 
     private bool IsLowResourceEnvironmentSystem()
     {
-        return FrameworkDescription.Instance.IsWindows() ? CheckWindowsMemory() : CheckUnixMemory();
+        return FrameworkDescription.Instance.OSPlatform switch
+        {
+            OSPlatformName.Windows => CheckWindowsMemory(),
+            OSPlatformName.Linux => CheckUnixMemory(),
+            _ => false,
+        };
     }
 
     internal bool CheckWindowsMemory()


### PR DESCRIPTION
## Summary of changes

Remove low-memory check in debugger on macos

## Reason for change

This check is breaking the build on `master` due to broken smoke tests 

## Implementation details

Don't do a low-memory check on mac

## Test coverage

I'll do a run to confirm the tests are passing

## Other details

This obviously needs a proper fix later, this is just a workaround