### PR TITLE
Make various tweaks to pipeline

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4985,10 +4985,8 @@ stages:
         workingDirectory: system-tests
         displayName: Run tests
         env:
-          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
+          DD_API_KEY: 00000000000000000000000000000000 # Doesn't need to be a valid key (except for e2e, but they don't run here)
           TEST_LIBRARY: dotnet
-          SYSTEM_TESTS_AWS_ACCESS_KEY_ID: $(SYSTEM_TESTS_IDM_AWS_ACCESS_KEY_ID)
-          SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY: $(SYSTEM_TESTS_IDM_AWS_SECRET_ACCESS_KEY)
 
       - script: |
           mkdir -p all_logs

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1,6 +1,7 @@
 # Change the default BuildId to not include a '.' in the name (use '_' instead)
 name: $(Date:yyyyMMdd)-$(Rev:rr)
 
+# master/hotfix branches should always run
 trigger:
   branches:
     include:
@@ -9,46 +10,14 @@ trigger:
       - hotfix/*
     exclude:
       - refs/pull/*/head
-  paths:
-    exclude:
-      - .azure-pipelines/noop-pipeline.yml
-      - .azure-pipelines/monitoring.yml
-      - .github/
-      - docs/
-      - tracer/README.MD
-      - tracer/dependabot/
-      - LICENSE
-      - LICENSE-3rdparty.csv
-      - NOTICE
-      - .vsconfig
-# The following is a list of shared asset locations.
-# This is the config for the Tracer CI pipeline,
-# so we are excluding shared assets that are not currently used by the Tracer.
-# We make this list granular, rather than catch-all, on purpose.
-# It makes it easier to selectively remove items from the list, once the Tracer starts using them.
-#     - The Managed Loader:
-      - shared/samples/Datadog.AutoInstrumentation.ManagedLoader.Demo/
-      - shared/src/managed-lib/ManagedLoader/
-#     - Dynamic Bindings for DiagnosticSource:
-      - shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/
-      - shared/src/managed-lib/DynamicDiagnosticSourceBindings/
-#     - Logging damo samples:
-      - shared/samples/Datadog.Logging.Demo/
-#     - Managed utility APIs (may be used transitively):
-      - shared/src/managed-src/Datadog.Collections/
-      - shared/src/managed-src/Datadog.Util/
-#     - Managed Logging APIs (may be used transitively):
-      - shared/src/managed-src/Datadog.Logging.Emission/
-      - shared/src/managed-src/Datadog.Logging.Composition/
-      - shared/src/managed-src/Datadog.Logging/
-#     - Fmt lib:
-      - shared/src/native-lib/fmt_x64-windows-static/
-      - shared/src/native-lib/fmt_x86-windows-static/
-#     - Spdlob lib:
-      - shared/src/native-lib/spdlog/
-#     - Mics common native sources:
-      - shared/src/native-src/
 
+# Changes in PRs and other branches need to run, if
+# - There were any code changes
+# - There were any changes to the AzDo or GitLab builds
+# They don't need to run if there are changes to
+# - Standalone samples
+# - Docs
+# - Any other non-build related files (but these rarely change, so just suck it up)
 pr:
   branches:
     include:
@@ -56,20 +25,10 @@ pr:
   paths:
     exclude:
       - .azure-pipelines/noop-pipeline.yml
-      - .azure-pipelines/monitoring.yml
       - .github/
-      - .gitlab-ci.yml
-      - blog/
       - docs/
-      - tracer/dependabot/
       - tracer/README.MD
-      - tracer/src/Datadog.Trace/DuckTyping/README.md
-      - tracer/samples
-      - tracer/build/_build/Build.GitHub.cs
-      - tracer/build/_build/Build.Gitlab.cs
-      - LICENSE
-      - LICENSE-3rdparty.csv
-      - NOTICE
+      - tracer/samples/
 
 schedules:
   - cron: "0 3 * * *"
@@ -84,6 +43,9 @@ schedules:
         - release/1.x
     always: true
 
+  # The name of this schedule is checked from within Nuke, and is used
+  # to ensure we do a run in which we set DD_TRACE_DEBUG=1 in integration tests
+  # to catch any debug-specific issues
   - cron: "0 4 * * *"
     displayName: Daily Debug Run
     branches:
@@ -3282,7 +3244,7 @@ stages:
 
     # Enable the Datadog Agent service for this job
     services:
-      dd_agent: dd_agent
+      dd_agent: dd_agent_no_pull
 
     steps:
     - template: steps/clone-repo.yml


### PR DESCRIPTION
## Summary of changes

Various tweaks to the CI pipeline

## Reason for change

- We're skipping running the pipelines sometimes when we shouldn't. This can causes issues e.g. when doing releases.
- We're specifying a bunch of files that basically never change in our exclude list, which just adds clutter for little benefit
- The windows exploration tests are explicitly pulling the agent when they shouldn't need to. This can cause flake due to docker rate limits
- Add some documentation

## Implementation details

Mostly the delete key and some extra comments

## Test coverage

This is the test. It should hopefully reduce the cases where the gitlab build fails because the azdo pipeline didn't run.

