### PR TITLE
Fayssal/update bp infra

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -7,7 +7,7 @@
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
 
 stages:
-  - infra-update
+  # - infra-update
   - check-azure-pipeline
   - benchmarks
   - benchmarks-win
@@ -36,40 +36,40 @@ check_azure_pipeline:
   variables:
     TEST_BRANCH: "master"
 
-update-bp-infra:
-  stage: infra-update
-  tags: ["arch:amd64"]
-  interruptible: false
-  timeout: 3h
-  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
+# update-bp-infra:
+#   stage: infra-update
+#   tags: ["arch:amd64"]
+#   interruptible: false
+#   timeout: 3h
+#   # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+#   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
-  script:
-    - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-    - mkdir -p ~/.aws
-    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
-    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
-    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
-    - export AWS_PROFILE=ephemeral-infra-ci
-    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
-    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-    - infra launch --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
-  after_script:
-    - !reference [.setup, script]
-    - |
-      infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
-        --region "${AWS_REGION}" \
-        --bypass-stack-destroy
-  rules:
-    - when: manual
-  variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-    AWS_REGION: "us-east-1"
-    CLEANUP: "false"
-    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
-    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
-    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
-    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
+#   script:
+#     - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+#     - mkdir -p ~/.aws
+#     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+#     - export AWS_PROFILE=ephemeral-infra-ci
+#     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+#     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+#     - infra launch --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+#   after_script:
+#     - !reference [.setup, script]
+#     - |
+#       infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
+#         --region "${AWS_REGION}" \
+#         --bypass-stack-destroy
+#   rules:
+#     - when: manual
+#   variables:
+#     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+#     AWS_REGION: "us-east-1"
+#     CLEANUP: "false"
+#     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+#     AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+#     AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+#     AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 .benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -46,7 +46,7 @@ update-bp-infra:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
   script:
-    - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
     - mkdir -p ~/.aws
     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
@@ -492,7 +492,7 @@ profiler_cpu_timer_create-arm64:
   script:
     - source build-id.txt
     - echo "Building for the following build https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId&view=results"
-    - export BP_INFRA_BENCHMARKING_PLATFORM_BRANCH=fayssal/update-bp-infra-dotnet-macro
+    - export BP_INFRA_BENCHMARKING_PLATFORM_BRANCH=dd-trace-dotnet/macro
     - git clone --branch $BP_INFRA_BENCHMARKING_PLATFORM_BRANCH https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./ephemeral-infra/run-windows-benchmarks.sh
   after_script:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -5,7 +5,7 @@
     - export AWS_PROFILE=ephemeral-infra-ci
     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-    
+
 stages:
   - infra-update
   - check-azure-pipeline
@@ -13,7 +13,7 @@ stages:
   - benchmarks-win
 
 variables:
-  MACROBENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dotnet-throughput-2
+  MACROBENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dotnet-throughput-3
 
 check_azure_pipeline:
   stage: check-azure-pipeline
@@ -33,6 +33,8 @@ check_azure_pipeline:
   timeout: 1h
   rules:
     - when: manual
+  variables:
+    TEST_BRANCH: "master"
 
 update-bp-infra:
   stage: infra-update

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -7,7 +7,7 @@
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
 
 stages:
-  # - infra-update
+  - infra-update
   - check-azure-pipeline
   - benchmarks
   - benchmarks-win
@@ -36,40 +36,40 @@ check_azure_pipeline:
   variables:
     TEST_BRANCH: "master"
 
