### PR TITLE
Update to use `9.0.203` of the .NET SDK

### DIFF
--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -7,7 +7,7 @@ pr:
 
 # Global variables
 variables:
-  dotnetCoreSdkLatestVersion: 9.0.102
+  dotnetCoreSdkLatestVersion: 9.0.203
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])] # required by update-github-status
   TargetBranch: $[variables['System.PullRequest.TargetBranch']]
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -382,7 +382,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -445,7 +445,7 @@ stages:
       timeoutInMinutes: 60 #default value
       dependsOn: []
       pool:
-        name: azure-linux-scale-set
+        name: azure-linux-scale-set-2
       
       steps:
         - template: steps/clone-repo.yml
@@ -508,7 +508,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -559,7 +559,7 @@ stages:
           artifactSuffix: linux-musl-x64
           useNativeSdkVersion: ""
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -621,7 +621,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1173,7 +1173,7 @@ stages:
           artifactSuffix: linux-musl-x64
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1273,7 +1273,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
       - template: steps/clone-repo.yml
@@ -1470,7 +1470,7 @@ stages:
       matrix:
         $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_x64_matrix'] ]
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1959,7 +1959,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2046,7 +2046,7 @@ stages:
   - job: Linux
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2236,7 +2236,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2317,7 +2317,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2431,7 +2431,7 @@ stages:
           publishTargetFramework: "net9.0"
           lambdaBaseImage: "public.ecr.aws/lambda/dotnet:9"
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2615,7 +2615,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2789,7 +2789,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2883,7 +2883,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2971,7 +2971,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     steps:
 
@@ -3369,7 +3369,7 @@ stages:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_linux_matrix'] ]
 
     pool:
-      name: azure-linux-scale-set
+      name: azure-linux-scale-set-2
 
     # Enable the Datadog Agent service for this job
     services:
@@ -3996,12 +3996,12 @@ stages:
         x64:
           baseImage: debian
           artifactSuffix: linux-x64
-          poolName: azure-linux-scale-set
+          poolName: azure-linux-scale-set-2
           targetArch: x64
         alpine_x64:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
-          poolName: azure-linux-scale-set
+          poolName: azure-linux-scale-set-2
           targetArch: x64
         arm64:
           baseImage: debian

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -103,10 +103,10 @@ schedules:
 # Global variables
 variables:
   buildConfiguration: Release
-  dotnetCoreSdkLatestVersion: 9.0.102
+  dotnetCoreSdkLatestVersion: 9.0.203
   # This is required until we're out of rc.
   # After GA we can do a find and replace and get rid of this
-  dotnetCoreSdkLatestVersionShort: 9.0.102
+  dotnetCoreSdkLatestVersionShort: 9.0.203
   nativeBuildDotnetSdkVersion: 7.0.306
   relativeArtifacts: /tracer/src/bin/artifacts
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -253,7 +253,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -280,7 +280,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -326,7 +326,7 @@ stages:
 
   - job: build
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -1067,7 +1067,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-3
+    name: azure-windows-scale-set-2
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -1130,7 +1130,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1309,7 +1309,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1364,7 +1364,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-3
+    name: azure-windows-scale-set-2
 
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -1565,7 +1565,7 @@ stages:
     - job: standalone
       timeoutInMinutes: 60 #default value
       pool:
-        name: azure-windows-scale-set-3
+        name: azure-windows-scale-set-2
       steps:
         - template: steps/clone-repo.yml
           parameters:
@@ -1611,7 +1611,7 @@ stages:
           net9.0:
             framework: net9.0
       pool:
-        name: azure-windows-scale-set-3
+        name: azure-windows-scale-set-2
       steps:
         - template: steps/clone-repo.yml
           parameters:
@@ -1680,7 +1680,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     timeoutInMinutes: 90
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
@@ -1760,7 +1760,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_debugger_matrix'] ]
@@ -1822,7 +1822,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1881,7 +1881,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2011,7 +2011,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     timeoutInMinutes: 60 #default value
 
     steps:
@@ -2090,7 +2090,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_msi_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     variables:
       relativeMsiOutputDirectory: /artifacts/msi/$(targetPlatform)/en-us
 
@@ -2173,7 +2173,7 @@ stages:
   - job: fleet_installer_tests
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
     variables:
       framework: net462
 
@@ -2711,7 +2711,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2929,7 +2929,7 @@ stages:
     condition: false
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -3310,7 +3310,7 @@ stages:
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_windows_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     # Enable the Datadog Agent service for this job
     services:
