### PR TITLE
Only call `set context_info` if comment injection succeeds

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -105,7 +105,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                         // PropagateDataViaContext (full)    - this makes a special set context_info for Microsoft SQL Server (nothing else supported)
                         var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(tracer.Settings.DbmPropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span, tracer.Settings.InjectContextIntoStoredProceduresEnabled);
                         // try context injection only after comment injection, so that if it fails, we still have service level propagation
-                        var traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(tracer.Settings.DbmPropagationMode, integrationId, command, scope.Span);
+                        bool traceParentInjectedInContext = false;
+
+                        if (traceParentInjectedInComment)
+                        {
+                            traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(tracer.Settings.DbmPropagationMode, integrationId, command, scope.Span);
+                        }
 
                         if (traceParentInjectedInComment || traceParentInjectedInContext)
                         {


### PR DESCRIPTION
## Summary of changes

With the change to somewhat supporting propagation for stored procedures, the comment injection can "fail" (or be skipped) if we do not inject comments we can't call `set context_info` as it causes issues on the backend.

## Reason for change

We either need comments or comments and `context_info`.

## Implementation details

Wrap it in an `if`

## Test coverage

Doesn't appear that we have easy tests surrounding JUST the `context_info` unfortunately.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
