### PR TITLE
Protect against null ref in W3CTraceContextPropagator.cs

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -668,6 +668,7 @@ namespace Datadog.Trace.Propagators
         // internal for regression testing
         internal static bool TryGetSingle(IEnumerable<string?> values, out string value)
         {
+            // null values is handled in TryGetSingleRare
             // fast path for string[], List<string>, and others
             if (values is IReadOnlyList<string?> list)
             {
@@ -687,6 +688,12 @@ namespace Datadog.Trace.Propagators
         // internal for regression testing
         internal static bool TryGetSingleRare(IEnumerable<string?> values, out string value)
         {
+            if (values is null)
+            {
+                value = string.Empty;
+                return false;
+            }
+
             using var enumerator = values.GetEnumerator();
 
             if (!enumerator.MoveNext())

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -118,6 +118,8 @@ namespace Datadog.Trace.Tests.Propagators
                 },
                 false                                                               // Multiple headers should fail
             };
+
+            yield return new object[] { null, false };                              // null values - regression test
         }
 
         public static IEnumerable<string> GetYieldValues(params string[] values)
@@ -1091,6 +1093,12 @@ namespace Datadog.Trace.Tests.Propagators
         }
 
         [Fact]
+        public void TryGetSingleRare_ShouldReturnFalse_ForNullValues()
+        {
+            W3CTraceContextPropagator.TryGetSingleRare(null, out _).Should().BeFalse();
+        }
+
+        [Fact]
         public void TryGetSingleRare_ShouldReturnFalse_ForEmptyValues()
         {
             W3CTraceContextPropagator.TryGetSingleRare(Array.Empty<string>(), out _).Should().BeFalse();
@@ -1110,9 +1118,15 @@ namespace Datadog.Trace.Tests.Propagators
         }
 
         [Fact]
-        public void TryGetSingle_ShouoldReturnFalse_ForEmptyValeus()
+        public void TryGetSingle_ShouldReturnFalse_ForEmptyValeus()
         {
             W3CTraceContextPropagator.TryGetSingle(Array.Empty<string>(), out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public void TryGetSingle_ShouldReturnFalse_ForNullValeus()
+        {
+            W3CTraceContextPropagator.TryGetSingle(null, out _).Should().BeFalse();
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes

Adds a null check for `TryGetSingleRare` which will prevent `NullReferenceException`s from being thrown by `TryGetSingle`/`TryGetSingleRare`.

## Reason for change

Spotted in Error Tracking.

I'm not fully sure what the real world case is that causes this though for the header to return an `null` value

## Implementation details

Added a null check in `TryGetSingleRare` - the parent `TryGetSingle` will fall through on `null` to this function so it handles both.

## Test coverage

Added `null` tests. Again, unsure exactly what the realworld cause of it so pretty synthetic as it doesn't address why the value is null but will at least not have an exception.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
