### PR TITLE
More dynamically choose which test configurations to run

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/AdoNetIntegrationTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/AdoNetIntegrationTest.cs
@@ -1,0 +1,24 @@
+// <copyright file="AdoNetIntegrationTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
+{
+    [IntegrationArea(KnownTestAreas.AdoNet)]
+    public abstract class AdoNetIntegrationTest : TracingIntegrationTest
+    {
+        protected AdoNetIntegrationTest(string sampleAppName, ITestOutputHelper output)
+            : base(sampleAppName, output)
+        {
+        }
+
+        protected AdoNetIntegrationTest(string sampleAppName, string samplePathOverrides, ITestOutputHelper output)
+            : base(sampleAppName, samplePathOverrides, output)
+        {
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class DapperTests : TracingIntegrationTest
+    public class DapperTests : AdoNetIntegrationTest
     {
         public DapperTests(ITestOutputHelper output)
             : base("Dapper", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [UsesVerify]
-    public class FakeCommandTests : TracingIntegrationTest
+    public class FakeCommandTests : AdoNetIntegrationTest
     {
         public FakeCommandTests(ITestOutputHelper output)
             : base("FakeDbCommand", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class MicrosoftDataSqlClientTests : TracingIntegrationTest
+    public class MicrosoftDataSqlClientTests : AdoNetIntegrationTest
     {
         public MicrosoftDataSqlClientTests(ITestOutputHelper output)
             : base("Microsoft.Data.SqlClient", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -20,7 +20,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [UsesVerify]
-    public class MicrosoftDataSqliteTests : TracingIntegrationTest
+    public class MicrosoftDataSqliteTests : AdoNetIntegrationTest
     {
         public MicrosoftDataSqliteTests(ITestOutputHelper output)
             : base("Microsoft.Data.Sqlite", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
     [UsesVerify]
-    public class MySqlCommandTests : TracingIntegrationTest
+    public class MySqlCommandTests : AdoNetIntegrationTest
     {
         public MySqlCommandTests(ITestOutputHelper output)
             : base("MySql", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class MySqlConnectorTests : TracingIntegrationTest
+    public class MySqlConnectorTests : AdoNetIntegrationTest
     {
         public MySqlConnectorTests(ITestOutputHelper output)
             : base("MySqlConnector", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
     [UsesVerify]
-    public class NpgsqlCommandTests : TracingIntegrationTest
+    public class NpgsqlCommandTests : AdoNetIntegrationTest
     {
         public NpgsqlCommandTests(ITestOutputHelper output)
             : base("Npgsql", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/OracleTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/OracleTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet;
 [Trait("RequiresDockerDependency", "true")]
 [UsesVerify]
 [Trait("SkipInCI", "True")] // This test requires the Oracle DB image, which is huge (8GB unpacked), so we cannot enable it without taking precautionary measures.
-public class OracleTests : TracingIntegrationTest
+public class OracleTests : AdoNetIntegrationTest
 {
     public OracleTests(ITestOutputHelper output)
         : base("OracleMDA", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
-    public class SqlCommand20Tests : TracingIntegrationTest
+    public class SqlCommand20Tests : AdoNetIntegrationTest
     {
         public SqlCommand20Tests(ITestOutputHelper output)
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
     [UsesVerify]
-    public class SystemDataSqlClientTests : TracingIntegrationTest
+    public class SystemDataSqlClientTests : AdoNetIntegrationTest
     {
         public SystemDataSqlClientTests(ITestOutputHelper output)
             : base("SqlServer", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [UsesVerify]
-    public class SystemDataSqliteTests : TracingIntegrationTest
+    public class SystemDataSqliteTests : AdoNetIntegrationTest
     {
         public SystemDataSqliteTests(ITestOutputHelper output)
             : base("SQLite.Core", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/CombinatorialOrPairwiseDataAttribute.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/CombinatorialOrPairwiseDataAttribute.cs
@@ -3,8 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 using Xunit.Sdk;
@@ -13,7 +16,51 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
 {
     public class CombinatorialOrPairwiseDataAttribute : DataAttribute
     {
-        public static bool UseFullTestConfiguration()
+        public static bool ShouldUseFullTestConfiguration(MethodInfo testMethod)
+        {
+            // if we don't need to run the full we can just return false right away
+            if (!UseFullTestConfiguration())
+            {
+                return false;
+            }
+
+            // we know that files have changed, we can try to determine _which_ area(s) we need to test
+            // ex: CHANGED_INTEGRATION_AREAS=AdoNet,Aws,Http -> AdoNet, Aws, Http
+            var changedAreas = GetChangedIntegrationAreas();
+            if (changedAreas.Length == 0)
+            {
+                // no specific area was changed (it may not yet be supported by this) run the full suite
+                return true;
+            }
+
+            // we know that a specific area was changed, we can try to determine if this test is related to it
+            var testType = testMethod.DeclaringType;
+            if (testType == null)
+            {
+                // if we can't determine the test class, run the full suite (I don't think this can happen?)
+                return true;
+            }
+
+            // if we know that a specific area was changed, we can try to determine if this test is related to it
+            // ex: [IntegrationArea("AdoNet,Aws")] -> AdoNet, Aws
+            var testedAreas = GetTestedAreas(testType);
+
+            if (testedAreas.Count == 0)
+            {
+                return true;
+            }
+
+            return changedAreas.Any(changedArea => testedAreas.Contains(changedArea, StringComparer.OrdinalIgnoreCase));
+        }
+
+        public override IEnumerable<object?[]> GetData(MethodInfo testMethod)
+        {
+            return ShouldUseFullTestConfiguration(testMethod)
+                ? new CombinatorialDataAttribute().GetData(testMethod)
+                : new PairwiseDataAttribute().GetData(testMethod);
+        }
+
+        private static bool UseFullTestConfiguration()
         {
             // USE_FULL_TEST_CONFIG is set in Target RunIntegrationTests when RequiresThoroughTesting() is true
             var fullTest = Environment.GetEnvironmentVariable("USE_FULL_TEST_CONFIG") ?? string.Empty;
@@ -28,11 +75,31 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
             return string.Equals(fullTest, "True", StringComparison.OrdinalIgnoreCase);
         }
 
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        private static HashSet<string> GetTestedAreas(Type testType)
         {
-            return UseFullTestConfiguration()
-                ? new CombinatorialDataAttribute().GetData(testMethod)
-                : new PairwiseDataAttribute().GetData(testMethod);
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var attribute = testType.GetCustomAttribute<IntegrationAreaAttribute>();
+            if (attribute != null)
+            {
+                foreach (var area in attribute.Areas)
+                {
+                    result.Add(area);
+                }
+            }
+
+            return result;
+        }
+
+        private static string[] GetChangedIntegrationAreas()
+        {
+            var changedAreas = Environment.GetEnvironmentVariable("CHANGED_INTEGRATION_AREAS") ?? string.Empty;
+
+            if (string.IsNullOrEmpty(changedAreas))
+            {
+                return [];
+            }
+
+            return changedAreas.Split([','], StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IntegrationAreaAttribute.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IntegrationAreaAttribute.cs
@@ -1,0 +1,23 @@
+// <copyright file="IntegrationAreaAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
+{
+    /// <summary>
+    /// Optional attribute to mark a test class with the integration areas it is testing to help
+    /// dynamically choose whether to run a full or reduced test suite based on changed files in PRs.
+    /// Supports multiple areas - use <see cref="KnownTestAreas"/>.
+    /// </summary>
+    /// <param name="areas">The <see cref="KnownTestAreas"/> that this test touches.</param>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class IntegrationAreaAttribute(params string[] areas) : Attribute
+    {
+        public string[] Areas { get; } = areas;
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/KnownTestAreas.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/KnownTestAreas.cs
@@ -1,0 +1,13 @@
+// <copyright file="KnownTestAreas.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
+{
+    public class KnownTestAreas
+    {
+        public const string AdoNet = "AdoNet";
+        public const string Http = "Http";
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [IntegrationArea(KnownTestAreas.Http)]
     [CollectionDefinition(nameof(HttpMessageHandlerTests), DisableParallelization = true)]
     public class HttpMessageHandlerTests : TracingIntegrationTest
     {


### PR DESCRIPTION
## Summary of changes

This adds changed "areas" to determine whether to run the full or reduced test configurations to more aggressively run fewer tests on PRs by choosing the pairwise test suites based on more specific changed files.

This only will change the tests run on PRs.

## Reason for change

`RequiresThoroughTesting()` is a relatively blunt tool that will treat _any_ changed integration as a requirement to run the full test suite for _every_ integration. This means that we don't get the benefit of running pairwise test suites that often on PRs which increases the overall CI runtime and flakiness.

This adds more logic around the integration tests and `RequiresThoroughTesting()` to apply a heuristic based on changed file paths and the current test method being run to determine whether or not we should run the full test suite.

> This only applies to tests using the new `CombinatorialOrPairwiseData` attribute.

## Implementation details

`RequiresThoroughTesting()` will set `CHANGED_INTEGRATION_AREAS` equal to the various detected "areas" that have been changed in the tracer - these areas will require the full test suite to be run for them.

Integration tests now can be marked with `[IntegrationArea(KnownTestAreas.NAME)]` to help them choose to run the pairwise test suite more often.

## Test coverage

- I could've ran this locally but

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
