### PR TITLE
[IAST] New sampling mechanism

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -577,7 +577,7 @@ internal static partial class IastModule
         var traceContext = currentSpan?.Context?.TraceContext;
         var rootSpan = traceContext?.RootSpan;
 
-        if (traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed(rootSpan, vulnerabilityType, GetRouteVulnerabilityStats) != true)
+        if (traceContext?.IastRequestContext?.AddVulnerabilityTypeAllowed(rootSpan, vulnerabilityType, GetRouteVulnerabilityStats) != true)
         {
             // we are inside a request but we don't accept more vulnerabilities or IastRequestContext is null, which means that iast is
             // not activated for this particular request
@@ -672,7 +672,7 @@ internal static partial class IastModule
             return IastModuleResponse.Empty;
         }
 
-        if (isRequest && traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed(rootSpan, vulnerabilityType, GetRouteVulnerabilityStats) != true)
+        if (isRequest && traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed() != true)
         {
             // we are inside a request but we don't accept more vulnerabilities or IastRequestContext is null, which means that iast is
             // not activated for this particular request
@@ -701,6 +701,13 @@ internal static partial class IastModule
 
             // Contains at least one range that is not safe (when analyzing a vulnerability that can have secure marks)
             ranges = unsafeRanges;
+        }
+
+        if (isRequest && traceContext?.IastRequestContext?.AddVulnerabilityTypeAllowed(rootSpan, vulnerabilityType, GetRouteVulnerabilityStats) != true)
+        {
+            // we are inside a request but we don't accept more vulnerabilities or IastRequestContext is null, which means that iast is
+            // not activated for this particular request
+            return IastModuleResponse.Empty;
         }
 
         var location = addLocation ? GetLocation(externalStack, currentSpan) : null;

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -622,7 +622,7 @@ internal static partial class IastModule
         {
             var route = span.GetTag(Tags.HttpRoute) ?? string.Empty;
             var method = span.GetTag(Tags.HttpMethod) ?? string.Empty;
-            var key = $"{route}:{method}";
+            var key = $"{method}#{route}";
             if (key.Length > 1)
             {
                 return _vulnerabilityStats.GetOrAdd(key, (k) => new(k));

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -618,15 +618,18 @@ internal static partial class IastModule
             _vulnerabilityStats.Clear(); // Poor man's LRU cache
         }
 
-        var key = string.Empty;
         if (span?.Type == SpanTypes.Web)
         {
             var route = span.GetTag(Tags.HttpRoute) ?? string.Empty;
             var method = span.GetTag(Tags.HttpMethod) ?? string.Empty;
-            key = $"{route}:{method}";
+            var key = $"{route}:{method}";
+            if (key.Length > 1)
+            {
+                return _vulnerabilityStats.GetOrAdd(key, (k) => new(k));
+            }
         }
 
-        return _vulnerabilityStats.GetOrAdd(key, (k) => new(k));
+        return new VulnerabilityStats(string.Empty);
     }
 
     internal static void UpdateRouteVulnerabilityStats(ref VulnerabilityStats stats)

--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -103,18 +103,20 @@ internal class IastRequestContext
                 _routeVulnerabilityStats = getForCurrentRoute(span);
                 _requestVulnerabilityStats = new(_routeVulnerabilityStats.Route);
             }
