### PR TITLE
Update Windows to hosted managed DevOps pool

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -135,7 +135,6 @@ variables:
   DOTNET_CLI_UI_LANGUAGE: 'en'
   DOTNET_MULTILEVEL_LOOKUP: 0
   NUGET_XMLDOC_MODE: 'skip'
-  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -251,7 +251,7 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/install-latest-dotnet-sdk.yml
 
-    - script: tracer\build.cmd BuildTracerHome BuildNativeLoader
+    - script: tracer\build.cmd Info BuildTracerHome BuildNativeLoader
       displayName: Build tracer home
       retryCountOnTaskFailure: 1
 
@@ -1665,6 +1665,13 @@ stages:
       displayName: 'Initialize LocalDB'
       workingDirectory: $(Build.Repository.LocalPath)
 
+    - script: tracer\build.cmd Info
+      displayName: Run integration tests
+      env:
+        DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        enable_crash_dumps: true
+        Filter: $(IntegrationTestFilter)
+
     - script: tracer\build.cmd CompileTrimmingSamples BuildWindowsIntegrationTests BuildWindowsRegressionTests RunIntegrationTests RunWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Run integration tests
       env:
@@ -2198,6 +2205,12 @@ stages:
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        baseImage: $(baseImage)
+        command: "Info --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter $(IntegrationTestFilter) --SampleName $(IntegrationTestSampleName)"
+        apikey: $(DD_LOGGER_DD_API_KEY)
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -251,7 +251,7 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/install-latest-dotnet-sdk.yml
 
-    - script: tracer\build.cmd Info BuildTracerHome BuildNativeLoader
+    - script: tracer\build.cmd BuildTracerHome BuildNativeLoader
       displayName: Build tracer home
       retryCountOnTaskFailure: 1
 
@@ -1665,13 +1665,6 @@ stages:
       displayName: 'Initialize LocalDB'
       workingDirectory: $(Build.Repository.LocalPath)
 
-    - script: tracer\build.cmd Info
-      displayName: Run integration tests
-      env:
-        DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: true
-        Filter: $(IntegrationTestFilter)
-
     - script: tracer\build.cmd CompileTrimmingSamples BuildWindowsIntegrationTests BuildWindowsRegressionTests RunIntegrationTests RunWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Run integration tests
       env:
@@ -2205,12 +2198,6 @@ stages:
     - template: steps/download-samples.yml
       parameters:
         framework: $(publishTargetFramework)
-    - template: steps/run-in-docker.yml
-      parameters:
-        build: true
-        baseImage: $(baseImage)
-        command: "Info --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter $(IntegrationTestFilter) --SampleName $(IntegrationTestSampleName)"
-        apikey: $(DD_LOGGER_DD_API_KEY)
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -216,7 +216,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -243,7 +243,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -289,7 +289,7 @@ stages:
 
   - job: build
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -1028,7 +1028,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-2
+    name: azure-managed-windows-x64-2
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -1090,7 +1090,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1267,7 +1267,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1321,7 +1321,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-2
+    name: azure-managed-windows-x64-2
 
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -1519,7 +1519,7 @@ stages:
     - job: standalone
       timeoutInMinutes: 60 #default value
       pool:
-        name: azure-windows-scale-set-2
+        name: azure-managed-windows-x64-2
       steps:
         - template: steps/clone-repo.yml
           parameters:
@@ -1565,7 +1565,7 @@ stages:
           net9.0:
             framework: net9.0
       pool:
-        name: azure-windows-scale-set-2
+        name: azure-managed-windows-x64-2
       steps:
         - template: steps/clone-repo.yml
           parameters:
@@ -1633,7 +1633,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     timeoutInMinutes: 90
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
@@ -1712,7 +1712,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_debugger_matrix'] ]
@@ -1773,7 +1773,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1832,7 +1832,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1961,7 +1961,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     timeoutInMinutes: 60 #default value
 
     steps:
@@ -2039,7 +2039,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_msi_matrix'] ]
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     variables:
       relativeMsiOutputDirectory: /artifacts/msi/$(targetPlatform)/en-us
 
@@ -2122,7 +2122,7 @@ stages:
   - job: fleet_installer_tests
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
     variables:
       framework: net48
 
@@ -2640,7 +2640,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2856,7 +2856,7 @@ stages:
     condition: false
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -3221,7 +3221,7 @@ stages:
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_windows_matrix'] ]
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     # Enable the Datadog Agent service for this job
     services:
@@ -3375,7 +3375,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -3606,7 +3606,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -5951,7 +5951,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-windows-scale-set-2
+      name: azure-managed-windows-x64-2
 
     steps:
     - template: steps/install-docker-compose-v1.yml

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -75,7 +75,7 @@ partial class Build : NukeBuild
     readonly bool? NewIsPrerelease;
 
     [Parameter("Prints the available drive space before executing each target. Defaults to false")]
-    readonly bool PrintDriveSpace = true;
+    readonly bool PrintDriveSpace = false;
 
     [Parameter("Override the default test filters for integration tests. (Optional)")]
     readonly string Filter;

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -75,7 +75,7 @@ partial class Build : NukeBuild
     readonly bool? NewIsPrerelease;
 
     [Parameter("Prints the available drive space before executing each target. Defaults to false")]
-    readonly bool PrintDriveSpace = false;
+    readonly bool PrintDriveSpace = true;
 
     [Parameter("Override the default test filters for integration tests. (Optional)")]
     readonly string Filter;


### PR DESCRIPTION
## Summary of changes

Move the Windows VMs from a VMSS pool to use a Hosted Managed DevOps Pool

## Reason for change

We want to unify the infrastructure hence the move from VMSS to hosted pools

## Implementation details

- Set up a new hosted devops pool (I will document this process in confluence once I'm/we're happy)
- Reused the same image, so should have identical behaviour otherwise
- Update ultimate-pipeline to use the new pool

## Test coverage

This is the test

## Other details

Supersedes
- https://github.com/DataDog/dd-trace-dotnet/pull/6819

As it's a new pool, we have to _manually_ specify pre-provisioning. I've currently set this to 9-5 UTC with 10VMs but we can tweak that as we see fit. It's currently just to ensure we're getting some pre-provisioning benefit. We can tweak that as we see fit (and can use predictive mode in ~3 weeks time, once Azure has time to analyze our usage)