-# update-bp-infra:
-#   stage: infra-update
-#   tags: ["arch:amd64"]
-#   interruptible: false
-#   timeout: 3h
-#   # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
-#   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
+update-bp-infra:
+  stage: infra-update
+  tags: ["arch:amd64"]
+  interruptible: false
+  timeout: 3h
+  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
-#   script:
-#     - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-#     - mkdir -p ~/.aws
-#     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
-#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
-#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
-#     - export AWS_PROFILE=ephemeral-infra-ci
-#     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
-#     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-#     - infra launch --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
-#   after_script:
-#     - !reference [.setup, script]
-#     - |
-#       infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
-#         --region "${AWS_REGION}" \
-#         --bypass-stack-destroy
-#   rules:
-#     - when: manual
-#   variables:
-#     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-#     AWS_REGION: "us-east-1"
-#     CLEANUP: "false"
-#     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
-#     AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
-#     AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
-#     AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
+  script:
+    - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - mkdir -p ~/.aws
+    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+    - export AWS_PROFILE=ephemeral-infra-ci
+    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+    - infra launch --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+  # after_script:
+  #   - !reference [.setup, script]
+  #   - |
+  #     infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
+  #       --region "${AWS_REGION}" \
+  #       --bypass-stack-destroy
+  rules:
+    - when: manual
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    AWS_REGION: "us-east-1"
+    CLEANUP: "false"
+    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 .benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -21,13 +21,6 @@ check_azure_pipeline:
   script:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./wait-for-pipeline.sh
-  artifacts:
-    name: "artifacts"
-    when: always
-    paths:
-      - artifacts/
-      - build-id.txt
-    expire_in: 3 months
   interruptible: true
   tags: ["arch:amd64"]
   timeout: 1h
@@ -93,12 +86,6 @@ update-bp-infra:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./steps/setup-sut.sh
     - bp-runner bp-runner.yml --debug
-  artifacts:
-    name: "artifacts"
-    when: always
-    paths:
-      - artifacts/
-    expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
@@ -277,12 +264,6 @@ profiler_cpu_timer_create:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./steps/setup-sut.sh
     - bp-runner bp-runner.arm.yml --debug
-  artifacts:
-    name: "artifacts"
-    when: always
-    paths:
-      - artifacts/
-    expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
@@ -458,12 +439,6 @@ profiler_cpu_timer_create-arm64:
   timeout: 1h
   rules:
     - when: on_success
-  artifacts:
-    name: "artifacts"
-    when: always
-    paths:
-      - artifacts/
-    expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -7,7 +7,7 @@
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
 
 stages:
-  # - infra-update
+  - infra-update
   - check-azure-pipeline
   - benchmarks
   - benchmarks-win
@@ -36,40 +36,41 @@ check_azure_pipeline:
   variables:
     TEST_BRANCH: "master"
 
-# update-bp-infra:
-#   stage: infra-update
-#   tags: ["arch:amd64"]
-#   interruptible: false
-#   timeout: 3h
-#   # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
-#   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
+update-bp-infra:
+  stage: infra-update
+  tags: ["arch:amd64"]
+  interruptible: false
+  timeout: 3h
+  allow_failure: true
+  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
-#   script:
-#     - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-#     - mkdir -p ~/.aws
-#     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
-#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
-#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
-#     - export AWS_PROFILE=ephemeral-infra-ci
-#     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
-#     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-#     - infra launch --no-cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
-#   # after_script:
-#   #   - !reference [.setup, script]
-#   #   - |
-#   #     infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
-#   #       --region "${AWS_REGION}" \
-#   #       --bypass-stack-destroy
-#   rules:
-#     - when: manual
-#   variables:
-#     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-#     AWS_REGION: "us-east-1"
-#     CLEANUP: "false"
-#     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
-#     AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
-#     AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
-#     AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
+  script:
+    - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - mkdir -p ~/.aws
+    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+    - export AWS_PROFILE=ephemeral-infra-ci
+    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+    - infra launch --no-cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+  after_script:
+    - !reference [.setup, script]
+    - |
+      infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
+        --region "${AWS_REGION}" \
+        --bypass-stack-destroy
+  rules:
+    - when: manual
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    AWS_REGION: "us-east-1"
+    CLEANUP: "false"
+    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 .benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -491,7 +491,7 @@ profiler_cpu_timer_create-arm64:
   script:
     - source build-id.txt
     - echo "Building for the following build https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId&view=results"
-    - export BP_INFRA_BENCHMARKING_PLATFORM_BRANCH=dd-trace-dotnet/macro
+    - export BP_INFRA_BENCHMARKING_PLATFORM_BRANCH=fayssal/update-bp-infra-dotnet-macro
     - git clone --branch $BP_INFRA_BENCHMARKING_PLATFORM_BRANCH https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./ephemeral-infra/run-windows-benchmarks.sh
   after_script:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -1,4 +1,13 @@
