### PR TITLE
Revert 'Reapply "Revert Load the tracer/profiler after guardrails checks" (#6959)'

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -121,6 +121,8 @@ namespace datadog::shared::nativeloader
         const auto process_name = ::shared::GetCurrentProcessName();
         Log::Debug("ProcessName: ", process_name);
 
+        Log::Debug("CorProfiler::Initialize");
+
         const auto& include_process_names = GetEnvironmentValues(EnvironmentVariables::IncludeProcessNames);
 
         // if there is a process inclusion list, attach clrprofiler only if this
@@ -254,35 +256,24 @@ namespace datadog::shared::nativeloader
             return E_FAIL;
         }
 
-        if (m_dispatcher == nullptr)
-        {
-            Log::Error("Dispatcher is not set.");
-            single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
-            return E_FAIL;
-        }
-
-        if (FAILED(m_dispatcher->Initialize()))
-        {
-            Log::Error("Error initializing the dispatcher.");
-            single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
-            return E_FAIL;
-        }
-
         //
         // Get and set profiler pointers
         //
+        if (m_dispatcher == nullptr)
+        {
+            single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
+            return E_FAIL;
+        }
         IDynamicInstance* cpInstance = m_dispatcher->GetContinuousProfilerInstance();
         if (cpInstance != nullptr)
         {
             m_cpProfiler = cpInstance->GetProfilerCallback();
         }
-
         IDynamicInstance* tracerInstance = m_dispatcher->GetTracerInstance();
         if (tracerInstance != nullptr)
         {
             m_tracerProfiler = tracerInstance->GetProfilerCallback();
         }
-
         IDynamicInstance* customInstance = m_dispatcher->GetCustomInstance();
         if (customInstance != nullptr)
         {
@@ -338,12 +329,14 @@ namespace datadog::shared::nativeloader
             return E_FAIL;
         }
 
-        Log::Debug("CorProfiler::Initialize: MaskLow: ", mask_low, ", MaskHi: ", mask_hi);
+        Log::Debug("CorProfiler::Initialize: MaskLow: ", mask_low);
+        Log::Debug("CorProfiler::Initialize: MaskHi : ", mask_hi);
 
         if (instrumented_assembly_generator::IsInstrumentedAssemblyGeneratorEnabled())
         {
             m_writeToDiskCorProfilerInfo = std::make_shared<instrumented_assembly_generator::CorProfilerInfo>(
                 pICorProfilerInfoUnk);
+
         }
         else
         {

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
@@ -27,6 +27,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerClassFactory::QueryInterface(REFIID riid, v
     {
         *ppvObject = this;
         this->AddRef();
+
+        // We try to load the class factory of all target cor profilers.
+        // Errors are already logged in the dispatcher.
+        m_dispatcher->LoadClassFactory(riid);
         return S_OK;
     }
 
@@ -64,10 +68,13 @@ HRESULT STDMETHODCALLTYPE CorProfilerClassFactory::CreateInstance(IUnknown* pUnk
 
     auto profiler = new datadog::shared::nativeloader::CorProfiler(m_dispatcher);
     HRESULT res = profiler->QueryInterface(riid, ppvObject);
-    if (FAILED(res))
+    if (SUCCEEDED(res))
+    {
+        m_dispatcher->LoadInstance(pUnkOuter, riid);
+    }
+    else
     {
         delete profiler;
-        *ppvObject = nullptr;
     }
 
     Log::Debug("CorProfilerClassFactory::CreateInstance: ", res);

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -22,41 +22,8 @@ namespace datadog::shared::nativeloader
     DynamicDispatcherImpl::DynamicDispatcherImpl() :
         m_continuousProfilerInstance(nullptr),
         m_tracerInstance(nullptr),
-        m_customInstance(nullptr),
-        m_initialized(false),
-        m_initializationResult(E_UNEXPECTED)
+        m_customInstance(nullptr)
     {
-    }
-
-    HRESULT DynamicDispatcherImpl::Initialize()
-    {
-        if (m_initialized)
-        {
-            return m_initializationResult;
-        }
-
-        m_initialized = true;
-
-        LoadConfiguration(GetConfigurationFilePath());
-
-        m_initializationResult = LoadClassFactory(IID_IClassFactory);
-
-        if (FAILED(m_initializationResult))
-        {
-            Log::Error("Error loading all cor profiler class factories.");
-            return m_initializationResult;
-        }
-
-        m_initializationResult = LoadInstance();
-
-        if (FAILED(m_initializationResult))
-        {
-            Log::Error("Error loading all cor profiler instances.");
-            return m_initializationResult;
-        }
-
-        m_initializationResult = S_OK;
-        return m_initializationResult;
     }
 
     void DynamicDispatcherImpl::LoadConfiguration(fs::path&& configFilePath)
@@ -190,8 +157,7 @@ namespace datadog::shared::nativeloader
 
     HRESULT DynamicDispatcherImpl::LoadClassFactory(REFIID riid)
     {
-        // We consider the loading a success if at least one class factory is properly loaded.
-        HRESULT GHR = E_FAIL;
+        HRESULT GHR = S_OK;
 
         if (m_continuousProfilerInstance != nullptr)
         {
@@ -205,20 +171,12 @@ namespace datadog::shared::nativeloader
                 else
                 {
                     Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load continuous profiler class factory in: ",
-                        m_continuousProfilerInstance->GetFilePath(), ", error code: ", result);
+                        m_continuousProfilerInstance->GetFilePath());
                 }
 
                 // If we cannot load the class factory we release the instance.
-                m_continuousProfilerInstance = nullptr;
-
-                if (GHR != S_OK)
-                {
-                    GHR = result;
-                }
-            }
-            else
-            {
-                GHR = S_OK;
+                m_continuousProfilerInstance.release();
+                GHR = result;
             }
         }
 
@@ -233,21 +191,12 @@ namespace datadog::shared::nativeloader
                 }
                 else
                 {
-                    Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ",
-                        m_tracerInstance->GetFilePath(), ", error code: ", result);
+                    Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ", m_tracerInstance->GetFilePath());
                 }
 
                 // If we cannot load the class factory we release the instance.
