### PR TITLE
Do not log a debug message when setting `context_info`

### DIFF
--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -339,12 +339,6 @@ namespace Datadog.Trace.DatabaseMonitoring
                 parameter.DbType = DbType.Binary;
                 injectionCommand.Parameters.Add(parameter);
 
-                if (Log.IsEnabled(LogEventLevel.Debug))
-                {
-                    // avoid building the string representation in the general case where debug is disabled
-                    Log.Debug("Propagating span data for DBM for {Integration} via context_info with value {ContextValue} (propagation level: {PropagationLevel}", integrationId, HexConverter.ToString(contextValue), propagationLevel);
-                }
-
                 try
                 {
                     injectionCommand.ExecuteNonQuery();


### PR DESCRIPTION
## Summary of changes

This removes a debug log message with the string representation of the `context_info` data, I don't think it is usable(?) and in some logs it gets called way too much.

## Reason for change

Some log files were full with just these log statements which makes them (1) large on disk and (2) difficult to go through.

## Implementation details

Highlighted the code then pressed delete

## Test coverage

None

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