+.setup:
+  script:
+    - mkdir -p ~/.aws
+    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER > ~/.aws/config || exit $?
+    - export AWS_PROFILE=ephemeral-infra-ci
+    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+    
 stages:
+  - infra-update
   - check-azure-pipeline
   - benchmarks
   - benchmarks-win
@@ -23,7 +32,42 @@ check_azure_pipeline:
   tags: ["arch:amd64"]
   timeout: 1h
   rules:
-    - when: on_success
+    - when: manual
+
+update-bp-infra:
+  stage: infra-update
+  tags: ["arch:amd64"]
+  interruptible: false
+  timeout: 3h
+  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
+
+  script:
+    - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - mkdir -p ~/.aws
+    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+    - export AWS_PROFILE=ephemeral-infra-ci
+    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+    - infra launch --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+  after_script:
+    - !reference [.setup, script]
+    - |
+      infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
+        --region "${AWS_REGION}" \
+        --bypass-stack-destroy
+  rules:
+    - when: manual
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    AWS_REGION: "us-east-1"
+    CLEANUP: "false"
+    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 .benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -7,7 +7,7 @@
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
 
 stages:
-  - infra-update
+  # - infra-update
   - check-azure-pipeline
   - benchmarks
   - benchmarks-win
@@ -36,40 +36,40 @@ check_azure_pipeline:
   variables:
     TEST_BRANCH: "master"
 
-update-bp-infra:
-  stage: infra-update
-  tags: ["arch:amd64"]
-  interruptible: false
-  timeout: 3h
-  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
+# update-bp-infra:
+#   stage: infra-update
+#   tags: ["arch:amd64"]
+#   interruptible: false
+#   timeout: 3h
+#   # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+#   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
-  script:
-    - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-    - mkdir -p ~/.aws
-    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
-    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
-    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
-    - export AWS_PROFILE=ephemeral-infra-ci
-    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
-    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-    - infra launch --no-cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
-  # after_script:
-  #   - !reference [.setup, script]
-  #   - |
-  #     infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
-  #       --region "${AWS_REGION}" \
-  #       --bypass-stack-destroy
-  rules:
-    - when: manual
-  variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-    AWS_REGION: "us-east-1"
-    CLEANUP: "false"
-    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
-    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
-    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
-    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
+#   script:
+#     - git clone --branch fayssal/update-bp-infra-dotnet-macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+#     - mkdir -p ~/.aws
+#     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+#     - export AWS_PROFILE=ephemeral-infra-ci
+#     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+#     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+#     - infra launch --no-cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+#   # after_script:
+#   #   - !reference [.setup, script]
+#   #   - |
+#   #     infra cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml \
+#   #       --region "${AWS_REGION}" \
+#   #       --bypass-stack-destroy
+#   rules:
+#     - when: manual
+#   variables:
+#     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+#     AWS_REGION: "us-east-1"
+#     CLEANUP: "false"
+#     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+#     AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+#     AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+#     AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 .benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -53,7 +53,7 @@ update-bp-infra:
     - export AWS_PROFILE=ephemeral-infra-ci
     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-    - infra launch --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+    - infra launch --no-cleanup --provision ./platform/ephemeral-infra/provisions/macrobenchmark-ami.yaml --region "${AWS_REGION}" --bypass-stack-destroy
   # after_script:
   #   - !reference [.setup, script]
   #   - |

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -32,9 +32,7 @@ check_azure_pipeline:
   tags: ["arch:amd64"]
   timeout: 1h
   rules:
-    - when: manual
-  variables:
-    TEST_BRANCH: "master"
+    - when: on_success
 
 update-bp-infra:
   stage: infra-update

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -21,6 +21,13 @@ check_azure_pipeline:
   script:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./wait-for-pipeline.sh
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+      - build-id.txt
+    expire_in: 3 months
   interruptible: true
   tags: ["arch:amd64"]
   timeout: 1h