@@ -3674,7 +3674,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -3905,7 +3905,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -6446,7 +6446,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set-2
 
     steps:
     - template: steps/install-docker-compose-v1.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -720,7 +720,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -763,7 +763,7 @@ stages:
     dependsOn: []
 
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -813,7 +813,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -855,7 +855,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -903,7 +903,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1222,7 +1222,7 @@ stages:
           artifactSuffix: linux-musl-arm64
 
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1325,7 +1325,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -1520,7 +1520,7 @@ stages:
         matrix:
           $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_arm64_matrix'] ]
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
       workspace:
         clean: all
       steps:
@@ -3034,7 +3034,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -3110,7 +3110,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -3222,7 +3222,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -4006,12 +4006,12 @@ stages:
         arm64:
           baseImage: debian
           artifactSuffix: linux-arm64
-          poolname: azure-managed-linux-arm64-1
+          poolname: azure-managed-linux-arm64-2
           targetArch: arm64
         alpine_arm64:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
-          poolname: azure-managed-linux-arm64-1
+          poolname: azure-managed-linux-arm64-2
           targetArch: arm64
 
     pool:
@@ -5811,7 +5811,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -5895,7 +5895,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -5969,7 +5969,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -6061,7 +6061,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -6786,7 +6786,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "context": "../tracer/build/_build",
   "build": {
     "args": {
-      "DOTNETSDK_VERSION": "9.0.102"
+      "DOTNETSDK_VERSION": "9.0.203"
     }
   },
   // Allow access to host machine

--- a/.github/actions/run-in-docker/action.yml
+++ b/.github/actions/run-in-docker/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         docker build \
-          --build-arg DOTNETSDK_VERSION=9.0.102 \
+          --build-arg DOTNETSDK_VERSION=9.0.203 \
           --tag dd-trace-dotnet/${{ inputs.baseImage }}-builder \
           --target builder \
           --file "${GITHUB_WORKSPACE}/tracer/build/_build/docker/${{ inputs.baseImage }}.dockerfile" \

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Assign to vNext Milestone"
         run: ./tracer/build.sh AssignPullRequestToMilestone

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Check Snapshots"
         run: ./tracer/build.sh SummaryOfSnapshotChanges

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Add labels"
         run: ./tracer/build.sh AssignLabelsToPullRequest

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Output current version"
         id: versions

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
       with:
-        dotnet-version: '9.0.102'
+        dotnet-version: '9.0.203'
 
     - name: Download datadog-ci
       run: |
@@ -101,7 +101,7 @@ jobs:
 
     - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
       with:
-        dotnet-version: '9.0.102'
+        dotnet-version: '9.0.203'
 
     - name: Download datadog-ci
       run: |

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -33,7 +33,7 @@ jobs:
 
     - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
       with:
-        dotnet-version: '9.0.102'
+        dotnet-version: '9.0.203'
 
     - name: "Get current version"
       id: versions

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Configure Git Credentials"
         run: |

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion

--- a/.github/workflows/generate_package_versions.yml
+++ b/.github/workflows/generate_package_versions.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Removing existing Datadog.Trace.Trimming.xml"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" -Recurse -File | Remove-Item

--- a/.github/workflows/verify_files_without_nullability.yml
+++ b/.github/workflows/verify_files_without_nullability.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Removing existing missing-nullability-files.csv"
         run: Get-ChildItem –Path ".\tracer\missing-nullability-files.csv" | Remove-Item

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/verify_solution_changes_are_persisted.yml
+++ b/.github/workflows/verify_solution_changes_are_persisted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Regenerating Solutions"
         run: .\tracer\build.ps1 RegenerateSolutions

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 Restore CompileManagedSrc

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
         with:
-          dotnet-version: '9.0.102'
+          dotnet-version: '9.0.203'
 
       - name: "Regenerate docs/span_metadata.md"
         run: .\tracer\build.ps1 GenerateSpanDocumentation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ build:
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `
         -e NUGET_CERT_REVOCATION_MODE=offline `
-        registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest `
+        datadog/dd-trace-dotnet-docker-build:9-0-203 `
         Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,8 +332,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.203}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.203}
     command: dotnet /build/bin/Debug/_build.dll BuildAndRunProfilerIntegrationTests
     volumes:
       - ./:/project
@@ -383,8 +383,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.203}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.203}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -479,8 +479,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.203}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.203}
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project
@@ -531,8 +531,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.203}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.203}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -588,8 +588,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.203}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.203}
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests
     volumes:
       - ./:/project
@@ -662,8 +662,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.203}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.203}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -760,8 +760,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.102}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.102}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-9.0.203}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-9.0.203}
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.102",
+    "version": "9.0.203",
     "rollForward": "minor"
   }
 }

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -32,8 +32,8 @@ RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION -Sha256 $ENV
 # Install .NET 9
 # To find these links, visit https://dotnet.microsoft.com/en-us/download, click the Windows, x64 installer, and grab the download url + SHA512 hash
 ENV DOTNET_VERSION="9.0.203" \
