### PR TITLE
Try to work around crash tracking errors

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -170,7 +170,7 @@ steps:
     displayName: Check logs for evidence of crash output
     # This job sometimes hangs, and when it does, we lose all the logs, so explicitly end it early instead
     timeoutInMinutes: 15
-    condition: eq(variables['runCrashTest'], 'true')
+    condition: and(succeeded(), eq(variables['runCrashTest'], 'true'))
 
 - ${{ if eq(parameters.isLinux, true) }}:
     - script: |

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -153,7 +153,7 @@ steps:
         LOGS+="$line"$'\n'  # Capture each line into LOGS variable
         # Profiling is disabled using DD_PROFILING_ENABLED=0 because there is a flaky freeze we are working around
         # Once we figure out the freeze, we can re-enable
-      done < <(${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e DD_PROFILING_ENABLED=0 -e CRASH_APP_ON_STARTUP=1 -e DD_CRASHTRACKING_INTERNAL_LOG_TO_CONSOLE=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
+      done < <(${{ parameters.dockerComposePath }} --rm -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e DD_PROFILING_ENABLED=0 -e CRASH_APP_ON_STARTUP=1 -e DD_CRASHTRACKING_INTERNAL_LOG_TO_CONSOLE=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }} 2>&1)
 
       # check logs for evidence of crash detection in the output
       expected="The crash may have been caused by automatic instrumentation"

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -153,7 +153,7 @@ steps:
         LOGS+="$line"$'\n'  # Capture each line into LOGS variable
         # Profiling is disabled using DD_PROFILING_ENABLED=0 because there is a flaky freeze we are working around
         # Once we figure out the freeze, we can re-enable
-      done < <(${{ parameters.dockerComposePath }} --rm -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e DD_PROFILING_ENABLED=0 -e CRASH_APP_ON_STARTUP=1 -e DD_CRASHTRACKING_INTERNAL_LOG_TO_CONSOLE=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }} 2>&1)
+      done < <(${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run --rm -e dockerTag=$(dockerTag) -e DD_PROFILING_ENABLED=0 -e CRASH_APP_ON_STARTUP=1 -e DD_CRASHTRACKING_INTERNAL_LOG_TO_CONSOLE=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }} 2>&1)
 
       # check logs for evidence of crash detection in the output
       expected="The crash may have been caused by automatic instrumentation"


### PR DESCRIPTION
## Summary of changes

Try some things to avoid hanging in crash tracking tests

## Reason for change

We see hanging in the crash tracking sometimes, and based on newly added debug logs, it seems to happen _after_ `dd-dotnet` has exited. That means our options are basically:

- either dd-dotnet did not in fact exit properly (but that would be very surprising since we're printing the "exit" message at the very end)
- or it did not correctly resume the threads of the crashing app
- or it's not crashtracking that is causing the timeout

I suspect the answer is 2, but ChatGPT suggested these changes as possible workarounds for niche issues for the final option, so trying them.

Also, we're currently running the crash test when the job has already failed, when we shouldn't be

## Implementation details

- Clean up the docker image
- pipe stderr as well as stdout
- Fix `condition`

## Test coverage

If this test passes, that's good enough, and we'll just keep an eye out to see if it keeps happening anyway

