### PR TITLE
[IAST] Iast Aspects logs refactor

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Aspects/AWSSDK.SimpleEmail/AmazonSimpleEmailAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AWSSDK.SimpleEmail/AmazonSimpleEmailAspect.cs
@@ -34,7 +34,7 @@ public class AmazonSimpleEmailAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(MailkitAspect)}.{nameof(Send)}");
+            IastModule.LogAspectException(ex);
             return message;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
@@ -31,7 +31,7 @@ public class HttpResponseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex);
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
@@ -37,7 +37,7 @@ public class ControllerBaseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(ControllerBaseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex);
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -42,7 +42,7 @@ public class EntityCommandAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(EntityCommandAspect)}.{nameof(ReviewSqlCommand)}");
+            IastModule.LogAspectException(ex);
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -40,7 +40,7 @@ public class EntityFrameworkCoreAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(EntityFrameworkCoreAspect)}.{nameof(ReviewSqlString)}");
+            IastModule.LogAspectException(ex);
             return sqlAsString;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MailKit/MailkitAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MailKit/MailkitAspect.cs
@@ -90,7 +90,7 @@ public class MailkitAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(MailkitAspect)}.{nameof(CheckForVulnerability)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -103,7 +103,7 @@ public class MailkitAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(MailkitAspect)}.{nameof(ConvertToMimekit)} (DuckCast)");
+            IastModule.LogAspectException(ex, "(DuckCast)");
         }
 
         return textPart;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
@@ -35,7 +35,7 @@ public class BsonAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(BsonAspect)}.{nameof(AnalyzeJsonString)}");
+            IastModule.LogAspectException(ex);
             return json;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
@@ -53,7 +53,7 @@ public class MongoDatabaseAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
+            IastModule.LogAspectException(ex);
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -35,7 +35,7 @@ public class ISessionAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
+            IastModule.LogAspectException(ex);
             return query;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/Newtonsoft.Json/NewtonsoftJsonAspects.cs
@@ -63,7 +63,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.Ctor");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -85,7 +85,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.{nameof(ParseObject)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -113,7 +113,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.{nameof(ParseArray)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -136,7 +136,7 @@ public class NewtonsoftJsonAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(NewtonsoftJsonAspects)}.{nameof(ParseToken)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/SecurityControlsAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/SecurityControlsAspect.cs
@@ -36,7 +36,7 @@ public class SecurityControlsAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SecurityControlsAspect)}.{nameof(MarkAsSecure)}");
+            IastModule.LogAspectException(ex);
         }
 
         return target;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -41,7 +41,7 @@ public class DbCommandAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DbCommandAspect)}.{nameof(ReviewExecuteNonQuery)}");
+            IastModule.LogAspectException(ex);
             return command;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
@@ -37,7 +37,7 @@ public partial class DirectoryEntryAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DirectoryEntryAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
@@ -37,7 +37,7 @@ public partial class DirectorySearcherAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DirectorySearcherAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
@@ -35,7 +35,7 @@ public partial class PrincipalContextAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(PrincipalContextAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
@@ -34,7 +34,7 @@ public partial class SearchRequestAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SearchRequestAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -83,7 +83,7 @@ public class DirectoryAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -68,7 +68,7 @@ public class DirectoryInfoAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -101,7 +101,7 @@ public class FileAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(FileAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }
@@ -152,7 +152,7 @@ public class FileAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(FileAspect)}.{nameof(ReviewPathRead)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -41,7 +41,7 @@ public class FileInfoAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -45,7 +45,7 @@ public class FileStreamAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -41,7 +41,7 @@ public class StreamReaderAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
@@ -40,7 +40,7 @@ public class StreamWriterAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StreamWriterAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return path;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net.Mail/SmtpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net.Mail/SmtpClientAspect.cs
@@ -38,7 +38,7 @@ public class SmtpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SmtpClientAspect)}.{nameof(Send)}");
+            IastModule.LogAspectException(ex);
             return message;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -62,7 +62,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }
