### PR TITLE
Update Serverless teams in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,11 +128,14 @@ fault_tolerant_*.h                         @DataDog/debugger-dotnet
 /tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs   @DataDog/debugger-dotnet
 Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 
+# Serverless (General)
+/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/  @DataDog/tracing-dotnet @DataDog/apm-serverless
+
 # Serverless (AWS)
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/                     @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 /tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaMetadata.cs  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/                       @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/test/test-applications/integrations/Samples.AWS.Lambda/                    @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/test-applications/integrations/Samples.AWS.*/                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 /tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 docker-compose.serverless.yml                                                      @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,14 +134,19 @@ Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 # Serverless (AWS)
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/                     @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 /tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaMetadata.cs  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsServerlessTests.cs    @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/                       @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 /tracer/test/test-applications/integrations/Samples.AWS.*/                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 /tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 docker-compose.serverless.yml                                                      @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/build/_build/docker/serverless.lambda.dockerfile                           @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/.gitlab/download-serverless-artifacts.sh                                          @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/docs/development/Serverless.md                                                    @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 
 # Serverless (Azure/GCP)
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp
 /tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/ServerlessMiniAgent.cs   @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp
+/tracer/test/Datadog.Trace.Tests/ServerlessMiniAgentTests.cs                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp
 /tracer/test/test-applications/azure-functions/                                          @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp
 
 # Shared code we could move to the root folder

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,15 +128,18 @@ fault_tolerant_*.h                         @DataDog/debugger-dotnet
 /tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs   @DataDog/debugger-dotnet
 Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 
-# Serverless
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/   @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/       @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/test-applications/azure-functions/                    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/test-applications/integrations/Samples.AWS.Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/        @DataDog/tracing-dotnet  @DataDog/serverless-aws
-docker-compose.serverless.yml                                      @DataDog/tracing-dotnet  @DataDog/serverless-aws
+# Serverless (AWS)
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/
+/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaMetadata.cs  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/                       @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/test-applications/integrations/Samples.AWS.Lambda/                    @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+docker-compose.serverless.yml                                                      @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+
+# Serverless (Azure/GCP)
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp
+/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/ServerlessMiniAgent.cs   @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp
+/tracer/test/test-applications/azure-functions/                                          @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp
 
 # Shared code we could move to the root folder
 /tracer/build/                            @DataDog/apm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -129,19 +129,19 @@ fault_tolerant_*.h                         @DataDog/debugger-dotnet
 Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 
 # Serverless (General)
-/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/  @DataDog/tracing-dotnet @DataDog/apm-serverless
+/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/                         @DataDog/tracing-dotnet @DataDog/apm-serverless
 
 # Serverless (AWS)
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/                     @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaMetadata.cs  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsServerlessTests.cs    @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/                       @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/test/test-applications/integrations/Samples.AWS.*/                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-docker-compose.serverless.yml                                                      @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/build/_build/docker/serverless.lambda.dockerfile                           @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/.gitlab/download-serverless-artifacts.sh                                          @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/docs/development/Serverless.md                                                    @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/                           @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaMetadata.cs        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsServerlessTests.cs          @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/test-applications/integrations/Samples.AWS.*/                               @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+docker-compose.serverless.yml                                                            @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/build/_build/docker/serverless.lambda.dockerfile                                 @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/.gitlab/download-serverless-artifacts.sh                                                @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/docs/development/Serverless.md                                                          @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
 
 # Serverless (Azure/GCP)
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-gcp


### PR DESCRIPTION
## Summary of changes

Update `CODEOWNERS` for serverless-related files.

## Reason for change

Recent team changes.

## Implementation details

- add team `apm-serverless` to all serverless files
- use team `serverless-azure-gcp` instead of `serverless-aws` for Azure-related files
- added serverless-related files that were missing

## Test coverage

n/a

## Other details
n/a
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
