### PR TITLE
Adds a "flaky" attribute, that we can use to automatically retry flaky tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -50,6 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsStackExchangeRedis(metadataSchemaVersion);
 
+        [Flaky("The PING_REPLICA sometimes invokes the master server instead. We believe it's infrastructure related")]
         [SkippableTheory]
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -289,7 +289,7 @@ namespace Datadog.Trace.TestHelpers
 
                         // If this throws, we just let it bubble up, regardless of whether there's a retry, as this indicates an xunit infra issue
                         var summary = await RunTest(messageBus);
-                        if (summary.Failed == 0 || attemptsRemaining == 0)
+                        if (summary.Failed == 0 || attemptsRemaining <= 0)
                         {
                             // No failures, or not allowed to retry
                             return summary;

--- a/tracer/test/Datadog.Trace.TestHelpers/FlakyAttribute.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/FlakyAttribute.cs
@@ -11,8 +11,11 @@ namespace Datadog.Trace.TestHelpers;
 /// Marks a test as flaky, so that it is automatically retried by <see cref="CustomTestFramework"/>
 /// </summary>
 /// <param name="reason">The reason that this test was marked flaky e.g. it relies on flaky infrastructure, hits a known runtime bug etc</param>
+/// <param name="maxRetries">The maximum number of times a test should be retried</param>
 [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-public class FlakyAttribute(string reason) : Attribute
+public class FlakyAttribute(string reason, int maxRetries = 1) : Attribute
 {
     public string Reason { get; } = reason;
+
+    public int MaxRetries { get; } = maxRetries;
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/FlakyAttribute.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/FlakyAttribute.cs
@@ -1,0 +1,18 @@
+// <copyright file="FlakyAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.TestHelpers;
+
+/// <summary>
+/// Marks a test as flaky, so that it is automatically retried by <see cref="CustomTestFramework"/>
+/// </summary>
+/// <param name="reason">The reason that this test was marked flaky e.g. it relies on flaky infrastructure, hits a known runtime bug etc</param>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public class FlakyAttribute(string reason) : Attribute
+{
+    public string Reason { get; } = reason;
+}


### PR DESCRIPTION
## Summary of changes

Adds a `[Flaky]` attribute, to allow auto-retrying tests that we know are flaky, but which we can't handle in other ways

## Reason for change

We have some tests that we know are flaky, but which we have low concern that the flake is related to a tracing issue _and_ we don't have an easy way of identifying the specific type of flake. Flakiness in the `PING` on ARM64 in our StackExchangeRedis tests are a good example case of this.

The `[Flaky]` attribute is intended to be used specifically for these cases. If we have a more reliable way of detecting the flake, we should use that instead, as that ensures we don't mask "real" issues. You should also provide a good description of the reason for adding the attribute, to make it easier to assess later if/when it should be removed.

## Implementation details

Update the `CustomMethodExecuter` in our custom XUnit framework to automatically retry a failed test when it fails the first time if the `[Flaky]` attribute has been used. 

The core "run test" code has been pulled out into a local method. Reused some of the existing code for sending metrics when this happens, so we can track how often we're retrying methods (essentially the same as we do currently for the flaky named-pipes tests).

## Test coverage

Marked the StackExchangeRedis tests as flaky as a practical test, but also tested locally.

The following stack shows 2 retries - one which succeeded on the second attempt, and one which failed (reduced some of the lines for brevity)

```
IntegrationTests: STARTED: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v0)
IntegrationTests: FAILURE: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v0) (0.0205627s)
IntegrationTests: No CI API Key found, skipping dd_trace_dotnet.ci.tests.retries metric submission
IntegrationTests: RETRYING: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v0) (1 attempts remaining, The PING_REPLICA sometimes invokes the master server instead. We believe it's infrastructure related)
IntegrationTests: STARTED: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v0)
IntegrationTests: SUCCESS: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v0) (0.0020421s)

IntegrationTests: STARTED: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v1)
IntegrationTests: FAILURE: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v1) (0.0145637s)
IntegrationTests: No CI API Key found, skipping dd_trace_dotnet.ci.tests.retries metric submission
IntegrationTests: RETRYING: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v1) (1 attempts remaining, The PING_REPLICA sometimes invokes the master server instead. We believe it's infrastructure related)
IntegrationTests: STARTED: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v1)
IntegrationTests: FAILURE: IntegrationTests.StackExchangeRedisTests.SubmitsTraces(, v1) (0.0011947s)
    IntegrationTests.StackExchangeRedisTests.SubmitsTraces(packageVersion: "", metadataSchemaVersion: "v1") [FAIL]
  Failed IntegrationTests.StackExchangeRedisTests.SubmitsTraces(packageVersion: "", metadataSchemaVersion: "v1") [1 ms]
  Error Message:
   System.Exception : Testing the flake
  Stack Trace:
     at IntegrationTests.StackExchangeRedisTests.SubmitsTraces(String packageVersion, String metadataSchemaVersion) in C:\repos\dd-trace-dotnet-2\tracer\test\IntegrationTests\StackExchangeRedisTests.cs:line 63
   at InvokeStub_StackExchangeRedisTests.SubmitsTraces(Object, Span`1)
   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  Standard Output Messages:
 Platform: X64
 TargetPlatform: X64
 Configuration: Debug
 TargetFramework: net9.0
 .NET Core: True
 Native Loader DLL: C:\repos\dd-trace-dotnet-2\shared\bin\monitoring-home\win-x64\Datadog.Trace.ClrProfiler.Native.dll
Results File: C:\repos\dd-trace-dotnet-2\artifacts\build_data\results\IntegrationTests\andrew.lock_DESKTOP-514BHMB_2025-04-24_10_16_26.trx
Failed!  - Failed:     1, Passed:     1, Skipped:     0, Total:     2, Duration: 4 ms - IntegrationTests.dll (net9.0)
```

## Other details

We can potentially simplify some of the named pipe retry tests to use this attribute, but there's not a big need to do so