### PR TITLE
[Test Optimization] Override trace enabled env-var on CI Visibility mode.

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -311,6 +311,13 @@ namespace Datadog.Trace.Configuration
                                       .WithKeys(ConfigurationKeys.ApmTracingEnabled)
                                       .AsBool(defaultValue: true);
 
+            var ciVisibilityEnabled = config
+                                     .WithKeys(ConfigurationKeys.CIVisibility.Enabled)
+                                     .AsBool(defaultValue: false);
+
+            // If CI Visibility is enabled then we should enable tracing.
+            _traceEnabled = _traceEnabled || ciVisibilityEnabled;
+
             if (AzureAppServiceMetadata?.IsUnsafeToTrace == true)
             {
                 telemetry.Record(ConfigurationKeys.TraceEnabled, false, ConfigurationOrigins.Calculated);


### PR DESCRIPTION
## Summary of changes

This PR overrides the trace enabled settings when we are in CI Visibility mode. 

## Reason for change

`DD_TRACE_ENABLED=false` shouldn't disable CI Visibility.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
