### PR TITLE
Try to fix flake in building runner tool

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -23,6 +23,7 @@
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <BuildInParallel>false</BuildInParallel>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
## Summary of changes

Try to fix the flake we're been seeing in the `dotnet pack` stack of the runner build

## Reason for change

Seeing flake like this, which [seems to be happening in `9.0.2xx` of the SDK](https://github.com/dotnet/sdk/issues/17454)

```
The "GenerateToolsSettingsFile" task failed unexpectedly.
System.IO.IOException: The process cannot access the file 'D:\a\1\s\tracer\src\Datadog.Trace.Tools.Runner\obj\DotnetToolSettings.xml' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)
   at System.Xml.XmlWriterSettings.CreateWriter(String outputFileName)
   at System.Xml.Linq.XDocument.Save(String fileName, SaveOptions options)
   at Microsoft.NET.Build.Tasks.TaskBase.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(TaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```

## Implementation details

Try setting `BuildInParallel=false` [as suggested in this issue](https://github.com/dotnet/sdk/issues/17454#issuecomment-2660206217)

## Test coverage

If this build works, we're ok

## Other details

The issue appears to be fixed in the .NET 10 SDK:
- https://github.com/dotnet/sdk/issues/17454#issuecomment-2660206217

I've asked to see if it will backported, but no answer yet 🙄 