-
-            // Check route budget
-            var index = (int)VulnerabilityTypeUtils.FromName(vulnerabilityType);
-            _requestVulnerabilityStats[index]++;
-
-            var txt = $"Vulnerability {vulnerabilityType} detected for Route {_requestVulnerabilityStats.Route}. Current count: {_requestVulnerabilityStats[index]}  Route count: {_routeVulnerabilityStats[index]}";
-            Log.Information("Vulnerability Sampler: {Txt}", txt);
-
-            if (_requestVulnerabilityStats[index] <= _routeVulnerabilityStats[index] || _routeVulnerabilityStats[index] == 0)
+            else if (_requestVulnerabilityStats.Route.Length > 0)
             {
-                _routeVulnerabilityStatsDirty = true;
-                return true;
+                // Check route budget
+                var index = (int)VulnerabilityTypeUtils.FromName(vulnerabilityType);
+                _requestVulnerabilityStats[index]++;
+
+                var txt = $"Vulnerability {vulnerabilityType} detected for Route {_requestVulnerabilityStats.Route}. Current count: {_requestVulnerabilityStats[index]}  Route count: {_routeVulnerabilityStats[index]}";
+                Log.Information("Vulnerability Sampler: {Txt}", txt);
+
+                if (_requestVulnerabilityStats[index] <= _routeVulnerabilityStats[index] || _routeVulnerabilityStats[index] == 0)
+                {
+                    _routeVulnerabilityStatsDirty = true;
+                    return true;
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using System.Threading;
 using System.Web;
 #if !NETFRAMEWORK
@@ -69,6 +70,8 @@ internal class IastRequestContext
 
             if (_routeVulnerabilityStatsDirty)
             {
+                Log.Information("Updating Vulnerability Stats for Route {Route}", _routeVulnerabilityStats.Route);
+                _routeVulnerabilityStats.TransferNewVulns(ref _requestVulnerabilityStats);
                 IastModule.UpdateRouteVulnerabilityStats(ref _routeVulnerabilityStats);
             }
 
@@ -104,10 +107,13 @@ internal class IastRequestContext
             // Check route budget
             var index = (int)VulnerabilityTypeUtils.FromName(vulnerabilityType);
             _requestVulnerabilityStats[index]++;
+
+            var txt = $"Vulnerability {vulnerabilityType} detected for Route {_requestVulnerabilityStats.Route}. Current count: {_requestVulnerabilityStats[index]}  Route count: {_routeVulnerabilityStats[index]}";
+            Log.Information("Vulnerability Sampler: {Txt}", txt);
+
             if (_requestVulnerabilityStats[index] <= _routeVulnerabilityStats[index] || _routeVulnerabilityStats[index] == 0)
             {
                 _routeVulnerabilityStatsDirty = true;
-                _routeVulnerabilityStats[index] = _requestVulnerabilityStats[index];
                 return true;
             }
         }

--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -53,13 +53,13 @@ internal class IastRequestContext
                 if (AddVulnerabilitiesAllowed())
                 {
                     // Global budget not depleted. Reset route stats so vulns can be detected again.
-                    Log.Debug("Clearing Vulnerability Stats for Route {Route}", _routeVulnerabilityStats.Route);
+                    Log.Debug("Clearing Vulnerability Stats for Route {Route} (Budget left)", _routeVulnerabilityStats.Route);
                     _routeVulnerabilityStats = new VulnerabilityStats(_requestVulnerabilityStats.Route);
                 }
                 else
                 {
                     // Global budget depleted. Update route stats so vulns new can be detected.
-                    Log.Debug("Updating Vulnerability Stats for Route {Route}", _routeVulnerabilityStats.Route);
+                    Log.Debug("Updating Vulnerability Stats for Route {Route} (Budget depleted)", _routeVulnerabilityStats.Route);
                     _routeVulnerabilityStats.TransferNewVulns(ref _requestVulnerabilityStats);
                 }
 
@@ -124,7 +124,8 @@ internal class IastRequestContext
                 string debugTxt = string.Empty;
                 if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
                 {
-                    debugTxt = $"Vulnerability {vulnerabilityType} detected for Route {_requestVulnerabilityStats.Route}. Current count: {_requestVulnerabilityStats[index]}  Route count: {_routeVulnerabilityStats[index]}";
+                    var currentVulns = (_vulnerabilityBatch?.Vulnerabilities.Count ?? 0) + 1;
+                    debugTxt = $"Vulnerability {vulnerabilityType} detected for Route {_requestVulnerabilityStats.Route}. Current count: {_requestVulnerabilityStats[index]}  Route count: {_routeVulnerabilityStats[index]}  Budget: {currentVulns} out of {Iast.Instance.Settings.VulnerabilitiesPerRequest}";
                 }
 
                 _routeVulnerabilityStatsDirty = true;

--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -70,8 +70,19 @@ internal class IastRequestContext
 
             if (_routeVulnerabilityStatsDirty)
             {
-                Log.Debug("Updating Vulnerability Stats for Route {Route}", _routeVulnerabilityStats.Route);
-                _routeVulnerabilityStats.TransferNewVulns(ref _requestVulnerabilityStats);
+                if (AddVulnerabilitiesAllowed())
+                {
+                    // Global budget not depleted. Reset route stats so vulns can be detected again.
+                    Log.Debug("Clearing Vulnerability Stats for Route {Route}", _routeVulnerabilityStats.Route);
+                    _routeVulnerabilityStats = new VulnerabilityStats(_requestVulnerabilityStats.Route);
+                }
+                else
+                {
+                    // Global budget depleted. Update route stats so vulns new can be detected.
+                    Log.Debug("Updating Vulnerability Stats for Route {Route}", _routeVulnerabilityStats.Route);
+                    _routeVulnerabilityStats.TransferNewVulns(ref _requestVulnerabilityStats);
+                }
+
                 IastModule.UpdateRouteVulnerabilityStats(ref _routeVulnerabilityStats);
             }
 

--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -136,6 +136,10 @@ internal class IastRequestContext
 
                 Log.Debug("Vulnerability Sampler SKIPPED: {Txt}", debugTxt);
             }
