### PR TITLE
Improve batching of system tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4594,7 +4594,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
     scenarioGroups: "appsec"
-    additionalScenarios: '[\"PARAMETRIC\", \"REMOTE_CONFIG_SCENARIOS\", \"TELEMETRY_SCENARIOS\", \"DEFAULT\", \"INTEGRATIONS\", \"INTEGRATIONS_AWS\", \"CROSSED_TRACING_LIBRARIES\", \"DEBUGGER_SCENARIOS\", \"+S PROFILING +S TRACE_PROPAGATION_STYLE_W3C +S LIBRARY_CONF_CUSTOM_HEADER_TAGS\"]'
+    additionalScenarios: '[\"REMOTE_CONFIG_SCENARIOS\", \"TELEMETRY_SCENARIOS\", \"DEFAULT\", \"INTEGRATIONS\", \"INTEGRATIONS_AWS\", \"CROSSED_TRACING_LIBRARIES\", \"DEBUGGER_SCENARIOS\", \"+S PROFILING +S TRACE_PROPAGATION_STYLE_W3C +S LIBRARY_CONF_CUSTOM_HEADER_TAGS\"]'
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -4626,35 +4626,40 @@ stages:
             set -e
             
             source venv/bin/activate
-            PYTHONPATH=. python utils/scripts/compute-workflow-parameters.py dotnet -g $(scenarioGroups) > out.txt
+            # Try to get each workflow to take 15 mins = 900s
+            PYTHONPATH=. python utils/scripts/compute-workflow-parameters.py dotnet -g $(scenarioGroups) -t 900 > out.txt
 
-            endtoend_scenarios=$(grep 'endtoend_scenarios' out.txt | sed 's/.*=//g')
-            parametric_scenarios=$(grep 'parametric_scenarios' out.txt | sed 's/.*=//g')
+            endtoend_scenario_groups=$(grep 'endtoend_defs_parallel_jobs' out.txt | sed 's/.*=//g')
             endtoend_weblogs=$(grep 'endtoend_weblogs' out.txt | sed 's/.*=//g')
+            additional_scenarios="$(additionalScenarios)"
 
-            echo "Found scenarios: $endtoend_scenarios"
-            echo "Found parametric scenarios: $parametric_scenarios"
+            echo "Found scenario groups: endtoend_scenario_groups"
             echo "Found weblogs: $endtoend_weblogs"
-            echo "Additional manual scenarios: $(additionalScenarios)"
+            echo "Additional manual scenarios: $additional_scenarios"
             
             # Write the weblogs to a file (for later use to generate the docker images)
             python -c "import json; variants = json.loads('$endtoend_weblogs'); print('\n'.join(variants))" > /tmp/weblogs_list.txt
-        
-            # Inline python script to cross the data into a json
-            echo "import json" > cross.py
-            echo "script_scenarios = json.loads('$endtoend_scenarios')" >> cross.py
-            echo "script_parametric_scenarios = json.loads('$parametric_scenarios')" >> cross.py
-            echo "script_weblogs   = json.loads('$endtoend_weblogs')" >> cross.py
-            echo "extra_scenarios  = json.loads('$(additionalScenarios)')" >> cross.py
-            echo 'combined_scenarios = script_scenarios + script_parametric_scenarios + extra_scenarios' >> cross.py
-            echo 'matrix_items = {}' >> cross.py
-            echo 'for s in combined_scenarios:' >> cross.py
-            echo '    for w in script_weblogs:' >> cross.py
-            echo '        matrix_items[s + " (" + w + ")"] = {"SCENARIO": s, "WEBLOG_VARIANT": w}' >> cross.py
-            echo 'print(json.dumps(matrix_items))' >> cross.py
-            
-            python cross.py > matrix.json
-            
+            # Generate matrix and write to file
+            jq -c -n --argjson main "$endtoend_scenario_groups" --argjson webs "$endtoend_weblogs" --argjson extra "$additional_scenarios" '
+              (
+                $main | map({
+                  ("APPSEC (" + .weblog + ") " + (.weblog_instance|tostring)): {
+                    SCENARIO: (.scenarios | map("+S " + .) | join(" ")), N: 1, I: 1,
+                    WEBLOG_VARIANT: .weblog
+                  }
+                })
+              ) + (
+                [ $extra[] as $scenario | $webs[] as $weblog |
+                  { ($scenario + " (" + $weblog + ") 1"): { SCENARIO: $scenario, WEBLOG_VARIANT: $weblog, N: 1, I: 1 } }
+                ]
+              ) + (
+              [ $webs[] as $weblog | range(1; 4) as $i |
+                { ("PARAMETRIC (" + $weblog + ") \($i)"): {
+                  SCENARIO: "PARAMETRIC", WEBLOG_VARIANT: $weblog, N: 3, I: $i
+                }}
+              ]
+              ) | add
+            ' > matrix.json            
             echo "##vso[task.setvariable variable=matrixJson;isOutput=true]$(cat matrix.json)"
             echo "Json: $(cat matrix.json)"
           displayName: Generate scenarios matrix JSON
@@ -4746,7 +4751,7 @@ stages:
         displayName: Install runner
         workingDirectory: system-tests
 
-      - script: ./run.sh $(SCENARIO)
+      - script: ./run.sh $(SCENARIO) --splits=$(N) --group=$(I)
         workingDirectory: system-tests
         displayName: Run tests
         env:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4633,7 +4633,7 @@ stages:
             endtoend_weblogs=$(grep 'endtoend_weblogs' out.txt | sed 's/.*=//g')
             additional_scenarios="$(additionalScenarios)"
 
-            echo "Found scenario groups: endtoend_scenario_groups"
+            echo "Found scenario groups: $endtoend_scenario_groups"
             echo "Found weblogs: $endtoend_weblogs"
             echo "Additional manual scenarios: $additional_scenarios"
             


### PR DESCRIPTION
## Summary of changes

Update how we generate batches

## Reason for change

The current design is splitting every system tests in the APPSEC scenario into its own job, but running all the parameteric tests in one job. That means there's a big disparity between the shortest and longest jobs which isn't ideal.

Ideally, we want all jobs to take the same length of time. That means we're reducing the wall time maximally, while also not over-using runners (which are a finite resources).

## Implementation details

- Split the parametric jobs (which currently take 30-40mins) into 3 separate jobs.
- Group the APPSEC jobs into multiple batches, to reduce the setup time for each (and reduce the number of agents in use, which should overall improve throughput) (each batch targets ~15mins)
- Implement in `jq` (the python inside of bash inside of yaml was breaking my brain). 
- ChatGPT did the heavy lifting, but confirmed it generates what I expected

## Test coverage

This is the test

## Other details

As long as we're getting the same results, we're good.

Before:
![image](https://github.com/user-attachments/assets/6c57ec60-00a8-4e6f-88b9-7590efbb448b)
![image](https://github.com/user-attachments/assets/f1b2c145-fd1b-4153-bab6-5bd1291ee731)
![image](https://github.com/user-attachments/assets/9f343c72-8897-4993-92e8-e6e504cf7e79)


After
![image](https://github.com/user-attachments/assets/ae134a1a-b63f-4854-8740-f5251ef111fe)
