### PR TITLE
Auto-delete hotfix branches

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -39,6 +39,7 @@ schedules:
         - release/*
         - hotfix/*
       exclude:
+        - release/2.x
         - release/1.x
     always: true
 

--- a/.github/workflows/auto_delete_hotfix_branch_post_release.yml
+++ b/.github/workflows/auto_delete_hotfix_branch_post_release.yml
@@ -1,0 +1,48 @@
+name: Auto delete hotfix branch after release
+# We run a scheduled nightly job on hotfix branches (same as master), but we don't need this after
+# doing a release, so delete the branch
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update_benchmark_branches:
+    # only run on "hotfix" releases, i.e releases that _don't_ end with .0
+    # i.e. run on 
+    # - 3.2.1
+    # - 4.1.2
+    # - 3.15.2-prerelease
+    # but not on
+    # - 3.2.0
+    # - 4.1.0
+    # - 3.15.0-prerelease
+    if: |
+      !endsWith(github.event.release.tag_name, '.0')
+      && !endsWith(github.event.release.tag_name, '.0-prerelease')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Creates and deletes branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '9.0.203'
+
+      - name: "Output current version"
+        id: versions
+        run: ./tracer/build.sh OutputCurrentVersionToGitHub
+
+      - name: "Configure Git Credentials"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: "Delete old hotfix branch"
+        run: |
+          hotfix_branch=hotfix/${{ steps.versions.outputs.full_version }}
+          git push origin --delete $hotfix_branch;


### PR DESCRIPTION
## Summary of changes

- Automatically delete the hotfix branch after a release
- Don't run the nightly job on the legacy `release/2.x`branch

## Reason for change

We're currently running nightly jobs on `hotfix/*` branches. That's useful _prior_ to a release, but not afterwards. So we should delete the hotfix branch otherwise we're just wasting resources.

Similarly we don't need to (and can't really) run on the v2 release branch any more, so exclude that from the nightly

## Implementation details

Add a github workflow that runs on release publish. This was based on [the workflow that we recently deleted](https://github.com/DataDog/dd-trace-dotnet/blob/fe3bd068c0fe41f3adb1e84e85a80953886a6c59/.github/workflows/auto_update_benchmark_branches.yml) for creating and deleting benchmark branches (which we similarly don't need any more)

## Test coverage

We can't really test this so YOLO

## Other details

I manually deleted the existing `hotfix/*` branches