### PR TITLE
Update Linux x64 to hosted managed DevOps pool

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -345,7 +345,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -408,7 +408,7 @@ stages:
       timeoutInMinutes: 60 #default value
       dependsOn: []
       pool:
-        name: azure-managed-linux-x64-2
+        name: azure-managed-linux-x64-1
       
       steps:
         - template: steps/clone-repo.yml
@@ -471,7 +471,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -522,7 +522,7 @@ stages:
           artifactSuffix: linux-musl-x64
           useNativeSdkVersion: ""
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -584,7 +584,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1132,7 +1132,7 @@ stages:
           artifactSuffix: linux-musl-x64
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1231,7 +1231,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
       - template: steps/clone-repo.yml
@@ -1425,7 +1425,7 @@ stages:
       matrix:
         $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_x64_matrix'] ]
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1910,7 +1910,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1996,7 +1996,7 @@ stages:
   - job: Linux
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2184,7 +2184,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2259,7 +2259,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2374,7 +2374,7 @@ stages:
           publishTargetFramework: "net9.0"
           lambdaBaseImage: "public.ecr.aws/lambda/dotnet:9"
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2551,7 +2551,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2717,7 +2717,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2810,7 +2810,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2897,7 +2897,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
 
@@ -3279,7 +3279,7 @@ stages:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_linux_matrix'] ]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     # Enable the Datadog Agent service for this job
     services:
@@ -3697,12 +3697,12 @@ stages:
         x64:
           baseImage: debian
           artifactSuffix: linux-x64
-          poolName: azure-managed-linux-x64-2
+          poolName: azure-managed-linux-x64-1
           targetArch: x64
         alpine_x64:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
-          poolName: azure-managed-linux-x64-2
+          poolName: azure-managed-linux-x64-1
           targetArch: x64
         arm64:
           baseImage: debian

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -345,7 +345,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -408,7 +408,7 @@ stages:
       timeoutInMinutes: 60 #default value
       dependsOn: []
       pool:
-        name: azure-linux-scale-set-2
+        name: azure-managed-linux-x64-2
       
       steps:
         - template: steps/clone-repo.yml
@@ -471,7 +471,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -522,7 +522,7 @@ stages:
           artifactSuffix: linux-musl-x64
           useNativeSdkVersion: ""
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -584,7 +584,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1132,7 +1132,7 @@ stages:
           artifactSuffix: linux-musl-x64
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1231,7 +1231,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
       - template: steps/clone-repo.yml
@@ -1425,7 +1425,7 @@ stages:
       matrix:
         $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_x64_matrix'] ]
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1910,7 +1910,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1996,7 +1996,7 @@ stages:
   - job: Linux
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2184,7 +2184,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2259,7 +2259,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2374,7 +2374,7 @@ stages:
           publishTargetFramework: "net9.0"
           lambdaBaseImage: "public.ecr.aws/lambda/dotnet:9"
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2551,7 +2551,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2717,7 +2717,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2810,7 +2810,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -2897,7 +2897,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     steps:
 
@@ -3279,7 +3279,7 @@ stages:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_linux_matrix'] ]
 
     pool:
-      name: azure-linux-scale-set-2
+      name: azure-managed-linux-x64-2
 
     # Enable the Datadog Agent service for this job
     services:
@@ -3697,12 +3697,12 @@ stages:
         x64:
           baseImage: debian
           artifactSuffix: linux-x64
-          poolName: azure-linux-scale-set-2
+          poolName: azure-managed-linux-x64-2
           targetArch: x64
         alpine_x64:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
-          poolName: azure-linux-scale-set-2
+          poolName: azure-managed-linux-x64-2
           targetArch: x64
         arm64:
           baseImage: debian


### PR DESCRIPTION
## Summary of changes

- Switch to using Managed DevOps pools
- Fix caching for latest updates

## Reason for change

We want to unify the infrastructure hence the move from VMSS to hosted pools

## Implementation details

- Set up a new hosted devops pool (documentation in-progress)
- Rebuilt the images to fix caching
- Update `ultimate-pipeline` to use the new pool

## Test coverage

This is the test

## Other details

As it's a new pool, we have to manually specify pre-provisioning. I've currently set this to 9-5 UTC with 10VMs but we can tweak that as we see fit. It's currently just to ensure we're getting some pre-provisioning benefit. We can tweak that as we see fit (and can use predictive mode in ~3 weeks time, once Azure has time to analyze our usage)