@@ -108,7 +108,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }
@@ -143,7 +143,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }
@@ -166,7 +166,7 @@ public class HttpClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -65,7 +65,7 @@ public class WebClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(WebClientAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }
@@ -139,7 +139,7 @@ public class WebClientAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(WebClientAspect)}.{nameof(ReviewUri)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -34,7 +34,7 @@ public class WebRequestAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(WebRequestAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }
@@ -56,7 +56,7 @@ public class WebRequestAspect
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            IastModule.LogAspectException(ex, $"{nameof(WebRequestAspect)}.{nameof(Review)}");
+            IastModule.LogAspectException(ex);
             return parameter;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebUtilityAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebUtilityAspect.cs
@@ -36,7 +36,7 @@ public class WebUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(WebUtilityAspect)}.{nameof(XssEscape)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -60,7 +60,7 @@ public class WebUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(WebUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
@@ -45,7 +45,7 @@ public class ActivatorAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(ActivatorAspect)}.{nameof(ReflectionInjectionParam)}");
+            IastModule.LogAspectException(ex);
             return param;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
@@ -37,7 +37,7 @@ public class AssemblyAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(AssemblyAspect)}.{nameof(ReflectionAssemblyInjection)}");
+            IastModule.LogAspectException(ex);
             return assemblyString;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
@@ -51,7 +51,7 @@ public class TypeAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(TypeAspect)}.{nameof(ReflectionInjectionParam)}");
+            IastModule.LogAspectException(ex);
             return param;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Runtime/DefaultInterpolatedStringHandlerAspect.cs
@@ -38,7 +38,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted1)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -59,7 +59,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted2)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -83,7 +83,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted3)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -106,7 +106,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted4)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -130,7 +130,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted5)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -154,7 +154,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted6)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -179,7 +179,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendFormatted7)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -198,7 +198,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(AppendLiteral)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -217,7 +217,7 @@ public class DefaultInterpolatedStringHandlerAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(DefaultInterpolatedStringHandlerAspect)}.{nameof(ToStringAndClear)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
@@ -40,7 +40,7 @@ public class HashAlgorithmAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HashAlgorithmAspect)}.{nameof(ComputeHash)}");
+            IastModule.LogAspectException(ex);
             return target;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
@@ -29,7 +29,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(ProcessCipherClassCreation)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -47,7 +47,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitDES)}");
+            IastModule.LogAspectException(ex);
         }
 
         return target;
@@ -67,7 +67,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitRC2)}");
+            IastModule.LogAspectException(ex);
         }
 
         return target;
@@ -87,7 +87,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitTripleDES)}");
+            IastModule.LogAspectException(ex);
         }
 
         return target;
@@ -107,7 +107,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitRijndaelManaged)}");
+            IastModule.LogAspectException(ex);
         }
 
         return target;
@@ -127,7 +127,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(InitAesCryptoServiceProvider)}");
+            IastModule.LogAspectException(ex);
         }
 
         return target;
@@ -157,7 +157,7 @@ public class SymmetricAlgorithmAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SymmetricAlgorithmAspect)}.{nameof(Create)}");
+            IastModule.LogAspectException(ex);
             return target;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/JsonDocumentAspects.cs
@@ -37,7 +37,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(Parse)}");
+            IastModule.LogAspectException(ex);
         }
 
         return doc;
@@ -60,7 +60,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetString)} (DuckCast)");
+            IastModule.LogAspectException(ex);
             return null;
         }
 
@@ -77,7 +77,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return str;
@@ -101,7 +101,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetRawText)} (DuckCast)");
+            IastModule.LogAspectException(ex);
             return null;
         }
 
@@ -118,7 +118,7 @@ public class JsonDocumentAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(JsonDocumentAspects)}.{nameof(GetRawText)}");
+            IastModule.LogAspectException(ex);
         }
 
         return str;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -34,7 +34,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -54,7 +54,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -76,7 +76,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -99,7 +99,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -121,7 +121,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -146,7 +146,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -172,7 +172,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -199,7 +199,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -226,7 +226,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -253,7 +253,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -290,7 +290,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -315,7 +315,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Append)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -341,7 +341,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendLine)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -362,7 +362,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -384,7 +384,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -407,7 +407,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -428,7 +428,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -450,7 +450,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -473,7 +473,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -497,7 +497,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -519,7 +519,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendFormat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -541,7 +541,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(CopyTo)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -564,7 +564,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -590,7 +590,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -615,7 +615,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -640,7 +640,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -667,7 +667,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -693,7 +693,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -719,7 +719,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -745,7 +745,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -771,7 +771,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -797,7 +797,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -823,7 +823,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -849,7 +849,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -875,7 +875,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -901,7 +901,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -927,7 +927,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -953,7 +953,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -979,7 +979,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1005,7 +1005,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1026,7 +1026,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1047,7 +1047,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1070,7 +1070,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1091,7 +1091,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1114,7 +1114,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1133,7 +1133,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(SetLength)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -1153,7 +1153,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1174,7 +1174,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1195,7 +1195,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1216,7 +1216,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1238,7 +1238,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1260,7 +1260,7 @@ public class StringBuilderAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringBuilderAspects)}.{nameof(AppendJoin)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Extensions/JavaScriptSerializerAspects.cs
@@ -38,7 +38,7 @@ public class JavaScriptSerializerAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(JavaScriptSerializerAspects)}.{nameof(DeserializeObject)} (DuckCast)");
+            IastModule.LogAspectException(ex);
             return null;
         }
 
