### PR TITLE
Benchmarks: Disable Benchmarks.OpenTelemetry.Api from running in the `RunBenchmarks` Nuke build target

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -547,7 +547,7 @@ partial class Build : NukeBuild
         {
             var benchmarkProjectsWithSettings = new Tuple<string, Func<DotNetRunSettings, DotNetRunSettings>>[] {
                 new(Projects.BenchmarksTrace, s => s),
-                new(Projects.BenchmarksOpenTelemetryApi, s => s),
+                // new(Projects.BenchmarksOpenTelemetryApi, s => s),
                 new(Projects.BenchmarksOpenTelemetryInstrumentedApi,
                     s => s.SetProcessEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true")
                           .SetProcessEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false")


### PR DESCRIPTION
## Summary of changes
Self-titled.

## Reason for change
The previous PR https://github.com/DataDog/dd-trace-dotnet/pull/6968 added two new projects to measure the overhead we introduce when instrumenting the OpenTelemetry Tracing API: `Benchmarks.OpenTelemetry.Api` and `Benchmarks.OpenTelemetry.InstrumentedApi`. This exceeds the timeout of our current microbenchmarks CI stage so disable `Benchmarks.OpenTelemetry.Api` since that project doesn't run any Datadog components and won't be changing any time soon.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
