### PR TITLE
Don't run throughput tests on PRs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4501,14 +4501,14 @@ stages:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
 - stage: throughput
-  condition: and(succeeded(), eq(variables.isMainRepository, true))
+  # By default throughput tests happen on release or master branches only, or when running a benchmarks only build. Overridable by setting 'run_extended_throughput_tests' to true
+  condition: and(succeeded(), eq(variables.isMainRepository, true), or(eq(variables.isMainOrReleaseBranch, 'true'), not(eq(variables['isBenchmarksOnlyBuild'], 'False')), eq(variables.run_extended_throughput_tests, 'true')))
   dependsOn: [package_linux, package_arm64, build_windows_tracer, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
     isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
-    # By default all throughput tests happen on release or master branches only, or when running a benchmarks only build. Overridable by setting 'run_extended_throughput_tests' to true
-    runExtendedThroughputTests: $[or(eq(variables.isMainOrReleaseBranch, 'true'), not(eq(variables['isBenchmarksOnlyBuild'], 'False')), eq(variables.run_extended_throughput_tests, 'true'))]
+    runExtendedThroughputTests: true
     CrankDir: $(System.DefaultWorkingDirectory)/tracer/build/crank
   jobs:
   - template: steps/update-github-status-jobs.yml


### PR DESCRIPTION
## Summary of changes

Don't run the old throughput tests on PRs

## Reason for change

- We haven't had a successful run for a week
- We're migrating to the microbenchmark platform

## Implementation details

Don't run by default on PRs (though allow manual triggering). I haven't _completely_ deleted them yet (that's done in https://github.com/DataDog/dd-trace-dotnet/pull/6790) because we're not completely happy with the results from the microbenchmark platform, and so we're still using them to gate the release

## Test coverage

This is the test. As long as the throughput tests don't run, I think we're fine