@@ -57,7 +57,7 @@ public class JavaScriptSerializerAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(JavaScriptSerializerAspects)}.{nameof(DeserializeObject)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
@@ -31,7 +31,7 @@ public class HttpControllerAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpControllerAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex);
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
@@ -40,7 +40,7 @@ public class HttpSessionStateBaseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpSessionStateBaseAspect)}.{nameof(Add)}");
+            IastModule.LogAspectException(ex);
             return value;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
@@ -43,7 +43,7 @@ public class SessionExtensionsAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SessionExtensionsAspect)}.{nameof(ReviewTbv)}");
+            IastModule.LogAspectException(ex);
             return value;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpCookieAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpCookieAspect.cs
@@ -39,7 +39,7 @@ public class HttpCookieAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpCookieAspect)}.{nameof(GetValue)}");
+            IastModule.LogAspectException(ex);
         }
 
         return value;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
@@ -32,7 +32,7 @@ public class HttpResponseAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            IastModule.LogAspectException(ex);
             return url;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpUtilityAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpUtilityAspect.cs
@@ -34,7 +34,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpUtilityAspect)}.{nameof(XssEscape)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -58,7 +58,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -83,7 +83,7 @@ public class HttpUtilityAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(HttpUtilityAspect)}.{nameof(SsrfEscape)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
@@ -40,7 +40,7 @@ public class SystemXmlAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(SystemXmlAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return xpath;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
@@ -35,7 +35,7 @@ public class XPathExtensionAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(XPathExtensionAspect)}.{nameof(ReviewPath)}");
+            IastModule.LogAspectException(ex);
             return xpath;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
@@ -30,7 +30,7 @@ public class RandomAspect
         }
         catch (global::System.Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(RandomAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
             return;
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -36,7 +36,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -65,7 +65,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -88,7 +88,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Trim)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -118,7 +118,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -141,7 +141,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -162,7 +162,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimStart)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -192,7 +192,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -215,7 +215,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -236,7 +236,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(TrimEnd)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -259,7 +259,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -281,7 +281,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat_0)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -303,7 +303,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat_1)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -325,7 +325,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -348,7 +348,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -371,7 +371,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -395,7 +395,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -420,7 +420,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -442,7 +442,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -463,7 +463,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -484,7 +484,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -506,7 +506,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -530,7 +530,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -553,7 +553,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -577,7 +577,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -601,7 +601,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Concat)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -626,7 +626,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Substring)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -649,7 +649,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Substring)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -670,7 +670,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToCharArray)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -693,7 +693,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToCharArray)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -717,7 +717,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -740,7 +740,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -762,7 +762,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -786,7 +786,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -809,7 +809,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -833,7 +833,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -855,7 +855,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -877,7 +877,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -899,7 +899,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Join)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -980,7 +980,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToUpper)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1002,7 +1002,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToUpper)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1023,7 +1023,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToUpperInvariant)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1044,7 +1044,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToLower)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1066,7 +1066,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToLower)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1087,7 +1087,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(ToLowerInvariant)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1109,7 +1109,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1132,7 +1132,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Remove)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1155,7 +1155,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Insert)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1177,7 +1177,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadLeft)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1200,7 +1200,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadLeft)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1222,7 +1222,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadRight)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1245,7 +1245,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(PadRight)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1267,7 +1267,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1290,7 +1290,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1314,7 +1314,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1336,7 +1336,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1359,7 +1359,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1383,7 +1383,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1408,7 +1408,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1431,7 +1431,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Format)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1489,7 +1489,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1513,7 +1513,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1537,7 +1537,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1560,7 +1560,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Replace)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1582,7 +1582,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1605,7 +1605,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1628,7 +1628,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1652,7 +1652,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1675,7 +1675,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1699,7 +1699,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1725,7 +1725,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1748,7 +1748,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1771,7 +1771,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1795,7 +1795,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Split)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -1836,7 +1836,7 @@ public class StringAspects
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"Error invoking {nameof(StringAspects)}.{nameof(Copy)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriAspect.cs
@@ -32,7 +32,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -57,7 +57,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -79,7 +79,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -101,7 +101,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -128,7 +128,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -150,7 +150,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -173,7 +173,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -200,7 +200,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -227,7 +227,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -254,7 +254,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -280,7 +280,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(TryCreate)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -301,7 +301,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(UnescapeDataString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -324,7 +324,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(EscapeUriString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -345,7 +345,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(EscapeDataString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -366,7 +366,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetAbsoluteUri)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -387,7 +387,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetAbsolutePath)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -408,7 +408,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetLocalPath)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -435,7 +435,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(MakeRelative)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -460,7 +460,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(MakeRelativeUri)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -481,7 +481,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetHost)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -502,7 +502,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetPathAndQuery)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -523,7 +523,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetAuthority)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -544,7 +544,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(GetQuery)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -566,7 +566,7 @@ public class UriAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriAspect)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/UriBuilderAspect.cs
@@ -36,7 +36,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -61,7 +61,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -87,7 +87,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -114,7 +114,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -142,7 +142,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -171,7 +171,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -196,7 +196,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(Init)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -219,7 +219,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(SetQuery)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -242,7 +242,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(SetPath)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -265,7 +265,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(GetHost)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -290,7 +290,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(GetQuery)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -315,7 +315,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(GetPath)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;
@@ -341,7 +341,7 @@ public class UriBuilderAspect
         }
         catch (Exception ex)
         {
-            IastModule.LogAspectException(ex, $"{nameof(UriBuilderAspect)}.{nameof(ToString)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -11,6 +11,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -916,11 +917,12 @@ internal static partial class IastModule
         }
     }
 
