### PR TITLE
Remove `package_linux` as a dependency of `integration_tests_linux`

### DIFF
--- a/.azure-pipelines/steps/restore-working-directory-for-tests.yml
+++ b/.azure-pipelines/steps/restore-working-directory-for-tests.yml
@@ -5,15 +5,24 @@ parameters:
     type: 'string'
     default: 'linux-x64'
 
+variables:
+  - ${{ if eq(parameters.artifactSuffix, 'linux-musl-x64') }}:
+      - universalSuffix: 'linux-x64'
+  - ${{ elseif eq(parameters.artifactSuffix, 'linux-musl-arm64') }}:
+      - universalSuffix: 'linux-arm64'
+  - ${{ else }}:
+      - universalSuffix: ${{ parameters.artifactSuffix }}
+
+
 steps:
 - template: ./restore-working-directory.yml
   parameters:
     artifact: build-${{ parameters.artifactSuffix }}-working-directory
 
 - task: DownloadPipelineArtifact@2
-  displayName: Download linux-universal-home-${{ replace(parameters.artifactSuffix, '-musl', '') }}
+  displayName: Download linux-universal-home-$(universalSuffix)
   inputs:
-    artifact: linux-universal-home-${{ replace(parameters.artifactSuffix, '-musl', '') }}
+    artifact: linux-universal-home-$(universalSuffix)
     path: $(monitoringHome)/${{ parameters.artifactSuffix }}
 
 - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/steps/restore-working-directory-for-tests.yml
+++ b/.azure-pipelines/steps/restore-working-directory-for-tests.yml
@@ -1,0 +1,23 @@
+# downloads the working directory and the tracer + profiler home assets
+# Beneficial as it can avoid the need to wait for the package stage
+parameters:
+  - name: 'artifactSuffix'
+    type: 'string'
+    default: 'linux-x64'
+
+steps:
+- template: ./restore-working-directory.yml
+  parameters:
+    artifact: build-${{ parameters.artifactSuffix }}-working-directory
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download linux-universal-home-${{ replace(parameters.artifactSuffix, '-musl', '') }}
+  inputs:
+    artifact: linux-universal-home-${{ replace(parameters.artifactSuffix, '-musl', '') }}
+    path: $(monitoringHome)/${{ parameters.artifactSuffix }}
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download profiler binaries
+  inputs:
+    artifact: linux-profiler-home-${{ parameters.artifactSuffix }}
+    path: $(monitoringHome)

--- a/.azure-pipelines/steps/restore-working-directory-for-tests.yml
+++ b/.azure-pipelines/steps/restore-working-directory-for-tests.yml
@@ -10,31 +10,17 @@ steps:
   parameters:
     artifact: build-${{ parameters.artifactSuffix }}-working-directory
 
-- ${{ if eq(parameters.artifactSuffix, 'linux-musl-x64') }}:
-    - script: echo 'linux-universal-home-linux-x64' for linux-musl-x64
-- ${{ elseif eq(parameters.artifactSuffix, 'linux-musl-arm64') }}:
-    - script: echo 'linux-universal-home-linux-arm64' for linux-musl-arm64
-- ${{ else }}:
-    - script: echo 'linux-universal-home-${{ parameters.artifactSuffix }}' for default
+- bash: |
+    input="${{ parameters.artifactSuffix }}"
+    output="${input/-musl/}"
+    echo "setting universalArtifactSuffix to ${output}"
+    echo "##vso[task.setvariable variable=universalArtifactSuffix]${output}"
 