-                m_tracerInstance = nullptr;
-                
-                if (GHR != S_OK)
-                {
-                    GHR = result;
-                }
-            }
-            else
-            {
-                GHR = S_OK;
+                m_tracerInstance.release();
+                GHR = result;
             }
         }
 
@@ -256,95 +205,58 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_customInstance->LoadClassFactory(riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load custom class factory in: ",
-                    m_customInstance->GetFilePath(), ", error code: ", result);
+                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load custom class factory in: ", m_customInstance->GetFilePath());
 
                 // If we cannot load the class factory we release the instance.
-                m_customInstance = nullptr;
-
-                if (GHR != S_OK)
-                {
-                    GHR = result;
-                }
-            }
-            else
-            {
-                GHR = S_OK;
+                m_customInstance.release();
+                GHR = result;
             }
         }
 
         return GHR;
     }
 
-    HRESULT DynamicDispatcherImpl::LoadInstance()
+    HRESULT DynamicDispatcherImpl::LoadInstance(IUnknown* pUnkOuter, REFIID riid)
     {
-        // We consider the loading a success if at least one class factory is properly loaded.
-        HRESULT GHR = E_FAIL;
+        HRESULT GHR = S_OK;
 
         if (m_continuousProfilerInstance != nullptr)
         {
-            HRESULT result = m_continuousProfilerInstance->LoadInstance();
-
+            HRESULT result = m_continuousProfilerInstance->LoadInstance(pUnkOuter, riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
-                     m_continuousProfilerInstance->GetFilePath(), ", error code: ", result);
+                    Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
+                     m_continuousProfilerInstance->GetFilePath());
 
                 // If we cannot load the class factory we release the instance.
-                m_continuousProfilerInstance = nullptr;
-
-                if (GHR != S_OK)
-                {
-                    GHR = result;
-                }
-            }
-            else
-            {
-                GHR = S_OK;
+                m_continuousProfilerInstance.release();
+                GHR = result;
             }
         }
 
         if (m_tracerInstance != nullptr)
         {
-            HRESULT result = m_tracerInstance->LoadInstance();
+            HRESULT result = m_tracerInstance->LoadInstance(pUnkOuter, riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the tracer instance in: ",
-                    m_tracerInstance->GetFilePath(), ", error code: ", result);
+                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the tracer instance in: ", m_tracerInstance->GetFilePath());
 
                 // If we cannot load the class factory we release the instance.
-                m_tracerInstance = nullptr;
-
-                if (GHR != S_OK)
-                {
-                    GHR = result;
-                }
-            }
-            else
-            {
-                GHR = S_OK;
+                m_tracerInstance.release();
+                GHR = result;
             }
         }
 
         if (m_customInstance != nullptr)
         {
-            HRESULT result = m_customInstance->LoadInstance();
+            HRESULT result = m_customInstance->LoadInstance(pUnkOuter, riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the custom instance in: ",
-                    m_customInstance->GetFilePath(), ", error code: ", result);
+                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the custom instance in: ", m_customInstance->GetFilePath());
 
                 // If we cannot load the class factory we release the instance.
-                m_customInstance = nullptr;
-
-                if (GHR != S_OK)
-                {
-                    GHR = result;
-                }
-            }
-            else
-            {
-                GHR = S_OK;
+                m_customInstance.release();
+                GHR = result;
             }
         }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
