### PR TITLE
Dump the docker compose logs to try to see what's going on

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2375,6 +2375,13 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         baseImage: $(baseImage) # for interpolation in the docker-compose file
 
+    - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) logs
+      displayName: docker-compose logs
+      env:
+        DD_LOGGER_DD_API_KEY: $(ddApiKey)
+      condition: succeededOrFailed()
+      continueOnError: true
+
     - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) down
       displayName: docker-compose stop services
       env:
@@ -3164,6 +3171,13 @@ stages:
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
             baseImage: $(baseImage) # for interpolation in the docker-compose file
+
+        - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) logs
+          displayName: docker-compose logs
+          env:
+            DD_LOGGER_DD_API_KEY: $(ddApiKey)
+          condition: succeededOrFailed()
+          continueOnError: true
 
         - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) down
           displayName: docker-compose stop services


### PR DESCRIPTION
## Summary of changes

Dump the docker-compose logs when tests fail

## Reason for change

We have seen some flake from the redis tests, and would like some more information

## Implementation details

Added a `docker-compose logs` to the linux and arm64 images

## Test coverage

I'll check the results in this test

## Other details

If this generates too many logs by default, we could update the condition to only run on failure?
