### PR TITLE
Bump the gh-actions-packages group across 3 directories with 10 updates

### DIFF
--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -33,18 +33,18 @@ runs:
         cp ./tracer/build/_build/docker/system-tests.dockerfile ${{inputs.artifacts_path}}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 #v2.10.0
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 #v3.10.0
 
     - name: Login to Docker
       shell: bash
       run: docker login -u publisher -p ${{ inputs.github_token }} ghcr.io
 
     - name: Docker Build linux-x64 and linux-arm64 images
-      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
+      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
       with:
         push: true
         tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot

--- a/.github/actions/publish-debug-symbols/action.yml
+++ b/.github/actions/publish-debug-symbols/action.yml
@@ -25,7 +25,7 @@ runs:
 
     # Use the same go version as in https://github.com/DataDog/profiling-backend/blob/prod/debug-symbol-upload/Dockerfile#L21
     - name: Install Go
-      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
         go-version: '^1.22.3'
 

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -18,9 +18,9 @@ jobs:
       issues: write # need to potentially create a new milestone
     steps:
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -23,11 +23,11 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@dd2324fc52d5d43c699a5636bcf19fceaa70c284 # v7.0.7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "bot/test-package-versions-bump"
@@ -50,7 +50,7 @@ jobs:
             
       - name: Send Slack notification about generating failure
         if: failure()
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           # This data can be any valid JSON from a previous step in the GitHub Action
           payload: |

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -36,7 +36,7 @@ jobs:
           }
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ steps.select_branch.outputs.ref }}
 
@@ -45,7 +45,7 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29 # v3.10.0
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "version-bump-${{steps.versions.outputs.full_version}}"

--- a/.github/workflows/auto_deploy_aas_test_apps.yml
+++ b/.github/workflows/auto_deploy_aas_test_apps.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Clone dd-trace-dotnet repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
         name: 'Open Code Freeze Milestone'

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -14,9 +14,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -15,11 +15,11 @@ jobs:
       contents: write # Creates and deletes branches
     steps:
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Clone dd-trace-dotnet repository
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
       name: 'Close Code Freeze Milestone'

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Clone dd-trace-dotnet repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
         name: 'Open Code Freeze Milestone'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+    - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: '9.0.203'
 
@@ -33,7 +33,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+      uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
       with:
         languages: csharp, cpp
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
         ./tracer/build.sh BuildProfilerHome BuildNativeLoader
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+      uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
 
     - name: filter-sarif cpp
       uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0.1
@@ -97,9 +97,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+    - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: '9.0.203'
 
@@ -109,7 +109,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+      uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
       with:
         languages: csharp, cpp
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -130,7 +130,7 @@ jobs:
         ./tracer/build.sh BuildTracerHome
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+      uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
 
     - name: filter-sarif cpp
       uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0.1

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -27,11 +27,11 @@ jobs:
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
     steps:
     - name: Checkout
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+    - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: '9.0.203'
 

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
           echo "Using sha $commitsha"
           echo "sha=${commitsha}" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 
@@ -104,7 +104,7 @@ jobs:
           git push origin "v${{steps.versions.outputs.full_version}}"
 
       - name: Create Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1.0.0
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v1.0.0
         with:
           draft: true
           name: "${{steps.versions.outputs.full_version}}"

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -27,14 +27,14 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Configure Git Credentials"
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
       statuses: write # add status checks (?) 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check code meets quality standards
         id: datadog-static-analysis
         uses: DataDog/datadog-static-analyzer-github-action@v1

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -28,9 +28,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
-        uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29 # v3.10.0
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "version-bump-${{steps.versions.outputs.full_version}}"

--- a/.github/workflows/generate_package_versions.yml
+++ b/.github/workflows/generate_package_versions.yml
@@ -22,9 +22,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/publish_debug_symbols.yml
+++ b/.github/workflows/publish_debug_symbols.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Download Linux native symbols v${{ github.event.inputs.version }}

--- a/.github/workflows/scheduled_aas_deploy.yml
+++ b/.github/workflows/scheduled_aas_deploy.yml
@@ -92,7 +92,7 @@ jobs:
       # Checkout and deploy if we should proceed
       - name: Clone repository
         if: steps.check_skip.outputs.should_proceed == 'true'
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/deploy-aas-dev-apps
         if: steps.check_skip.outputs.should_proceed == 'true'

--- a/.github/workflows/scheduled_code_freeze.yml
+++ b/.github/workflows/scheduled_code_freeze.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Checkout for PR updates
         if: steps.check_skip.outputs.should_proceed == 'true' && success()
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Update PR statuses
       - uses: ./.github/actions/pr-status-updater

--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -15,9 +15,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/verify_files_without_nullability.yml
+++ b/.github/workflows/verify_files_without_nullability.yml
@@ -15,9 +15,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -15,9 +15,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/verify_solution_changes_are_persisted.yml
+++ b/.github/workflows/verify_solution_changes_are_persisted.yml
@@ -15,9 +15,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -15,9 +15,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -15,9 +15,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-dotnet@71a4fd9b27383962fc5df13a9c871636b43199b4 # v1.10.0
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '9.0.203'
 


### PR DESCRIPTION
This is a rebasing and re-running of #6789 to ensure that all the actions we expect _actually_ run. This will give us some confidence about the updates. 