+            else
+            {
+                return true;
+            }
         }
 
         return false;

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityStats.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityStats.cs
@@ -58,4 +58,16 @@ internal unsafe struct VulnerabilityStats
             Unsafe.WriteUnaligned<ushort>(ref data[index * ElementSize], value);
         }
     }
+
+    public void TransferNewVulns(ref VulnerabilityStats stats)
+    {
+        for (int x = 0; x < Length; x++)
+        {
+            var value = stats[x];
+            if (value > this[x])
+            {
+                this[x] = value;
+            }
+        }
+    }
 }

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityStats.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityStats.cs
@@ -1,0 +1,61 @@
+// <copyright file="VulnerabilityStats.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+#if !NETCOREAPP
+using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
+#else
+using System.Runtime.CompilerServices;
+#endif
+
+namespace Datadog.Trace.Iast;
+
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+internal unsafe struct VulnerabilityStats
+{
+    private const int ElementSize = 2; // sizeof(ushort)
+    private const int Size = ElementSize * Length;
+    private fixed byte data[Size];
+
+    public const int Length = VulnerabilityTypeUtils.Count;
+
+    public VulnerabilityStats(string? route)
+    {
+        Route = route;
+    }
+
+    public string? Route { get; }
+
+    public ushort this[int index]
+    {
+        get
+        {
+            if (index < 0 || index >= Length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            return Unsafe.ReadUnaligned<ushort>(ref data[index * ElementSize]);
+        }
+
+        set
+        {
+            if (index < 0 || index >= Length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            Unsafe.WriteUnaligned<ushort>(ref data[index * ElementSize], value);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityType.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityType.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 #nullable enable
+using Datadog.Trace.SourceGenerators;
+
 namespace Datadog.Trace.Iast;
 
 /// <summary>
@@ -90,5 +92,5 @@ internal enum VulnerabilityType
     SessionTimeout = 25,
 
     /// <summary> EMAIL_HTML_INJECTION vulnerability </summary>
-    EmailHtmlInjection = 26
+    EmailHtmlInjection = 26,
 }

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityTypeUtils.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityTypeUtils.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 using System.ComponentModel;
+using Datadog.Trace.Telemetry.Metrics;
 using static Datadog.Trace.Telemetry.Metrics.MetricTags;
 
 namespace Datadog.Trace.Iast;
@@ -14,6 +15,9 @@ namespace Datadog.Trace.Iast;
 /// </summary>
 internal static class VulnerabilityTypeUtils
 {
+    /// <summary> The number of vulnerability types </summary>
+    public const int Count = 27;
+
     /// <summary> Undefined vulnerability </summary>
     public const string None = "NONE";
 
@@ -130,7 +134,7 @@ internal static class VulnerabilityTypeUtils
         };
     }
 
-    public static IastVulnerabilityType GetTag(string vulnerability)
+    public static IastVulnerabilityType FromName(string vulnerability)
     {
         return vulnerability switch
         {

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -427,7 +427,7 @@ public class AspNetCore5IastTestsStackTraces : AspNetCore5IastTests
 public class AspNetCore5IastTestsCompatEditAndContinue : AspNetCore5IastTests
 {
     public AspNetCore5IastTestsCompatEditAndContinue(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-        : base(fixture, outputHelper, enableIast: true, testName: "AspNetCore5IastTestsCompat", samplingRate: 100, isIastDeduplicationEnabled: false, vulnerabilitiesPerRequest: 200, redactionEnabled: true)
+        : base(fixture, outputHelper, enableIast: true, testName: "AspNetCore5IastTestsCompat", samplingRate: 100, isIastDeduplicationEnabled: false, vulnerabilitiesPerRequest: 3, redactionEnabled: true)
     {
         SetEnvironmentVariable("COMPLUS_ForceEnc", "1");
     }
@@ -763,7 +763,7 @@ public class AspNetCore5IastTestsFullSamplingIastDisabled : AspNetCore5IastTests
 public class AspNetCore5IastTestsFullSamplingRedactionEnabled : AspNetCore5IastTestsFullSampling
 {
     public AspNetCore5IastTestsFullSamplingRedactionEnabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-        : base(fixture, outputHelper, enableIast: true, isIastDeduplicationEnabled: false, testName: "AspNetCore5IastTestsRedactionEnabled", redactionEnabled: true, vulnerabilitiesPerRequest: 100)
+        : base(fixture, outputHelper, enableIast: true, isIastDeduplicationEnabled: false, testName: "AspNetCore5IastTestsRedactionEnabled", redactionEnabled: true, vulnerabilitiesPerRequest: 3)
     {
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -343,6 +343,28 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();
     }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task TestIastVulnerabilitySampling()
+    {
+        var filename = "Iast.VulnerabilitySampling.AspNetCore5.IastEnabled";
+        var url1 = $"/Iast/Sampling1?parameter=name";
+        var url2 = $"/Iast/Sampling2?parameter=name";
+        IncludeAllHttpSpans = true;
+
+        await TryStartApp();
+        var agent = Fixture.Agent;
+        var spans = await SendRequestsAsync(agent, [url1, url2, url1, url2]);
+        var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web && x.Name == "aspnet_core.request").ToList();
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddIastScrubbing(forceMetaStruct: true);
+
+        await VerifyHelper.VerifySpans(spansFiltered, settings)
+                          .UseFileName(filename)
+                          .DisableRequireUniquePrefix();
+    }
 }
 
 // Classes to test particular features

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -613,7 +613,7 @@ public class AspNetCore5IastTestsTwoVulnerabilityPerRequestIastEnabled : AspNetC
     [Trait("RunOnWindows", "True")]
     public async Task TestIastLocationSpanId()
     {
-        var url = "/Iast/WeakHashing";
+        var url = "/Iast/WeakHashing2";
         IncludeAllHttpSpans = true;
         await TryStartApp();
         var agent = Fixture.Agent;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -349,11 +349,12 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
     public async Task TestIastVulnerabilitySampling()
     {
         var filename = "Iast.VulnerabilitySampling.AspNetCore5.IastEnabled";
-        var url1 = $"/Iast/Sampling1?parameter=name";
-        var url2 = $"/Iast/Sampling2?parameter=name";
+        var url1 = $"/Iast/Sampling1";
+        var url2 = $"/Iast/Sampling2";
         IncludeAllHttpSpans = true;
 
-        // Each route has 3 vulnerabilities (as the budget), sot firts call to the route will rend 3 vulns, depleting budget.
+        // Each route has 3 vulnerabilities (as the budget)
+        // First call to the route will rend 3 vulns, depleting budget.
         // Second call will render none (sampling mechanism) and will reset as the budget was not depleted this time
         // Third call will render all 3 vulns again (as the budget was reset)
         // The same behabiour is repeated for the second route

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/VulnerabilityStatsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/VulnerabilityStatsTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="VulnerabilityStatsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Iast;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests.IAST
+{
+    public class VulnerabilityStatsTests
+    {
+        [Fact]
+        public void GivenSomeVulnerabilityStats_WhenManipulated_DataIsCoherent()
+        {
+            VulnerabilityTypeUtils.Count.Should().Be(Enum.GetValues(typeof(VulnerabilityType)).Length, "VulnerabilityTypeUtils.Count should hold the number of different vulnerability types defined in VulnerabilityType enum");
+            VulnerabilityStats.Length.Should().Be(VulnerabilityTypeUtils.Count);
+
+            var empty = new VulnerabilityStats();
+            empty.Route.Should().BeNull();
+            for (int index = 0; index < VulnerabilityStats.Length; index++)
+            {
+                empty[index].Should().Be(0);
+            }
+
+            var route = "route";
+            var stats = new VulnerabilityStats(route);
+            stats.Route.Should().Be(route);
+
+            ushort sqlI = 31000;
+            ushort weakHash = 25000;
+            ushort ssrf = 25;
+            stats[(int)VulnerabilityType.SqlInjection] = sqlI;
+            stats[(int)VulnerabilityType.WeakHash] = weakHash;
+            stats[(int)VulnerabilityType.Ssrf] = ssrf;
+
+            for (int index = 0; index < VulnerabilityStats.Length; index++)
+            {
+                if (index == (int)VulnerabilityType.SqlInjection)
+                {
+                    stats[index].Should().Be(sqlI);
+                }
+                else if (index == (int)VulnerabilityType.WeakHash)
+                {
+                    stats[index].Should().Be(weakHash);
+                }
+                else if (index == (int)VulnerabilityType.Ssrf)
+                {
+                    stats[index].Should().Be(ssrf);
+                }
+                else
+                {
+                    stats[index].Should().Be(0);
+                }
+            }
+
+            var stats2 = new VulnerabilityStats(route);
+            stats2[(int)VulnerabilityType.SqlInjection] = (ushort)(sqlI + 10);
+            stats2[(int)VulnerabilityType.WeakHash] = (ushort)(10);
+            stats2[(int)VulnerabilityType.Ssrf] = (ushort)(ssrf + 10);
+            stats.TransferNewVulns(ref stats2);
+
+            for (int index = 0; index < VulnerabilityStats.Length; index++)
+            {
+                if (index == (int)VulnerabilityType.SqlInjection)
+                {
+                    stats[index].Should().Be(stats2[index]);
+                }
+                else if (index == (int)VulnerabilityType.WeakHash)
+                {
+                    stats[index].Should().Be(weakHash);
+                }
+                else if (index == (int)VulnerabilityType.Ssrf)
+                {
+                    stats[index].Should().Be(stats2[index]);
+                }
+                else
+                {
+                    stats[index].Should().Be(0);
+                }
+            }
+        }
+    }
+}

--- a/tracer/test/snapshots/Iast.AspNetCore5.enableIast=True.path =_Iast_AllVulnerabilitiesCookie.verified.txt
+++ b/tracer/test/snapshots/Iast.AspNetCore5.enableIast=True.path =_Iast_AllVulnerabilitiesCookie.verified.txt
@@ -44,69 +44,6 @@
       "evidence": {
         "value": "AllVulnerabilitiesCookieKey"
       }
-    },
-    {
-      "type": "NO_SAMESITE_COOKIE",
-      "hash": -636226626,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.0"
-      }
-    },
-    {
-      "type": "NO_HTTPONLY_COOKIE",
-      "hash": -60481650,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.0"
-      }
-    },
-    {
-      "type": "INSECURE_COOKIE",
-      "hash": 990913114,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.0"
-      }
-    },
-    {
-      "type": "NO_SAMESITE_COOKIE",
-      "hash": -636226626,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.1"
-      }
-    },
-    {
-      "type": "NO_HTTPONLY_COOKIE",
-      "hash": -60481650,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.1"
-      }
-    },
-    {
-      "type": "INSECURE_COOKIE",
-      "hash": 990913114,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.1"
-      }
-    },
-    {
-      "type": "NO_SAMESITE_COOKIE",
-      "hash": -636226626,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.2"
-      }
-    },
-    {
-      "type": "NO_HTTPONLY_COOKIE",
-      "hash": -60481650,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.2"
-      }
-    },
-    {
-      "type": "INSECURE_COOKIE",
-      "hash": 990913114,
-      "evidence": {
-        "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.2"
-      }
     }
   ]
 }

