### PR TITLE
No longer forgive `spans.Array` from being `null`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -405,9 +405,9 @@ namespace Datadog.Trace.Agent
                 for (var i = 0; i < spans.Count; i++)
                 {
                     var index = i + spans.Offset;
-                    if (spans.Array![index].GetMetric(Metrics.SingleSpanSampling.SamplingMechanism) is not null)
+                    if (spans.Array?[index].GetMetric(Metrics.SingleSpanSampling.SamplingMechanism) is not null)
                     {
-                        singleSpanSamplingSpans.Add(spans.Array![index]);
+                        singleSpanSamplingSpans.Add(spans.Array[index]);
                     }
                 }
 
@@ -451,7 +451,7 @@ namespace Datadog.Trace.Agent
             }
 
             // Add the current keep rate to the root span
-            var rootSpan = spans.Array![spans.Offset].Context.TraceContext?.RootSpan;
+            var rootSpan = spans.Array?[spans.Offset].Context.TraceContext?.RootSpan;
 
             if (rootSpan is not null)
             {


### PR DESCRIPTION
## Summary of changes

Remove the `!` to be a `?`. I _think_ the `!` isn't accurate as `Array` can be `null`

## Reason for change

I noticed a error in error tracking for a NullReferenceException in this method and this looked pretty suspect to me, but we do this in other places as well 🤔 

## Implementation details

! -> ?

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
