### PR TITLE
[ASM] Added more traces to waf init

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
@@ -454,8 +454,25 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                 return null;
             }
 
-            Log.Debug("GetDelegateForNativeFunction {FunctionName} -  {FuncPtr}: ", functionName, funcPtr);
-            return (T)Marshal.GetDelegateForFunctionPointer(funcPtr, typeof(T));
+            try
+            {
+                Log.Debug("GetDelegateForNativeFunction {FunctionName} -  {FuncPtr}: ", functionName, funcPtr);
+                var res = (T)Marshal.GetDelegateForFunctionPointer(funcPtr, typeof(T));
+                if (res is null)
+                {
+                    Log.Error("GetDelegateForFunctionPointer for {FunctionName} returned null", functionName);
+                    ExportErrorHappened = true;
+                    return null;
+                }
+
+                return res;
+            }
+            catch (Exception err)
+            {
+                Log.Error(err, "GetDelegateForFunctionPointer for {FunctionName} threw an exception", functionName);
+                ExportErrorHappened = true;
+                return null;
+            }
         }
 
         private T GetDelegateForNativeFunction<T>(IntPtr handle, string functionName)


### PR DESCRIPTION
## Summary of changes
Added error traces to `GetDelegateForNativeFunction`

## Reason for change
Try to diagnose a random exception in arm64

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