-- ${{ if eq(parameters.artifactSuffix, 'linux-musl-x64') }}:
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux-universal-home-linux-x64
-      inputs:
-        artifact: linux-universal-home-linux-x64
-        path: $(monitoringHome)/${{ parameters.artifactSuffix }}
-- ${{ elseif eq(parameters.artifactSuffix, 'linux-musl-arm64') }}:
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux-universal-home-linux-arm64
-      inputs:
-        artifact: linux-universal-home-linux-arm64
-        path: $(monitoringHome)/${{ parameters.artifactSuffix }}
-- ${{ else }}:
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux-universal-home-${{ parameters.artifactSuffix }}
-      inputs:
-        artifact: linux-universal-home-${{ parameters.artifactSuffix }}
-        path: $(monitoringHome)/${{ parameters.artifactSuffix }}
+- task: DownloadPipelineArtifact@2
+  displayName: Download universal home binaries
+  inputs:
+    artifact: linux-universal-home-$(universalArtifactSuffix)
+    path: $(monitoringHome)/${{ parameters.artifactSuffix }}
 
 - task: DownloadPipelineArtifact@2
   displayName: Download profiler binaries

--- a/.azure-pipelines/steps/restore-working-directory-for-tests.yml
+++ b/.azure-pipelines/steps/restore-working-directory-for-tests.yml
@@ -5,25 +5,36 @@ parameters:
     type: 'string'
     default: 'linux-x64'
 
-variables:
-  - ${{ if eq(parameters.artifactSuffix, 'linux-musl-x64') }}:
-      - universalSuffix: 'linux-x64'
-  - ${{ elseif eq(parameters.artifactSuffix, 'linux-musl-arm64') }}:
-      - universalSuffix: 'linux-arm64'
-  - ${{ else }}:
-      - universalSuffix: ${{ parameters.artifactSuffix }}
-
-
 steps:
 - template: ./restore-working-directory.yml
   parameters:
     artifact: build-${{ parameters.artifactSuffix }}-working-directory
 
