### PR TITLE
Fix arm64 SQL server not found flaky tests

### DIFF
--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.NServiceBus/Program.cs
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.NServiceBus/Program.cs
@@ -107,18 +107,26 @@ namespace ServiceBus.Minimal.NServiceBus
 
             var masterConnection = connectionString.Replace(builder.InitialCatalog, "master");
 
-            using (var connection = new SqlConnection(masterConnection))
+            try
             {
-                connection.Open();
-
-                using (var command = connection.CreateCommand())
+                using (var connection = new SqlConnection(masterConnection))
                 {
-                    command.CommandText = $@"
+                    connection.Open();
+
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = $@"
     if(db_id('{database}') is null)
         create database [{database}]
     ";
-                    command.ExecuteNonQuery();
+                        command.ExecuteNonQuery();
+                    }
                 }
+            }
+            catch (SqlException ex)
+            {
+                Console.WriteLine(ex);
+                Console.WriteLine($"Unable to open connection to connection string {connectionString}");
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

In some alpine, arm64 tests, some SqlServer tests are failing because the server is not found.

This PR adds the skip (13) return code to the samples, so we can skip the test and log it.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
