### PR TITLE
[Tracer] Fix possible crash in ContextTracker on shutdown

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -94,9 +94,9 @@ namespace Datadog.Trace.ContinuousProfiler
                     return true;
                 }
             }
-            catch (ObjectDisposedException e)
+            catch (Exception e)
             {
-                // seen in a crash: weird but possible on shutdown probably
+                // seen in a crash: weird but possible on shutdown probably if the object is disposed
                 Log.Warning(e, "Disposed tracing context pointer wrapper for the thread {ThreadID}", Environment.CurrentManagedThreadId.ToString());
                 _traceContextPtr.Value = IntPtr.Zero;
                 return false;

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -85,11 +85,21 @@ namespace Datadog.Trace.ContinuousProfiler
             WriteToNative(SpanContext.Zero);
         }
 
-        private void EnsureIsInitialized()
+        private bool EnsureIsInitialized()
         {
-            if (_traceContextPtr.IsValueCreated)
+            try
             {
-                return;
+                if (_traceContextPtr.IsValueCreated)
+                {
+                    return true;
+                }
+            }
+            catch (ObjectDisposedException e)
+            {
+                // seen in a crash: weird but possible on shutdown probably
+                Log.Warning(e, "Disposed tracing context pointer wrapper for the thread {ThreadID}", Environment.CurrentManagedThreadId.ToString());
+                _traceContextPtr.Value = IntPtr.Zero;
+                return false;
             }
 
             try
@@ -100,7 +110,10 @@ namespace Datadog.Trace.ContinuousProfiler
             {
                 Log.Warning(e, "Unable to get the tracing context pointer for the thread {ThreadID}", Environment.CurrentManagedThreadId.ToString());
                 _traceContextPtr.Value = IntPtr.Zero;
+                return false;
             }
+
+            return true;
         }
 
         private void WriteToNative(in SpanContext ctx)
@@ -110,7 +123,10 @@ namespace Datadog.Trace.ContinuousProfiler
                 return;
             }
 
-            EnsureIsInitialized();
+            if (!EnsureIsInitialized())
+            {
+                return;
+            }
 
             var ctxPtr = _traceContextPtr.Value;
 


### PR DESCRIPTION
## Summary of changes
Protect against disposed ThreadLocal

## Reason for change
Fix crash

## Implementation details
A disposed ThreadLocal object can throw an exception when IsValueCreated property getter is called. This might happen during shutdown.

## Test coverage
N/A

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