--- a/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
@@ -1,0 +1,224 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/sampling1,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.Sampling (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/sampling1,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/sampling1,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/Sampling1?parameter=name,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
+        "value": "SHA1"
+      }
+    },
+    {
+      "type": "SQL_INJECTION",
+      "hash": 1413035770,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Sampling"
+      },
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "SELECT Surname from Persons where name = '"
+          },
+          {
+            "value": "name",
+            "source": 0
+          },
+          {
+            "value": "'"
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.parameter",
+      "name": "parameter",
+      "value": "name"
+    }
+  ]
+},
+      _dd.iast.json.metastruct.test: true
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      iast: 
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: aspnet_core.request,
+    Resource: GET /iast/sampling1,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.Sampling (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/sampling1,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/sampling1,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/Sampling1?parameter=name,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: aspnet_core.request,
+    Resource: GET /iast/sampling2,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.Sampling (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/sampling2,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/sampling2,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
+        "value": "SHA1"
+      }
+    },
+    {
+      "type": "SQL_INJECTION",
+      "hash": 1413035770,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Sampling"
+      },
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "SELECT Surname from Persons where name = '"
+          },
+          {
+            "value": "name",
+            "source": 0
+          },
+          {
+            "value": "'"
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.parameter",
+      "name": "parameter",
+      "value": "name"
+    }
+  ]
+},
+      _dd.iast.json.metastruct.test: true
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      iast: 
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_8,
+    Name: aspnet_core.request,
+    Resource: GET /iast/sampling2,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.Sampling (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/sampling2,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/sampling2,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
@@ -33,6 +33,18 @@
         "method": "WeakHashing"
       },
       "evidence": {
+        "value": "MD5"
+      }
+    },
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
         "value": "SHA1"
       }
     },
