### PR TITLE
Disable Kafka header injection when brokers return unknown error

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -107,6 +107,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 }
             }
 
+            KafkaHelper.DisableHeadersIfUnsupportedBroker(exception);
             state.Scope.DisposeWithException(exception);
             return response;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
@@ -84,6 +84,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, in CallTargetState state)
         {
+            KafkaHelper.DisableHeadersIfUnsupportedBroker(exception);
             state.Scope.DisposeWithException(exception);
             return CallTargetReturn.GetDefault();
         }

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Properties/launchSettings.json
@@ -15,6 +15,34 @@
         "DD_TRACE_DEBUG": "1"
       },
       "nativeDebugging": true
+    },
+    "WithDatadog": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DD_ENV": "",
+        "DD_SERVICE": "Samples.Kafka",
+        "DD_VERSION": "",
+
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home"
+      },
+      "nativeDebugging": false
+    },
+    "NoDatadog": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DD_ENV": "",
+        "DD_SERVICE": "",
+        "DD_VERSION": ""
+      },
+      "nativeDebugging": false
     }
   }
 }


### PR DESCRIPTION
## Summary of changes

This will disable our header injection for the Kafka instrumentation when a message is produced and we detect that the broker may not support headers in messages. This happens in brokers before version 0.11, which is quite old so we think it is a very rare issue.

## Reason for change

For Kakfa brokers before 0.11 they do not support headers in messages, yet we always try to inject headers in the messages.
When we hit this case the broker rejects the message and an unknown broker error is returned, but since header injection works fine it never gets disabled as the API supports the headers, but not the broker.

This checks any exception after producing a message for `Unknown broker error` and if it is detected we then _assume_ that this is caused by our header injection and a topic that was created with a broker before 0.11 or a broker that is before 0.11

## Implementation details

## Test coverage

Unsure how to best add a test for this scenario without making an entirely separate sample application and docker composes, what I ended up doing was changing our docker compose to the below which appear to run Kafka brokers before 0.11. I then ran our sample project locally and reproduced the errors ->

```text
[DBG] Span closed: [s_id: 59bb8f7c569c5d48, p_id: null, t_id: 681cb83800000000f364d9d830bb265b] for (Service: Samples.Kafka-kafka, Resource: Produce Topic sample-topic, Operation: kafka.produce, Tags: [error.msg (tag):Unknown broker error,error.type (tag):System.Exception,error.stack (tag):System.Exception: Unknown broker error
```

With this change we _still_ get those errors, just after the "first" one is detected we then disable header injection:

```text
[ERR] Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled. Confluent.Kafka.ProduceException`2[System.String,System.String]: Unknown broker error
```

The sample application though runs many produce messages at the same time, this first batch will still fail, but after we disable it the next set of produce message calls succeed (without header injection).

I had to strip many of the `environment` stuff as with them they were throwing tons of errors in the containers.

```docker
  kafka-zookeeper:
    image: confluentinc/cp-zookeeper:3.3.0
    hostname: kafka-zookeeper
    container_name: kafka-zookeeper
    ports:
      - "2181:2181"
    restart: unless-stopped
    environment:
      ZOOKEEPER_CLIENT_PORT: 2181
      ZOOKEEPER_TICK_TIME: 2000

  kafka-broker:
    image: confluentinc/cp-kafka:3.3.1  # Kafka 0.10.2.2
    hostname: kafka-broker
    container_name: kafka-broker
    depends_on:
      - kafka-zookeeper
    ports:
      - "9092:9092"
      - "9101:9101"
    restart: unless-stopped
    environment:
      KAFKA_BROKER_ID: 1
      KAFKA_ZOOKEEPER_CONNECT: kafka-zookeeper:2181
      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
      KAFKA_LOG_MESSAGE_FORMAT_VERSION: "0.10.2"
```

## Other details

We do not have the ability to query the Kafka broker version.
The messages with the injected headers will fail, but we decided that we won't be retrying these messages without the headers.
Fixes https://datadoghq.atlassian.net/browse/DSMON-668

I followed the error message in https://github.com/DataDog/dd-trace-py/pull/13313/
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