-    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.203-win-x64.exe" \
-    DOTNET_SHA512="91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
+    DOTNET_DOWNLOAD_URL="https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-win-x64.exe" \
+    DOTNET_SHA512="77b87bd1785d5272912d6d8b732871ce3dd2f52a481aca24504c19e247772244310f89d686c9cdf50d518c1839238aa4775417e3a37ca33e6310b4ea01f05f1e"
 
 COPY install_dotnet.ps1 .
 RUN powershell -Command .\install_dotnet.ps1  -Version $ENV:DOTNET_VERSION -Sha512 $ENV:DOTNET_SHA512 $ENV:DOTNET_DOWNLOAD_URL

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -10,9 +10,10 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 USER ContainerAdministrator
 
 # VS Build tool link found from https://learn.microsoft.com/en-gb/visualstudio/releases/2022/release-history#release-dates-and-build-numbers
-ENV VSBUILDTOOLS_VERSION="17.11.35327.3" \
-    VSBUILDTOOLS_SHA256="471C9A89FA8BA27D356748AE0CF25EB1F362184992DC0BB6E9CCF10178C43C27" \
-    VSBUILDTOOLS_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/69e24482-3b48-44d3-af65-51f866a08313/471c9a89fa8ba27d356748ae0cf25eb1f362184992dc0bb6e9ccf10178c43c27/vs_BuildTools.exe" \
+# You can grab the SHA for the downloaded file using (Get-FileHash -Algorithm SHA256 $out).Hash
+ENV VSBUILDTOOLS_VERSION="17.13.35931.197" \
+    VSBUILDTOOLS_SHA256="353141457ABCC59EB9C38B2F30084E7271C6BCFB4E185466D98161BADA905759" \
+    VSBUILDTOOLS_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/8fada5c7-8417-4239-acc3-bd499af09222/353141457abcc59eb9c38b2f30084e7271c6bcfb4e185466d98161bada905759/vs_BuildTools.exe" \
     VSBUILDTOOLS_INSTALL_ROOT="c:\devtools\vstudio"
 
 # Install VS
@@ -30,8 +31,8 @@ RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION -Sha256 $ENV
 
 # Install .NET 9
 # To find these links, visit https://dotnet.microsoft.com/en-us/download, click the Windows, x64 installer, and grab the download url + SHA512 hash
-ENV DOTNET_VERSION="9.0.102" \
-    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.102-win-x64.exe" \
+ENV DOTNET_VERSION="9.0.203" \
+    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/5f46239c-783c-4d49-a4a2-cd5b0a47ec51/9b72af54efd90a3874b63e4dd43855e7/dotnet-sdk-9.0.203-win-x64.exe" \
     DOTNET_SHA512="91505782b13937392bd73d1531c01807275ef476f9e37f8ef22c2cee4b19be8282207149b4eb958668dee0c05cef02b0a6bc375b71e8e94864c3d89dea7ba534"
 
 COPY install_dotnet.ps1 .

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -11,7 +11,7 @@ $BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 $IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 &docker build `
-   --build-arg DOTNETSDK_VERSION=9.0.102 `
+   --build-arg DOTNETSDK_VERSION=9.0.203 `
    --tag $IMAGE_NAME `
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -7,7 +7,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=9.0.102 \
+   --build-arg DOTNETSDK_VERSION=9.0.203 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/alpine.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
## Summary of changes

Updates to use `9.0.203` (and .NET runtime `9.0.4`) instead of `9.0.102`

## Reason for change

We've been seeing a bunch of crashes in CI unrelated to the tracer, and hoping that this improves things

## Implementation details

- Find replace `9.0.102` -> `9.0.203`
- Update the Linux x64 VM
- Update the Windows VM (generally not required, but it's been a while)
- Update the Linux arm64 VM
- Update the GitLab build Windows Container
- Switch to the other scale sets to avoid breaking other PRs

## Test coverage

This is the test. If it all builds ok, we can merge. 

## Other details

Post merge we need to:
- [ ] Merge this https://github.com/DataDog/images/pull/7014
- [ ] Update the gitlab build to use the mirrored image above (once it's being mirrored)
- [ ] Adjust the VM allocation for the scalesets
- [ ] Fix the macro benchmarks to install 9.0.203
- [ ] Fix the micro benchmarks to install 9.0.203
- [ ] Fix the serverless benchmarks to install 9.0.203

This _may_ affect some people's Visual Studio installation. If you've been building with `9.0.102`, you'll need to update to the latest Visual Studio, so that you can use the `9.0.2xx` line