@@ -86,6 +93,12 @@ update-bp-infra:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./steps/setup-sut.sh
     - bp-runner bp-runner.yml --debug
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
@@ -264,6 +277,12 @@ profiler_cpu_timer_create:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./steps/setup-sut.sh
     - bp-runner bp-runner.arm.yml --debug
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
@@ -439,6 +458,12 @@ profiler_cpu_timer_create-arm64:
   timeout: 1h
   rules:
     - when: on_success
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -69,7 +69,7 @@ run-benchmarks:
     # - ./platform/steps/upload-to-bp-ui.sh
     
   rules:
-    - when: manual
+    - when: on_success
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     AWS_REGION: "us-east-1"

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -7,45 +7,45 @@
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
 
 stages:
-  - infra-update
+  # - infra-update
   - benchmarks
 
 
-update-bp-infra:
-  stage: infra-update
-  timeout: 3h
-  tags: ["arch:amd64"]
-  interruptible: false
-  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
+# update-bp-infra:
+#   stage: infra-update
+#   timeout: 3h
+#   tags: ["arch:amd64"]
+#   interruptible: false
+#   # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+#   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
-  script:
-    - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-    - mkdir -p ~/.aws
-    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
-    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
-    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
-    - export AWS_PROFILE=ephemeral-infra-ci
-    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
-    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-    - infra launch --provision ./platform/ephemeral-infra/base-instance.yaml --region "${AWS_REGION}" --bypass-stack-destroy
-  after_script:
-    - !reference [.setup, script]
-    - |
-      infra cleanup --provision ./platform/ephemeral-infra/base-instance.yaml \
-        --region "${AWS_REGION}" \
-        --bypass-stack-destroy
+#   script:
+#     - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+#     - mkdir -p ~/.aws
+#     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+#     - export AWS_PROFILE=ephemeral-infra-ci
+#     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+#     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+#     - infra launch --provision ./platform/ephemeral-infra/base-instance.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+#   after_script:
+#     - !reference [.setup, script]
+#     - |
+#       infra cleanup --provision ./platform/ephemeral-infra/base-instance.yaml \
+#         --region "${AWS_REGION}" \
+#         --bypass-stack-destroy
     
-  rules:
-    - when: manual
-  variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-    AWS_REGION: "us-east-1"
-    CLEANUP: "false"
-    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
-    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
-    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
-    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
+  # rules:
+  #   - when: manual
+  # variables:
+  #   FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+  #   AWS_REGION: "us-east-1"
+  #   CLEANUP: "false"
+  #   AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+  #   AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+  #   AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+  #   AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 run-benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -92,7 +92,15 @@ upload-to-bp-ui:
     # - ./platform/steps/launch-instance.sh
     # - ./platform/steps/post-pr-comment.sh
     # Temporarely commented out pending issue resolution with sending files to backend
-    - ./platform/steps/upload-to-bp-ui.sh  
+    - ./platform/steps/upload-to-bp-ui.sh
+
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - candidate-results/
+    expire_in: 3 months
+    
   rules:
     - when: manual
   variables:

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -56,7 +56,7 @@ run-benchmarks:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
   script:
-    - git clone --branch dd-trace-dotnet/micro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
     - ./platform/steps/launch-instance.sh
   after_script:
     - !reference [.setup, script]

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -13,9 +13,9 @@ stages:
 
 update-bp-infra:
   stage: infra-update
+  timeout: 3h
   tags: ["arch:amd64"]
-  interruptible: true
-  timeout: 1h
+  interruptible: false
   # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -7,7 +7,45 @@
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
 
 stages:
+  - infra-update
   - benchmarks
+
+
+update-bp-infra:
+  stage: infra-update
+  tags: ["arch:amd64"]
+  interruptible: true
+  timeout: 1h
+  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
+
+  script:
+    - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - mkdir -p ~/.aws
+    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+    - export AWS_PROFILE=ephemeral-infra-ci
+    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+    - infra launch --provision ./platform/ephemeral-infra/base-instance.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+  after_script:
+    - !reference [.setup, script]
+    - |
+      infra cleanup --provision ./platform/ephemeral-infra/base-instance.yaml \
+        --region "${AWS_REGION}" \
+        --bypass-stack-destroy
+    
+  rules:
+    - when: manual
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    AWS_REGION: "us-east-1"
+    CLEANUP: "false"
+    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 run-benchmarks:
   stage: benchmarks
