### PR TITLE
Explicitly end crashtracking job that hangs

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -168,6 +168,8 @@ steps:
       dockerTag: $(dockerTag)
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
     displayName: Check logs for evidence of crash output
+    # This job sometimes hangs, and when it does, we lose all the logs, so explicitly end it early instead
+    timeoutInMinutes: 15
     condition: eq(variables['runCrashTest'], 'true')
 
 - ${{ if eq(parameters.isLinux, true) }}:


### PR DESCRIPTION
## Summary of changes

Add a timeout to the crash-tracking smoke test job

## Reason for change

This job regularly hangs, and we don't know why, because when it does, the job times out, and we lose all the logs.

## Implementation details

Add a timeout to the _task_ so that the job can upload the logs and give us a shot at fixing it.

## Test coverage

This is the test

## Other details

I don't know why we didn't do this before 🙈 