@@ -20,10 +20,9 @@ namespace datadog::shared::nativeloader
     {
     public:
         virtual ~IDynamicDispatcher() = default;
-        virtual HRESULT Initialize() = 0;
         virtual void LoadConfiguration(fs::path&& configFilePath) = 0;
         virtual HRESULT LoadClassFactory(REFIID riid) = 0;
-        virtual HRESULT LoadInstance() = 0;
+        virtual HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) = 0;
         virtual HRESULT STDMETHODCALLTYPE DllCanUnloadNow() = 0;
         virtual IDynamicInstance* GetContinuousProfilerInstance() = 0;
         virtual IDynamicInstance* GetTracerInstance() = 0;
@@ -42,18 +41,13 @@ namespace datadog::shared::nativeloader
 
     public:
         DynamicDispatcherImpl();
-        HRESULT Initialize() override;
         void LoadConfiguration(fs::path&& configFilePath) override;
         HRESULT LoadClassFactory(REFIID riid) override;
-        HRESULT LoadInstance() override;
+        HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override;
         HRESULT STDMETHODCALLTYPE DllCanUnloadNow() override;
         IDynamicInstance* GetContinuousProfilerInstance() override;
         IDynamicInstance* GetTracerInstance() override;
         IDynamicInstance* GetCustomInstance() override;
-
-    private:
-        bool m_initialized;
-        HRESULT m_initializationResult;
     };
 
 } // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
@@ -72,7 +72,7 @@ namespace datadog::shared::nativeloader
         return res;
     }
 
-    HRESULT DynamicInstanceImpl::LoadInstance()
+    HRESULT DynamicInstanceImpl::LoadInstance(IUnknown* pUnkOuter, REFIID riid)
     {
         Log::Debug("DynamicInstanceImpl::LoadInstance");
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.h
@@ -20,7 +20,7 @@ namespace datadog::shared::nativeloader
     public:
         virtual ~IDynamicInstance() = default;
         virtual HRESULT LoadClassFactory(REFIID riid) = 0;
-        virtual HRESULT LoadInstance() = 0;
+        virtual HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) = 0;
         virtual HRESULT STDMETHODCALLTYPE DllCanUnloadNow() = 0;
         virtual ICorProfilerCallback10* GetProfilerCallback() = 0;
         virtual std::string GetFilePath() = 0;
@@ -42,7 +42,7 @@ namespace datadog::shared::nativeloader
         DynamicInstanceImpl(const std::string& filePath, const std::string& clsid);
         ~DynamicInstanceImpl() override;
         HRESULT LoadClassFactory(REFIID riid) override;
-        HRESULT LoadInstance() override;
+        HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override;
         HRESULT STDMETHODCALLTYPE DllCanUnloadNow() override;
         ICorProfilerCallback10* GetProfilerCallback() override;
         std::string GetFilePath() override;

--- a/shared/src/native-src/dynamic_library_base.cpp
+++ b/shared/src/native-src/dynamic_library_base.cpp
@@ -93,7 +93,7 @@ bool DynamicLibraryBase::Load()
 
 bool DynamicLibraryBase::Unload()
 {
-    _logger->Debug("Unloading ", _filePath);
+    _logger->Debug("Unload");
     if (_instance == nullptr)
     {
         _logger->Warn("Unload: Unable to unload dynamic library '", _filePath,

--- a/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_dynamic_instance.h
+++ b/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_dynamic_instance.h
@@ -34,10 +34,10 @@ public:
         return m_loadClassFactory;
     }
 
-    HRESULT LoadInstance() override
+    HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override
     {
         if (GetFilePath() != "Test")
-            return DynamicInstanceImpl::LoadInstance();
+            return DynamicInstanceImpl::LoadInstance(pUnkOuter, riid);
         return m_loadInstance;
     }
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ProcessBasicChecksTests.cs
@@ -214,8 +214,6 @@ namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks
         public async Task WorkingWithContinuousProfiler(string enabled, bool? ssiInjectionEnabled)
         {
             SkipOn.Platform(SkipOn.PlatformValue.MacOs);
-            // The continuous profiler isn't currently supported on ARM
-            SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
 
             var ssiInjection = ssiInjectionEnabled is null
                                    ? null

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -230,9 +230,6 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     public async Task WorkingWithContinuousProfiler()
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
-        // The continuous profiler isn't currently supported on ARM
-        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
-
         string archFolder;
 
         if (FrameworkDescription.Instance.ProcessArchitecture == ProcessArchitecture.Arm64)


### PR DESCRIPTION
## Summary of changes

This reverts commit c66626c394f5d8e0b12d4c2a7dc52955bd6b99bd.

## Reason for change

We're seeing crashes in arm64 on fedora 35 only, when we initialize the WAF. Reverting this for now while we investigate to unblock `master`

## Implementation details

Revert the reapplied revert

## Test coverage

Covered by existing

## Other details
