### PR TITLE
[IAST] Change cookie filter default value

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
@@ -37,7 +37,7 @@ internal class IastSettings
     /// <summary>
     /// Default values readaction regex if none specified via env DD_IAST_REDACTION_VALUES_REGEXP
     /// </summary>
-    internal const string DefaultCookieFilterRegex = @".{32,}";
+    internal const string DefaultCookieFilterRegex = @".*";
 
     public IastSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/CookieAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/CookieAnalyzerTests.cs
@@ -25,14 +25,14 @@ namespace Datadog.Trace.Tests.Util.Http
         private const double Timeout = 10_000;
 
         [Theory]
-        [InlineData("TestCookie", false)]
-        [InlineData("TestCookie.0123456789", false)]
+        [InlineData("TestCookie", true)]
+        [InlineData("TestCookie.0123456789", true)]
         [InlineData("TestCookie.00112233445566778899--", true)]
-        [InlineData(".AspNetCore.", false)]
-        [InlineData(".AspNetCore.Whatever", false)]
-        [InlineData(".AspNetCore.0123456789abcdefghi", false)]
+        [InlineData(".AspNetCore.", true)]
+        [InlineData(".AspNetCore.Whatever", true)]
+        [InlineData(".AspNetCore.0123456789abcdefghi", true)]
         [InlineData(".AspNetCore.0123456789abcdefghijklmnopqrstuv", true)]
-        [InlineData(".Other.0123456789", false)]
+        [InlineData(".Other.0123456789", true)]
         [InlineData("3F53C576-71D7-4CD8-A7D7-D13B9AB48102", true)]
         [InlineData("d54c62958f7893f18924aefb3549bcb0f38d3f0b", true)]
 

--- a/tracer/test/snapshots/Iast.AspNetCore5.enableIast=True.path =_Iast_AllVulnerabilitiesCookie.verified.txt
+++ b/tracer/test/snapshots/Iast.AspNetCore5.enableIast=True.path =_Iast_AllVulnerabilitiesCookie.verified.txt
@@ -26,21 +26,21 @@
   "vulnerabilities": [
     {
       "type": "NO_SAMESITE_COOKIE",
-      "hash": 845204325,
+      "hash": -636226626,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }
     },
     {
       "type": "NO_HTTPONLY_COOKIE",
-      "hash": 377812170,
+      "hash": -60481650,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }
     },
     {
       "type": "INSECURE_COOKIE",
-      "hash": -2037976906,
+      "hash": 990913114,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
@@ -91,14 +91,14 @@
     },
     {
       "type": "NO_SAMESITE_COOKIE",
-      "hash": 264671858,
+      "hash": -636226626,
       "evidence": {
         "value": "ASP.NET_SessionId"
       }
     },
     {
       "type": "INSECURE_COOKIE",
-      "hash": -974040902,
+      "hash": 990913114,
       "evidence": {
         "value": "ASP.NET_SessionId"
       }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableIast=True.path=_Iast_AllVulnerabilitiesCookie.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableIast=True.path=_Iast_AllVulnerabilitiesCookie.verified.txt
@@ -23,21 +23,21 @@
   "vulnerabilities": [
     {
       "type": "NO_SAMESITE_COOKIE",
-      "hash": 845204325,
+      "hash": -636226626,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }
     },
     {
       "type": "NO_HTTPONLY_COOKIE",
-      "hash": 377812170,
+      "hash": -60481650,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }
     },
     {
       "type": "INSECURE_COOKIE",
-      "hash": -2037976906,
+      "hash": 990913114,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableIast=True.path=_Iast_AllVulnerabilitiesCookie.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableIast=True.path=_Iast_AllVulnerabilitiesCookie.verified.txt
@@ -23,21 +23,21 @@
   "vulnerabilities": [
     {
       "type": "NO_SAMESITE_COOKIE",
-      "hash": 845204325,
+      "hash": -636226626,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }
     },
     {
       "type": "NO_HTTPONLY_COOKIE",
-      "hash": 377812170,
+      "hash": -60481650,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }
     },
     {
       "type": "INSECURE_COOKIE",
-      "hash": -2037976906,
+      "hash": 990913114,
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }


### PR DESCRIPTION
## Summary of changes
Change default value of `DD_IAST_COOKIE_FILTER_PATTERN` so it filters all cookies disregarding the name, assigning all of them the same Hash

[APPSEC-57407](https://datadoghq.atlassian.net/browse/APPSEC-57407)

## Reason for change
Avoid random cookie name generation floods

## Implementation details
Set the default value to `.*`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->


[APPSEC-57407]: https://datadoghq.atlassian.net/browse/APPSEC-57407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