@@ -31,7 +69,7 @@ run-benchmarks:
     # - ./platform/steps/upload-to-bp-ui.sh
     
   rules:
-    - when: on_success
+    - when: manual
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     AWS_REGION: "us-east-1"

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -92,15 +92,7 @@ upload-to-bp-ui:
     # - ./platform/steps/launch-instance.sh
     # - ./platform/steps/post-pr-comment.sh
     # Temporarely commented out pending issue resolution with sending files to backend
-    - ./platform/steps/upload-to-bp-ui.sh
-
-  artifacts:
-    name: "artifacts"
-    when: always
-    paths:
-      - candidate-results/
-    expire_in: 3 months
-    
+    - ./platform/steps/upload-to-bp-ui.sh  
   rules:
     - when: manual
   variables:

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -61,12 +61,12 @@ run-benchmarks:
   after_script:
     - !reference [.setup, script]
     - |
-      infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-test.yaml \
+      infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-main.yaml \
         --region "${AWS_REGION}" \
         --bypass-stack-destroy
     - ./platform/steps/post-pr-comment.sh
-    Temporarely commented out pending issue resolution with sending files to backend
-    - ./platform/steps/upload-to-bp-ui.sh
+    # Temporarely commented out pending issue resolution with sending files to backend
+    # - ./platform/steps/upload-to-bp-ui.sh
     
   rules:
     - when: manual

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -61,7 +61,7 @@ run-benchmarks:
   after_script:
     - !reference [.setup, script]
     - |
-      infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-main.yaml \
+      infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-test.yaml \
         --region "${AWS_REGION}" \
         --bypass-stack-destroy
     - ./platform/steps/post-pr-comment.sh

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -58,13 +58,13 @@ run-benchmarks:
   script:
     - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
     - ./platform/steps/launch-instance.sh
-  after_script:
-    - !reference [.setup, script]
-    - |
-      infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-test.yaml \
-        --region "${AWS_REGION}" \
-        --bypass-stack-destroy
-    - ./platform/steps/post-pr-comment.sh
+  # after_script:
+  #   - !reference [.setup, script]
+  #   - |
+  #     infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-test.yaml \
+  #       --region "${AWS_REGION}" \
+  #       --bypass-stack-destroy
+  #   - ./platform/steps/post-pr-comment.sh
     # Temporarely commented out pending issue resolution with sending files to backend
     # - ./platform/steps/upload-to-bp-ui.sh
     

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -7,45 +7,45 @@
     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
 
 stages:
-  # - infra-update
+  - infra-update
   - benchmarks
 
+update-bp-infra:
+  stage: infra-update
+  timeout: 3h
+  tags: ["arch:amd64"]
+  interruptible: false
+  allow_failure: true
+  # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
-# update-bp-infra:
-#   stage: infra-update
-#   timeout: 3h
-#   tags: ["arch:amd64"]
-#   interruptible: false
-#   # Image created in the following job https://gitlab.ddbuild.io/DataDog/benchmarking-platform-tools/-/jobs/869830045
-#   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
-
-#   script:
-#     - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
-#     - mkdir -p ~/.aws
-#     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
-#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
-#     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
-#     - export AWS_PROFILE=ephemeral-infra-ci
-#     - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
-#     - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
-#     - infra launch --provision ./platform/ephemeral-infra/base-instance.yaml --region "${AWS_REGION}" --bypass-stack-destroy
-#   after_script:
-#     - !reference [.setup, script]
-#     - |
-#       infra cleanup --provision ./platform/ephemeral-infra/base-instance.yaml \
-#         --region "${AWS_REGION}" \
-#         --bypass-stack-destroy
+  script:
+    - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - mkdir -p ~/.aws
+    - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
+    - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-private-key" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-private-key.pem
+    - export AWS_PROFILE=ephemeral-infra-ci
+    - export BP_INFRA_KEY_PAIR_NAME=$(cat ~/.aws/key-pair-name.txt)
+    - export BP_INFRA_KEY_PAIR_PRIVATE_KEY_PATH=~/.aws/key-pair-private-key.pem
+    - infra launch --provision ./platform/ephemeral-infra/base-instance.yaml --region "${AWS_REGION}" --bypass-stack-destroy
+  after_script:
+    - !reference [.setup, script]
+    - |
+      infra cleanup --provision ./platform/ephemeral-infra/base-instance.yaml \
+        --region "${AWS_REGION}" \
+        --bypass-stack-destroy
     
