### PR TITLE
Use DataDog/ensure-ci-success instead of wechuli/allcheckspassed

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -33,7 +33,6 @@ jobs:
             profiler_execution_benchmarks
             dd-gitlab/download-serverless-artifacts
             dd-gitlab/download-single-step-artifacts
-            integration_tests_arm64_debugger
 
 # Why some checks are excluded? Success ratio are too low :
 # - consolidated-pipeline : 10%

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,6 +1,10 @@
 name: All Green
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
   push:
     branches:
       - master
@@ -14,15 +18,34 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      contents: read
+      statuses: read
     steps:
-      - uses: wechuli/allcheckspassed@e22f45a4f25f4cf821d1273705ac233355400db1
+      - uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
         with:
-          delay: 10  # wait for this delay before starting
-          polling_interval: 1 # after a failure, how long do it wait before checking again
-          retries: 60  # how many retries before stopping 
-          # checks_exclude: ''  # comma separated list of checks to exclude, nothing right now
+          initial-delay-seconds: 10  # wait for this delay before starting
+          max-retries: 60  # how many retries before stopping 
+          ignored-name-patterns: |
+            consolidated-pipeline
+            throughput
+            dd-gitlab/run-benchmarks
+            .github/dependabot.yml
+            dd-gitlab/default-pipeline
+            benchmarks
+            profiler_execution_benchmarks
+            dd-gitlab/download-serverless-artifacts
+            dd-gitlab/download-single-step-artifacts
+            throughput_profiler
+            integration_tests_arm64_debugger
 
-# Why some checks are excluded?
-#
-# - 
+# Why some checks are excluded? Success ratio are too low :
+# - consolidated-pipeline : 10%
+# - throughput : 20%
+# - dd-gitlab/run-benchmarks : 62%
+# - .github/dependabot.yml : 80%
+# - dd-gitlab/default-pipeline : 81%
+# - benchmarks : 84%
+# - profiler_execution_benchmarks : 84%
+# - dd-gitlab/download-serverless-artifacts : 86%
+# - dd-gitlab/download-single-step-artifacts : 88%
+# - throughput_profiler : 89%
+# - integration_tests_arm64_debugger : 89%

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -26,7 +26,6 @@ jobs:
           max-retries: 60  # how many retries before stopping 
           ignored-name-patterns: |
             consolidated-pipeline
-            throughput
             dd-gitlab/run-benchmarks
             .github/dependabot.yml
             dd-gitlab/default-pipeline
@@ -34,7 +33,6 @@ jobs:
             profiler_execution_benchmarks
             dd-gitlab/download-serverless-artifacts
             dd-gitlab/download-single-step-artifacts
-            throughput_profiler
             integration_tests_arm64_debugger
 
 # Why some checks are excluded? Success ratio are too low :


### PR DESCRIPTION
## Summary of changes

Use DataDog/ensure-ci-success instead of wechuli/allcheckspassed for `all-green` job

## Reason for change

This action checks the commit statuses API, so it get results from azure

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