@@ -114,19 +126,19 @@
     TraceId: Id_5,
     SpanId: Id_6,
     Name: aspnet_core.request,
-    Resource: GET /iast/sampling2,
+    Resource: GET /iast/sampling1,
     Service: Samples.Security.AspNetCore5,
     Type: web,
     Tags: {
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.Sampling (Samples.Security.AspNetCore5),
-      aspnet_core.route: iast/sampling2,
+      aspnet_core.route: iast/sampling1,
       component: aspnet_core,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
-      http.route: iast/sampling2,
+      http.route: iast/sampling1,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.url: http://localhost:00000/Iast/Sampling1?parameter=name,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,
@@ -135,6 +147,18 @@
       _dd.iast.json:
 {
   "vulnerabilities": [
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
+        "value": "MD5"
+      }
+    },
     {
       "type": "WEAK_HASH",
       "hash": 414128505,
@@ -212,6 +236,99 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
+        "value": "MD5"
+      }
+    },
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
+        "value": "SHA1"
+      }
+    },
+    {
+      "type": "SQL_INJECTION",
+      "hash": 1413035770,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Sampling"
+      },
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "SELECT Surname from Persons where name = '"
+          },
+          {
+            "value": "name",
+            "source": 0
+          },
+          {
+            "value": "'"
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.parameter",
+      "name": "parameter",
+      "value": "name"
+    }
+  ]
+},
+      _dd.iast.json.metastruct.test: true
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      iast: 
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_10,
+    Name: aspnet_core.request,
+    Resource: GET /iast/sampling2,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.Sampling (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/sampling2,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/sampling2,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
       _dd.iast.enabled: 1
     },
     Metrics: {
@@ -219,6 +336,99 @@
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_11,
+    SpanId: Id_12,
+    Name: aspnet_core.request,
+    Resource: GET /iast/sampling2,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.Sampling (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/sampling2,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/sampling2,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
+        "value": "MD5"
+      }
+    },
+    {
+      "type": "WEAK_HASH",
+      "hash": 414128505,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
+      "evidence": {
+        "value": "SHA1"
+      }
+    },
+    {
+      "type": "SQL_INJECTION",
+      "hash": 1413035770,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Sampling"
+      },
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "SELECT Surname from Persons where name = '"
+          },
+          {
+            "value": "name",
+            "source": 0
+          },
+          {
+            "value": "'"
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.parameter",
+      "name": "parameter",
+      "value": "name"
+    }
+  ]
+},
+      _dd.iast.json.metastruct.test: true
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      iast: 
     }
   }
 ]

