### PR TITLE
Add `net8.0` and `net9.0` to trimming nuspec

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
+++ b/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
@@ -19,6 +19,8 @@
     <tags>Datadog APM tracing profiling instrumentation trimming</tags>
     <repository type="git" url="https://github.com/DataDog/dd-trace-dotnet.git" />
     <dependencies>
+      <group targetFramework="net9.0" />
+      <group targetFramework="net8.0" />
       <group targetFramework="net7.0" />
       <group targetFramework="net6.0" />
       <group targetFramework="net5.0" />


### PR DESCRIPTION
## Summary of changes

Adds `net8.0` and `net9.0` to trimming `nuspec` file.

## Reason for change

Seems strange to have the others declared and was asked if we support those later ones which we do.

## Implementation details

## Test coverage

## Other details

I'm actually unsure why we have a `nuspec` for this
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
