### PR TITLE
Remove deprecated field in `datadog-static-analyzer-github-action`

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       actions: read # read secrets
       contents: read
-      statuses: write # add status checks (?) 
+      statuses: write # add status checks (?)
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -18,8 +18,6 @@ jobs:
         with:
           dd_api_key: ${{ secrets.DD_API_KEY }}
           dd_app_key: ${{ secrets.DD_APP_KEY }}
-          dd_service: dd-trace-dotnet
           dd_site: datadoghq.com
-          dd_env: ci
           cpu_count: 2
-          
+


### PR DESCRIPTION
## Summary of changes

Removes [deprecated fields](https://github.com/DataDog/datadog-static-analyzer-github-action#deprecated-inputs) in the [datadog-static-analyzer-github-action](https://github.com/DataDog/datadog-static-analyzer-github-action)

## Reason for change

The field is deprecated

## Implementation details

2 Input fields to GH action were removed


## Test coverage

## Other details

Clone of 
- https://github.com/DataDog/dd-trace-dotnet/pull/6639