-- task: DownloadPipelineArtifact@2
-  displayName: Download linux-universal-home-$(universalSuffix)
-  inputs:
-    artifact: linux-universal-home-$(universalSuffix)
-    path: $(monitoringHome)/${{ parameters.artifactSuffix }}
+- ${{ if eq(parameters.artifactSuffix, 'linux-musl-x64') }}:
+    - script: echo 'linux-universal-home-linux-x64' for linux-musl-x64
+- ${{ elseif eq(parameters.artifactSuffix, 'linux-musl-arm64') }}:
+    - script: echo 'linux-universal-home-linux-arm64' for linux-musl-arm64
+- ${{ else }}:
+    - script: echo 'linux-universal-home-${{ parameters.artifactSuffix }}' for default
+
+- ${{ if eq(parameters.artifactSuffix, 'linux-musl-x64') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download linux-universal-home-linux-x64
+      inputs:
+        artifact: linux-universal-home-linux-x64
+        path: $(monitoringHome)/${{ parameters.artifactSuffix }}
+- ${{ elseif eq(parameters.artifactSuffix, 'linux-musl-arm64') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download linux-universal-home-linux-arm64
+      inputs:
+        artifact: linux-universal-home-linux-arm64
+        path: $(monitoringHome)/${{ parameters.artifactSuffix }}
+- ${{ else }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download linux-universal-home-${{ parameters.artifactSuffix }}
+      inputs:
+        artifact: linux-universal-home-${{ parameters.artifactSuffix }}
+        path: $(monitoringHome)/${{ parameters.artifactSuffix }}
 
 - task: DownloadPipelineArtifact@2
   displayName: Download profiler binaries

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2217,7 +2217,7 @@ stages:
 
 - stage: integration_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_linux_tracer, build_linux_universal, generate_variables, merge_commit_id, build_samples]
+  dependsOn: [build_linux_tracer, build_linux_universal, build_linux_profiler, generate_variables, merge_commit_id, build_samples]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -2244,14 +2244,9 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
 
-    - template: steps/restore-working-directory.yml
+    - template: steps/restore-working-directory-for-tests.yml
       parameters:
-        artifact: build-$(artifactSuffix)-working-directory
-    - task: DownloadPipelineArtifact@2
-      displayName: Download universal native binaries
-      inputs:
-        artifact: linux-universal-home-linux-x64
-        path: $(monitoringHome)/$(artifactSuffix)
+        artifactSuffix: $(artifactSuffix)
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
@@ -2324,14 +2319,9 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
 
-    - template: steps/restore-working-directory.yml
+    - template: steps/restore-working-directory-for-tests.yml
       parameters:
-        artifact: build-$(artifactSuffix)-working-directory
-    - task: DownloadPipelineArtifact@2
-      displayName: Download universal native binaries
-      inputs:
-        artifact: linux-universal-home-linux-x64
-        path: $(monitoringHome)/$(artifactSuffix)
+        artifactSuffix: $(artifactSuffix)
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
@@ -2444,14 +2434,9 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
 
-    - template: steps/restore-working-directory.yml
+    - template: steps/restore-working-directory-for-tests.yml
       parameters:
-        artifact: build-$(artifactSuffix)-working-directory
-    - task: DownloadPipelineArtifact@2
-      displayName: Download universal native binaries
-      inputs:
-        artifact: linux-universal-home-linux-x64
-        path: $(monitoringHome)/$(artifactSuffix)
+        artifactSuffix: $(artifactSuffix)
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
@@ -2627,14 +2612,9 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
 
-    - template: steps/restore-working-directory.yml
+    - template: steps/restore-working-directory-for-tests.yml
       parameters:
-        artifact: build-$(artifactSuffix)-working-directory
-    - task: DownloadPipelineArtifact@2
-      displayName: Download universal native binaries
-      inputs:
-        artifact: linux-universal-home-linux-x64
-        path: $(monitoringHome)/$(artifactSuffix)
+        artifactSuffix: $(artifactSuffix)
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -3045,14 +3025,9 @@ stages:
             targetShaId: $(targetShaId)
             targetBranch: $(targetBranch)
 
-        - template: steps/restore-working-directory.yml
+        - template: steps/restore-working-directory-for-tests.yml
           parameters:
-            artifact: build-$(artifactSuffix)-working-directory
-        - task: DownloadPipelineArtifact@2
-          displayName: Download universal native binaries
-          inputs:
-            artifact: linux-universal-home-linux-arm64
-            path: $(monitoringHome)/$(artifactSuffix)
+            artifactSuffix: $(artifactSuffix)
         - template: steps/download-samples.yml
           parameters:
             framework: $(publishTargetFramework)
@@ -3119,14 +3094,9 @@ stages:
             targetShaId: $(targetShaId)
             targetBranch: $(targetBranch)
 
-        - template: steps/restore-working-directory.yml
+        - template: steps/restore-working-directory-for-tests.yml
           parameters:
-            artifact: build-$(artifactSuffix)-working-directory
-        - task: DownloadPipelineArtifact@2
-          displayName: Download universal native binaries
-          inputs:
-            artifact: linux-universal-home-linux-arm64
-            path: $(monitoringHome)/$(artifactSuffix)
+            artifactSuffix: $(artifactSuffix)
         - template: steps/download-samples.yml
           parameters:
             framework: $(publishTargetFramework)
@@ -3237,14 +3207,9 @@ stages:
             targetShaId: $(targetShaId)
             targetBranch: $(targetBranch)
 
-        - template: steps/restore-working-directory.yml
+        - template: steps/restore-working-directory-for-tests.yml
           parameters:
-            artifact: build-$(artifactSuffix)-working-directory
-        - task: DownloadPipelineArtifact@2
-          displayName: Download universal native binaries
-          inputs:
-            artifact: linux-universal-home-linux-arm64
-            path: $(monitoringHome)/$(artifactSuffix)
+            artifactSuffix: $(artifactSuffix)
 
         - template: steps/run-in-docker.yml
           parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2217,7 +2217,7 @@ stages:
 
 - stage: integration_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [package_linux, generate_variables, merge_commit_id, build_samples]
+  dependsOn: [build_linux_tracer, build_linux_universal, generate_variables, merge_commit_id, build_samples]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -2247,6 +2247,11 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
+    - task: DownloadPipelineArtifact@2
+      displayName: Download universal native binaries
+      inputs:
+        artifact: linux-universal-home-linux-x64
+        path: $(monitoringHome)/$(artifactSuffix)
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
@@ -2259,12 +2264,6 @@ stages:
         baseImage: $(baseImage)
         command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter $(IntegrationTestFilter) --SampleName $(IntegrationTestSampleName)"
         apikey: $(DD_LOGGER_DD_API_KEY)
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux monitoring home
-      inputs:
-        artifact: linux-monitoring-home-$(artifactSuffix)
-        path: $(monitoringHome)
 
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
@@ -2328,6 +2327,11 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
+    - task: DownloadPipelineArtifact@2
+      displayName: Download universal native binaries
+      inputs:
+        artifact: linux-universal-home-linux-x64
+        path: $(monitoringHome)/$(artifactSuffix)
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
@@ -2340,12 +2344,6 @@ stages:
         baseImage: $(baseImage)
         command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter $(IntegrationTestFilter) --SampleName $(IntegrationTestSampleName)"
         apiKey: $(DD_LOGGER_DD_API_KEY)
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux monitoring home
-      inputs:
-        artifact: linux-monitoring-home-$(artifactSuffix)
-        path: $(monitoringHome)
 
     - script: |
         docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
@@ -2449,12 +2447,11 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
-
     - task: DownloadPipelineArtifact@2
-      displayName: Download linux monitoring home
+      displayName: Download universal native binaries
       inputs:
-        artifact: linux-monitoring-home-$(artifactSuffix)
-        path: $(monitoringHome)
+        artifact: linux-universal-home-linux-x64
+        path: $(monitoringHome)/$(artifactSuffix)
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
@@ -2603,7 +2600,7 @@ stages:
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
     )
-  dependsOn: [package_linux, generate_variables, merge_commit_id]
+  dependsOn: [build_linux_tracer, build_linux_universal, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -2633,6 +2630,11 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-$(artifactSuffix)-working-directory
+    - task: DownloadPipelineArtifact@2
+      displayName: Download universal native binaries
+      inputs:
+        artifact: linux-universal-home-linux-x64
+        path: $(monitoringHome)/$(artifactSuffix)
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -2642,12 +2644,6 @@ stages:
         baseImage: $(baseImage)
         command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64 --debugtype portable --optimize $(optimize)"
         apikey: $(DD_LOGGER_DD_API_KEY)
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux monitoring home
-      inputs:
-        artifact: linux-monitoring-home-$(artifactSuffix)
-        path: $(monitoringHome)
 
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
@@ -3022,7 +3018,7 @@ stages:
 
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [package_arm64, generate_variables, merge_commit_id, build_samples]
+  dependsOn: [build_arm64_tracer, build_arm64_universal, generate_variables, merge_commit_id, build_samples]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -3052,7 +3048,11 @@ stages:
         - template: steps/restore-working-directory.yml
           parameters:
             artifact: build-$(artifactSuffix)-working-directory
-
+        - task: DownloadPipelineArtifact@2
+          displayName: Download universal native binaries
+          inputs:
+            artifact: linux-universal-home-linux-arm64
+            path: $(monitoringHome)/$(artifactSuffix)
         - template: steps/download-samples.yml
           parameters:
             framework: $(publishTargetFramework)
@@ -3063,12 +3063,6 @@ stages:
             baseImage: $(baseImage)
             command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter $(IntegrationTestFilter) --SampleName $(IntegrationTestSampleName)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download $(artifactSuffix) monitoring home
-          inputs:
-            artifact: linux-monitoring-home-$(artifactSuffix)
-            path: $(monitoringHome)
 
         - script: |
             docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
@@ -3128,6 +3122,11 @@ stages:
         - template: steps/restore-working-directory.yml
           parameters:
             artifact: build-$(artifactSuffix)-working-directory
+        - task: DownloadPipelineArtifact@2
+          displayName: Download universal native binaries
+          inputs:
+            artifact: linux-universal-home-linux-arm64
+            path: $(monitoringHome)/$(artifactSuffix)
         - template: steps/download-samples.yml
           parameters:
             framework: $(publishTargetFramework)
@@ -3138,12 +3137,6 @@ stages:
             baseImage: $(baseImage)
             command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter $(IntegrationTestFilter) --SampleName $(IntegrationTestSampleName)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download $(artifactSuffix) monitoring home
-          inputs:
-            artifact: linux-monitoring-home-$(artifactSuffix)
-            path: $(monitoringHome)
 
         - script: |
             docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) IntegrationTests.ARM64
@@ -3218,7 +3211,7 @@ stages:
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
     )
-  dependsOn: [package_arm64, generate_variables, merge_commit_id]
+  dependsOn: [build_arm64_tracer, build_arm64_universal, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -3247,6 +3240,11 @@ stages:
         - template: steps/restore-working-directory.yml
           parameters:
             artifact: build-$(artifactSuffix)-working-directory
+        - task: DownloadPipelineArtifact@2
+          displayName: Download universal native binaries
+          inputs:
+            artifact: linux-universal-home-linux-arm64
+            path: $(monitoringHome)/$(artifactSuffix)
 
         - template: steps/run-in-docker.yml
           parameters:
@@ -3254,12 +3252,6 @@ stages:
             baseImage: $(baseImage)
             command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64 --debugtype portable --optimize $(optimize)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download $(artifactSuffix) monitoring home
-          inputs:
-            artifact: linux-monitoring-home-$(artifactSuffix)
-            path: $(monitoringHome)
 
         - script: |
             docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2585,7 +2585,7 @@ stages:
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
     )
-  dependsOn: [build_linux_tracer, build_linux_universal, generate_variables, merge_commit_id]
+  dependsOn: [build_linux_tracer, build_linux_universal, build_linux_profiler, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -2998,7 +2998,7 @@ stages:
 
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_arm64_tracer, build_arm64_universal, generate_variables, merge_commit_id, build_samples]
+  dependsOn: [build_arm64_tracer, build_arm64_universal, build_arm64_profiler, generate_variables, merge_commit_id, build_samples]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -3181,7 +3181,7 @@ stages:
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
     )
-  dependsOn: [build_arm64_tracer, build_arm64_universal, generate_variables, merge_commit_id]
+  dependsOn: [build_arm64_tracer, build_arm64_universal, build_arm64_profiler, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]


### PR DESCRIPTION
## Summary of changes

Instead of waiting for `package_linux` to aggregate all the assets, download them manually

## Reason for change

Currently, in the consolidated pipeline, we have the following dependencies before we can run the linux integration tests:

```
build_linux_tracer     \
build_linux_universal  |  -->  package_linux  --> integration_tests_linux
build_linux_profiler   | 
build_linux_dd_dotnet  /
```

but we don't actually _need_ the `package_linux` package outputs, it's just a nicety that it aggregates all the outputs. However, having this extra stage delays the start of the tests. Additionally, because (on ARM64 particularly) there's an additional delay associated with provisioning, this can delay by 10+ minutes.

Instead, we can just download the assets directly, instead of requiring `package_linux` to do it, so we have something like this instead:

```
build_linux_tracer     \
build_linux_universal  |  --> integration_tests_linux
build_linux_profiler   /
```

Which should save 3-10 minutes depending on how overloaded CI is.

Note we don't need to do this for Windows, because we build all that in one stage (currently)

## Implementation details

- Created a `restore-working-directory-for-tests.yml` helper step, which downloads the working directory + profiler, + universal (native loader) and puts them in the right place. 
- Replace `steps/restore-working-directory.yml` with `steps/restore-working-directory-for-tests.yml` in linux/arm64 integration tests
- Remove explicit download of monitoring-home
- Update `dependsOn` from `package_linux` to `build_linux_tracer, build_linux_universal, build_linux_profiler` (and similar for arm64)

## Test coverage

I've run some tests, but as long as this builds we're ok

## Other details

We potentially _could_ combine all the linux `build` stages into one stage with multiple jobs 🤔 