### PR TITLE
rewrite GenerateSpanDocumentation using roslyn to parse the files

### DIFF
--- a/docs/span_attribute_schema/v0.md
+++ b/docs/span_attribute_schema/v0.md
@@ -149,6 +149,7 @@ Type | `dynamodb`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 aws_service | `DynamoDB`
 aws.agent | `dotnet-aws-sdk`
 aws.operation | Yes
@@ -172,6 +173,7 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 aws_service | `Kinesis`
 aws.agent | `dotnet-aws-sdk`
 aws.operation | Yes
@@ -186,6 +188,31 @@ http.url | Yes
 region | No
 span.kind | `producer`
 streamname | Yes
+
+## AwsS3Request
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `s3.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+aws_service | `S3`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `S3`
+bucketname | No
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+objectkey | No
+region | No
+span.kind | `client`
 
 ## AwsSqsRequest
 ### Span properties
@@ -239,70 +266,134 @@ region | No
 span.kind | `client`
 topicname | Yes
 
+## AwsEventBridgeRequest
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `eventbridge.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+aws_service | `EventBridge`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `EventBridge`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+region | No
+rulename | Yes
+span.kind | `client`
+
+## AwsStepFunctionsRequest
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `stepfunctions.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+aws_service | `StepFunctions`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `StepFunctions`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+region | No
+span.kind | `producer`
+statemachinename | Yes
+
 ## AzureServiceBusInbound
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `Message`; `ServiceBusReceiver.Peek`; `ServiceBusReceiver.Receive`; `ServiceBusReceiver.ReceiveDeferred`; `ServiceBusProcessor.ProcessMessage`; `ServiceBusSessionProcessor.ProcessSessionMessage`
+Name | `servicebus.receive`; `servicebus.process`; `consumer`
 Type | `http`; `custom`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 az.namespace | `Microsoft.ServiceBus`
-az.schema_url | Yes
-messaging.operation | `receive`; `process`
-messaging.source.name | Yes
-messaging.system | `servicebus`
-net.peer.name | Yes
+az.schema_url | No
+component | Optional: `servicebus`
+kind | Optional: `consumer`
+messaging.destination.name | No
+messaging.operation | Optional: `receive`; `process`
+messaging.source.name | No
+messaging.system | Optional: `servicebus`
+net.peer.name | No
 otel.library.name | Yes
 otel.library.version | No
 otel.status_code | `STATUS_CODE_UNSET`; `STATUS_CODE_OK`; `STATUS_CODE_ERROR`
 otel.status_description | No
 otel.trace_id | Yes
+peer.address | No
+server.address | No
 span.kind | `consumer`
 
 ## AzureServiceBusOutbound
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `Message`
+Name | `producer`
 Type | `custom`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 az.namespace | `Microsoft.ServiceBus`
-az.schema_url | Yes
+az.schema_url | No
+component | Optional: `servicebus`
+kind | Optional: `producer`
 messaging.destination.name | Yes
-messaging.system | `servicebus`
-net.peer.name | Yes
+messaging.system | Optional: `servicebus`
+net.peer.name | No
 otel.library.name | Yes
 otel.library.version | No
 otel.status_code | `STATUS_CODE_UNSET`; `STATUS_CODE_OK`; `STATUS_CODE_ERROR`
 otel.status_description | No
 otel.trace_id | Yes
+peer.address | No
+server.address | No
 span.kind | `producer`
 
 ## AzureServiceBusRequest
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `ServiceBusSender.Send`; `ServiceBusReceiver.Complete`; `ServiceBusSessionReceiver.RenewSessionLock`; `ServiceBusSessionReceiver.SetSessionState`; `ServiceBusSessionReceiver.GetSessionState`; `ServiceBusSender.Schedule`; `ServiceBusSender.Cancel`; `ServiceBusReceiver.RenewMessageLock`; `ServiceBusReceiver.Abandon`; `ServiceBusReceiver.Defer`; `ServiceBusReceiver.DeadLetter`
+Name | `servicebus.publish`; `servicebus.settle`; `client.request`
 Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 az.namespace | `Microsoft.ServiceBus`
-az.schema_url | Yes
+az.schema_url | No
+component | Optional: `servicebus`
+kind | Optional: `client`
 messaging.destination.name | No
-messaging.operation | Optional: `publish`; `receive`; `settle`
+messaging.operation | Optional: `publish`; `settle`
 messaging.source.name | No
-messaging.system | `servicebus`
-net.peer.name | Yes
+messaging.system | Optional: `servicebus`
+net.peer.name | No
 otel.library.name | Yes
 otel.library.version | No
 otel.status_code | `STATUS_CODE_UNSET`; `STATUS_CODE_OK`; `STATUS_CODE_ERROR`
 otel.status_description | No
 otel.trace_id | Yes
+peer.address | No
+server.address | No
 span.kind | `client`
 
 ## CosmosDb
@@ -423,6 +514,7 @@ Type | `graphql`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 component | `HotChocolate`
 graphql.operation.name | No
 graphql.operation.type | No
@@ -462,6 +554,7 @@ kafka.group | No
 kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
+messaging.destination.name | Yes
 messaging.kafka.bootstrap.servers | Yes
 span.kind | `consumer`
 ### Metrics
@@ -485,6 +578,7 @@ kafka.group | No
 kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
+messaging.destination.name | Yes
 messaging.kafka.bootstrap.servers | Yes
 span.kind | `producer`
 ### Metrics
@@ -538,6 +632,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 _dd.dbm_trace_injected | No
 component | `MySql`
 db.name | Yes
@@ -612,6 +707,17 @@ cmd.shell | No
 cmd.truncated | No
 span.kind | `internal`
 
+## Protobuf
+### Tags
+Name | Required |
+---------|----------------|
+Tags.SchemaDefinition | Yes
+Tags.SchemaId | Yes
+Tags.SchemaName | Yes
+Tags.SchemaOperation | Yes
+Tags.SchemaType | `protobuf`
+Tags.SchemaWeight | Yes
+
 ## RabbitMQ
 ### Span properties
 Name | Required |
@@ -631,6 +737,34 @@ component | `RabbitMQ`
 message.size | No
 out.host | No
 span.kind | Yes
+
+## RemotingClient
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `dotnet_remoting.client.request`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+component | `Remoting`
+rpc.method | Yes
+rpc.system | `dotnet_remoting`
+span.kind | `client`
+
+## RemotingServer
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `dotnet_remoting.server.request`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+component | `Remoting`
+rpc.method | Yes
+rpc.system | `dotnet_remoting`
+span.kind | `server`
 
 ## Service Remoting - Client
 ### Span properties
@@ -744,9 +878,11 @@ Type | `sql`
 Name | Required |
 ---------|----------------|
 _dd.base_service | No
+_dd.dbm_trace_injected | No
 component | `SqlClient`
 db.name | No
 db.type | `sql-server`
+dd.instrumentation.time_ms | No
 out.host | Yes
 span.kind | `client`
 

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -154,6 +154,7 @@ Type | `dynamodb`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 _dd.peer.service.source | `tablename`; `peer.service`
 aws_service | `DynamoDB`
 aws.agent | `dotnet-aws-sdk`
@@ -180,6 +181,7 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 _dd.peer.service.source | `streamname`; `peer.service`
 aws_service | `Kinesis`
 aws.agent | `dotnet-aws-sdk`
@@ -197,6 +199,34 @@ peer.service.remapped_from | No
 region | No
 span.kind | `producer`
 streamname | Yes
+
+## AwsS3Request
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `aws.s3.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+_dd.peer.service.source | No
+aws_service | `S3`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `S3`
+bucketname | No
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+objectkey | No
+peer.service | No
+peer.service.remapped_from | No
+region | No
+span.kind | `client`
 
 ## AwsSqsInbound
 ### Span properties
