### PR TITLE
[ASM] Disabled sampling in API Sec schema extractor in Standalone mode

### DIFF
--- a/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
@@ -126,7 +126,7 @@
         "_dd.tracer_kr": 0.0,
         "process_id": 8928.0,
         "_dd.appsec.enabled": 1.0,
-        "_sampling_priority_v1": 1.0,
+        "_sampling_priority_v1": 2.0,
         "_dd.top_level": 1.0
       }
     }

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -96,7 +96,7 @@ internal readonly struct TraceChunkModel
                 {
                     IsRunningInAzureAppService = settings.IsRunningInAzureAppService;
                     AzureAppServiceSettings = settings.AzureAppServiceMetadata ?? null;
-                    IsApmEnabled = settings.ApmTracingEnabledInternal;
+                    IsApmEnabled = settings.ApmTracingEnabled;
                 }
 
                 if (tracer.GitMetadataTagsProvider?.TryExtractGitMetadata(out var gitMetadata) == true &&

--- a/tracer/src/Datadog.Trace/AppSec/ApiSec/ApiSecurity.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ApiSec/ApiSecurity.cs
@@ -18,6 +18,7 @@ internal class ApiSecurity
 
     private readonly int _maxRoutesSize;
     private readonly bool _enabled;
+    private readonly bool _apmTracingEnabled;
     private readonly bool _endpointsCollectionEnabled;
     private readonly int _endpointsCollectionMessageLimit;
     private readonly TimeSpan _minTimeBetweenReprocessTimeSpan;
@@ -28,6 +29,7 @@ internal class ApiSecurity
     {
         // todo: later, will be enabled by default, depending on if Security is enabled
         _enabled = securitySettings.ApiSecurityEnabled;
+        _apmTracingEnabled = securitySettings.ApmTracingEnabled;
         _minTimeBetweenReprocessTimeSpan = TimeSpan.FromSeconds(securitySettings.ApiSecuritySampleDelay);
         _maxRoutesSize = maxRouteSize;
         _endpointsCollectionEnabled = securitySettings.ApiSecurityEndpointCollectionEnabled;
@@ -40,7 +42,7 @@ internal class ApiSecurity
         {
             var samplingPriority = localRootSpan.Context.TraceContext.GetOrMakeSamplingDecision();
 
-            if (_enabled && lastWafCall && SamplingPriorityValues.IsKeep(samplingPriority))
+            if (_enabled && lastWafCall && (!_apmTracingEnabled || SamplingPriorityValues.IsKeep(samplingPriority)))
             {
                 var httpRouteTag = localRootSpan.GetTag(Tags.AspNetCoreEndpoint) ?? localRootSpan.GetTag(Tags.HttpRoute);
                 var httpMethod = localRootSpan.GetTag(Tags.HttpMethod);

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -597,7 +597,7 @@ namespace Datadog.Trace.AppSec
             }
         }
 
-        internal void SetTraceSamplingPriority(Span span)
+        internal void SetTraceSamplingPriority(Span span, bool setSource = true)
         {
             if (!_settings.KeepTraces)
             {
@@ -608,7 +608,10 @@ namespace Datadog.Trace.AppSec
             else if (_rateLimiter?.Allowed(span) ?? false)
             {
                 span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
-                span.Context.TraceContext?.Tags.EnableTraceSources(TraceSources.Asm);
+                if (setSource)
+                {
+                    span.Context.TraceContext?.Tags.EnableTraceSources(TraceSources.Asm);
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -47,6 +47,8 @@ namespace Datadog.Trace.AppSec
             CanBeToggled = !enabledEnvVar.ConfigurationResult.IsValid;
             AppsecEnabled = enabledEnvVar.WithDefault(false);
 
+            ApmTracingEnabled = config.WithKeys(ConfigurationKeys.ApmTracingEnabled).AsBool(true);
+
             Rules = config.WithKeys(ConfigurationKeys.AppSec.Rules).AsString();
             CustomIpHeader = config.WithKeys(ConfigurationKeys.AppSec.CustomIpHeader).AsString();
             var extraHeaders = config.WithKeys(ConfigurationKeys.AppSec.ExtraHeaders).AsString();
@@ -183,6 +185,8 @@ namespace Datadog.Trace.AppSec
         public int ApiSecurityEndpointCollectionMessageLimit { get; }
 
         public bool AppsecEnabled { get; }
+
+        public bool ApmTracingEnabled { get; }
 
         public bool UseUnsafeEncoder { get; }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
@@ -32,7 +32,7 @@ internal class ApmAgentWriter : IEventWriter
         var api = new Api(apiRequestFactory, null, updateSampleRates, partialFlushEnabled);
         var statsAggregator = StatsAggregator.Create(api, settings, discoveryService);
 
-        _agentWriter = new AgentWriter(api, statsAggregator, null, maxBufferSize: maxBufferSize, apmTracingEnabled: settings.ApmTracingEnabledInternal);
+        _agentWriter = new AgentWriter(api, statsAggregator, null, maxBufferSize: maxBufferSize, apmTracingEnabled: settings.ApmTracingEnabled);
     }
 
     public ApmAgentWriter(IApi api, int maxBufferSize = DefaultMaxBufferSize)

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -630,7 +630,7 @@ namespace Datadog.Trace.Configuration
             StatsComputationEnabled = config
                                      .WithKeys(ConfigurationKeys.StatsComputationEnabled)
                                      .AsBool(defaultValue: (IsRunningInGCPFunctions || IsRunningMiniAgentInAzureFunctions));
-            if (!ApmTracingEnabledInternal && StatsComputationEnabled)
+            if (!ApmTracingEnabled && StatsComputationEnabled)
             {
                 telemetry.Record(ConfigurationKeys.StatsComputationEnabled, false, ConfigurationOrigins.Calculated);
                 StatsComputationEnabled = false;
@@ -801,7 +801,7 @@ namespace Datadog.Trace.Configuration
         /// Default is <c>true</c>.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.ApmTracingEnabled"/>
-        internal bool ApmTracingEnabledInternal => DynamicSettings.ApmTracingEnabled ?? _apmTracingEnabled;
+        internal bool ApmTracingEnabled => DynamicSettings.ApmTracingEnabled ?? _apmTracingEnabled;
 
         /// <summary>
         /// Gets a value indicating whether profiling is enabled.

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.Propagators
             if (context.SpanContext is { } spanContext)
             {
                 // If apm tracing is disabled and no other product owns the trace -> stop propagation
-                if (spanContext.TraceContext is { Tracer.Settings.ApmTracingEnabledInternal: false } trace &&
+                if (spanContext.TraceContext is { Tracer.Settings.ApmTracingEnabled: false } trace &&
                     !trace.Tags.HasTraceSources())
                 {
                     return;

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -404,7 +404,7 @@ namespace Datadog.Trace
                     // When apm tracing is disabled, only distributed traces with the `_dd.p.ts` tag (with a trace source)
                     // are propagated downstream, however we need 1 trace per minute sent to the backend, so
                     // we unset sampling priority so the rate limiter decides.
-                    if (Settings?.ApmTracingEnabledInternal == false)
+                    if (Settings?.ApmTracingEnabled == false)
                     {
                         // If the trace has appsec propagation tag, the default priority is user keep
                         samplingPriority = propagatedTags.HasTraceSources(TraceSources.Asm) ? SamplingPriorityValues.UserKeep : null;

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -268,7 +268,7 @@ namespace Datadog.Trace
             // Note: the order that rules are registered is important, as they are evaluated in order.
             // The first rule that matches will be used to determine the sampling rate.
 
-            if (settings.ApmTracingEnabledInternal == false &&
+            if (settings.ApmTracingEnabled == false &&
                 (Security.Instance.Settings.AppsecEnabled || Iast.Iast.Instance.Settings.Enabled))
             {
                 // Custom sampler for ASM and IAST standalone billing mode
@@ -353,7 +353,7 @@ namespace Datadog.Trace
 
             var statsAggregator = StatsAggregator.Create(api, settings, discoveryService);
 
-            return new AgentWriter(api, statsAggregator, statsd, maxBufferSize: settings.TraceBufferSize, batchInterval: settings.TraceBatchInterval, apmTracingEnabled: settings.ApmTracingEnabledInternal);
+            return new AgentWriter(api, statsAggregator, statsd, maxBufferSize: settings.TraceBufferSize, batchInterval: settings.TraceBatchInterval, apmTracingEnabled: settings.ApmTracingEnabled);
         }
 
         protected virtual IDiscoveryService GetDiscoveryService(TracerSettings settings)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ApiSec/ApiSecurityTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ApiSec/ApiSecurityTests.cs
@@ -23,18 +23,24 @@ namespace Datadog.Trace.Security.Unit.Tests.ApiSec;
 public class ApiSecurityTests
 {
     [Theory]
-    [InlineData(true, true, SamplingPriorityValues.UserKeep, true, "route0")]
-    [InlineData(true, true, SamplingPriorityValues.AutoKeep, true, "route1")]
-    [InlineData(true, true, SamplingPriorityValues.AutoReject, false, "route2")]
-    [InlineData(true, false, SamplingPriorityValues.AutoKeep, false, "route3")]
-    [InlineData(false, false, SamplingPriorityValues.AutoKeep, false, "route4")]
-    [InlineData(true, true, SamplingPriorityValues.AutoKeep, false, null)]
-    public void ApiSecurityTest(bool enable, bool lastCall, int samplingPriority, bool expectedResult, string route)
+    [InlineData(true, true, true, SamplingPriorityValues.UserKeep, true, "route0")]
+    [InlineData(true, true, true, SamplingPriorityValues.AutoKeep, true, "route1")]
+    [InlineData(true, true, true, SamplingPriorityValues.AutoReject, false, "route2")]
+    [InlineData(true, true, false, SamplingPriorityValues.AutoKeep, false, "route3")]
+    [InlineData(false, true, false, SamplingPriorityValues.AutoKeep, false, "route4")]
+    [InlineData(true, true, true, SamplingPriorityValues.AutoKeep, false, null)]
+    [InlineData(true, false, true, SamplingPriorityValues.AutoReject, true, "route2")]
+    [InlineData(true, false, false, SamplingPriorityValues.AutoKeep, false, "route3")]
+    public void ApiSecurityTest(bool enable, bool apmTracingEnabled, bool lastCall, int samplingPriority, bool expectedResult, string route)
     {
         var apiSec = new ApiSecurity(
             new SecuritySettings(
                 new CustomSettingsForTests(
-                    new Dictionary<string, object> { { Configuration.ConfigurationKeys.AppSec.ApiSecurityEnabled, enable } }),
+                    new Dictionary<string, object>
+                    {
+                        { Configuration.ConfigurationKeys.AppSec.ApiSecurityEnabled, enable },
+                        { Configuration.ConfigurationKeys.ApmTracingEnabled, apmTracingEnabled },
+                    }),
                 new NullConfigurationTelemetry()));
         var dic = new Dictionary<string, object>();
         var tc = new TraceContext(Mock.Of<IDatadogTracer>(), new TraceTagCollection());

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/StandaloneASMBillingTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/StandaloneASMBillingTests.cs
@@ -22,7 +22,7 @@ public class StandaloneASMBillingTests
             { ConfigurationKeys.ApmTracingEnabled, false }
         });
         var tracerSettings = new TracerSettings(settings, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
-        Assert.False(tracerSettings.ApmTracingEnabledInternal);
+        Assert.False(tracerSettings.ApmTracingEnabled);
     }
 
     [Fact]

--- a/tracer/test/snapshots/Security.ApiSecurity.AspNetCore2.ApiSecOn.__url=_dataapi_empty-model_body={-property_expectedStatusCode=NoContent_containsAttack=False.verified.txt
+++ b/tracer/test/snapshots/Security.ApiSecurity.AspNetCore2.ApiSecOn.__url=_dataapi_empty-model_body={-property_expectedStatusCode=NoContent_containsAttack=False.verified.txt
@@ -41,7 +41,6 @@
       span.kind: server,
       _dd.appsec.s.req.body: [{"Property":[8],"Property2":[8],"Property3":[4],"Property4":[4]}],
       _dd.appsec.s.req.headers: [{"connection":[8],"content-length":[8],"content-type":[8],"host":[8],"user-agent":[8],"x-forwarded-for":[8]}],
-      _dd.appsec.s.res.headers: [{}],
       _dd.runtime_family: dotnet
     },
     Metrics: {
@@ -49,7 +48,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.ApiSecurity.AspNetCore2.ApiSecOn.__url=_dataapi_model_body={-property_expectedStatusCode=OK_containsAttack=False.verified.txt
+++ b/tracer/test/snapshots/Security.ApiSecurity.AspNetCore2.ApiSecOn.__url=_dataapi_model_body={-property_expectedStatusCode=OK_containsAttack=False.verified.txt
@@ -50,7 +50,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.__url=_dataapi_empty-model_body={-property_expectedStatusCode=NoContent_containsAttack=False.verified.txt
+++ b/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.__url=_dataapi_empty-model_body={-property_expectedStatusCode=NoContent_containsAttack=False.verified.txt
@@ -50,7 +50,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.__url=_dataapi_model_body={-property_expectedStatusCode=OK_containsAttack=False.verified.txt
+++ b/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.__url=_dataapi_model_body={-property_expectedStatusCode=OK_containsAttack=False.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -52,7 +52,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetFxWebApiApiSecurity.enableApiSecurity=True.__scenario=scan-empty-model.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetFxWebApiApiSecurity.enableApiSecurity=True.__scenario=scan-empty-model.verified.txt
@@ -52,7 +52,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetFxWebApiApiSecurity.enableApiSecurity=True.__scenario=scan-without-attack.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetFxWebApiApiSecurity.enableApiSecurity=True.__scenario=scan-without-attack.verified.txt
@@ -53,7 +53,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5ApiSecurity.enableApiSecurity=True.__scenario=scan-empty-model.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5ApiSecurity.enableApiSecurity=True.__scenario=scan-empty-model.verified.txt
@@ -56,7 +56,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5ApiSecurity.enableApiSecurity=True.__scenario=scan-without-attack.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5ApiSecurity.enableApiSecurity=True.__scenario=scan-without-attack.verified.txt
@@ -57,7 +57,7 @@
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]


### PR DESCRIPTION
## Summary of changes
Ignore sampling decision in API Sec sampler when in standalone mode

## Reason for change
Most of the schemas were being dropped in standalone mode
[Jira ticket](https://datadoghq.atlassian.net/browse/APPSEC-57334?atlOrigin=eyJpIjoiMTQ5NTFmMWQ0YmI2NDZkYzlhMDdlMGI0Y2ZjOGEzN2QiLCJwIjoiaiJ9)

## Implementation details

## Test coverage
Added unit tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