--- a/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
@@ -15,7 +15,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/sampling1,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/Sampling1?parameter=name,
+      http.url: http://localhost:00000/Iast/Sampling1,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,
@@ -49,34 +49,16 @@
       }
     },
     {
-      "type": "SQL_INJECTION",
-      "hash": 1413035770,
+      "type": "WEAK_RANDOMNESS",
+      "hash": -1130147155,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
-        "method": "Sampling"
+        "method": "WeakRandomness"
       },
       "evidence": {
-        "valueParts": [
-          {
-            "value": "SELECT Surname from Persons where name = '"
-          },
-          {
-            "value": "name",
-            "source": 0
-          },
-          {
-            "value": "'"
-          }
-        ]
+        "value": "System.Random"
       }
-    }
-  ],
-  "sources": [
-    {
-      "origin": "http.request.parameter",
-      "name": "parameter",
-      "value": "name"
     }
   ]
 },
@@ -108,7 +90,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/sampling1,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/Sampling1?parameter=name,
+      http.url: http://localhost:00000/Iast/Sampling1,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,
@@ -138,7 +120,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/sampling1,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/Sampling1?parameter=name,
+      http.url: http://localhost:00000/Iast/Sampling1,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,
@@ -172,34 +154,16 @@
       }
     },
     {
-      "type": "SQL_INJECTION",
-      "hash": 1413035770,
+      "type": "WEAK_RANDOMNESS",
+      "hash": -1130147155,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
-        "method": "Sampling"
+        "method": "WeakRandomness"
       },
       "evidence": {
-        "valueParts": [
-          {
-            "value": "SELECT Surname from Persons where name = '"
-          },
-          {
-            "value": "name",
-            "source": 0
-          },
-          {
-            "value": "'"
-          }
-        ]
+        "value": "System.Random"
       }