@@ -262,6 +292,7 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 _dd.peer.service.source | `queuename`; `peer.service`
 aws_service | `SQS`
 aws.agent | `dotnet-aws-sdk`
@@ -316,6 +347,7 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 _dd.peer.service.source | `topicname`; `peer.service`
 aws_service | `SNS`
 aws.agent | `dotnet-aws-sdk`
@@ -344,6 +376,7 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 _dd.peer.service.source | `topicname`; `peer.service`
 aws_service | `SNS`
 aws.agent | `dotnet-aws-sdk`
@@ -363,76 +396,243 @@ region | No
 span.kind | `client`
 topicname | Yes
 
+## AwsEventBridgeInbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `aws.eventbridge.process`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+aws_service | `EventBridge`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `EventBridge`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+region | No
+rulename | Yes
+span.kind | `consumer`
+
+## AwsEventBridgeOutbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `aws.eventbridge.send`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.peer.service.source | `rulename`; `peer.service`
+aws_service | `EventBridge`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `EventBridge`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+peer.service | Yes
+peer.service.remapped_from | No
+region | No
+rulename | Yes
+span.kind | `producer`
+
+## AwsEventBridgeRequest
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `aws.eventbridge.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+aws_service | `EventBridge`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `EventBridge`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+peer.service | Yes
+peer.service.remapped_from | No
+region | No
+rulename | Yes
+span.kind | `client`
+
+## AwsStepFunctionsInbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `aws.stepfunctions.process`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+aws_service | `StepFunctions`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `StepFunctions`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+region | No
+span.kind | `consumer`
+
+## AwsStepFunctionsOutbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `aws.stepfunctions.send`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+_dd.peer.service.source | `statemachinename`; `peer.service`
+aws_service | `StepFunctions`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `StepFunctions`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+peer.service | Yes
+peer.service.remapped_from | No
+region | No
+span.kind | `producer`
+statemachinename | Yes
+
+## AwsStepFunctionsRequest
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `aws.stepfunctions.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+_dd.peer.service.source | `statemachinename`; `peer.service`
+aws_service | `StepFunctions`
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `StepFunctions`
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+peer.service | Yes
+peer.service.remapped_from | No
+region | No
+span.kind | `client`
+
 ## AzureServiceBusInbound
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `Message`; `ServiceBusReceiver.Peek`; `ServiceBusReceiver.Receive`; `ServiceBusReceiver.ReceiveDeferred`; `ServiceBusProcessor.ProcessMessage`; `ServiceBusSessionProcessor.ProcessSessionMessage`
+Name | `servicebus.receive`; `servicebus.process`; `consumer`
 Type | `http`; `custom`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 az.namespace | `Microsoft.ServiceBus`
