### PR TITLE
use 2 hours for "all green" check

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
         with:
           initial-delay-seconds: 10  # wait for this delay before starting
-          max-retries: 60  # how many retries before stopping 
+          max-retries: 120  # how many retries before stopping 
           ignored-name-patterns: |
             consolidated-pipeline
             dd-gitlab/run-benchmarks


### PR DESCRIPTION
## Summary of changes

Use 2h for all green check

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