-    }
-  ],
-  "sources": [
-    {
-      "origin": "http.request.parameter",
-      "name": "parameter",
-      "value": "name"
     }
   ]
 },
@@ -231,7 +195,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/sampling2,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.url: http://localhost:00000/Iast/Sampling2,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,
@@ -265,34 +229,16 @@
       }
     },
     {
-      "type": "SQL_INJECTION",
-      "hash": 1413035770,
+      "type": "WEAK_RANDOMNESS",
+      "hash": -1130147155,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
-        "method": "Sampling"
+        "method": "WeakRandomness"
       },
       "evidence": {
-        "valueParts": [
-          {
-            "value": "SELECT Surname from Persons where name = '"
-          },
-          {
-            "value": "name",
-            "source": 0
-          },
-          {
-            "value": "'"
-          }
-        ]
+        "value": "System.Random"
       }
-    }
-  ],
-  "sources": [
-    {
-      "origin": "http.request.parameter",
-      "name": "parameter",
-      "value": "name"
     }
   ]
 },
@@ -324,7 +270,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/sampling2,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.url: http://localhost:00000/Iast/Sampling2,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,
@@ -354,7 +300,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/sampling2,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/Sampling2?parameter=name,
+      http.url: http://localhost:00000/Iast/Sampling2,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,
@@ -388,34 +334,16 @@
       }
     },
     {
-      "type": "SQL_INJECTION",
-      "hash": 1413035770,
+      "type": "WEAK_RANDOMNESS",
+      "hash": -1130147155,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
-        "method": "Sampling"
+        "method": "WeakRandomness"
       },
       "evidence": {
-        "valueParts": [
-          {
-            "value": "SELECT Surname from Persons where name = '"
-          },
-          {
-            "value": "name",
-            "source": 0
-          },
-          {
-            "value": "'"
-          }
-        ]
+        "value": "System.Random"
       }