The biggest risks are to the [softprops/action-gh-release](https://github.com/softprops/action-gh-release) and [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) actions. The former can only be tested in a release, whereas the latter can be tested by running the test-package-version action (which I did [here](https://github.com/DataDog/dd-trace-dotnet/actions/runs/14773784822/job/41478311113) and it worked ok).

It's a scary bunch of updates, but we need to do them at _some_ point...

---

Bumps the gh-actions-packages group with 6 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [actions/checkout](https://github.com/actions/checkout) | `2.7.0` | `4.2.2` |
| [actions/setup-dotnet](https://github.com/actions/setup-dotnet) | `1.10.0` | `4.3.1` |
| [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) | `3.10.0` | `7.0.8` |
| [slackapi/slack-github-action](https://github.com/slackapi/slack-github-action) | `1.26.0` | `2.0.0` |
| [github/codeql-action](https://github.com/github/codeql-action) | `2.28.1` | `3.28.12` |
| [softprops/action-gh-release](https://github.com/softprops/action-gh-release) | `1` | `2` |

Bumps the gh-actions-packages group with 3 updates in the /.github/actions/create-system-test-docker-base-images directory: [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action), [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) and [docker/build-push-action](https://github.com/docker/build-push-action).
Bumps the gh-actions-packages group with 1 update in the /.github/actions/publish-debug-symbols directory: [actions/setup-go](https://github.com/actions/setup-go).

Updates `actions/checkout` from 2.7.0 to 4.2.2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/checkout/releases">actions/checkout's releases</a>.</em></p>
<blockquote>
<h2>v4.2.2</h2>
<h2>What's Changed</h2>
<ul>
<li><code>url-helper.ts</code> now leverages well-known environment variables by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1941">actions/checkout#1941</a></li>
<li>Expand unit test coverage for <code>isGhes</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1946">actions/checkout#1946</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v4.2.1...v4.2.2">https://github.com/actions/checkout/compare/v4.2.1...v4.2.2</a></p>
<h2>v4.2.1</h2>
<h2>What's Changed</h2>
<ul>
<li>Check out other refs/* by commit if provided, fall back to ref by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1924">actions/checkout#1924</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/Jcambass"><code>@​Jcambass</code></a> made their first contribution in <a href="https://redirect.github.com/actions/checkout/pull/1919">actions/checkout#1919</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v4.2.0...v4.2.1">https://github.com/actions/checkout/compare/v4.2.0...v4.2.1</a></p>
<h2>v4.2.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Add Ref and Commit outputs by <a href="https://github.com/lucacome"><code>@​lucacome</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
<li>Dependabot updates in <a href="https://redirect.github.com/actions/checkout/pull/1777">actions/checkout#1777</a> &amp; <a href="https://redirect.github.com/actions/checkout/pull/1872">actions/checkout#1872</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/yasonk"><code>@​yasonk</code></a> made their first contribution in <a href="https://redirect.github.com/actions/checkout/pull/1869">actions/checkout#1869</a></li>
<li><a href="https://github.com/lucacome"><code>@​lucacome</code></a> made their first contribution in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v4.1.7...v4.2.0">https://github.com/actions/checkout/compare/v4.1.7...v4.2.0</a></p>
<h2>v4.1.7</h2>
<h2>What's Changed</h2>
<ul>
<li>Bump the minor-npm-dependencies group across 1 directory with 4 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1739">actions/checkout#1739</a></li>
<li>Bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1697">actions/checkout#1697</a></li>
<li>Check out other refs/* by commit by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
<li>Pin actions/checkout's own workflows to a known, good, stable version. by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1776">actions/checkout#1776</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> made their first contribution in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v4.1.6...v4.1.7">https://github.com/actions/checkout/compare/v4.1.6...v4.1.7</a></p>
<h2>v4.1.6</h2>
<h2>What's Changed</h2>
<ul>
<li>Check platform to set archive extension appropriately by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1732">actions/checkout#1732</a></li>
<li>Update for 4.1.6 release by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1733">actions/checkout#1733</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/checkout/compare/v4.1.5...v4.1.6">https://github.com/actions/checkout/compare/v4.1.5...v4.1.6</a></p>
<h2>v4.1.5</h2>
<h2>What's Changed</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/actions/checkout/blob/main/CHANGELOG.md">actions/checkout's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>v4.2.2</h2>
<ul>
<li><code>url-helper.ts</code> now leverages well-known environment variables by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1941">actions/checkout#1941</a></li>
<li>Expand unit test coverage for <code>isGhes</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1946">actions/checkout#1946</a></li>
</ul>
<h2>v4.2.1</h2>
<ul>
<li>Check out other refs/* by commit if provided, fall back to ref by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1924">actions/checkout#1924</a></li>
</ul>
<h2>v4.2.0</h2>
<ul>
<li>Add Ref and Commit outputs by <a href="https://github.com/lucacome"><code>@​lucacome</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1180">actions/checkout#1180</a></li>
<li>Dependency updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>- <a href="https://redirect.github.com/actions/checkout/pull/1777">actions/checkout#1777</a>, <a href="https://redirect.github.com/actions/checkout/pull/1872">actions/checkout#1872</a></li>
</ul>
<h2>v4.1.7</h2>
<ul>
<li>Bump the minor-npm-dependencies group across 1 directory with 4 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1739">actions/checkout#1739</a></li>
<li>Bump actions/checkout from 3 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1697">actions/checkout#1697</a></li>
<li>Check out other refs/* by commit by <a href="https://github.com/orhantoy"><code>@​orhantoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1774">actions/checkout#1774</a></li>
<li>Pin actions/checkout's own workflows to a known, good, stable version. by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1776">actions/checkout#1776</a></li>
</ul>
<h2>v4.1.6</h2>
<ul>
<li>Check platform to set archive extension appropriately by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1732">actions/checkout#1732</a></li>
</ul>
<h2>v4.1.5</h2>
<ul>
<li>Update NPM dependencies by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1703">actions/checkout#1703</a></li>
<li>Bump github/codeql-action from 2 to 3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1694">actions/checkout#1694</a></li>
<li>Bump actions/setup-node from 1 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1696">actions/checkout#1696</a></li>
<li>Bump actions/upload-artifact from 2 to 4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1695">actions/checkout#1695</a></li>
<li>README: Suggest <code>user.email</code> to be <code>41898282+github-actions[bot]@users.noreply.github.com</code> by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1707">actions/checkout#1707</a></li>
</ul>
<h2>v4.1.4</h2>
<ul>
<li>Disable <code>extensions.worktreeConfig</code> when disabling <code>sparse-checkout</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1692">actions/checkout#1692</a></li>
<li>Add dependabot config by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1688">actions/checkout#1688</a></li>
<li>Bump the minor-actions-dependencies group with 2 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1693">actions/checkout#1693</a></li>
<li>Bump word-wrap from 1.2.3 to 1.2.5 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1643">actions/checkout#1643</a></li>
</ul>
<h2>v4.1.3</h2>
<ul>
<li>Check git version before attempting to disable <code>sparse-checkout</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1656">actions/checkout#1656</a></li>
<li>Add SSH user parameter by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1685">actions/checkout#1685</a></li>
<li>Update <code>actions/checkout</code> version in <code>update-main-version.yml</code> by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1650">actions/checkout#1650</a></li>
</ul>
<h2>v4.1.2</h2>
<ul>
<li>Fix: Disable sparse checkout whenever <code>sparse-checkout</code> option is not present <a href="https://github.com/dscho"><code>@​dscho</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1598">actions/checkout#1598</a></li>
</ul>
<h2>v4.1.1</h2>
<ul>
<li>Correct link to GitHub Docs by <a href="https://github.com/peterbe"><code>@​peterbe</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1511">actions/checkout#1511</a></li>
<li>Link to release page from what's new section by <a href="https://github.com/cory-miller"><code>@​cory-miller</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/1514">actions/checkout#1514</a></li>
</ul>
<h2>v4.1.0</h2>
<ul>
<li><a href="https://redirect.github.com/actions/checkout/pull/1396">Add support for partial checkout filters</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683"><code>11bd719</code></a> Prepare 4.2.2 Release (<a href="https://redirect.github.com/actions/checkout/issues/1953">#1953</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/e3d2460bbb42d7710191569f88069044cfb9d8cf"><code>e3d2460</code></a> Expand unit test coverage (<a href="https://redirect.github.com/actions/checkout/issues/1946">#1946</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/163217dfcd28294438ea1c1c149cfaf66eec283e"><code>163217d</code></a> <code>url-helper.ts</code> now leverages well-known environment variables. (<a href="https://redirect.github.com/actions/checkout/issues/1941">#1941</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871"><code>eef6144</code></a> Prepare 4.2.1 release (<a href="https://redirect.github.com/actions/checkout/issues/1925">#1925</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/6b42224f41ee5dfe5395e27c8b2746f1f9955030"><code>6b42224</code></a> Add workflow file for publishing releases to immutable action package (<a href="https://redirect.github.com/actions/checkout/issues/1919">#1919</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/de5a000abf73b6f4965bd1bcdf8f8d94a56ea815"><code>de5a000</code></a> Check out other refs/* by commit if provided, fall back to ref (<a href="https://redirect.github.com/actions/checkout/issues/1924">#1924</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/d632683dd7b4114ad314bca15554477dd762a938"><code>d632683</code></a> Prepare 4.2.0 release (<a href="https://redirect.github.com/actions/checkout/issues/1878">#1878</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/6d193bf28034eafb982f37bd894289fe649468fc"><code>6d193bf</code></a> Bump braces from 3.0.2 to 3.0.3 (<a href="https://redirect.github.com/actions/checkout/issues/1777">#1777</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/db0cee9a514becbbd4a101a5fbbbf47865ee316c"><code>db0cee9</code></a> Bump the minor-npm-dependencies group across 1 directory with 4 updates (<a href="https://redirect.github.com/actions/checkout/issues/1872">#1872</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/b6849436894e144dbce29d7d7fda2ae3bf9d8365"><code>b684943</code></a> Add Ref and Commit outputs (<a href="https://redirect.github.com/actions/checkout/issues/1180">#1180</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/actions/checkout/compare/v2.7.0...11bd71901bbe5b1630ceea73d27597364c9af683">compare view</a></li>
</ul>
</details>
<br />

Updates `actions/setup-dotnet` from 1.10.0 to 4.3.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/setup-dotnet/releases">actions/setup-dotnet's releases</a>.</em></p>
<blockquote>
<h2>v4.3.1</h2>
<h2>What's Changed</h2>
<ul>
<li><code>v4</code> - Remove <code>azureedge.net</code> fallback logic and update install scripts by <a href="https://github.com/zaataylor"><code>@​zaataylor</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/572">actions/setup-dotnet#572</a>
As outlined in<a href="https://devblogs.microsoft.com/dotnet/critical-dotnet-install-links-are-changing/#call-to-action"> Critical .NET Install Links Are Changing</a>, remove the storage account fallback logic added for v4 in <a href="https://redirect.github.com/actions/setup-dotnet/pull/566">actions/setup-dotnet#566</a> and update the install scripts accordingly.
<strong>Related issue</strong>: <a href="https://redirect.github.com/dotnet/install-scripts/issues/559">dotnet/install-scripts#559</a></li>
<li>upgrade <code>@​actions/cache</code> to 4.0.2 by <a href="https://github.com/HarithaVattikuti"><code>@​HarithaVattikuti</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/615">actions/setup-dotnet#615</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/setup-dotnet/compare/v4...v4.3.1">https://github.com/actions/setup-dotnet/compare/v4...v4.3.1</a></p>
<h2>v4.3.0</h2>
<h2>What's Changed</h2>
<ul>
<li>README update - add permissions section by <a href="https://github.com/benwells"><code>@​benwells</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/587">actions/setup-dotnet#587</a></li>
<li>Configure Dependabot settings by <a href="https://github.com/HarithaVattikuti"><code>@​HarithaVattikuti</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/585">actions/setup-dotnet#585</a></li>
<li>Upgrade <strong>cache</strong> from 3.2.4 to 4.0.0 by <a href="https://github.com/aparnajyothi-y"><code>@​aparnajyothi-y</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/586">actions/setup-dotnet#586</a></li>
<li>Upgrade <strong>actions/publish-immutable-action</strong> from 0.0.3 to 0.0.4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/590">actions/setup-dotnet#590</a></li>
<li>Upgrade <strong><code>@​actions/http-client</code></strong> from 2.2.1 to 2.2.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/592">actions/setup-dotnet#592</a></li>
<li>Upgrade <strong>undici</strong> from 5.28.4 to 5.28.5 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/596">actions/setup-dotnet#596</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/benwells"><code>@​benwells</code></a> made their first contribution in <a href="https://redirect.github.com/actions/setup-dotnet/pull/587">actions/setup-dotnet#587</a></li>
<li><a href="https://github.com/aparnajyothi-y"><code>@​aparnajyothi-y</code></a> made their first contribution in <a href="https://redirect.github.com/actions/setup-dotnet/pull/586">actions/setup-dotnet#586</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/setup-dotnet/compare/v4...v4.3.0">https://github.com/actions/setup-dotnet/compare/v4...v4.3.0</a></p>
<h2>v4.2.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Enhance Workflows, Update Dependencies and Installer Scripts by <a href="https://github.com/priyagupta108"><code>@​priyagupta108</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/555">actions/setup-dotnet#555</a></li>
<li>V4 - Use new .NET CDN URLs and update to latest install scripts by <a href="https://github.com/heavymachinery"><code>@​heavymachinery</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/566">actions/setup-dotnet#566</a></li>
</ul>
<p>Some .NET binaries and installers currently hosted on Azure Content Delivery Network (CDN) domains ending in .azureedge.net will move to new domains as the provider, edg.io, will <a href="https://learn.microsoft.com/en-us/azure/cdn/edgio-retirement-faq">soon cease operations</a>. There may be downtime or unavailability of .azureedge.net domains in the future as the .NET team is required to <a href="https://learn.microsoft.com/azure/frontdoor/migrate-cdn-to-front-door">migrate to a new CDN</a> and set of domains moving forward.</p>
<p>If your workflows are pinned to specific SHAs or minor tags, please upgrade to a major release tag to avoid service disruptions. Edgio has confirmed their services will be operational until <a href="https://learn.microsoft.com/en-us/azure/cdn/edgio-retirement-faq">at least January 15, 2025</a>.</p>
<p>For updates, follow <a href="https://redirect.github.com/dotnet/core/issues/9671">dotnet/core#9671</a>.</p>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/priyagupta108"><code>@​priyagupta108</code></a> made their first contribution in <a href="https://redirect.github.com/actions/setup-dotnet/pull/555">actions/setup-dotnet#555</a></li>
<li><a href="https://github.com/heavymachinery"><code>@​heavymachinery</code></a> made their first contribution in <a href="https://redirect.github.com/actions/setup-dotnet/pull/566">actions/setup-dotnet#566</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/setup-dotnet/compare/v4...v4.2.0">https://github.com/actions/setup-dotnet/compare/v4...v4.2.0</a></p>
<h2>v4.1.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Add workflow file for publishing releases to immutable action package by <a href="https://github.com/Jcambass"><code>@​Jcambass</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/548">actions/setup-dotnet#548</a></li>
<li>Upgrade IA Publish by <a href="https://github.com/Jcambass"><code>@​Jcambass</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/550">actions/setup-dotnet#550</a></li>
</ul>
<h3>Bug fixes :</h3>
<ul>
<li>Fixed Basic Validation failure checks by <a href="https://github.com/HarithaVattikuti"><code>@​HarithaVattikuti</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/545">actions/setup-dotnet#545</a></li>
<li>Revise <code>isGhes</code> logic by <a href="https://github.com/jww3"><code>@​jww3</code></a> in <a href="https://redirect.github.com/actions/setup-dotnet/pull/556">actions/setup-dotnet#556</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/setup-dotnet/commit/67a3573c9a986a3f9c594539f4ab511d57bb3ce9"><code>67a3573</code></a> cache upgrade from 4.0.0 to 4.0.2 (<a href="https://redirect.github.com/actions/setup-dotnet/issues/615">#615</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/83c0c1a6c843e2d7e6b14cc940a4a8c77243829b"><code>83c0c1a</code></a> <code>v4</code> - Remove <code>azureedge.net</code> fallback logic and update install scripts (<a href="https://redirect.github.com/actions/setup-dotnet/issues/572">#572</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/3951f0dfe7a07e2313ec93c75700083e2005cbab"><code>3951f0d</code></a> Bump undici from 5.28.4 to 5.28.5 (<a href="https://redirect.github.com/actions/setup-dotnet/issues/596">#596</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/4849e736f1bd76c37a6dd7d4b8f84581fb6d8baf"><code>4849e73</code></a> Bump <code>@​actions/http-client</code> from 2.2.1 to 2.2.3 (<a href="https://redirect.github.com/actions/setup-dotnet/issues/592">#592</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/3e76c4dc412e00b3fcb875aaddbf27000f2d428b"><code>3e76c4d</code></a> Bump actions/publish-immutable-action from 0.0.3 to 0.0.4 (<a href="https://redirect.github.com/actions/setup-dotnet/issues/590">#590</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/91b379339b47ad470db060ea16315b66313ae78e"><code>91b3793</code></a> Configure Dependabot settings (<a href="https://redirect.github.com/actions/setup-dotnet/issues/585">#585</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/4b37d22250db48bbc2ccdde8ef5dbf479769f7ac"><code>4b37d22</code></a> upgrade cache from 3.2.4 to 4.0.0 (<a href="https://redirect.github.com/actions/setup-dotnet/issues/586">#586</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/f9d0f6282caace67f83f94183a90502136d73900"><code>f9d0f62</code></a> Update README.md (<a href="https://redirect.github.com/actions/setup-dotnet/issues/587">#587</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/87b7050bc53ea08284295505d98d2aa94301e852"><code>87b7050</code></a> V4 - Use new .NET CDN URLs and update to latest install scripts (<a href="https://redirect.github.com/actions/setup-dotnet/issues/566">#566</a>)</li>
<li><a href="https://github.com/actions/setup-dotnet/commit/e4c228a8417679d13c6a1e7131e3e8d82dff4cd3"><code>e4c228a</code></a> Enhance Workflows, Update Dependencies and Installer Scripts (<a href="https://redirect.github.com/actions/setup-dotnet/issues/555">#555</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/actions/setup-dotnet/compare/71a4fd9b27383962fc5df13a9c871636b43199b4...67a3573c9a986a3f9c594539f4ab511d57bb3ce9">compare view</a></li>
</ul>
</details>
<br />

Updates `peter-evans/create-pull-request` from 3.10.0 to 7.0.8
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/peter-evans/create-pull-request/releases">peter-evans/create-pull-request's releases</a>.</em></p>
<blockquote>
<h2>Create Pull Request v7.0.8</h2>
<h2>What's Changed</h2>
<ul>
<li>build(deps-dev): bump ts-jest from 29.2.5 to 29.2.6 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3751">peter-evans/create-pull-request#3751</a></li>
<li>build(deps-dev): bump eslint-import-resolver-typescript from 3.8.1 to 3.8.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3752">peter-evans/create-pull-request#3752</a></li>
<li>build(deps): bump <code>@​octokit/plugin-paginate-rest</code> from 11.4.2 to 11.4.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3753">peter-evans/create-pull-request#3753</a></li>
<li>build(deps-dev): bump prettier from 3.5.1 to 3.5.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3754">peter-evans/create-pull-request#3754</a></li>
<li>fix: suppress output for some git operations by <a href="https://github.com/peter-evans"><code>@​peter-evans</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3776">peter-evans/create-pull-request#3776</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/peter-evans/create-pull-request/compare/v7.0.7...v7.0.8">https://github.com/peter-evans/create-pull-request/compare/v7.0.7...v7.0.8</a></p>
<h2>Create Pull Request v7.0.7</h2>
<p>⚙️ Fixes an issue with commit signing where modifications to the same file in multiple commits squash into the first commit.</p>
<h2>What's Changed</h2>
<ul>
<li>build(deps): bump <code>@​octokit/core</code> from 6.1.2 to 6.1.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3593">peter-evans/create-pull-request#3593</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.68 to 18.19.70 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3594">peter-evans/create-pull-request#3594</a></li>
<li>Update distribution by <a href="https://github.com/actions-bot"><code>@​actions-bot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3603">peter-evans/create-pull-request#3603</a></li>
<li>build(deps-dev): bump typescript from 5.7.2 to 5.7.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3610">peter-evans/create-pull-request#3610</a></li>
<li>build(deps): bump octokit dependencies by <a href="https://github.com/peter-evans"><code>@​peter-evans</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3618">peter-evans/create-pull-request#3618</a></li>
<li>docs: add workflow tip for showing message via workflow command by <a href="https://github.com/ybiquitous"><code>@​ybiquitous</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3626">peter-evans/create-pull-request#3626</a></li>
<li>build(deps-dev): bump eslint-plugin-prettier from 5.2.1 to 5.2.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3628">peter-evans/create-pull-request#3628</a></li>
<li>build(deps): bump node-fetch-native from 1.6.4 to 1.6.6 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3627">peter-evans/create-pull-request#3627</a></li>
<li>build(deps-dev): bump undici from 6.21.0 to 6.21.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3630">peter-evans/create-pull-request#3630</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.70 to 18.19.71 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3629">peter-evans/create-pull-request#3629</a></li>
<li>Update distribution by <a href="https://github.com/actions-bot"><code>@​actions-bot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3647">peter-evans/create-pull-request#3647</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.71 to 18.19.74 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3657">peter-evans/create-pull-request#3657</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.74 to 18.19.75 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3663">peter-evans/create-pull-request#3663</a></li>
<li>build(deps): bump <code>@​octokit/plugin-rest-endpoint-methods</code> from 13.3.0 to 13.3.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3670">peter-evans/create-pull-request#3670</a></li>
<li>build(deps-dev): bump prettier from 3.4.2 to 3.5.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3671">peter-evans/create-pull-request#3671</a></li>
<li>Update distribution by <a href="https://github.com/actions-bot"><code>@​actions-bot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3680">peter-evans/create-pull-request#3680</a></li>
<li>build(deps): bump <code>@​octokit/request-error</code> from 6.1.6 to 6.1.7 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3685">peter-evans/create-pull-request#3685</a></li>
<li>build(deps): bump <code>@​octokit/plugin-paginate-rest</code> from 11.4.0 to 11.4.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3688">peter-evans/create-pull-request#3688</a></li>
<li>build(deps): bump <code>@​octokit/endpoint</code> from 10.1.2 to 10.1.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3700">peter-evans/create-pull-request#3700</a></li>
<li>Update distribution by <a href="https://github.com/actions-bot"><code>@​actions-bot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3691">peter-evans/create-pull-request#3691</a></li>
<li>build(deps-dev): bump prettier from 3.5.0 to 3.5.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3709">peter-evans/create-pull-request#3709</a></li>
<li>build(deps-dev): bump eslint-import-resolver-typescript from 3.7.0 to 3.8.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3710">peter-evans/create-pull-request#3710</a></li>
<li>build(deps): bump <code>@​octokit/plugin-paginate-rest</code> from 11.4.1 to 11.4.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3713">peter-evans/create-pull-request#3713</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.75 to 18.19.76 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3712">peter-evans/create-pull-request#3712</a></li>
<li>build(deps): bump <code>@​octokit/core</code> from 6.1.3 to 6.1.4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3711">peter-evans/create-pull-request#3711</a></li>
<li>Update distribution by <a href="https://github.com/actions-bot"><code>@​actions-bot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3736">peter-evans/create-pull-request#3736</a></li>
<li>Use showFileAtRefBase64 to read per-commit file contents by <a href="https://github.com/grahamc"><code>@​grahamc</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3744">peter-evans/create-pull-request#3744</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/ybiquitous"><code>@​ybiquitous</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3626">peter-evans/create-pull-request#3626</a></li>
<li><a href="https://github.com/grahamc"><code>@​grahamc</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3744">peter-evans/create-pull-request#3744</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/peter-evans/create-pull-request/compare/v7.0.6...v7.0.7">https://github.com/peter-evans/create-pull-request/compare/v7.0.6...v7.0.7</a></p>
<h2>Create Pull Request v7.0.6</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/271a8d0340265f705b14b6d32b9829c1cb33d45e"><code>271a8d0</code></a> fix: suppress output for some git operations (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3776">#3776</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/6f7efd1c24d02e0d947dd3f6f9618019afb36781"><code>6f7efd1</code></a> test: update cpr-example-command</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/13c47c574799c8eb0a033eba252619135e70f392"><code>13c47c5</code></a> build(deps-dev): bump prettier from 3.5.1 to 3.5.2 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3754">#3754</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/63e58290d72e889603c931363c5169ba1bbe3fed"><code>63e5829</code></a> build(deps): bump <code>@​octokit/plugin-paginate-rest</code> from 11.4.2 to 11.4.3 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3753">#3753</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/a92c90fcab983421cc9bc736a06daea58c68d0db"><code>a92c90f</code></a> build(deps-dev): bump eslint-import-resolver-typescript (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3752">#3752</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/b23b62d48799ec46790610dd74b29cb9ba2eef30"><code>b23b62d</code></a> build(deps-dev): bump ts-jest from 29.2.5 to 29.2.6 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3751">#3751</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/dd2324fc52d5d43c699a5636bcf19fceaa70c284"><code>dd2324f</code></a> fix: use showFileAtRefBase64 to read per-commit file contents (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3744">#3744</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/367180cbdfa0448fc1ca9136e4adb020658cf4e5"><code>367180c</code></a> ci: remove testv5 cmd</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/25575a12f382fb9c68692ffce1174138b61417d7"><code>25575a1</code></a> build: update distribution (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3736">#3736</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/a56e7a56e9186132269996d8937494f12ff51f77"><code>a56e7a5</code></a> build(deps): bump <code>@​octokit/core</code> from 6.1.3 to 6.1.4 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3711">#3711</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/peter-evans/create-pull-request/compare/v3.10.0...271a8d0340265f705b14b6d32b9829c1cb33d45e">compare view</a></li>
</ul>
</details>
<br />

Updates `slackapi/slack-github-action` from 1.26.0 to 2.0.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/slackapi/slack-github-action/releases">slackapi/slack-github-action's releases</a>.</em></p>
<blockquote>
<h2>Slack Send v2.0.0</h2>
<p><strong>YAML! And more API methods! With improved erroring! And more!</strong></p>
<p>Sending data to Slack can now be done with the YAML format, and that data can be sent to [a Slack API method][methods] or <a href="https://github.com/slackapi/slack-github-action/tree/main#sending-techniques">technique of choice</a> with the provided payload. And additional configurations can improve error handling or customize values between steps.</p>
<p>Breaking changes happen with this update and recommended migration strategies are detailed below. Adding this step to new workflows might prefer to follow the <a href="https://github.com/slackapi/slack-github-action/tree/main#slack-send-github-action"><code>README</code></a> instead :books:</p>
<h2>What's changed</h2>
<p>Both inputs of payload variables, techniques for sending the payload, additional configurations, and expected outputs were changed:</p>
<ul>
<li><strong>Sending variables</strong>
<ul>
<li>Breaking changes
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#only-one-payload-input-can-be-provided">Only one payload input can be provided</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#only-one-technique-to-send-can-be-provided">Only one technique to send can be provided</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#variable-replacements-no-longer-happen-by-default">Variable replacements no longer happen by default</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#payload-file-path-parsed-option-was-removed">Payload file path parsed option was removed</a></li>
</ul>
</li>
<li>Enhancements
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#payloads-can-now-be-written-in-yaml">Payloads can now be written in YAML</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#payload-can-now-be-written-in-unwrapped-json">Payload can now be written in unwrapped JSON</a></li>
</ul>
</li>
</ul>
</li>
<li><strong>Sending techniques</strong>
<ul>
<li>Technique 1: Slack Workflow Builder
<ul>
<li>Breaking changes
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#the-webhook-type-must-be-specified-in-webhook-inputs">The webhook type must be specified in webhook inputs</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#payload-flattening-no-longer-happens-by-default">Payload flattening no longer happens by default</a></li>
</ul>
</li>
<li>Enhancements
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#the-webhook-url-can-be-specified-in-webhook-inputs">The webhook URL can be specified in webhook inputs</a></li>
</ul>
</li>
</ul>
</li>
<li>Technique 2: Slack API method
<ul>
<li>Breaking changes
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#the-slack-api-method-now-must-be-specified-in-inputs">The Slack API method now must be specified in inputs</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#a-token-must-be-provided-with-other-inputs">A token must be provided with other inputs</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#inputs-to-the-slack-api-method-must-be-provided-in-payloads">Inputs to the Slack API method must be provided in payloads</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#messages-cannot-be-sent-to-multiple-channels-in-one-step">Messages cannot be sent to multiple channels in one step</a></li>
</ul>
</li>
</ul>
</li>
<li>Technique 3: Slack incoming webhook
<ul>
<li>Breaking changes
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#the-webhook-type-must-be-specified-for-incoming-webhooks">The webhook type must be specified for incoming webhooks</a></li>
</ul>
</li>
<li>Enhancements
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#the-webhook-url-can-be-specified-for-incoming-webhooks">The webhook URL can be specified for incoming webhook</a></li>
</ul>
</li>
</ul>
</li>
</ul>
</li>
<li><strong>Additional configurations</strong>
<ul>
<li>Enhancements
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#steps-can-exit-with-an-error-after-a-failed-slack-api-call">Steps can exit with an error after a failed Slack API call</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#failed-requests-can-be-retried-various-amounts-of-times">Failed requests can be retried various amounts of times</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#provided-payloads-can-be-flattened-with-a-delimiter">Provided payloads can be flattened with a delimiter</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#provided-payloads-can-have-templated-variables-replaced">Provided payloads can have templated variables replaced</a></li>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#proxying-https-requests-can-be-done-within-inputs">Proxying HTTPS requests can be done within inputs</a></li>
</ul>
</li>
</ul>
</li>
<li><strong>Expected outputs</strong>
<ul>
<li>Breaking changes
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#the-time-value-is-now-returned-as-the-unix-epoch-time">The time value is now returned as the Unix epoch time</a></li>
</ul>
</li>
<li>Enhancements
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/blob/HEAD/#an-ok-value-is-added-to-represent-response-success">An ok value is added to represent response success</a></li>
</ul>
</li>
</ul>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/slackapi/slack-github-action/commit/485a9d42d3a73031f12ec201c457e2162c45d02d"><code>485a9d4</code></a> Release</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/e598089eaef53883a2d9b325e044899548518a03"><code>e598089</code></a> chore(release): tag version 2.0.0</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/e9b3a6beef047e819b8fb417da538f97a93a2ec8"><code>e9b3a6b</code></a> feat!: wrap payloads to send to a &quot;method&quot; with &quot;token&quot; or &quot;webhook&quot; (<a href="https://redirect.github.com/slackapi/slack-github-action/issues/333">#333</a>)</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/74ae656892e6e68e5168be5fb5fc1368a5569b3b"><code>74ae656</code></a> chore(release): tag version 1.27.1</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/bd0e2818bf5e26dd18c03ce249d01eceb8e1cb04"><code>bd0e281</code></a> build(deps): bump codecov/codecov-action from 4.5.0 to 4.6.0 (<a href="https://redirect.github.com/slackapi/slack-github-action/issues/355">#355</a>)</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/e1275295793d6d76cbc729c451b2e81dbf52ecaa"><code>e127529</code></a> build(deps): bump <code>@​actions/core</code> from 1.10.1 to 1.11.1 (<a href="https://redirect.github.com/slackapi/slack-github-action/issues/354">#354</a>)</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/6b51022aeafdaaaccae849ca0a1b963ed597bf1f"><code>6b51022</code></a> build(deps-dev): bump eslint-plugin-jsdoc from 50.3.1 to 50.4.3 (<a href="https://redirect.github.com/slackapi/slack-github-action/issues/353">#353</a>)</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/555e4ad8ef03a28151a2332aeba97ed5e3aeea37"><code>555e4ad</code></a> build(deps-dev): bump eslint-plugin-import from 2.30.0 to 2.31.0 (<a href="https://redirect.github.com/slackapi/slack-github-action/issues/352">#352</a>)</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/8d4500e89ea2d0c66975b82ebffbca9da18ecefc"><code>8d4500e</code></a> build(deps): bump <code>@​slack/web-api</code> from 7.5.0 to 7.7.0 (<a href="https://redirect.github.com/slackapi/slack-github-action/issues/351">#351</a>)</li>
<li><a href="https://github.com/slackapi/slack-github-action/commit/d0dece60f0be2ec50f76b5de480d355c020cd2e1"><code>d0dece6</code></a> build(deps-dev): bump mocha from 10.7.3 to 10.8.2 (<a href="https://redirect.github.com/slackapi/slack-github-action/issues/350">#350</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/slackapi/slack-github-action/compare/70cd7be8e40a46e8b0eced40b0de447bdb42f68e...485a9d42d3a73031f12ec201c457e2162c45d02d">compare view</a></li>
</ul>
</details>
<br />

Updates `github/codeql-action` from 2.28.1 to 3.28.12
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/github/codeql-action/releases">github/codeql-action's releases</a>.</em></p>
<blockquote>
<h2>v3.28.12</h2>
<h1>CodeQL Action Changelog</h1>
<p>See the <a href="https://github.com/github/codeql-action/releases">releases page</a> for the relevant changes to the CodeQL CLI and language packs.</p>
<h2>3.28.12 - 19 Mar 2025</h2>
<ul>
<li>Dependency caching should now cache more dependencies for Java <code>build-mode: none</code> extractions. This should speed up workflows and avoid inconsistent alerts in some cases.</li>
<li>Update default CodeQL bundle version to 2.20.7. <a href="https://redirect.github.com/github/codeql-action/pull/2810">#2810</a></li>
</ul>
<p>See the full <a href="https://github.com/github/codeql-action/blob/v3.28.12/CHANGELOG.md">CHANGELOG.md</a> for more information.</p>
<h2>v3.28.11</h2>
<h1>CodeQL Action Changelog</h1>
<p>See the <a href="https://github.com/github/codeql-action/releases">releases page</a> for the relevant changes to the CodeQL CLI and language packs.</p>
<h2>3.28.11 - 07 Mar 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.6. <a href="https://redirect.github.com/github/codeql-action/pull/2793">#2793</a></li>
</ul>
<p>See the full <a href="https://github.com/github/codeql-action/blob/v3.28.11/CHANGELOG.md">CHANGELOG.md</a> for more information.</p>
<h2>v3.28.10</h2>
<h1>CodeQL Action Changelog</h1>
<p>See the <a href="https://github.com/github/codeql-action/releases">releases page</a> for the relevant changes to the CodeQL CLI and language packs.</p>
<h2>3.28.10 - 21 Feb 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.5. <a href="https://redirect.github.com/github/codeql-action/pull/2772">#2772</a></li>
<li>Address an issue where the CodeQL Bundle would occasionally fail to decompress on macOS. <a href="https://redirect.github.com/github/codeql-action/pull/2768">#2768</a></li>
</ul>
<p>See the full <a href="https://github.com/github/codeql-action/blob/v3.28.10/CHANGELOG.md">CHANGELOG.md</a> for more information.</p>
<h2>v3.28.9</h2>
<h1>CodeQL Action Changelog</h1>
<p>See the <a href="https://github.com/github/codeql-action/releases">releases page</a> for the relevant changes to the CodeQL CLI and language packs.</p>
<h2>3.28.9 - 07 Feb 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.4. <a href="https://redirect.github.com/github/codeql-action/pull/2753">#2753</a></li>
</ul>
<p>See the full <a href="https://github.com/github/codeql-action/blob/v3.28.9/CHANGELOG.md">CHANGELOG.md</a> for more information.</p>
<h2>v3.28.8</h2>
<h1>CodeQL Action Changelog</h1>
<p>See the <a href="https://github.com/github/codeql-action/releases">releases page</a> for the relevant changes to the CodeQL CLI and language packs.</p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/github/codeql-action/blob/main/CHANGELOG.md">github/codeql-action's changelog</a>.</em></p>
<blockquote>
<h1>CodeQL Action Changelog</h1>
<p>See the <a href="https://github.com/github/codeql-action/releases">releases page</a> for the relevant changes to the CodeQL CLI and language packs.</p>
<h2>[UNRELEASED]</h2>
<p>No user facing changes.</p>
<h2>3.28.12 - 19 Mar 2025</h2>
<ul>
<li>Dependency caching should now cache more dependencies for Java <code>build-mode: none</code> extractions. This should speed up workflows and avoid inconsistent alerts in some cases.</li>
<li>Update default CodeQL bundle version to 2.20.7. <a href="https://redirect.github.com/github/codeql-action/pull/2810">#2810</a></li>
</ul>
<h2>3.28.11 - 07 Mar 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.6. <a href="https://redirect.github.com/github/codeql-action/pull/2793">#2793</a></li>
</ul>
<h2>3.28.10 - 21 Feb 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.5. <a href="https://redirect.github.com/github/codeql-action/pull/2772">#2772</a></li>
<li>Address an issue where the CodeQL Bundle would occasionally fail to decompress on macOS. <a href="https://redirect.github.com/github/codeql-action/pull/2768">#2768</a></li>
</ul>
<h2>3.28.9 - 07 Feb 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.4. <a href="https://redirect.github.com/github/codeql-action/pull/2753">#2753</a></li>
</ul>
<h2>3.28.8 - 29 Jan 2025</h2>
<ul>
<li>Enable support for Kotlin 2.1.10 when running with CodeQL CLI v2.20.3. <a href="https://redirect.github.com/github/codeql-action/pull/2744">#2744</a></li>
</ul>
<h2>3.28.7 - 29 Jan 2025</h2>
<p>No user facing changes.</p>
<h2>3.28.6 - 27 Jan 2025</h2>
<ul>
<li>Re-enable debug artifact upload for CLI versions 2.20.3 or greater. <a href="https://redirect.github.com/github/codeql-action/pull/2726">#2726</a></li>
</ul>
<h2>3.28.5 - 24 Jan 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.3. <a href="https://redirect.github.com/github/codeql-action/pull/2717">#2717</a></li>
</ul>
<h2>3.28.4 - 23 Jan 2025</h2>
<p>No user facing changes.</p>
<h2>3.28.3 - 22 Jan 2025</h2>
<ul>
<li>Update default CodeQL bundle version to 2.20.2. <a href="https://redirect.github.com/github/codeql-action/pull/2707">#2707</a></li>
<li>Fix an issue downloading the CodeQL Bundle from a GitHub Enterprise Server instance which occurred when the CodeQL Bundle had been synced to the instance using the <a href="https://github.com/github/codeql-action-sync-tool">CodeQL Action sync tool</a> and the Actions runner did not have Zstandard installed. <a href="https://redirect.github.com/github/codeql-action/pull/2710">#2710</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/github/codeql-action/commit/5f8171a638ada777af81d42b55959a643bb29017"><code>5f8171a</code></a> Merge pull request <a href="https://redirect.github.com/github/codeql-action/issues/2814">#2814</a> from github/update-v3.28.12-6349095d1</li>
<li><a href="https://github.com/github/codeql-action/commit/bb59f7707d836b040802dbdf2ad1a16482d319da"><code>bb59f77</code></a> Update changelog for v3.28.12</li>
<li><a href="https://github.com/github/codeql-action/commit/6349095d19ec30397ffb02a63b7aa4f867deb563"><code>6349095</code></a> Merge pull request <a href="https://redirect.github.com/github/codeql-action/issues/2810">#2810</a> from github/update-bundle/codeql-bundle-v2.20.7</li>
<li><a href="https://github.com/github/codeql-action/commit/d7d03fda1241f6b0b3fae460c9f19c6e887158ad"><code>d7d03fd</code></a> Add changelog note</li>
<li><a href="https://github.com/github/codeql-action/commit/4e3a5342c5e8e627915b9a29b363f49da8c4a32e"><code>4e3a534</code></a> Update default bundle to codeql-bundle-v2.20.7</li>
<li><a href="https://github.com/github/codeql-action/commit/55f023701cfc1e7d11ef2ae0c5ec3193dae4fce4"><code>55f0237</code></a> Merge pull request <a href="https://redirect.github.com/github/codeql-action/issues/2802">#2802</a> from github/mbg/dependency-caching/java-buildless</li>
<li><a href="https://github.com/github/codeql-action/commit/6a151cd77488e58567da1dcf953e7aeeaca4950c"><code>6a151cd</code></a> Merge pull request <a href="https://redirect.github.com/github/codeql-action/issues/2811">#2811</a> from github/dependabot/github_actions/actions-c2c311...</li>
<li><a href="https://github.com/github/codeql-action/commit/7866bcdb1b15b5d5cba0021b87f36d9f6d977156"><code>7866bcd</code></a> Manually bump workflow to match autogenerated file</li>
<li><a href="https://github.com/github/codeql-action/commit/611289e0b0ce1f6fc14820f1b72edaed2de4ba2c"><code>611289e</code></a> build(deps): bump ruby/setup-ruby in the actions group</li>
<li><a href="https://github.com/github/codeql-action/commit/4c409a5b664afa7d5b12cd8487e310f286487472"><code>4c409a5</code></a> Remove temporary dependency directory in <code>analyze</code> post action</li>
<li>Additional commits viewable in <a href="https://github.com/github/codeql-action/compare/b8d3b6e8af63cde30bdc382c0bc28114f4346c88...5f8171a638ada777af81d42b55959a643bb29017">compare view</a></li>
</ul>
</details>
<br />

Updates `softprops/action-gh-release` from 1 to 2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/softprops/action-gh-release/releases">softprops/action-gh-release's releases</a>.</em></p>
<blockquote>
<h2>v2.0.0</h2>
<ul>
<li>update actions.yml declaration to node20 to address warnings</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/softprops/action-gh-release/blob/master/CHANGELOG.md">softprops/action-gh-release's changelog</a>.</em></p>
<blockquote>
<h2>2.2.1</h2>
<h2>What's Changed</h2>
<h3>Bug fixes 🐛</h3>
<ul>
<li>fix: big file uploads by <a href="https://github.com/xen0n"><code>@​xen0n</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/562">softprops/action-gh-release#562</a></li>
</ul>
<h3>Other Changes 🔄</h3>
<ul>
<li>chore(deps): bump <code>@​types/node</code> from 22.10.1 to 22.10.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/559">softprops/action-gh-release#559</a></li>
<li>chore(deps): bump <code>@​types/node</code> from 22.10.2 to 22.10.5 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/569">softprops/action-gh-release#569</a></li>
<li>chore: update error and warning messages for not matching files in files field by <a href="https://github.com/ytimocin"><code>@​ytimocin</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/568">softprops/action-gh-release#568</a></li>
</ul>
<h2>2.2.0</h2>
<h2>What's Changed</h2>
<h3>Exciting New Features 🎉</h3>
<ul>
<li>feat: read the release assets asynchronously by <a href="https://github.com/xen0n"><code>@​xen0n</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/552">softprops/action-gh-release#552</a></li>
</ul>
<h3>Bug fixes 🐛</h3>
<ul>
<li>fix(docs): clarify the default for tag_name by <a href="https://github.com/alexeagle"><code>@​alexeagle</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/544">softprops/action-gh-release#544</a></li>
</ul>
<h3>Other Changes 🔄</h3>
<ul>
<li>chore(deps): bump typescript from 5.6.3 to 5.7.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/548">softprops/action-gh-release#548</a></li>
<li>chore(deps): bump <code>@​types/node</code> from 22.9.0 to 22.9.4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/547">softprops/action-gh-release#547</a></li>
<li>chore(deps): bump cross-spawn from 7.0.3 to 7.0.6 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/545">softprops/action-gh-release#545</a></li>
<li>chore(deps): bump <code>@​vercel/ncc</code> from 0.38.2 to 0.38.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/543">softprops/action-gh-release#543</a></li>
<li>chore(deps): bump prettier from 3.3.3 to 3.4.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/550">softprops/action-gh-release#550</a></li>
<li>chore(deps): bump <code>@​types/node</code> from 22.9.4 to 22.10.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/551">softprops/action-gh-release#551</a></li>
<li>chore(deps): bump prettier from 3.4.1 to 3.4.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/554">softprops/action-gh-release#554</a></li>
</ul>
<h2>2.1.0</h2>
<h2>What's Changed</h2>
<h3>Exciting New Features 🎉</h3>
<ul>
<li>feat: add support for release assets with multiple spaces within the name by <a href="https://github.com/dukhine"><code>@​dukhine</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/518">softprops/action-gh-release#518</a></li>
<li>feat: preserve upload order by <a href="https://github.com/richarddd"><code>@​richarddd</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/500">softprops/action-gh-release#500</a></li>
</ul>
<h3>Other Changes 🔄</h3>
<ul>
<li>chore(deps): bump <code>@​types/node</code> from 22.8.2 to 22.8.7 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/softprops/action-gh-release/pull/539">softprops/action-gh-release#539</a></li>
</ul>
<h2>2.0.9</h2>
<ul>
<li>maintenance release with updated dependencies</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/softprops/action-gh-release/commit/c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda"><code>c95fe14</code></a> release 2.2.1</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/deddb09c649128250e79ebf595ae168f5f302345"><code>deddb09</code></a> fix: big file uploads (<a href="https://redirect.github.com/softprops/action-gh-release/issues/562">#562</a>)</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/33fcd69d45750cc90b61169c42f09eb1746d1aa6"><code>33fcd69</code></a> chore: update error and warning messages for not matching files in files fiel...</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/01050bd877daa443ee33099556bc8ad4fb2f8191"><code>01050bd</code></a> chore(deps): bump <code>@​types/node</code> from 22.10.2 to 22.10.5 (<a href="https://redirect.github.com/softprops/action-gh-release/issues/569">#569</a>)</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/92dffe6c28ac278510d01d723882bf82bd907f89"><code>92dffe6</code></a> chore(deps): bump <code>@​types/node</code> from 22.10.1 to 22.10.2 (<a href="https://redirect.github.com/softprops/action-gh-release/issues/559">#559</a>)</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/7b4da11513bf3f43f9999e90eabced41ab8bb048"><code>7b4da11</code></a> release 2.2.0</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/64f1fa19ef459b1f7a022d7e159cb9131810c277"><code>64f1fa1</code></a> feat: read the release assets asynchronously (<a href="https://redirect.github.com/softprops/action-gh-release/issues/552">#552</a>)</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/9e35a64dfd1e0667392cb69005a3f9fa5ff84bf3"><code>9e35a64</code></a> chore(deps): bump prettier from 3.4.1 to 3.4.2 (<a href="https://redirect.github.com/softprops/action-gh-release/issues/554">#554</a>)</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/92bc83c4214f780e84c7d2a85464a2ca05ebc2f0"><code>92bc83c</code></a> chore(deps): bump <code>@​types/node</code> from 22.9.4 to 22.10.1 (<a href="https://redirect.github.com/softprops/action-gh-release/issues/551">#551</a>)</li>
<li><a href="https://github.com/softprops/action-gh-release/commit/09f0e372033d09fffd26c136ef4c0fd905dfdc84"><code>09f0e37</code></a> chore(deps): bump prettier from 3.3.3 to 3.4.1 (<a href="https://redirect.github.com/softprops/action-gh-release/issues/550">#550</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/softprops/action-gh-release/compare/de2c0eb89ae2a093876385947365aca7b0e5f844...c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda">compare view</a></li>
</ul>
</details>
<br />

Updates `docker/setup-qemu-action` from 2.2.0 to 3.6.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/docker/setup-qemu-action/releases">docker/setup-qemu-action's releases</a>.</em></p>
<blockquote>
<h2>v3.6.0</h2>
<ul>
<li>Display binfmt version by <a href="https://github.com/crazy-max"><code>@​crazy-max</code></a> in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/202">docker/setup-qemu-action#202</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/docker/setup-qemu-action/compare/v3.5.0...v3.6.0">https://github.com/docker/setup-qemu-action/compare/v3.5.0...v3.6.0</a></p>
<h2>v3.5.0</h2>
<ul>
<li>Bump <code>@​docker/actions-toolkit</code> from 0.54.0 to 0.56.0 in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/205">docker/setup-qemu-action#205</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/docker/setup-qemu-action/compare/v3.4.0...v3.5.0">https://github.com/docker/setup-qemu-action/compare/v3.4.0...v3.5.0</a></p>
<h2>v3.4.0</h2>
<ul>
<li>Bump <code>@​docker/actions-toolkit</code> from 0.49.0 to 0.54.0 in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/193">docker/setup-qemu-action#193</a> <a href="https://redirect.github.com/docker/setup-qemu-action/pull/197">docker/setup-qemu-action#197</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/docker/setup-qemu-action/compare/v3.3.0...v3.4.0">https://github.com/docker/setup-qemu-action/compare/v3.3.0...v3.4.0</a></p>
<h2>v3.3.0</h2>
<ul>
<li>Add <code>cache-image</code> input to enable/disable caching of binfmt image by <a href="https://github.com/crazy-max"><code>@​crazy-max</code></a> in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/130">docker/setup-qemu-action#130</a></li>
<li>Bump <code>@​actions/core</code> from 1.10.1 to 1.11.1 in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/172">docker/setup-qemu-action#172</a></li>
<li>Bump <code>@​docker/actions-toolkit</code> from 0.35.0 to 0.49.0 in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/187">docker/setup-qemu-action#187</a></li>
<li>Bump cross-spawn from 7.0.3 to 7.0.6 in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/182">docker/setup-qemu-action#182</a></li>
<li>Bump path-to-regexp from 6.2.2 to 6.3.0 in <a href="https://redirect.github.com/docker/setup-qemu-action/pull/162">docker/setup-qemu-action#162</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/docker/setup-qemu-action/compare/v3.2.0...v3.3.0">https://github.com/docker/setup-qemu-action/compare/v3.2.0...v3.3.0</a></p>
<...

_Description has been truncated_

> **Note**
> Automatic rebases have been disabled on this pull request as it has been open for over 30 days.
