### PR TITLE
[Dynamic Instrumentation] DEBUG-3796 Fix rate limiting for probes that don't have limit

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
@@ -418,7 +418,7 @@ internal class ProbeExpressionEvaluator
             }
             else
             {
-                when = current.Key == null // span decoration doesn't must to have a condition
+                when = current.Key == null // span decoration doesn't must have a condition
                            ? new CompiledExpression<bool>((_, _, _, _, _) => true, null, null, null)
                            : ProbeExpressionParser<bool>.ParseExpression(current.Key.Value.Json, scopeMembers);
             }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Debugger.Expressions
 {
@@ -54,6 +55,11 @@ namespace Datadog.Trace.Debugger.Expressions
             catch (Exception e)
             {
                 Log.Error(e, "Failed to create probe processor for probe: {Id}", probe.Id);
+            }
+
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug("Successfully created probe processor for probe: {Id}", probe.Id);
                 Log.Debug("Probe definition is {Probe}", JsonConvert.SerializeObject(probe));
             }
         }

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -239,6 +239,7 @@ namespace Datadog.Trace.Debugger
                                     fetchProbeStatus.Add(new FetchProbeStatus(probe.Id, probe.Version ?? 0, new ProbeStatus(probe.Id, Sink.Models.Status.RECEIVED, errorMessage: null)));
                                     break;
                                 case LiveProbeResolveStatus.Error:
+                                    Log.Warning("ProbeID {ProbeID} error resolving live. Error: {Error}", probe.Id, message);
                                     fetchProbeStatus.Add(new FetchProbeStatus(probe.Id, probe.Version ?? 0, new ProbeStatus(probe.Id, Sink.Models.Status.ERROR, errorMessage: message)));
                                     break;
                             }
@@ -295,7 +296,7 @@ namespace Datadog.Trace.Debugger
                 case LogProbe logProbe:
                     ProbeRateLimiter.Instance.SetRate(probe.Id, logProbe.CaptureSnapshot ? 1 : 5000);
                     break;
-                case SpanDecorationProbe or MetricProbe:
+                case SpanDecorationProbe or MetricProbe or SpanProbe:
                     ProbeRateLimiter.Instance.TryAddSampler(probe.Id, NopAdaptiveSampler.Instance);
                     break;
             }

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -296,7 +296,7 @@ namespace Datadog.Trace.Debugger
                 case LogProbe logProbe:
                     ProbeRateLimiter.Instance.SetRate(probe.Id, logProbe.CaptureSnapshot ? 1 : 5000);
                     break;
-                case SpanDecorationProbe or MetricProbe or SpanProbe:
+                case SpanDecorationProbe or MetricProbe:
                     ProbeRateLimiter.Instance.TryAddSampler(probe.Id, NopAdaptiveSampler.Instance);
                     break;
             }

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -25,6 +25,7 @@ using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Vendors.Serilog.Events;
 using Datadog.Trace.Vendors.StatsdClient;
 using ProbeInfo = Datadog.Trace.Debugger.Expressions.ProbeInfo;
 
@@ -286,18 +287,17 @@ namespace Datadog.Trace.Debugger
 
         private static void SetRateLimit(ProbeDefinition probe)
         {
-            if (probe is not LogProbe logProbe)
+            switch (probe)
             {
-                return;
-            }
-
-            if (logProbe.Sampling is { } sampling)
-            {
-                ProbeRateLimiter.Instance.SetRate(probe.Id, (int)sampling.SnapshotsPerSecond);
-            }
-            else
-            {
-                ProbeRateLimiter.Instance.SetRate(probe.Id, logProbe.CaptureSnapshot ? 1 : 5000);
+                case LogProbe { Sampling: { } sampling }:
+                    ProbeRateLimiter.Instance.SetRate(probe.Id, (int)sampling.SnapshotsPerSecond);
+                    break;
+                case LogProbe logProbe:
+                    ProbeRateLimiter.Instance.SetRate(probe.Id, logProbe.CaptureSnapshot ? 1 : 5000);
+                    break;
+                case SpanDecorationProbe or MetricProbe:
+                    ProbeRateLimiter.Instance.TryAddSampler(probe.Id, NopAdaptiveSampler.Instance);
+                    break;
             }
         }
 
@@ -516,6 +516,11 @@ namespace Datadog.Trace.Debugger
                     throw new ArgumentOutOfRangeException(
                         nameof(metricKind),
                         $"{metricKind} is not a valid value");
+            }
+
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug("Successfully sent metric {Metric}. ProbeId={ProbeId}", metricName, probeId);
             }
 
             SetProbeStatusToEmitting(probe);


### PR DESCRIPTION
## Summary of changes
Fix issue that cause span decoration probes to not proceed due a sampler.

## Implementation details
Span decoration probes (also metric probe) should not use the default rate limit. Currently, we don't add any limit when creating the probe, but during the processing of the probe, we are trying the get the probe metadata for that specific probe instance and when we can't find sampling, we are creatin gone with default limit. This PR fix that by providing a not limit sampler for those probes.