-az.schema_url | Yes
-messaging.operation | `receive`; `process`
-messaging.source.name | Yes
-messaging.system | `servicebus`
-net.peer.name | Yes
+az.schema_url | No
+component | Optional: `servicebus`
+kind | Optional: `consumer`
+messaging.destination.name | No
+messaging.operation | Optional: `receive`; `process`
+messaging.source.name | No
+messaging.system | Optional: `servicebus`
+net.peer.name | No
 otel.library.name | Yes
 otel.library.version | No
 otel.status_code | `STATUS_CODE_UNSET`; `STATUS_CODE_OK`; `STATUS_CODE_ERROR`
 otel.status_description | No
 otel.trace_id | Yes
+peer.address | No
+server.address | No
 span.kind | `consumer`
 
 ## AzureServiceBusOutbound
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `Message`
+Name | `producer`
 Type | `custom`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `messaging.destination.name`; `peer.service`
+_dd.base_service | No
+_dd.peer.service.source | `messaging.destination.name`; `message_bus.destination`; `peer.service`
 az.namespace | `Microsoft.ServiceBus`
-az.schema_url | Yes
+az.schema_url | No
+component | Optional: `servicebus`
+kind | Optional: `producer`
 messaging.destination.name | Yes
-messaging.system | `servicebus`
-net.peer.name | Yes
+messaging.system | Optional: `servicebus`
+net.peer.name | No
 otel.library.name | Yes
 otel.library.version | No
 otel.status_code | `STATUS_CODE_UNSET`; `STATUS_CODE_OK`; `STATUS_CODE_ERROR`
 otel.status_description | No
 otel.trace_id | Yes
+peer.address | No
 peer.service | Yes
 peer.service.remapped_from | No
+server.address | No
 span.kind | `producer`
 
 ## AzureServiceBusRequest
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `ServiceBusSender.Send`; `ServiceBusReceiver.Complete`; `ServiceBusSessionReceiver.RenewSessionLock`; `ServiceBusSessionReceiver.SetSessionState`; `ServiceBusSessionReceiver.GetSessionState`; `ServiceBusSender.Schedule`; `ServiceBusSender.Cancel`; `ServiceBusReceiver.RenewMessageLock`; `ServiceBusReceiver.Abandon`; `ServiceBusReceiver.Defer`; `ServiceBusReceiver.DeadLetter`
+Name | `servicebus.publish`; `servicebus.settle`; `client.request`
 Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `messaging.destination.name`; `peer.service`