-    public static void LogAspectException(Exception ex, string aspectInfo)
+    public static void LogAspectException(Exception ex, string extraInfo = "", [CallerFilePath] string filePath = "", [CallerMemberName] string memberName = "")
     {
         try
         {
-            var hashCode = aspectInfo.GetHashCode();
+            var text = $"{Path.GetFileNameWithoutExtension(filePath)}.{memberName} {extraInfo}";
+            var hashCode = text.GetHashCode();
             bool alreadyLogged;
             lock (LoggedAspectExceptionMessages)
             {
@@ -931,17 +933,17 @@ internal static partial class IastModule
 #pragma warning disable DDLOG004 // Message templates should be constant
             if (alreadyLogged)
             {
-                Log.Debug(ex, $"Error invoking {aspectInfo}");
+                Log.Debug(ex, $"Error invoking {extraInfo}");
             }
             else
             {
-                Log.Error(ex, $"Error invoking {aspectInfo}");
+                Log.Error(ex, $"Error invoking {extraInfo}");
             }
 #pragma warning restore DDLOG004 // Message templates should be constant
         }
         catch (Exception e)
         {
-            Log.Debug(e, "Error while logging aspect exception.");
+            Log.Debug(new AggregateException(ex, e), "Error while logging aspect exception");
         }
     }
 

--- a/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
+++ b/tracer/src/Datadog.Trace/Iast/Propagation/DefaultInterpolatedStringHandlerModuleImpl.cs
@@ -74,9 +74,9 @@ internal static class DefaultInterpolatedStringHandlerModuleImpl
                 tainted.Ranges = rangesResult;
             }
         }
-        catch (Exception error)
+        catch (Exception ex)
         {
-            IastModule.LogAspectException(error, $"{nameof(DefaultInterpolatedStringHandlerModuleImpl)}.{nameof(FullTaintIfAnyTainted)}");
+            IastModule.LogAspectException(ex);
         }
     }
 
@@ -113,9 +113,9 @@ internal static class DefaultInterpolatedStringHandlerModuleImpl
                 TaintedRefStructs.Pop();
             }
         }
-        catch (Exception err)
+        catch (Exception ex)
         {
-            IastModule.LogAspectException(err, $"{nameof(DefaultInterpolatedStringHandlerModuleImpl)}.{nameof(PropagateTaint)}");
+            IastModule.LogAspectException(ex);
         }
 
         return result;


### PR DESCRIPTION
## Summary of changes
Embedded in `IastModule.LogException` function, the caller data, instead of having to specify it explicitly on each call

## Reason for change
Some mistakes were made while creating new aspects, reporting the wrong function name to the `LogException `function

## Implementation details
Used compiler generated parameters decorated with `[CallerFilePath]` and `[CallerMemberName]` in the `LogException` method

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