-  # rules:
-  #   - when: manual
-  # variables:
-  #   FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-  #   AWS_REGION: "us-east-1"
-  #   CLEANUP: "false"
-  #   AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
-  #   AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
-  #   AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
-  #   AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
+  rules:
+    - when: manual
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    AWS_REGION: "us-east-1"
+    CLEANUP: "false"
+    AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
+    AWS_EPHEMERAL_INFRA_PROFILE_NAME: "ephemeral-infra-ci"
+    AWS_EPHEMERAL_INFRA_ARTIFACTS_BUCKET_URI: "s3://windows-benchmarking-results/$CI_PROJECT_NAME/$CI_COMMIT_REF_NAME/$CI_JOB_ID"
+    AWS_EPHEMERAL_INFRA_REGION: "us-east-1"
 
 run-benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -20,7 +20,7 @@ update-bp-infra:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
   script:
-    - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - git clone --branch dd-trace-dotnet/micro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
     - mkdir -p ~/.aws
     - /app/infra/tools/fetch-ssm-parameter.sh $AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER >> ~/.aws/config || exit $?
     - aws ssm get-parameter --region "$AWS_REGION" --name "ci.${CI_PROJECT_NAME}.ephemeral-infra-ci.windows-benchmarking-key-pair-name" --with-decryption --query "Parameter.Value" --out text >> ~/.aws/key-pair-name.txt
@@ -56,17 +56,17 @@ run-benchmarks:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-microbenchmarks-2
 
   script:
-    - git clone --branch fayssal/update-bp-infra-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
+    - git clone --branch dd-trace-dotnet/micro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform
     - ./platform/steps/launch-instance.sh
-  # after_script:
-  #   - !reference [.setup, script]
-  #   - |
-  #     infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-test.yaml \
-  #       --region "${AWS_REGION}" \
-  #       --bypass-stack-destroy
-  #   - ./platform/steps/post-pr-comment.sh
-    # Temporarely commented out pending issue resolution with sending files to backend
-    # - ./platform/steps/upload-to-bp-ui.sh
+  after_script:
+    - !reference [.setup, script]
+    - |
+      infra cleanup --provision ./platform/ephemeral-infra/ephemeral-instance-test.yaml \
+        --region "${AWS_REGION}" \
+        --bypass-stack-destroy
+    - ./platform/steps/post-pr-comment.sh
+    Temporarely commented out pending issue resolution with sending files to backend
+    - ./platform/steps/upload-to-bp-ui.sh
     
   rules:
     - when: manual


### PR DESCRIPTION
## Summary of changes
Enables the following by updating the BP infra:

- Running microbenchmarks with dotnet 9.0.203 
- Running Linux macrobenchmarks with dotnet 9.0.203 
- Running Windows microbenchmarks with dotnet 9.0.203 

## Reason for change
The benchmark runs have been failing since the dotnet SDK version has been updated

## Implementation details
- Rebuilt the Linux [macrobenchmark image](https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform/-/jobs/918214720) in order to use the latest version of the dotnet SDK
- Changed and rebuilt the macrobenchmark AMI
- Adapted the microbenchmark execution

## Test coverage
- [Successful execution of microbenchmarks](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/922908732)
- [Successful execution of Linux macrobenchmarks](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/922909429)
- [Successful execution of Windows macrobenchmarks](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/922909453)


## Other details
More documentation on [Benchmarking platform](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2419261562/Benchmarking+Platform)
More [Windows specific doc](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/4886233301/DRAFT+How+to+use+the+BP+for+Windows+benchmarks)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
