### PR TITLE
Revert "[Dynamic Instrumentation] DEBUG-3492 Remove duration from non…

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -334,11 +334,8 @@ namespace Datadog.Trace.Debugger.Snapshots
             JsonWriter.WritePropertyName("timestamp");
             JsonWriter.WriteValue(DateTimeOffset.Now.ToUnixTimeMilliseconds());
 
-            if (_probeLocation == ProbeLocation.Method)
-            {
-                JsonWriter.WritePropertyName("duration");
-                JsonWriter.WriteValue(_accumulatedDuration.TotalMilliseconds);
-            }
+            JsonWriter.WritePropertyName("duration");
+            JsonWriter.WriteValue(_accumulatedDuration.TotalMilliseconds);
 
             JsonWriter.WritePropertyName("language");
             JsonWriter.WriteValue(TracerConstants.Language);


### PR DESCRIPTION
This reverts commit 6e84c48168d2540cf92b4621dedfc17058de06f4.

## Reason for change
The PR #6735 broke all debugger tests. Reverting the merge commit of that PR for quick remediation.