+_dd.base_service | No
+_dd.peer.service.source | `messaging.destination.name`; `message_bus.destination`; `peer.service`
 az.namespace | `Microsoft.ServiceBus`
-az.schema_url | Yes
+az.schema_url | No
+component | Optional: `servicebus`
+kind | Optional: `client`
 messaging.destination.name | No
-messaging.operation | Optional: `publish`; `receive`; `settle`
+messaging.operation | Optional: `publish`; `settle`
 messaging.source.name | No
-messaging.system | `servicebus`
-net.peer.name | Yes
+messaging.system | Optional: `servicebus`
+net.peer.name | No
 otel.library.name | Yes
 otel.library.version | No
 otel.status_code | `STATUS_CODE_UNSET`; `STATUS_CODE_OK`; `STATUS_CODE_ERROR`
 otel.status_description | No
 otel.trace_id | Yes
+peer.address | No
 peer.service | Yes
 peer.service.remapped_from | No
+server.address | No
 span.kind | `client`
 
 ## CosmosDb
@@ -609,6 +809,7 @@ kafka.group | No
 kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
+messaging.destination.name | Yes
 messaging.kafka.bootstrap.servers | Yes
 span.kind | `consumer`
 ### Metrics
@@ -633,6 +834,7 @@ kafka.group | No
 kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
+messaging.destination.name | Yes
 messaging.kafka.bootstrap.servers | Yes
 peer.service | Yes
 peer.service.remapped_from | No
@@ -691,6 +893,7 @@ Type | `queue`
 ### Tags
 Name | Required |
 ---------|----------------|
+_dd.base_service | No
 _dd.peer.service.source | `out.host`; `peer.service`
 component | `msmq`
 msmq.command | Yes
@@ -816,6 +1019,17 @@ cmd.shell | No
 cmd.truncated | No
 span.kind | `internal`
 
+## Protobuf
+### Tags
+Name | Required |
+---------|----------------|
+Tags.SchemaDefinition | Yes
+Tags.SchemaId | Yes
+Tags.SchemaName | Yes
+Tags.SchemaOperation | Yes
+Tags.SchemaType | `protobuf`
+Tags.SchemaWeight | Yes
+
 ## Rabbit - Admin
 ### Span properties
 Name | Required |
@@ -880,6 +1094,37 @@ out.host | Yes
 peer.service | Yes
 peer.service.remapped_from | No
 span.kind | `producer`
+
+## RemotingClient
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `dotnet_remoting.client.request`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+_dd.peer.service.source | Optional: `peer.service`; `rpc.service`
+component | `Remoting`
+peer.service | No
+peer.service.remapped_from | No
+rpc.method | Yes
+rpc.system | `dotnet_remoting`
+span.kind | `client`; `server`
+
+## RemotingServer
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `dotnet_remoting.server.request`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+component | `Remoting`
+rpc.method | Yes
+rpc.system | `dotnet_remoting`
+span.kind | `client`; `server`
 
 ## Service Remoting - Client
 ### Span properties
@@ -1005,10 +1250,12 @@ Type | `sql`
 Name | Required |
 ---------|----------------|
 _dd.base_service | No
+_dd.dbm_trace_injected | No
 _dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `SqlClient`
 db.name | No
 db.type | `sql-server`
+dd.instrumentation.time_ms | No
 out.host | Yes
 peer.service | Yes
 peer.service.remapped_from | No

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.3.11" />
     <PackageReference Include="DiffMatchPatch" Version="1.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0"/>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />


### PR DESCRIPTION
## Summary of changes

Removed the artisan parsing code that was brittle and subject to failure if formatting was not perfect, and replaced it with code using roslyn to properly parse the C# code.

## Reason for change

The existing code required expression bodies, but the editorconfig suggest using block bodies everywhere, so changing this file was challenging with "reformat on save" turned on.

## Implementation details

used Roslyn. It's nice.

## Test coverage

No tests for this afaik. I regenerated the markdown using the old code, and than with the new code, and there was no change. Also manually tested that having an expression body now works.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
