### PR TITLE
Fix IAST DDBB flaky unit tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/SqlDDBBCreator.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/SqlDDBBCreator.cs
@@ -12,7 +12,7 @@ internal static class SqlDDBBCreator
         // Linux does not support localDB
         if (!InstrumentationTestsBase.IsWindows())
         {
-            return new SqlConnection("Data Source=.\\DUMMY;Initial Catalog=Dummy");
+            return new SqlConnection("Data Source=.\\DUMMY;Initial Catalog=Dummy;MultipleActiveResultSets=true");
         }
 
         var connection = OpenConnection();
@@ -47,7 +47,7 @@ internal static class SqlDDBBCreator
     private static SqlConnection OpenConnection()
     {
         int numAttempts = 3;
-        var connectionString = @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60";
+        var connectionString = @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60;MultipleActiveResultSets=true";
 
         for (int i = 0; i < numAttempts; i++)
         {


### PR DESCRIPTION
## Summary of changes

We are getting this error in the CI:

```
  Failed Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.SqlCommandTests.GivenASqlCommand_WhenCallingExecuteReaderWithTainted_VulnerabilityIsReported [3 ms]
  Error Message:
   System.InvalidOperationException : There is already an open DataReader associated with this Command which must be closed first.
  Stack Trace:
     at System.Data.SqlClient.SqlInternalConnectionTds.ValidateConnectionForExecute(SqlCommand command)
   at System.Data.SqlClient.SqlConnection.ValidateConnectionForExecute(String method, SqlCommand command)
   at System.Data.SqlClient.SqlCommand.ValidateCommand(Boolean async, String method)
   at System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, TaskCompletionSource`1 completion, Int32 timeout, Task& task, Boolean asyncWrite, String method)
   at System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String method)
   at System.Data.SqlClient.SqlCommand.ExecuteReader(CommandBehavior behavior)
   at System.Data.SqlClient.SqlCommand.ExecuteReader()
   at Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.SqlCommandTests.<GivenASqlCommand_WhenCallingExecuteReaderWithTainted_VulnerabilityIsReported>b__13_0() in D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SqlInjection\SqlCommandTests.cs:line 80
   at Samples.InstrumentedTests.Iast.InstrumentationTestsBase.TestRealDDBBLocalCall[T](Func`1 expression) in D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\InstrumentationTestsBase.cs:line 448
   at Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.SqlCommandTests.GivenASqlCommand_WhenCallingExecuteReaderWithTainted_VulnerabilityIsReported() in D:\a\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SqlInjection\SqlCommandTests.cs:line 80
```

This error occurs when there is already an open DataReader associated with a Command which must be closed first. Typically occurs due to attempting to execute another command on the same database connection while a DataReader is still open. 

An easy way to reproduce this kind of error in the tests is with the following code:

```
        Parallel.For(0, 100, i =>
        {
            TestRealDDBBLocalCall(() => new SqlCommand(notTaintedQuery, databaseConnection).ExecuteReader(CommandBehavior.Default));
            AssertNotVulnerable();
        });
```

While each test class has it's own connection instance, connection pooling, which is true by default can make different test classes actually use the same connection instance, causing the error.

This error might also be the cause of some other SQL related errors in the IAST unit tests, not being able to throw a vulnerability under Linux (in Linux tests, InvalidOperationException are caught).

Adding the MultipleActiveResultSets attribute to the connection string allows to avoid errors when the same connection is used concurrently.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
