### PR TITLE
Fix typo in universal build definition

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -484,7 +484,7 @@ stages:
         build: true
         target: builder
         baseImage: "universal"
-        useNativeSdkVersion: false
+        useNativeSdkVersion: true
         command: "Clean BuildNativeLoader BuildNativeWrapper ExtractDebugInfoLinux"
         retryCountForRunCommand: 1
 


### PR DESCRIPTION
## Summary of changes

`useNativeSdkVersion: false` -> `useNativeSdkVersion: true`

## Reason for change

The check for whether to use the non-native SDK is just checking for non-null. So the above checks are equivalent, and both mean `true`. But one is significantly more confusing than the other.

## Implementation details

Change `useNativeSdkVersion: false` -> `useNativeSdkVersion: true`
_Theoretically_ we could change the code that's reading this, but AzureDevops doesn't have first-class support for booleans, so we risk _other_ weirdness. And noone generally touches this anyway, so meh.

## Test coverage

If the build works, we're good.

## Other details

I originally misread this, and so pre-built the VMs with the wrong SDK and wrote the incorrect documentation 🙄 