### PR TITLE
Use mirrored, latest, image in GitLab build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ build:
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `
         -e NUGET_CERT_REVOCATION_MODE=offline `
-        datadog/dd-trace-dotnet-docker-build:9-0-203 `
+        registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest `
         Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out


### PR DESCRIPTION
## Summary of changes

Update the GitLab build to use the mirrored image instead of pulling from Dockerhub

## Reason for change

Dockerhub is rate limited. [We switched temporarily when bumping the SDK to 9.0.203](https://github.com/DataDog/dd-trace-dotnet/pull/6883), and now we should switch back

## Implementation details

Revert the gitlab change to use the image pushed in https://github.com/DataDog/images/pull/7014

## Test coverage

If the build works, we're good

## Other details

Follow on action from https://github.com/DataDog/dd-trace-dotnet/pull/6883