-    }
-  ],
-  "sources": [
-    {
-      "origin": "http.request.parameter",
-      "name": "parameter",
-      "value": "name"
     }
   ]
 },

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -246,6 +246,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("WeakHashing")]
         [Route("WeakHashing/{delay1}")]
+        [Route("WeakHashing2")]
         public IActionResult WeakHashing(int delay1 = 0, int delay2 = 0)
         {
             System.Threading.Thread.Sleep(delay1 + delay2);

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -1375,5 +1375,29 @@ namespace Samples.Security.AspNetCore5.Controllers
                 return Content("Nothing to display.");
             }
         }
+
+        [HttpGet("Sampling")]
+        [Route("Sampling1")]
+        [Route("Sampling2")]
+        public IActionResult Sampling(string parameter)
+        {
+            WeakHashing();
+
+            try
+            {
+                if (!string.IsNullOrEmpty(parameter))
+                {
+                    var taintedQuery = "SELECT Surname from Persons where name = '" + parameter + "'";
+                    var rname = new SQLiteCommand(taintedQuery, DbConnectionSystemData).ExecuteScalar();
+                    return Content($"Result: " + rname);
+                }
+            }
+            catch (SQLiteException ex)
+            {
+                return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
+            }
+
+            return BadRequest($"No query or username was provided");
+        }
     }
 }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -1380,25 +1380,11 @@ namespace Samples.Security.AspNetCore5.Controllers
         [HttpGet("Sampling")]
         [Route("Sampling1")]
         [Route("Sampling2")]
-        public IActionResult Sampling(string parameter)
+        public IActionResult Sampling()
         {
             WeakHashing();
-
-            try
-            {
-                if (!string.IsNullOrEmpty(parameter))
-                {
-                    var taintedQuery = "SELECT Surname from Persons where name = '" + parameter + "'";
-                    var rname = new SQLiteCommand(taintedQuery, DbConnectionSystemData).ExecuteScalar();
-                    return Content($"Result: " + rname);
-                }
-            }
-            catch (SQLiteException ex)
-            {
-                return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
-            }
-
-            return BadRequest($"No query or username was provided");
+            WeakRandomness();
+            return Content($"Result: 3 vulns should have been triggered");
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
Created a vulnerability budget by route and vulnerability type to avoid detecting the same vulnerabilities depleting the request budget, so more vulnerabilities can be detected in subsequent calls to the same endpoint.

## Reason for change
Many vulnerabilities were being skipped because of lack of budget because the same vulnerabilities were being detected in the same endpoints in the same order.

[Jira ticket](https://datadoghq.atlassian.net/browse/APPSEC-57275?atlOrigin=eyJpIjoiZDViNzQ3ZmMyNGVlNGI2MTk2MTQ2NDMzM2RmNDc0ZWYiLCJwIjoiaiJ9)

[RFC](https://docs.google.com/document/d/1CfGFm2Ouz5vxOhibNyLCZjGzLbDI3F0fO9irKWqxhVI)

## Implementation details
Vulnearbility detection count has been implemented in the `VulnerabilityStats` struct as an inline array, with each position representing the amount of times a vulnerability type has been detected for each route.

## Test coverage
Integration and unit tests have been provided

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
