### PR TITLE
[Dynamic Instrumentation] Remove reference types value from snapshot

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -188,11 +188,6 @@ namespace Datadog.Trace.Debugger.Snapshots
                 var stringValueTruncated = stringValue?.Length < limitInfo.MaxLength ? stringValue : stringValue?.Substring(0, limitInfo.MaxLength);
                 jsonWriter.WriteValue(stringValueTruncated);
             }
-            else
-            {
-                jsonWriter.WritePropertyName("value");
-                jsonWriter.WriteValue(type.Name);
-            }
         }
 
         private static void SerializeInstanceFieldsInternal(

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncCallChain.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncCallChain.verified.txt
@@ -19,8 +19,7 @@
                     "value": "1"
                   }
                 },
-                "type": "AsyncCallChain",
-                "value": "AsyncCallChain"
+                "type": "AsyncCallChain"
               }
             }
           },
@@ -37,8 +36,7 @@
                     "value": "1"
                   }
                 },
-                "type": "AsyncCallChain",
-                "value": "AsyncCallChain"
+                "type": "AsyncCallChain"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentEntryFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentEntryFullSnapshot.verified.txt
@@ -19,8 +19,7 @@
                     "value": "5"
                   }
                 },
-                "type": "AsyncFieldArgumentEntryFullSnapshot",
-                "value": "AsyncFieldArgumentEntryFullSnapshot"
+                "type": "AsyncFieldArgumentEntryFullSnapshot"
               }
             },
             "staticFields": {
@@ -43,8 +42,7 @@
                     "value": "5"
                   }
                 },
-                "type": "AsyncFieldArgumentEntryFullSnapshot",
-                "value": "AsyncFieldArgumentEntryFullSnapshot"
+                "type": "AsyncFieldArgumentEntryFullSnapshot"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentLocalExitFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentLocalExitFullSnapshot.verified.txt
@@ -19,8 +19,7 @@
                     "value": "5"
                   }
                 },
-                "type": "AsyncFieldArgumentLocalExitFullSnapshot",
-                "value": "AsyncFieldArgumentLocalExitFullSnapshot"
+                "type": "AsyncFieldArgumentLocalExitFullSnapshot"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInterfaceProperties.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInterfaceProperties.verified.txt
@@ -23,12 +23,10 @@
                     "value": "Show Me!"
                   }
                 },
-                "type": "Class",
-                "value": "Class"
+                "type": "Class"
               },
               "this": {
-                "type": "AsyncInterfaceProperties",
-                "value": "AsyncInterfaceProperties"
+                "type": "AsyncInterfaceProperties"
               }
             }
           },
@@ -49,12 +47,10 @@
                     "value": "Show Me!"
                   }
                 },
-                "type": "Class",
-                "value": "Class"
+                "type": "Class"
               },
               "this": {
-                "type": "AsyncInterfaceProperties",
-                "value": "AsyncInterfaceProperties"
+                "type": "AsyncInterfaceProperties"
               }
             },
             "locals": {
@@ -77,8 +73,7 @@
                     "value": ""
                   }
                 },
-                "type": "Class",
-                "value": "Class"
+                "type": "Class"
               }
             }
           }
@@ -133,12 +128,10 @@
                       "value": "Show Me!"
                     }
                   },
-                  "type": "Class",
-                  "value": "Class"
+                  "type": "Class"
                 },
                 "this": {
-                  "type": "AsyncInterfaceProperties",
-                  "value": "AsyncInterfaceProperties"
+                  "type": "AsyncInterfaceProperties"
                 }
               },
               "locals": {
@@ -157,8 +150,7 @@
                       "value": ""
                     }
                   },
-                  "type": "Class",
-                  "value": "Class"
+                  "type": "Class"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
@@ -27,8 +27,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -43,8 +42,7 @@
                         "value": "Harlem"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -62,8 +60,7 @@
                             "fields": {
                               "City": {
                                 "notCapturedReason": "depth",
-                                "type": "Place",
-                                "value": "Place"
+                                "type": "Place"
                               },
                               "HomeType": {
                                 "type": "BuildingType",
@@ -78,8 +75,7 @@
                                 "value": "Harlem"
                               }
                             },
-                            "type": "Address",
-                            "value": "Address"
+                            "type": "Address"
                           },
                           "Age": {
                             "type": "Double",
@@ -98,8 +94,7 @@
                             "value": "Ralph Jr."
                           }
                         },
-                        "type": "Person",
-                        "value": "Person"
+                        "type": "Person"
                       }
                     ],
                     "size": 1,
@@ -114,8 +109,7 @@
                     "value": "Ralph"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "someGenericObject": {
                 "fields": {
@@ -124,8 +118,7 @@
                     "value": "NestedAsyncGenericStruct"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "this": {
                 "fields": {
@@ -139,8 +132,7 @@
                         "fields": {
                           "City": {
                             "notCapturedReason": "depth",
-                            "type": "Place",
-                            "value": "Place"
+                            "type": "Place"
                           },
                           "HomeType": {
                             "type": "BuildingType",
@@ -155,8 +147,7 @@
                             "value": "Harlem"
                           }
                         },
-                        "type": "Address",
-                        "value": "Address"
+                        "type": "Address"
                       },
                       "Age": {
                         "type": "Double",
@@ -172,8 +163,7 @@
                               },
                               "Adrs": {
                                 "notCapturedReason": "depth",
-                                "type": "Address",
-                                "value": "Address"
+                                "type": "Address"
                               },
                               "Age": {
                                 "type": "Double",
@@ -192,8 +182,7 @@
                                 "value": "Ralph Jr."
                               }
                             },
-                            "type": "Person",
-                            "value": "Person"
+                            "type": "Person"
                           }
                         ],
                         "size": 1,
@@ -208,12 +197,10 @@
                         "value": "Ralph"
                       }
                     },
-                    "type": "Person",
-                    "value": "Person"
+                    "type": "Person"
                   }
                 },
-                "type": "NestedAsyncGenericStruct",
-                "value": "NestedAsyncGenericStruct"
+                "type": "NestedAsyncGenericStruct"
               }
             }
           },
@@ -238,8 +225,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -254,8 +240,7 @@
                         "value": "Harlem"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -273,8 +258,7 @@
                             "fields": {
                               "City": {
                                 "notCapturedReason": "depth",
-                                "type": "Place",
-                                "value": "Place"
+                                "type": "Place"
                               },
                               "HomeType": {
                                 "type": "BuildingType",
@@ -289,8 +273,7 @@
                                 "value": "Harlem"
                               }
                             },
-                            "type": "Address",
-                            "value": "Address"
+                            "type": "Address"
                           },
                           "Age": {
                             "type": "Double",
@@ -309,8 +292,7 @@
                             "value": "Ralph Jr."
                           }
                         },
-                        "type": "Person",
-                        "value": "Person"
+                        "type": "Person"
                       }
                     ],
                     "size": 1,
@@ -325,8 +307,7 @@
                     "value": "Ralph"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "someGenericObject": {
                 "fields": {
@@ -335,8 +316,7 @@
                     "value": "NestedAsyncGenericStruct"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "this": {
                 "fields": {
@@ -350,8 +330,7 @@
                         "fields": {
                           "City": {
                             "notCapturedReason": "depth",
-                            "type": "Place",
-                            "value": "Place"
+                            "type": "Place"
                           },
                           "HomeType": {
                             "type": "BuildingType",
@@ -366,8 +345,7 @@
                             "value": "Harlem"
                           }
                         },
-                        "type": "Address",
-                        "value": "Address"
+                        "type": "Address"
                       },
                       "Age": {
                         "type": "Double",
@@ -383,8 +361,7 @@
                               },
                               "Adrs": {
                                 "notCapturedReason": "depth",
-                                "type": "Address",
-                                "value": "Address"
+                                "type": "Address"
                               },
                               "Age": {
                                 "type": "Double",
@@ -403,8 +380,7 @@
                                 "value": "Ralph Jr."
                               }
                             },
-                            "type": "Person",
-                            "value": "Person"
+                            "type": "Person"
                           }
                         ],
                         "size": 1,
@@ -419,12 +395,10 @@
                         "value": "Ralph"
                       }
                     },
-                    "type": "Person",
-                    "value": "Person"
+                    "type": "Person"
                   }
                 },
-                "type": "NestedAsyncGenericStruct",
-                "value": "NestedAsyncGenericStruct"
+                "type": "NestedAsyncGenericStruct"
               }
             },
             "locals": {
@@ -440,8 +414,7 @@
                 "fields": {
                   "m_task": "ScrubbedValue"
                 },
-                "type": "TaskAwaiter",
-                "value": "TaskAwaiter"
+                "type": "TaskAwaiter"
               },
               "output": {
                 "type": "String",
@@ -463,8 +436,7 @@
                         "fields": {
                           "City": {
                             "notCapturedReason": "depth",
-                            "type": "Place",
-                            "value": "Place"
+                            "type": "Place"
                           },
                           "HomeType": {
                             "type": "BuildingType",
@@ -479,8 +451,7 @@
                             "value": "Harlem"
                           }
                         },
-                        "type": "Address",
-                        "value": "Address"
+                        "type": "Address"
                       },
                       "Age": {
                         "type": "Double",
@@ -496,8 +467,7 @@
                               },
                               "Adrs": {
                                 "notCapturedReason": "depth",
-                                "type": "Address",
-                                "value": "Address"
+                                "type": "Address"
                               },
                               "Age": {
                                 "type": "Double",
@@ -516,8 +486,7 @@
                                 "value": "Ralph Jr."
                               }
                             },
-                            "type": "Person",
-                            "value": "Person"
+                            "type": "Person"
                           }
                         ],
                         "size": 1,
@@ -532,12 +501,10 @@
                         "value": "Ralph"
                       }
                     },
-                    "type": "Person",
-                    "value": "Person"
+                    "type": "Person"
                   }
                 },
-                "type": "NestedAsyncGenericStruct",
-                "value": "NestedAsyncGenericStruct"
+                "type": "NestedAsyncGenericStruct"
               }
             }
           }
@@ -590,8 +557,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -606,8 +572,7 @@
                       "type": "String"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "isNull": "true",
@@ -628,8 +593,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -685,8 +649,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -701,8 +664,7 @@
                       "type": "String"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "isNull": "true",
@@ -723,8 +685,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -780,8 +741,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -796,8 +756,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "isNull": "true",
@@ -818,8 +777,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -875,8 +833,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -891,8 +848,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [],
@@ -914,8 +870,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -971,8 +926,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -987,8 +941,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -1011,8 +964,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1027,8 +979,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1047,8 +998,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -1069,8 +1019,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -1126,8 +1075,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -1142,8 +1090,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -1166,8 +1113,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1182,8 +1128,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1202,8 +1147,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -1228,8 +1172,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -1244,8 +1187,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -1263,8 +1205,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -1279,8 +1220,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -1299,8 +1239,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -1315,8 +1254,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "place": {
                   "fields": {
@@ -1329,8 +1267,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -1392,8 +1329,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -1408,8 +1344,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -1427,8 +1362,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -1443,8 +1377,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -1463,8 +1396,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -1479,8 +1411,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "someGenericObject": {
                   "fields": {
@@ -1489,8 +1420,7 @@
                       "value": "NestedAsyncGenericStruct"
                     }
                   },
-                  "type": "Generic",
-                  "value": "Generic"
+                  "type": "Generic"
                 },
                 "this": {
                   "fields": {
@@ -1504,8 +1434,7 @@
                           "fields": {
                             "City": {
                               "notCapturedReason": "depth",
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1520,8 +1449,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1537,8 +1465,7 @@
                                 },
                                 "Adrs": {
                                   "notCapturedReason": "depth",
-                                  "type": "Address",
-                                  "value": "Address"
+                                  "type": "Address"
                                 },
                                 "Age": {
                                   "type": "Double",
@@ -1557,8 +1484,7 @@
                                   "value": "Ralph Jr."
                                 }
                               },
-                              "type": "Person",
-                              "value": "Person"
+                              "type": "Person"
                             }
                           ],
                           "size": 1,
@@ -1573,12 +1499,10 @@
                           "value": "Ralph"
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   },
-                  "type": "NestedAsyncGenericStruct",
-                  "value": "NestedAsyncGenericStruct"
+                  "type": "NestedAsyncGenericStruct"
                 }
               },
               "locals": {
@@ -1590,8 +1514,7 @@
                   "fields": {
                     "m_task": "ScrubbedValue"
                   },
-                  "type": "TaskAwaiter",
-                  "value": "TaskAwaiter"
+                  "type": "TaskAwaiter"
                 },
                 "output": {
                   "isNull": "true",
@@ -1613,8 +1536,7 @@
                           "fields": {
                             "City": {
                               "notCapturedReason": "depth",
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1629,8 +1551,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1646,8 +1567,7 @@
                                 },
                                 "Adrs": {
                                   "notCapturedReason": "depth",
-                                  "type": "Address",
-                                  "value": "Address"
+                                  "type": "Address"
                                 },
                                 "Age": {
                                   "type": "Double",
@@ -1666,8 +1586,7 @@
                                   "value": "Ralph Jr."
                                 }
                               },
-                              "type": "Person",
-                              "value": "Person"
+                              "type": "Person"
                             }
                           ],
                           "size": 1,
@@ -1682,12 +1601,10 @@
                           "value": "Ralph"
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   },
-                  "type": "NestedAsyncGenericStruct",
-                  "value": "NestedAsyncGenericStruct"
+                  "type": "NestedAsyncGenericStruct"
                 }
               }
             }
@@ -1749,8 +1666,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -1765,8 +1681,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -1784,8 +1699,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -1800,8 +1714,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -1820,8 +1733,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -1836,8 +1748,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "someGenericObject": {
                   "fields": {
@@ -1846,8 +1757,7 @@
                       "value": "NestedAsyncGenericStruct"
                     }
                   },
-                  "type": "Generic",
-                  "value": "Generic"
+                  "type": "Generic"
                 },
                 "this": {
                   "fields": {
@@ -1861,8 +1771,7 @@
                           "fields": {
                             "City": {
                               "notCapturedReason": "depth",
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1877,8 +1786,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1894,8 +1802,7 @@
                                 },
                                 "Adrs": {
                                   "notCapturedReason": "depth",
-                                  "type": "Address",
-                                  "value": "Address"
+                                  "type": "Address"
                                 },
                                 "Age": {
                                   "type": "Double",
@@ -1914,8 +1821,7 @@
                                   "value": "Ralph Jr."
                                 }
                               },
-                              "type": "Person",
-                              "value": "Person"
+                              "type": "Person"
                             }
                           ],
                           "size": 1,
@@ -1930,12 +1836,10 @@
                           "value": "Ralph"
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   },
-                  "type": "NestedAsyncGenericStruct",
-                  "value": "NestedAsyncGenericStruct"
+                  "type": "NestedAsyncGenericStruct"
                 }
               },
               "locals": {
@@ -1947,8 +1851,7 @@
                   "fields": {
                     "m_task": "ScrubbedValue"
                   },
-                  "type": "TaskAwaiter",
-                  "value": "TaskAwaiter"
+                  "type": "TaskAwaiter"
                 },
                 "output": {
                   "type": "String",
@@ -1970,8 +1873,7 @@
                           "fields": {
                             "City": {
                               "notCapturedReason": "depth",
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1986,8 +1888,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -2003,8 +1904,7 @@
                                 },
                                 "Adrs": {
                                   "notCapturedReason": "depth",
-                                  "type": "Address",
-                                  "value": "Address"
+                                  "type": "Address"
                                 },
                                 "Age": {
                                   "type": "Double",
@@ -2023,8 +1923,7 @@
                                   "value": "Ralph Jr."
                                 }
                               },
-                              "type": "Person",
-                              "value": "Person"
+                              "type": "Person"
                             }
                           ],
                           "size": 1,
@@ -2039,12 +1938,10 @@
                           "value": "Ralph"
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   },
-                  "type": "NestedAsyncGenericStruct",
-                  "value": "NestedAsyncGenericStruct"
+                  "type": "NestedAsyncGenericStruct"
                 }
               }
             }
@@ -2106,8 +2003,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -2122,8 +2018,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -2141,8 +2036,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -2157,8 +2051,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -2177,8 +2070,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -2193,8 +2085,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "someGenericObject": {
                   "fields": {
@@ -2203,8 +2094,7 @@
                       "value": "NestedAsyncGenericStruct"
                     }
                   },
-                  "type": "Generic",
-                  "value": "Generic"
+                  "type": "Generic"
                 },
                 "this": {
                   "fields": {
@@ -2218,8 +2108,7 @@
                           "fields": {
                             "City": {
                               "notCapturedReason": "depth",
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -2234,8 +2123,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -2251,8 +2139,7 @@
                                 },
                                 "Adrs": {
                                   "notCapturedReason": "depth",
-                                  "type": "Address",
-                                  "value": "Address"
+                                  "type": "Address"
                                 },
                                 "Age": {
                                   "type": "Double",
@@ -2271,8 +2158,7 @@
                                   "value": "Ralph Jr."
                                 }
                               },
-                              "type": "Person",
-                              "value": "Person"
+                              "type": "Person"
                             }
                           ],
                           "size": 1,
@@ -2287,12 +2173,10 @@
                           "value": "Ralph"
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   },
-                  "type": "NestedAsyncGenericStruct",
-                  "value": "NestedAsyncGenericStruct"
+                  "type": "NestedAsyncGenericStruct"
                 }
               },
               "locals": {
@@ -2304,8 +2188,7 @@
                   "fields": {
                     "m_task": "ScrubbedValue"
                   },
-                  "type": "TaskAwaiter",
-                  "value": "TaskAwaiter"
+                  "type": "TaskAwaiter"
                 },
                 "output": {
                   "type": "String",
@@ -2327,8 +2210,7 @@
                           "fields": {
                             "City": {
                               "notCapturedReason": "depth",
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -2343,8 +2225,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -2360,8 +2241,7 @@
                                 },
                                 "Adrs": {
                                   "notCapturedReason": "depth",
-                                  "type": "Address",
-                                  "value": "Address"
+                                  "type": "Address"
                                 },
                                 "Age": {
                                   "type": "Double",
@@ -2380,8 +2260,7 @@
                                   "value": "Ralph Jr."
                                 }
                               },
-                              "type": "Person",
-                              "value": "Person"
+                              "type": "Person"
                             }
                           ],
                           "size": 1,
@@ -2396,12 +2275,10 @@
                           "value": "Ralph"
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   },
-                  "type": "NestedAsyncGenericStruct",
-                  "value": "NestedAsyncGenericStruct"
+                  "type": "NestedAsyncGenericStruct"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
@@ -72,16 +72,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "AsyncMethodInsideTaskRun",
-                "value": "AsyncMethodInsideTaskRun"
+                "type": "AsyncMethodInsideTaskRun"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "AsyncMethodInsideTaskRun",
-                "value": "AsyncMethodInsideTaskRun"
+                "type": "AsyncMethodInsideTaskRun"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodRedactionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodRedactionTest.verified.txt
@@ -9,16 +9,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "AsyncMethodRedactionTest",
-                "value": "AsyncMethodRedactionTest"
+                "type": "AsyncMethodRedactionTest"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "AsyncMethodRedactionTest",
-                "value": "AsyncMethodRedactionTest"
+                "type": "AsyncMethodRedactionTest"
               }
             },
             "locals": {
@@ -45,8 +43,7 @@
                     "type": "String"
                   }
                 },
-                "type": "OuterClass",
-                "value": "OuterClass"
+                "type": "OuterClass"
               },
               "b": {
                 "fields": {
@@ -63,8 +60,7 @@
                     "type": "String"
                   }
                 },
-                "type": "OuterClass",
-                "value": "OuterClass"
+                "type": "OuterClass"
               }
             }
           }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodWithNotHoistedLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodWithNotHoistedLocals.verified.txt
@@ -9,8 +9,7 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "AsyncMethodWithNotHoistedLocals",
-                "value": "AsyncMethodWithNotHoistedLocals"
+                "type": "AsyncMethodWithNotHoistedLocals"
               },
               "value": {
                 "type": "String",
@@ -21,8 +20,7 @@
           "return": {
             "arguments": {
               "this": {
-                "type": "AsyncMethodWithNotHoistedLocals",
-                "value": "AsyncMethodWithNotHoistedLocals"
+                "type": "AsyncMethodWithNotHoistedLocals"
               },
               "value": {
                 "type": "String",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncNoHoistedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncNoHoistedLocal.verified.txt
@@ -9,16 +9,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "AsyncNoHoistedLocal",
-                "value": "AsyncNoHoistedLocal"
+                "type": "AsyncNoHoistedLocal"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "AsyncNoHoistedLocal",
-                "value": "AsyncNoHoistedLocal"
+                "type": "AsyncNoHoistedLocal"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCall.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCall.verified.txt
@@ -13,8 +13,7 @@
                 "value": "0"
               },
               "this": {
-                "type": "AsyncRecursiveCall",
-                "value": "AsyncRecursiveCall"
+                "type": "AsyncRecursiveCall"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "AsyncRecursiveCall",
-                "value": "AsyncRecursiveCall"
+                "type": "AsyncRecursiveCall"
               }
             },
             "locals": {
@@ -76,8 +74,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "AsyncRecursiveCall",
-                "value": "AsyncRecursiveCall"
+                "type": "AsyncRecursiveCall"
               }
             }
           },
@@ -88,8 +85,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCall",
-                "value": "AsyncRecursiveCall"
+                "type": "AsyncRecursiveCall"
               }
             },
             "locals": {
@@ -139,8 +135,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCall",
-                "value": "AsyncRecursiveCall"
+                "type": "AsyncRecursiveCall"
               }
             }
           },
@@ -151,8 +146,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCall",
-                "value": "AsyncRecursiveCall"
+                "type": "AsyncRecursiveCall"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCallWithMultipleProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCallWithMultipleProbes.verified.txt
@@ -13,8 +13,7 @@
                 "value": "0"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {
@@ -76,8 +74,7 @@
                 "value": "0"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -88,8 +85,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {
@@ -139,8 +135,7 @@
                 "value": "0"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -151,71 +146,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
-              }
-            },
-            "locals": {
-              "@return": {
-                "type": "Int32",
-                "value": "3"
-              }
-            }
-          }
-        },
-        "duration": "ScrubbedValue",
-        "id": "ScrubbedValue",
-        "language": "dotnet",
-        "probe": {
-          "id": "ScrubbedValue",
-          "location": {
-            "method": "Recursive",
-            "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          },
-          "version": 0
-        },
-        "stack": "ScrubbedValue",
-        "timestamp": "ScrubbedValue"
-      }
-    },
-    "logger": {
-      "method": "Recursive",
-      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes",
-      "thread_id": "ScrubbedValue",
-      "thread_name": "ScrubbedValue",
-      "version": "2"
-    },
-    "message": "ScrubbedValue",
-    "service": "probes"
-  },
-  {
-    "dd.span_id": "ScrubbedValue",
-    "dd.trace_id": "ScrubbedValue",
-    "ddsource": "dd_debugger",
-    "debugger": {
-      "snapshot": {
-        "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "Int32",
-                "value": "1"
-              },
-              "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
-              }
-            }
-          },
-          "return": {
-            "arguments": {
-              "i": {
-                "type": "Int32",
-                "value": "2"
-              },
-              "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {
@@ -265,8 +196,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -277,8 +207,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {
@@ -328,8 +257,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -340,8 +268,68 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "3"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "Int32",
+                "value": "1"
+              },
+              "this": {
+                "type": "AsyncRecursiveCallWithMultipleProbes"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "i": {
+                "type": "Int32",
+                "value": "2"
+              },
+              "this": {
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {
@@ -391,8 +379,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -403,8 +390,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {
@@ -454,8 +440,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -466,8 +451,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {
@@ -517,8 +501,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             }
           },
@@ -529,8 +512,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
+                "type": "AsyncRecursiveCallWithMultipleProbes"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.verified.txt
@@ -32,8 +32,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -48,8 +47,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -67,8 +65,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -83,8 +80,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -103,8 +99,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -119,12 +114,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithArgsTest",
-                  "value": "AsyncSpanOnMethodWithArgsTest"
+                  "type": "AsyncSpanOnMethodWithArgsTest"
                 }
               },
               "locals": {
@@ -202,8 +195,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -218,8 +210,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -237,8 +228,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -253,8 +243,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -273,8 +262,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -289,12 +277,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithArgsTest",
-                  "value": "AsyncSpanOnMethodWithArgsTest"
+                  "type": "AsyncSpanOnMethodWithArgsTest"
                 }
               },
               "locals": {
@@ -372,8 +358,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -388,8 +373,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -407,8 +391,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -423,8 +406,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -443,8 +425,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -459,12 +440,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithArgsTest",
-                  "value": "AsyncSpanOnMethodWithArgsTest"
+                  "type": "AsyncSpanOnMethodWithArgsTest"
                 }
               },
               "locals": {
@@ -542,8 +521,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -558,8 +536,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -577,8 +554,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -593,8 +569,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -613,8 +588,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -629,12 +603,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithArgsTest",
-                  "value": "AsyncSpanOnMethodWithArgsTest"
+                  "type": "AsyncSpanOnMethodWithArgsTest"
                 }
               },
               "staticFields": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.verified.txt
@@ -32,8 +32,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -48,8 +47,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -67,8 +65,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -83,8 +80,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -103,8 +99,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -119,12 +114,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithExceptionProbeTest",
-                  "value": "AsyncSpanOnMethodWithExceptionProbeTest"
+                  "type": "AsyncSpanOnMethodWithExceptionProbeTest"
                 }
               },
               "locals": {
@@ -202,8 +195,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -218,8 +210,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -237,8 +228,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -253,8 +243,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -273,8 +262,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -289,12 +277,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithExceptionProbeTest",
-                  "value": "AsyncSpanOnMethodWithExceptionProbeTest"
+                  "type": "AsyncSpanOnMethodWithExceptionProbeTest"
                 }
               },
               "locals": {
@@ -372,8 +358,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -388,8 +373,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -407,8 +391,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -423,8 +406,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -443,8 +425,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -459,12 +440,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithExceptionProbeTest",
-                  "value": "AsyncSpanOnMethodWithExceptionProbeTest"
+                  "type": "AsyncSpanOnMethodWithExceptionProbeTest"
                 }
               },
               "locals": {
@@ -542,8 +521,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -558,8 +536,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -577,8 +554,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -593,8 +569,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -613,8 +588,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -629,12 +603,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "AsyncSpanOnMethodWithExceptionProbeTest",
-                  "value": "AsyncSpanOnMethodWithExceptionProbeTest"
+                  "type": "AsyncSpanOnMethodWithExceptionProbeTest"
                 }
               },
               "staticFields": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnTest.verified.txt
@@ -27,8 +27,7 @@
                         "value": "Maintenance"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   },
                   {
                     "fields": {
@@ -41,8 +40,7 @@
                         "value": "Ready"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   }
                 ],
                 "size": 2,
@@ -73,8 +71,7 @@
                     "value": "Maintenance"
                   }
                 },
-                "type": "Room",
-                "value": "Room"
+                "type": "Room"
               }
             },
             "staticFields": {
@@ -91,8 +88,7 @@
                         "value": "Maintenance"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   },
                   {
                     "fields": {
@@ -105,8 +101,7 @@
                         "value": "Ready"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   }
                 ],
                 "size": 2,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnWithExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnWithExceptionTest.verified.txt
@@ -27,8 +27,7 @@
                         "value": "Ready"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   },
                   {
                     "fields": {
@@ -41,8 +40,7 @@
                         "value": "Ready"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   }
                 ],
                 "size": 2,
@@ -82,8 +80,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "InvalidOperationException",
-                "value": "InvalidOperationException"
+                "type": "InvalidOperationException"
               },
               "room": {
                 "isNull": "true",
@@ -104,8 +101,7 @@
                         "value": "Ready"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   },
                   {
                     "fields": {
@@ -118,8 +114,7 @@
                         "value": "Ready"
                       }
                     },
-                    "type": "Room",
-                    "value": "Room"
+                    "type": "Room"
                   }
                 ],
                 "size": 2,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
@@ -46,8 +46,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "InvalidOperationException",
-                "value": "InvalidOperationException"
+                "type": "InvalidOperationException"
               }
             },
             "throwable": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncVoid.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncVoid.verified.txt
@@ -9,16 +9,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "AsyncVoid",
-                "value": "AsyncVoid"
+                "type": "AsyncVoid"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "AsyncVoid",
-                "value": "AsyncVoid"
+                "type": "AsyncVoid"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.BaseLocalWithConcreteTypeInAsyncMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.BaseLocalWithConcreteTypeInAsyncMethod.verified.txt
@@ -37,8 +37,7 @@
                     "value": "PiiBase"
                   }
                 },
-                "type": "Pii2",
-                "value": "Pii2"
+                "type": "Pii2"
               },
               "value": {
                 "type": "String",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
@@ -10,8 +10,7 @@
             "10": {
               "arguments": {
                 "this": {
-                  "type": "ByRefLikeTest",
-                  "value": "ByRefLikeTest"
+                  "type": "ByRefLikeTest"
                 }
               }
             }
@@ -55,8 +54,7 @@
             "11": {
               "arguments": {
                 "this": {
-                  "type": "ByRefLikeTest",
-                  "value": "ByRefLikeTest"
+                  "type": "ByRefLikeTest"
                 }
               }
             }
@@ -100,8 +98,7 @@
             "12": {
               "arguments": {
                 "this": {
-                  "type": "ByRefLikeTest",
-                  "value": "ByRefLikeTest"
+                  "type": "ByRefLikeTest"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.FixedBlockTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.FixedBlockTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "5"
               },
               "this": {
-                "type": "FixedBlockTest",
-                "value": "FixedBlockTest"
+                "type": "FixedBlockTest"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "5"
               },
               "this": {
-                "type": "FixedBlockTest",
-                "value": "FixedBlockTest"
+                "type": "FixedBlockTest"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -10,8 +10,7 @@
             "23": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -28,8 +27,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -44,8 +42,7 @@
                       "type": "String"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "isNull": "true",
@@ -66,8 +63,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -111,8 +107,7 @@
             "24": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -129,8 +124,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -145,8 +139,7 @@
                       "type": "String"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "isNull": "true",
@@ -167,8 +160,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -212,8 +204,7 @@
             "25": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -230,8 +221,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -246,8 +236,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "isNull": "true",
@@ -268,8 +257,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -313,8 +301,7 @@
             "26": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -331,8 +318,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -347,8 +333,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [],
@@ -370,8 +355,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -415,8 +399,7 @@
             "27": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -433,8 +416,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -449,8 +431,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -473,8 +454,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -489,8 +469,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -509,8 +488,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -531,8 +509,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -576,8 +553,7 @@
             "29": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -594,8 +570,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -610,8 +585,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -634,8 +608,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -650,8 +623,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -670,8 +642,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -696,8 +667,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -712,8 +682,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -731,8 +700,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -747,8 +715,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -767,8 +734,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -783,8 +749,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "place": {
                   "fields": {
@@ -797,8 +762,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -842,8 +806,7 @@
             "30": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -860,8 +823,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -876,8 +838,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -900,8 +861,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -916,8 +876,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -936,8 +895,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -962,8 +920,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -978,8 +935,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -997,8 +953,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -1013,8 +968,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -1033,8 +987,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -1049,8 +1002,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "place": {
                   "fields": {
@@ -1063,8 +1015,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -1108,8 +1059,7 @@
             "31": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -1126,8 +1076,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -1142,8 +1091,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -1166,8 +1114,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1182,8 +1129,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1202,8 +1148,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -1228,8 +1173,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -1244,8 +1188,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -1263,8 +1206,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -1279,8 +1221,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -1299,8 +1240,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -1315,8 +1255,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "place": {
                   "fields": {
@@ -1329,8 +1268,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -1374,8 +1312,7 @@
             "32": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -1392,8 +1329,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -1408,8 +1344,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -1432,8 +1367,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1448,8 +1382,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1468,8 +1401,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -1494,8 +1426,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -1510,8 +1441,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -1529,8 +1459,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -1545,8 +1474,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -1565,8 +1493,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -1581,8 +1508,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "place": {
                   "fields": {
@@ -1595,8 +1521,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -1640,8 +1565,7 @@
             "34": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -1658,8 +1582,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -1674,8 +1597,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -1698,8 +1620,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1714,8 +1635,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -1734,8 +1654,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -1760,8 +1679,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -1776,8 +1694,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -1795,8 +1712,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -1811,8 +1727,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -1831,8 +1746,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -1847,8 +1761,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "place": {
                   "fields": {
@@ -1861,8 +1774,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }
@@ -1906,8 +1818,7 @@
             "35": {
               "arguments": {
                 "this": {
-                  "type": "GenericByRefLikeTest",
-                  "value": "GenericByRefLikeTest"
+                  "type": "GenericByRefLikeTest"
                 }
               },
               "locals": {
@@ -1924,8 +1835,7 @@
                           "value": "City"
                         }
                       },
-                      "type": "Place",
-                      "value": "Place"
+                      "type": "Place"
                     },
                     "HomeType": {
                       "type": "BuildingType",
@@ -1940,8 +1850,7 @@
                       "value": "Harlem"
                     }
                   },
-                  "type": "Address",
-                  "value": "Address"
+                  "type": "Address"
                 },
                 "children": {
                   "elements": [
@@ -1964,8 +1873,7 @@
                                   "value": "City"
                                 }
                               },
-                              "type": "Place",
-                              "value": "Place"
+                              "type": "Place"
                             },
                             "HomeType": {
                               "type": "BuildingType",
@@ -1980,8 +1888,7 @@
                               "value": "Harlem"
                             }
                           },
-                          "type": "Address",
-                          "value": "Address"
+                          "type": "Address"
                         },
                         "Age": {
                           "type": "Double",
@@ -2000,8 +1907,7 @@
                           "value": "Ralph Jr."
                         }
                       },
-                      "type": "Person",
-                      "value": "Person"
+                      "type": "Person"
                     }
                   ],
                   "size": 1,
@@ -2026,8 +1932,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -2042,8 +1947,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -2061,8 +1965,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -2077,8 +1980,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -2097,8 +1999,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -2113,8 +2014,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "place": {
                   "fields": {
@@ -2127,8 +2027,7 @@
                       "value": "City"
                     }
                   },
-                  "type": "Place",
-                  "value": "Place"
+                  "type": "Place"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
@@ -27,8 +27,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -43,8 +42,7 @@
                         "value": "Elsewhere"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -63,8 +61,7 @@
                     "value": "Alfred Hitchcock"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "this": {
                 "fields": {
@@ -73,8 +70,7 @@
                     "value": "GenericMethodWithArguments"
                   }
                 },
-                "type": "GenericMethodWithArguments",
-                "value": "GenericMethodWithArguments"
+                "type": "GenericMethodWithArguments"
               }
             }
           },
@@ -99,8 +95,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -115,8 +110,7 @@
                         "value": "Elsewhere"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -135,8 +129,7 @@
                     "value": "Alfred Hitchcock"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "this": {
                 "fields": {
@@ -145,8 +138,7 @@
                     "value": "GenericMethodWithArguments"
                   }
                 },
-                "type": "GenericMethodWithArguments",
-                "value": "GenericMethodWithArguments"
+                "type": "GenericMethodWithArguments"
               }
             },
             "locals": {
@@ -211,8 +203,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -227,8 +218,7 @@
                           "value": "Elsewhere"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -247,8 +237,7 @@
                       "value": "Alfred Hitchcock"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
                   "fields": {
@@ -257,8 +246,7 @@
                       "value": "GenericMethodWithArguments"
                     }
                   },
-                  "type": "GenericMethodWithArguments",
-                  "value": "GenericMethodWithArguments"
+                  "type": "GenericMethodWithArguments"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
@@ -9,16 +9,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "GenericRefReturnTest",
-                "value": "GenericRefReturnTest"
+                "type": "GenericRefReturnTest"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "GenericRefReturnTest",
-                "value": "GenericRefReturnTest"
+                "type": "GenericRefReturnTest"
               }
             },
             "locals": {
@@ -46,8 +44,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "NullReferenceException",
-                "value": "NullReferenceException"
+                "type": "NullReferenceException"
               },
               "whatever": {
                 "fields": {
@@ -62,8 +59,7 @@
                         "value": "City"
                       }
                     },
-                    "type": "Place",
-                    "value": "Place"
+                    "type": "Place"
                   },
                   "HomeType": {
                     "type": "BuildingType",
@@ -78,8 +74,7 @@
                     "type": "String"
                   }
                 },
-                "type": "Address",
-                "value": "Address"
+                "type": "Address"
               }
             },
             "throwable": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtEntry.verified.txt
@@ -13,8 +13,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "GreaterThanArgumentTrueAtEntry",
-                "value": "GreaterThanArgumentTrueAtEntry"
+                "type": "GreaterThanArgumentTrueAtEntry"
               }
             },
             "staticFields": {
@@ -31,8 +30,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "GreaterThanArgumentTrueAtEntry",
-                "value": "GreaterThanArgumentTrueAtEntry"
+                "type": "GreaterThanArgumentTrueAtEntry"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtExit.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtExit.verified.txt
@@ -13,8 +13,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "GreaterThanArgumentTrueAtExit",
-                "value": "GreaterThanArgumentTrueAtExit"
+                "type": "GreaterThanArgumentTrueAtExit"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanDuration.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanDuration.verified.txt
@@ -13,8 +13,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "GreaterThanDuration",
-                "value": "GreaterThanDuration"
+                "type": "GreaterThanDuration"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanField.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanField.verified.txt
@@ -19,8 +19,7 @@
                     "value": "13"
                   }
                 },
-                "type": "GreaterThanField",
-                "value": "GreaterThanField"
+                "type": "GreaterThanField"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanFieldAsync.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanFieldAsync.verified.txt
@@ -19,8 +19,7 @@
                     "value": "13"
                   }
                 },
-                "type": "GreaterThanFieldAsync",
-                "value": "GreaterThanFieldAsync"
+                "type": "GreaterThanFieldAsync"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
@@ -19,8 +19,7 @@
                     "type": "String"
                   }
                 },
-                "type": "HasArgumentsAndLocals",
-                "value": "HasArgumentsAndLocals"
+                "type": "HasArgumentsAndLocals"
               }
             }
           },
@@ -37,8 +36,7 @@
                     "value": "First"
                   }
                 },
-                "type": "HasArgumentsAndLocals",
-                "value": "HasArgumentsAndLocals"
+                "type": "HasArgumentsAndLocals"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
@@ -25,12 +25,10 @@
                         "value": "First"
                       }
                     },
-                    "type": "Lazy`1",
-                    "value": "Lazy`1"
+                    "type": "Lazy`1"
                   }
                 },
-                "type": "HasFieldLazyValueInitialized",
-                "value": "HasFieldLazyValueInitialized"
+                "type": "HasFieldLazyValueInitialized"
               }
             }
           },
@@ -53,12 +51,10 @@
                         "value": "First"
                       }
                     },
-                    "type": "Lazy`1",
-                    "value": "Lazy`1"
+                    "type": "Lazy`1"
                   }
                 },
-                "type": "HasFieldLazyValueInitialized",
-                "value": "HasFieldLazyValueInitialized"
+                "type": "HasFieldLazyValueInitialized"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
@@ -21,12 +21,10 @@
                         "value": "False"
                       }
                     },
-                    "type": "Lazy`1",
-                    "value": "Lazy`1"
+                    "type": "Lazy`1"
                   }
                 },
-                "type": "HasFieldLazyValueNotInitialized",
-                "value": "HasFieldLazyValueNotInitialized"
+                "type": "HasFieldLazyValueNotInitialized"
               }
             }
           },
@@ -45,12 +43,10 @@
                         "value": "False"
                       }
                     },
-                    "type": "Lazy`1",
-                    "value": "Lazy`1"
+                    "type": "Lazy`1"
                   }
                 },
-                "type": "HasFieldLazyValueNotInitialized",
-                "value": "HasFieldLazyValueNotInitialized"
+                "type": "HasFieldLazyValueNotInitialized"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalListOfObjects.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalListOfObjects.verified.txt
@@ -17,8 +17,7 @@
                 "value": "Greg"
               },
               "this": {
-                "type": "HasLocalListOfObjects",
-                "value": "HasLocalListOfObjects"
+                "type": "HasLocalListOfObjects"
               }
             }
           },
@@ -33,8 +32,7 @@
                 "value": "Greg"
               },
               "this": {
-                "type": "HasLocalListOfObjects",
-                "value": "HasLocalListOfObjects"
+                "type": "HasLocalListOfObjects"
               }
             },
             "locals": {
@@ -63,8 +61,7 @@
                                 "value": "City"
                               }
                             },
-                            "type": "Place",
-                            "value": "Place"
+                            "type": "Place"
                           },
                           "HomeType": {
                             "type": "BuildingType",
@@ -79,8 +76,7 @@
                             "value": "Elsewhere"
                           }
                         },
-                        "type": "Address",
-                        "value": "Address"
+                        "type": "Address"
                       },
                       "Age": {
                         "type": "Double",
@@ -99,8 +95,7 @@
                         "value": "Simon"
                       }
                     },
-                    "type": "Person",
-                    "value": "Person"
+                    "type": "Person"
                   },
                   {
                     "fields": {
@@ -121,8 +116,7 @@
                                 "value": "City"
                               }
                             },
-                            "type": "Place",
-                            "value": "Place"
+                            "type": "Place"
                           },
                           "HomeType": {
                             "type": "BuildingType",
@@ -137,8 +131,7 @@
                             "value": "Here"
                           }
                         },
-                        "type": "Address",
-                        "value": "Address"
+                        "type": "Address"
                       },
                       "Age": {
                         "type": "Double",
@@ -157,8 +150,7 @@
                         "value": "Lucy"
                       }
                     },
-                    "type": "Person",
-                    "value": "Person"
+                    "type": "Person"
                   }
                 ],
                 "size": 2,
@@ -183,8 +175,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -199,8 +190,7 @@
                         "value": "Somewhere"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -218,8 +208,7 @@
                             "fields": {
                               "City": {
                                 "notCapturedReason": "depth",
-                                "type": "Place",
-                                "value": "Place"
+                                "type": "Place"
                               },
                               "HomeType": {
                                 "type": "BuildingType",
@@ -234,8 +223,7 @@
                                 "value": "Elsewhere"
                               }
                             },
-                            "type": "Address",
-                            "value": "Address"
+                            "type": "Address"
                           },
                           "Age": {
                             "type": "Double",
@@ -254,8 +242,7 @@
                             "value": "Simon"
                           }
                         },
-                        "type": "Person",
-                        "value": "Person"
+                        "type": "Person"
                       },
                       {
                         "fields": {
@@ -267,8 +254,7 @@
                             "fields": {
                               "City": {
                                 "notCapturedReason": "depth",
-                                "type": "Place",
-                                "value": "Place"
+                                "type": "Place"
                               },
                               "HomeType": {
                                 "type": "BuildingType",
@@ -283,8 +269,7 @@
                                 "value": "Here"
                               }
                             },
-                            "type": "Address",
-                            "value": "Address"
+                            "type": "Address"
                           },
                           "Age": {
                             "type": "Double",
@@ -303,8 +288,7 @@
                             "value": "Lucy"
                           }
                         },
-                        "type": "Person",
-                        "value": "Person"
+                        "type": "Person"
                       }
                     ],
                     "size": 2,
@@ -319,8 +303,7 @@
                     "value": "Greg"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "p2": {
                 "fields": {
@@ -341,8 +324,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -357,8 +339,7 @@
                         "value": "Elsewhere"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -377,8 +358,7 @@
                     "value": "Simon"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "p3": {
                 "fields": {
@@ -399,8 +379,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -415,8 +394,7 @@
                         "value": "Here"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -435,8 +413,7 @@
                     "value": "Lucy"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               }
             }
           }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
@@ -13,12 +13,10 @@
                 "value": "36"
               },
               "genericVar": {
-                "type": "GenericInstantiation",
-                "value": "GenericInstantiation"
+                "type": "GenericInstantiation"
               },
               "this": {
-                "type": "Test`1",
-                "value": "Test`1"
+                "type": "Test`1"
               }
             }
           },
@@ -29,12 +27,10 @@
                 "value": "36"
               },
               "genericVar": {
-                "type": "GenericInstantiation",
-                "value": "GenericInstantiation"
+                "type": "GenericInstantiation"
               },
               "this": {
-                "type": "Test`1",
-                "value": "Test`1"
+                "type": "Test`1"
               }
             },
             "locals": {
@@ -63,8 +59,7 @@
                                 "value": "City"
                               }
                             },
-                            "type": "Place",
-                            "value": "Place"
+                            "type": "Place"
                           },
                           "HomeType": {
                             "type": "BuildingType",
@@ -79,8 +74,7 @@
                             "value": "Elsewhere"
                           }
                         },
-                        "type": "Address",
-                        "value": "Address"
+                        "type": "Address"
                       },
                       "Age": {
                         "type": "Double",
@@ -99,8 +93,7 @@
                         "value": "GenericInstantiation!Simon"
                       }
                     },
-                    "type": "Person",
-                    "value": "Person"
+                    "type": "Person"
                   },
                   {
                     "fields": {
@@ -121,8 +114,7 @@
                                 "value": "City"
                               }
                             },
-                            "type": "Place",
-                            "value": "Place"
+                            "type": "Place"
                           },
                           "HomeType": {
                             "type": "BuildingType",
@@ -137,8 +129,7 @@
                             "value": "Here"
                           }
                         },
-                        "type": "Address",
-                        "value": "Address"
+                        "type": "Address"
                       },
                       "Age": {
                         "type": "Double",
@@ -157,8 +148,7 @@
                         "value": "GenericInstantiation!Lucy"
                       }
                     },
-                    "type": "Person",
-                    "value": "Person"
+                    "type": "Person"
                   }
                 ],
                 "size": 2,
@@ -191,8 +181,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -207,8 +196,7 @@
                         "value": "Somewhere"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -226,8 +214,7 @@
                             "fields": {
                               "City": {
                                 "notCapturedReason": "depth",
-                                "type": "Place",
-                                "value": "Place"
+                                "type": "Place"
                               },
                               "HomeType": {
                                 "type": "BuildingType",
@@ -242,8 +229,7 @@
                                 "value": "Elsewhere"
                               }
                             },
-                            "type": "Address",
-                            "value": "Address"
+                            "type": "Address"
                           },
                           "Age": {
                             "type": "Double",
@@ -262,8 +248,7 @@
                             "value": "GenericInstantiation!Simon"
                           }
                         },
-                        "type": "Person",
-                        "value": "Person"
+                        "type": "Person"
                       },
                       {
                         "fields": {
@@ -275,8 +260,7 @@
                             "fields": {
                               "City": {
                                 "notCapturedReason": "depth",
-                                "type": "Place",
-                                "value": "Place"
+                                "type": "Place"
                               },
                               "HomeType": {
                                 "type": "BuildingType",
@@ -291,8 +275,7 @@
                                 "value": "Here"
                               }
                             },
-                            "type": "Address",
-                            "value": "Address"
+                            "type": "Address"
                           },
                           "Age": {
                             "type": "Double",
@@ -311,8 +294,7 @@
                             "value": "GenericInstantiation!Lucy"
                           }
                         },
-                        "type": "Person",
-                        "value": "Person"
+                        "type": "Person"
                       }
                     ],
                     "size": 2,
@@ -327,8 +309,7 @@
                     "value": "GenericInstantiation!Lucy"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "p2": {
                 "fields": {
@@ -349,8 +330,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -365,8 +345,7 @@
                         "value": "Elsewhere"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -385,8 +364,7 @@
                     "value": "GenericInstantiation!Simon"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               },
               "p3": {
                 "fields": {
@@ -407,8 +385,7 @@
                             "value": "City"
                           }
                         },
-                        "type": "Place",
-                        "value": "Place"
+                        "type": "Place"
                       },
                       "HomeType": {
                         "type": "BuildingType",
@@ -423,8 +400,7 @@
                         "value": "Here"
                       }
                     },
-                    "type": "Address",
-                    "value": "Address"
+                    "type": "Address"
                   },
                   "Age": {
                     "type": "Double",
@@ -443,8 +419,7 @@
                     "value": "GenericInstantiation!Lucy"
                   }
                 },
-                "type": "Person",
-                "value": "Person"
+                "type": "Person"
               }
             }
           }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
@@ -19,8 +19,7 @@
                     "value": "7"
                   }
                 },
-                "type": "HasLocalsAndReturnValue",
-                "value": "HasLocalsAndReturnValue"
+                "type": "HasLocalsAndReturnValue"
               }
             }
           },
@@ -37,8 +36,7 @@
                     "value": "7"
                   }
                 },
-                "type": "HasLocalsAndReturnValue",
-                "value": "HasLocalsAndReturnValue"
+                "type": "HasLocalsAndReturnValue"
               }
             },
             "locals": {
@@ -95,8 +93,7 @@
                       "value": "7"
                     }
                   },
-                  "type": "HasLocalsAndReturnValue",
-                  "value": "HasLocalsAndReturnValue"
+                  "type": "HasLocalsAndReturnValue"
                 }
               }
             }
@@ -146,8 +143,7 @@
                       "value": "7"
                     }
                   },
-                  "type": "HasLocalsAndReturnValue",
-                  "value": "HasLocalsAndReturnValue"
+                  "type": "HasLocalsAndReturnValue"
                 }
               }
             }
@@ -201,8 +197,7 @@
                       "value": "7"
                     }
                   },
-                  "type": "HasLocalsAndReturnValue",
-                  "value": "HasLocalsAndReturnValue"
+                  "type": "HasLocalsAndReturnValue"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasReturnValue.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -15,8 +15,7 @@
                     "value": "0"
                   }
                 },
-                "type": "HasReturnValue",
-                "value": "HasReturnValue"
+                "type": "HasReturnValue"
               }
             }
           },
@@ -29,8 +28,7 @@
                     "value": "7"
                   }
                 },
-                "type": "HasReturnValue",
-                "value": "HasReturnValue"
+                "type": "HasReturnValue"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasVarAndMvar.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasVarAndMvar.verified.txt
@@ -15,12 +15,10 @@
                     "value": "Hello"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "this": {
-                "type": "Test`1",
-                "value": "Test`1"
+                "type": "Test`1"
               }
             }
           },
@@ -33,20 +31,17 @@
                     "value": "Hello"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "this": {
-                "type": "Test`1",
-                "value": "Test`1"
+                "type": "Test`1"
               }
             },
             "locals": {
               "@return": {
                 "elements": [
                   {
-                    "type": "Test`1",
-                    "value": "Test`1"
+                    "type": "Test`1"
                   }
                 ],
                 "size": 1,
@@ -55,8 +50,7 @@
               "kk": {
                 "elements": [
                   {
-                    "type": "Test`1",
-                    "value": "Test`1"
+                    "type": "Test`1"
                   }
                 ],
                 "size": 1,
@@ -69,8 +63,7 @@
               "tt": {
                 "elements": [
                   {
-                    "type": "Test`1",
-                    "value": "Test`1"
+                    "type": "Test`1"
                   }
                 ],
                 "size": 1,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
@@ -13,8 +13,7 @@
                 "value": "Last"
               },
               "this": {
-                "type": "InstanceMethodWithArguments",
-                "value": "InstanceMethodWithArguments"
+                "type": "InstanceMethodWithArguments"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "Last"
               },
               "this": {
-                "type": "InstanceMethodWithArguments",
-                "value": "InstanceMethodWithArguments"
+                "type": "InstanceMethodWithArguments"
               }
             },
             "locals": {
@@ -77,8 +75,7 @@
                   "value": "Last"
                 },
                 "this": {
-                  "type": "InstanceMethodWithArguments",
-                  "value": "InstanceMethodWithArguments"
+                  "type": "InstanceMethodWithArguments"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
@@ -15,8 +15,7 @@
                     "value": "0"
                   }
                 },
-                "type": "InstanceVoidMethod",
-                "value": "InstanceVoidMethod"
+                "type": "InstanceVoidMethod"
               }
             }
           },
@@ -29,8 +28,7 @@
                     "value": "7"
                   }
                 },
-                "type": "InstanceVoidMethod",
-                "value": "InstanceVoidMethod"
+                "type": "InstanceVoidMethod"
               }
             }
           }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InterfaceProperties.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InterfaceProperties.verified.txt
@@ -19,8 +19,7 @@
                     "value": "T Value"
                   }
                 },
-                "type": "Class`1",
-                "value": "Class`1"
+                "type": "Class`1"
               },
               "parameter2": {
                 "fields": {
@@ -37,12 +36,10 @@
                     "value": "Show Me!"
                   }
                 },
-                "type": "Class",
-                "value": "Class"
+                "type": "Class"
               },
               "this": {
-                "type": "InterfaceProperties",
-                "value": "InterfaceProperties"
+                "type": "InterfaceProperties"
               }
             }
           },
@@ -59,8 +56,7 @@
                     "value": "T Value"
                   }
                 },
-                "type": "Class`1",
-                "value": "Class`1"
+                "type": "Class`1"
               },
               "parameter2": {
                 "fields": {
@@ -77,12 +73,10 @@
                     "value": "Show Me!"
                   }
                 },
-                "type": "Class",
-                "value": "Class"
+                "type": "Class"
               },
               "this": {
-                "type": "InterfaceProperties",
-                "value": "InterfaceProperties"
+                "type": "InterfaceProperties"
               }
             },
             "locals": {
@@ -101,8 +95,7 @@
                     "value": "Value"
                   }
                 },
-                "type": "Class`1",
-                "value": "Class`1"
+                "type": "Class`1"
               },
               "iInterface": {
                 "fields": {
@@ -119,8 +112,7 @@
                     "value": ""
                   }
                 },
-                "type": "Class",
-                "value": "Class"
+                "type": "Class"
               }
             }
           }
@@ -171,8 +163,7 @@
                       "value": "T Value"
                     }
                   },
-                  "type": "Class`1",
-                  "value": "Class`1"
+                  "type": "Class`1"
                 },
                 "parameter2": {
                   "fields": {
@@ -189,12 +180,10 @@
                       "value": "Show Me!"
                     }
                   },
-                  "type": "Class",
-                  "value": "Class"
+                  "type": "Class"
                 },
                 "this": {
-                  "type": "InterfaceProperties",
-                  "value": "InterfaceProperties"
+                  "type": "InterfaceProperties"
                 }
               },
               "locals": {
@@ -209,8 +198,7 @@
                       "value": "Value"
                     }
                   },
-                  "type": "Class`1",
-                  "value": "Class`1"
+                  "type": "Class`1"
                 },
                 "iInterface": {
                   "fields": {
@@ -227,8 +215,7 @@
                       "value": ""
                     }
                   },
-                  "type": "Class",
-                  "value": "Class"
+                  "type": "Class"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InvalidCondition.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InvalidCondition.verified.txt
@@ -13,8 +13,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "InvalidCondition",
-                "value": "InvalidCondition"
+                "type": "InvalidCondition"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionFullSnapshot.verified.txt
@@ -14,8 +14,7 @@
                   "value": "1"
                 },
                 "this": {
-                  "type": "LineConditionFullSnapshot",
-                  "value": "LineConditionFullSnapshot"
+                  "type": "LineConditionFullSnapshot"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
@@ -13,8 +13,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "LineProbesWithRevertTest",
-                "value": "LineProbesWithRevertTest"
+                "type": "LineProbesWithRevertTest"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "LineProbesWithRevertTest",
-                "value": "LineProbesWithRevertTest"
+                "type": "LineProbesWithRevertTest"
               }
             },
             "locals": {
@@ -85,8 +83,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -148,8 +145,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -211,8 +207,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
@@ -14,8 +14,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -77,8 +76,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -140,8 +138,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -203,8 +200,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -266,8 +262,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
@@ -14,8 +14,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -77,8 +76,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -140,8 +138,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -203,8 +200,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
@@ -14,8 +14,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
@@ -14,8 +14,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -77,8 +76,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {
@@ -140,8 +138,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "LineProbesWithRevertTest",
-                  "value": "LineProbesWithRevertTest"
+                  "type": "LineProbesWithRevertTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplateFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplateFullSnapshot.verified.txt
@@ -14,8 +14,7 @@
                   "value": "1"
                 },
                 "this": {
-                  "type": "LineTemplateFullSnapshot",
-                  "value": "LineTemplateFullSnapshot"
+                  "type": "LineTemplateFullSnapshot"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ManyLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ManyLocals.verified.txt
@@ -9,16 +9,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "ManyLocals",
-                "value": "ManyLocals"
+                "type": "ManyLocals"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "ManyLocals",
-                "value": "ManyLocals"
+                "type": "ManyLocals"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
@@ -15,8 +15,7 @@
                     "value": "0"
                   }
                 },
-                "type": "MethodThrowExceptionTest",
-                "value": "MethodThrowExceptionTest"
+                "type": "MethodThrowExceptionTest"
               },
               "toSet": {
                 "type": "Int32",
@@ -33,8 +32,7 @@
                     "value": "2147483647"
                   }
                 },
-                "type": "MethodThrowExceptionTest",
-                "value": "MethodThrowExceptionTest"
+                "type": "MethodThrowExceptionTest"
               },
               "toSet": {
                 "type": "Int32",
@@ -66,8 +64,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "InvalidOperationException",
-                "value": "InvalidOperationException"
+                "type": "InvalidOperationException"
               },
               "numberSnapshot": {
                 "type": "Int32",
@@ -128,8 +125,7 @@
                       "value": "2147483647"
                     }
                   },
-                  "type": "MethodThrowExceptionTest",
-                  "value": "MethodThrowExceptionTest"
+                  "type": "MethodThrowExceptionTest"
                 },
                 "toSet": {
                   "type": "Int32",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ModuleUnloadTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ModuleUnloadTest.verified.txt
@@ -20,8 +20,7 @@
                       "value": "0"
                     }
                   },
-                  "type": "ExternalTest",
-                  "value": "ExternalTest"
+                  "type": "ExternalTest"
                 }
               }
             }
@@ -75,8 +74,7 @@
                       "value": "1208223660"
                     }
                   },
-                  "type": "ExternalTest",
-                  "value": "ExternalTest"
+                  "type": "ExternalTest"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "MultiProbeTest",
-                "value": "MultiProbeTest"
+                "type": "MultiProbeTest"
               }
             },
             "staticFields": {
@@ -35,8 +34,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "MultiProbeTest",
-                "value": "MultiProbeTest"
+                "type": "MultiProbeTest"
               }
             },
             "locals": {
@@ -97,8 +95,7 @@
                   "value": "6"
                 },
                 "this": {
-                  "type": "MultiProbeTest",
-                  "value": "MultiProbeTest"
+                  "type": "MultiProbeTest"
                 }
               },
               "staticFields": {
@@ -155,8 +152,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "MultiProbeTest",
-                "value": "MultiProbeTest"
+                "type": "MultiProbeTest"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "MultiProbeWithSpanTest",
-                "value": "MultiProbeWithSpanTest"
+                "type": "MultiProbeWithSpanTest"
               }
             },
             "staticFields": {
@@ -39,8 +38,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "MultiProbeWithSpanTest",
-                "value": "MultiProbeWithSpanTest"
+                "type": "MultiProbeWithSpanTest"
               }
             },
             "locals": {
@@ -109,8 +107,7 @@
                   "value": "6"
                 },
                 "this": {
-                  "type": "MultiProbeWithSpanTest",
-                  "value": "MultiProbeWithSpanTest"
+                  "type": "MultiProbeWithSpanTest"
                 }
               },
               "locals": {
@@ -177,8 +174,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "MultiProbeWithSpanTest",
-                "value": "MultiProbeWithSpanTest"
+                "type": "MultiProbeWithSpanTest"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
@@ -10,8 +10,7 @@
             "25": {
               "arguments": {
                 "this": {
-                  "type": "MultiScopesWithSameLocalNameTest",
-                  "value": "MultiScopesWithSameLocalNameTest"
+                  "type": "MultiScopesWithSameLocalNameTest"
                 }
               },
               "locals": {
@@ -65,8 +64,7 @@
             "25": {
               "arguments": {
                 "this": {
-                  "type": "MultiScopesWithSameLocalNameTest",
-                  "value": "MultiScopesWithSameLocalNameTest"
+                  "type": "MultiScopesWithSameLocalNameTest"
                 }
               },
               "locals": {
@@ -120,8 +118,7 @@
             "32": {
               "arguments": {
                 "this": {
-                  "type": "MultiScopesWithSameLocalNameTest",
-                  "value": "MultiScopesWithSameLocalNameTest"
+                  "type": "MultiScopesWithSameLocalNameTest"
                 }
               },
               "locals": {
@@ -175,8 +172,7 @@
             "32": {
               "arguments": {
                 "this": {
-                  "type": "MultiScopesWithSameLocalNameTest",
-                  "value": "MultiScopesWithSameLocalNameTest"
+                  "type": "MultiScopesWithSameLocalNameTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultidimensionalArrayTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultidimensionalArrayTest.verified.txt
@@ -9,8 +9,7 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "MultidimensionalArrayTest",
-                "value": "MultidimensionalArrayTest"
+                "type": "MultidimensionalArrayTest"
               }
             },
             "staticFields": {
@@ -117,8 +116,7 @@
           "return": {
             "arguments": {
               "this": {
-                "type": "MultidimensionalArrayTest",
-                "value": "MultidimensionalArrayTest"
+                "type": "MultidimensionalArrayTest"
               }
             },
             "staticFields": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
@@ -13,8 +13,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "MultipleLineProbes",
-                "value": "MultipleLineProbes"
+                "type": "MultipleLineProbes"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "MultipleLineProbes",
-                "value": "MultipleLineProbes"
+                "type": "MultipleLineProbes"
               }
             }
           }
@@ -71,8 +69,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "MultipleLineProbes",
-                  "value": "MultipleLineProbes"
+                  "type": "MultipleLineProbes"
                 }
               }
             }
@@ -120,8 +117,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "MultipleLineProbes",
-                  "value": "MultipleLineProbes"
+                  "type": "MultipleLineProbes"
                 }
               }
             }
@@ -169,8 +165,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "MultipleLineProbes",
-                  "value": "MultipleLineProbes"
+                  "type": "MultipleLineProbes"
                 }
               }
             }
@@ -218,8 +213,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "MultipleLineProbes",
-                  "value": "MultipleLineProbes"
+                  "type": "MultipleLineProbes"
                 }
               }
             }
@@ -267,8 +261,7 @@
                   "value": "Run"
                 },
                 "this": {
-                  "type": "MultipleLineProbes",
-                  "value": "MultipleLineProbes"
+                  "type": "MultipleLineProbes"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "IAmNotSupported"
               },
               "this": {
-                "type": "NormalStruct",
-                "value": "NormalStruct"
+                "type": "NormalStruct"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "IAmNotSupported"
               },
               "this": {
-                "type": "NormalStruct",
-                "value": "NormalStruct"
+                "type": "NormalStruct"
               }
             },
             "locals": {
@@ -76,8 +74,7 @@
                 "value": "IAmNotSupported"
               },
               "this": {
-                "type": "NotSupportedFailureTest",
-                "value": "NotSupportedFailureTest"
+                "type": "NotSupportedFailureTest"
               }
             }
           },
@@ -88,18 +85,15 @@
                 "value": "IAmNotSupported"
               },
               "this": {
-                "type": "NotSupportedFailureTest",
-                "value": "NotSupportedFailureTest"
+                "type": "NotSupportedFailureTest"
               }
             },
             "locals": {
               "@return": {
-                "type": "NormalStruct",
-                "value": "NormalStruct"
+                "type": "NormalStruct"
               },
               "ret": {
-                "type": "NormalStruct",
-                "value": "NormalStruct"
+                "type": "NormalStruct"
               }
             }
           }
@@ -140,8 +134,7 @@
             "24": {
               "arguments": {
                 "this": {
-                  "type": "NotSupportedFailureTest",
-                  "value": "NotSupportedFailureTest"
+                  "type": "NotSupportedFailureTest"
                 }
               },
               "locals": {
@@ -191,8 +184,7 @@
             "25": {
               "arguments": {
                 "this": {
-                  "type": "NotSupportedFailureTest",
-                  "value": "NotSupportedFailureTest"
+                  "type": "NotSupportedFailureTest"
                 }
               },
               "locals": {
@@ -242,8 +234,7 @@
             "26": {
               "arguments": {
                 "this": {
-                  "type": "NotSupportedFailureTest",
-                  "value": "NotSupportedFailureTest"
+                  "type": "NotSupportedFailureTest"
                 }
               },
               "locals": {
@@ -293,8 +284,7 @@
             "27": {
               "arguments": {
                 "this": {
-                  "type": "NotSupportedFailureTest",
-                  "value": "NotSupportedFailureTest"
+                  "type": "NotSupportedFailureTest"
                 }
               },
               "locals": {
@@ -344,8 +334,7 @@
             "28": {
               "arguments": {
                 "this": {
-                  "type": "NotSupportedFailureTest",
-                  "value": "NotSupportedFailureTest"
+                  "type": "NotSupportedFailureTest"
                 }
               },
               "locals": {
@@ -399,8 +388,7 @@
                   "value": "IAmNotSupported"
                 },
                 "this": {
-                  "type": "NormalStruct",
-                  "value": "NormalStruct"
+                  "type": "NormalStruct"
                 }
               }
             }
@@ -448,14 +436,12 @@
                   "value": "IAmNotSupported"
                 },
                 "this": {
-                  "type": "NotSupportedFailureTest",
-                  "value": "NotSupportedFailureTest"
+                  "type": "NotSupportedFailureTest"
                 }
               },
               "locals": {
                 "ret": {
-                  "type": "NormalStruct",
-                  "value": "NormalStruct"
+                  "type": "NormalStruct"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
@@ -15,12 +15,10 @@
                     "value": "Hello"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "gen2": {
-                "type": "OpenGenericMethodInDerivedGenericType",
-                "value": "OpenGenericMethodInDerivedGenericType"
+                "type": "OpenGenericMethodInDerivedGenericType"
               },
               "k": {
                 "fields": {
@@ -29,12 +27,10 @@
                     "value": "Hello"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "this": {
-                "type": "Test2`1",
-                "value": "Test2`1"
+                "type": "Test2`1"
               }
             }
           },
@@ -47,12 +43,10 @@
                     "value": "Hello"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "gen2": {
-                "type": "OpenGenericMethodInDerivedGenericType",
-                "value": "OpenGenericMethodInDerivedGenericType"
+                "type": "OpenGenericMethodInDerivedGenericType"
               },
               "k": {
                 "fields": {
@@ -61,12 +55,10 @@
                     "value": "Hello"
                   }
                 },
-                "type": "Generic",
-                "value": "Generic"
+                "type": "Generic"
               },
               "this": {
-                "type": "Test2`1",
-                "value": "Test2`1"
+                "type": "Test2`1"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PinnedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PinnedLocal.verified.txt
@@ -9,16 +9,20 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "PinnedLocal",
-                "value": "PinnedLocal"
+                "type": "PinnedLocal"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "PinnedLocal",
-                "value": "PinnedLocal"
+                "type": "PinnedLocal"
+              }
+            },
+            "locals": {
+              "p": {
+                "type": "Char",
+                "value": "h"
               }
             }
           }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RecursionWithInnerRefStructTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RecursionWithInnerRefStructTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "0"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "0"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -76,8 +74,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -88,8 +85,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -139,8 +135,7 @@
                 "value": "10"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -151,8 +146,7 @@
                 "value": "10"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -202,8 +196,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -214,8 +207,7 @@
                 "value": "2"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -265,8 +257,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -277,8 +268,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -328,8 +318,7 @@
                 "value": "4"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -340,8 +329,7 @@
                 "value": "4"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -391,8 +379,7 @@
                 "value": "5"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -403,8 +390,7 @@
                 "value": "5"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -454,8 +440,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -466,8 +451,7 @@
                 "value": "6"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -517,8 +501,7 @@
                 "value": "7"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -529,8 +512,7 @@
                 "value": "7"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -580,8 +562,7 @@
                 "value": "8"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -592,8 +573,7 @@
                 "value": "8"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -643,8 +623,7 @@
                 "value": "9"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             }
           },
@@ -655,8 +634,7 @@
                 "value": "9"
               },
               "this": {
-                "type": "RecursionWithInnerRefStructTest",
-                "value": "RecursionWithInnerRefStructTest"
+                "type": "RecursionWithInnerRefStructTest"
               }
             },
             "locals": {
@@ -728,12 +706,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -766,12 +742,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -849,12 +823,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -887,12 +859,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -970,12 +940,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1008,12 +976,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -1091,12 +1057,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1129,12 +1093,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -1212,12 +1174,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1250,12 +1210,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -1333,12 +1291,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1371,12 +1327,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -1454,12 +1408,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1492,12 +1444,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -1575,12 +1525,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1613,12 +1561,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -1696,12 +1642,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1734,12 +1678,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {
@@ -1817,12 +1759,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             }
           },
@@ -1855,12 +1795,10 @@
                     "value": "ScrubbedValue"
                   },
                   "_target": {
-                    "type": "Object",
-                    "value": "Object"
+                    "type": "Object"
                   }
                 },
-                "type": "Func`2",
-                "value": "Func`2"
+                "type": "Func`2"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RedactionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RedactionTest.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -9,16 +9,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "RedactionTest",
-                "value": "RedactionTest"
+                "type": "RedactionTest"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "RedactionTest",
-                "value": "RedactionTest"
+                "type": "RedactionTest"
               }
             },
             "locals": {
@@ -45,8 +43,7 @@
                     "type": "String"
                   }
                 },
-                "type": "OuterClass",
-                "value": "OuterClass"
+                "type": "OuterClass"
               },
               "b": {
                 "fields": {
@@ -63,8 +60,7 @@
                     "type": "String"
                   }
                 },
-                "type": "OuterClass",
-                "value": "OuterClass"
+                "type": "OuterClass"
               },
               "iamok": {
                 "fields": {
@@ -73,8 +69,7 @@
                     "value": "You should see me IAmOkType"
                   }
                 },
-                "type": "IAmOkType",
-                "value": "IAmOkType"
+                "type": "IAmOkType"
               },
               "redactedTypeA": {
                 "fields": {
@@ -83,8 +78,7 @@
                     "value": "You should not see me RedactMeTypeA"
                   }
                 },
-                "type": "RedactMeTypeA",
-                "value": "RedactMeTypeA"
+                "type": "RedactMeTypeA"
               },
               "redactedTypeB": {
                 "fields": {
@@ -93,8 +87,7 @@
                     "value": "You should not see me RedactMeTypeB"
                   }
                 },
-                "type": "RedactMeTypeB",
-                "value": "RedactMeTypeB"
+                "type": "RedactMeTypeB"
               },
               "redactedTypeC": {
                 "fields": {
@@ -103,8 +96,7 @@
                     "value": "You should not see me AnotherRedactMeTypeB"
                   }
                 },
-                "type": "AnotherRedactMeTypeB",
-                "value": "AnotherRedactMeTypeB"
+                "type": "AnotherRedactMeTypeB"
               }
             }
           }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RedactionTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RedactionTest_#1..verified.txt
@@ -9,16 +9,14 @@
           "entry": {
             "arguments": {
               "this": {
-                "type": "RedactionTest",
-                "value": "RedactionTest"
+                "type": "RedactionTest"
               }
             }
           },
           "return": {
             "arguments": {
               "this": {
-                "type": "RedactionTest",
-                "value": "RedactionTest"
+                "type": "RedactionTest"
               }
             },
             "locals": {
@@ -45,8 +43,7 @@
                     "type": "String"
                   }
                 },
-                "type": "OuterClass",
-                "value": "OuterClass"
+                "type": "OuterClass"
               },
               "b": {
                 "notCapturedReason": "redactedIdent",
@@ -59,8 +56,7 @@
                     "value": "You should see me IAmOkType"
                   }
                 },
-                "type": "IAmOkType",
-                "value": "IAmOkType"
+                "type": "IAmOkType"
               },
               "redactedTypeA": {
                 "notCapturedReason": "redactedType",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
@@ -19,8 +19,7 @@
                     "value": "IRun"
                   }
                 },
-                "type": "SimpleMethodWithLocalsAndArgsTest",
-                "value": "SimpleMethodWithLocalsAndArgsTest"
+                "type": "SimpleMethodWithLocalsAndArgsTest"
               }
             }
           },
@@ -37,8 +36,7 @@
                     "value": "IRun"
                   }
                 },
-                "type": "SimpleMethodWithLocalsAndArgsTest",
-                "value": "SimpleMethodWithLocalsAndArgsTest"
+                "type": "SimpleMethodWithLocalsAndArgsTest"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
@@ -19,8 +19,7 @@
                     "value": "IRun"
                   }
                 },
-                "type": "SimpleMethodWithLocalsAndArgsTest",
-                "value": "SimpleMethodWithLocalsAndArgsTest"
+                "type": "SimpleMethodWithLocalsAndArgsTest"
               }
             }
           },
@@ -37,8 +36,7 @@
                     "value": "IRun"
                   }
                 },
-                "type": "SimpleMethodWithLocalsAndArgsTest",
-                "value": "SimpleMethodWithLocalsAndArgsTest"
+                "type": "SimpleMethodWithLocalsAndArgsTest"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "NestedType",
-                "value": "NestedType"
+                "type": "NestedType"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "NestedType",
-                "value": "NestedType"
+                "type": "NestedType"
               }
             },
             "locals": {
@@ -54,8 +52,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "IntentionalDebuggerException",
-                "value": "IntentionalDebuggerException"
+                "type": "IntentionalDebuggerException"
               },
               "arr": {
                 "elements": [

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "NestedType",
-                "value": "NestedType"
+                "type": "NestedType"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "NestedType",
-                "value": "NestedType"
+                "type": "NestedType"
               }
             },
             "locals": {
@@ -54,8 +52,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "IntentionalDebuggerException",
-                "value": "IntentionalDebuggerException"
+                "type": "IntentionalDebuggerException"
               },
               "arr": {
                 "elements": [

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
@@ -13,8 +13,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "SimpleTypeNameInGlobalNamespaceTest",
-                "value": "SimpleTypeNameInGlobalNamespaceTest"
+                "type": "SimpleTypeNameInGlobalNamespaceTest"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "SimpleTypeNameInGlobalNamespaceTest",
-                "value": "SimpleTypeNameInGlobalNamespaceTest"
+                "type": "SimpleTypeNameInGlobalNamespaceTest"
               }
             },
             "locals": {
@@ -54,8 +52,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "IntentionalDebuggerException",
-                "value": "IntentionalDebuggerException"
+                "type": "IntentionalDebuggerException"
               },
               "arr": {
                 "elements": [

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -13,8 +13,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "SimpleTypeNameTest",
-                "value": "SimpleTypeNameTest"
+                "type": "SimpleTypeNameTest"
               }
             }
           },
@@ -25,8 +24,7 @@
                 "value": "Run"
               },
               "this": {
-                "type": "SimpleTypeNameTest",
-                "value": "SimpleTypeNameTest"
+                "type": "SimpleTypeNameTest"
               }
             },
             "locals": {
@@ -54,8 +52,7 @@
                   },
                   "StackTrace": "ScrubbedValue"
                 },
-                "type": "IntentionalDebuggerException",
-                "value": "IntentionalDebuggerException"
+                "type": "IntentionalDebuggerException"
               },
               "arr": {
                 "elements": [

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.verified.txt
@@ -32,8 +32,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -48,8 +47,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -67,8 +65,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -83,8 +80,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -103,8 +99,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -119,8 +114,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "person2": {
                   "fields": {
@@ -141,8 +135,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -157,8 +150,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -176,8 +168,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -192,8 +183,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -212,8 +202,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -228,12 +217,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "SpanOnMethodWithArgsTest",
-                  "value": "SpanOnMethodWithArgsTest"
+                  "type": "SpanOnMethodWithArgsTest"
                 }
               },
               "staticFields": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.verified.txt
@@ -32,8 +32,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -48,8 +47,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -67,8 +65,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -83,8 +80,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -103,8 +99,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -119,8 +114,7 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "person2": {
                   "fields": {
@@ -141,8 +135,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -157,8 +150,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -176,8 +168,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -192,8 +183,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -212,8 +202,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -228,12 +217,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "SpanOnMethodWithExceptionProbeTest",
-                  "value": "SpanOnMethodWithExceptionProbeTest"
+                  "type": "SpanOnMethodWithExceptionProbeTest"
                 }
               },
               "staticFields": {
@@ -305,8 +292,7 @@
                               "value": "City"
                             }
                           },
-                          "type": "Place",
-                          "value": "Place"
+                          "type": "Place"
                         },
                         "HomeType": {
                           "type": "BuildingType",
@@ -321,8 +307,7 @@
                           "value": "Harlem"
                         }
                       },
-                      "type": "Address",
-                      "value": "Address"
+                      "type": "Address"
                     },
                     "Age": {
                       "type": "Double",
@@ -340,8 +325,7 @@
                               "fields": {
                                 "City": {
                                   "notCapturedReason": "depth",
-                                  "type": "Place",
-                                  "value": "Place"
+                                  "type": "Place"
                                 },
                                 "HomeType": {
                                   "type": "BuildingType",
@@ -356,8 +340,7 @@
                                   "value": "Harlem"
                                 }
                               },
-                              "type": "Address",
-                              "value": "Address"
+                              "type": "Address"
                             },
                             "Age": {
                               "type": "Double",
@@ -376,8 +359,7 @@
                               "value": "Ralph Jr."
                             }
                           },
-                          "type": "Person",
-                          "value": "Person"
+                          "type": "Person"
                         }
                       ],
                       "size": 1,
@@ -392,12 +374,10 @@
                       "value": "Ralph"
                     }
                   },
-                  "type": "Person",
-                  "value": "Person"
+                  "type": "Person"
                 },
                 "this": {
-                  "type": "SpanOnMethodWithExceptionProbeTest",
-                  "value": "SpanOnMethodWithExceptionProbeTest"
+                  "type": "SpanOnMethodWithExceptionProbeTest"
                 }
               },
               "staticFields": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithDurationAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithDurationAtEntry.verified.txt
@@ -13,8 +13,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "TemplateWithDurationAtEntry",
-                "value": "TemplateWithDurationAtEntry"
+                "type": "TemplateWithDurationAtEntry"
               }
             },
             "staticFields": {
@@ -31,8 +30,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "TemplateWithDurationAtEntry",
-                "value": "TemplateWithDurationAtEntry"
+                "type": "TemplateWithDurationAtEntry"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtEntry.verified.txt
@@ -13,8 +13,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "TemplateWithLocalAtEntry",
-                "value": "TemplateWithLocalAtEntry"
+                "type": "TemplateWithLocalAtEntry"
               }
             },
             "staticFields": {
@@ -31,8 +30,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "TemplateWithLocalAtEntry",
-                "value": "TemplateWithLocalAtEntry"
+                "type": "TemplateWithLocalAtEntry"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtExit.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtExit.verified.txt
@@ -13,8 +13,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "TemplateWithLocalAtExit",
-                "value": "TemplateWithLocalAtExit"
+                "type": "TemplateWithLocalAtExit"
               }
             },
             "staticFields": {
@@ -31,8 +30,7 @@
                 "value": "3"
               },
               "this": {
-                "type": "TemplateWithLocalAtExit",
-                "value": "TemplateWithLocalAtExit"
+                "type": "TemplateWithLocalAtExit"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryCatchTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryCatchTest.verified.txt
@@ -14,8 +14,7 @@
                   "value": "TryCatchTest"
                 },
                 "this": {
-                  "type": "TryCatchTest",
-                  "value": "TryCatchTest"
+                  "type": "TryCatchTest"
                 }
               },
               "locals": {
@@ -73,8 +72,7 @@
                   "value": "TryCatchTest"
                 },
                 "this": {
-                  "type": "TryCatchTest",
-                  "value": "TryCatchTest"
+                  "type": "TryCatchTest"
                 }
               },
               "locals": {
@@ -132,8 +130,7 @@
                   "value": "TryCatchTest"
                 },
                 "this": {
-                  "type": "TryCatchTest",
-                  "value": "TryCatchTest"
+                  "type": "TryCatchTest"
                 }
               },
               "locals": {
@@ -191,8 +188,7 @@
                   "value": "TryCatchTest"
                 },
                 "this": {
-                  "type": "TryCatchTest",
-                  "value": "TryCatchTest"
+                  "type": "TryCatchTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryFinallyMethodAndLine.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryFinallyMethodAndLine.verified.txt
@@ -10,8 +10,7 @@
             "arguments": {
               "message": "ScrubbedValue",
               "this": {
-                "type": "TryFinallyMethodAndLine",
-                "value": "TryFinallyMethodAndLine"
+                "type": "TryFinallyMethodAndLine"
               }
             }
           },
@@ -19,14 +18,12 @@
             "arguments": {
               "message": "ScrubbedValue",
               "this": {
-                "type": "TryFinallyMethodAndLine",
-                "value": "TryFinallyMethodAndLine"
+                "type": "TryFinallyMethodAndLine"
               }
             },
             "locals": {
               "ctx": {
-                "type": "ParseContext",
-                "value": "ParseContext"
+                "type": "ParseContext"
               }
             }
           }
@@ -68,8 +65,7 @@
               "arguments": {
                 "message": "ScrubbedValue",
                 "this": {
-                  "type": "TryFinallyMethodAndLine",
-                  "value": "TryFinallyMethodAndLine"
+                  "type": "TryFinallyMethodAndLine"
                 }
               },
               "locals": {
@@ -120,14 +116,12 @@
               "arguments": {
                 "message": "ScrubbedValue",
                 "this": {
-                  "type": "TryFinallyMethodAndLine",
-                  "value": "TryFinallyMethodAndLine"
+                  "type": "TryFinallyMethodAndLine"
                 }
               },
               "locals": {
                 "ctx": {
-                  "type": "ParseContext",
-                  "value": "ParseContext"
+                  "type": "ParseContext"
                 }
               }
             }
@@ -172,14 +166,12 @@
               "arguments": {
                 "message": "ScrubbedValue",
                 "this": {
-                  "type": "TryFinallyMethodAndLine",
-                  "value": "TryFinallyMethodAndLine"
+                  "type": "TryFinallyMethodAndLine"
                 }
               },
               "locals": {
                 "ctx": {
-                  "type": "ParseContext",
-                  "value": "ParseContext"
+                  "type": "ParseContext"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryFinallyTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryFinallyTest.verified.txt
@@ -14,8 +14,7 @@
                   "value": "TryFinallyTest"
                 },
                 "this": {
-                  "type": "TryFinallyTest",
-                  "value": "TryFinallyTest"
+                  "type": "TryFinallyTest"
                 }
               },
               "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UnboundProbeBecomesBoundTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UnboundProbeBecomesBoundTest.verified.txt
@@ -20,8 +20,7 @@
                       "value": "0"
                     }
                   },
-                  "type": "ExternalTest",
-                  "value": "ExternalTest"
+                  "type": "ExternalTest"
                 }
               }
             }
@@ -75,8 +74,7 @@
                       "value": "1208223660"
                     }
                   },
-                  "type": "ExternalTest",
-                  "value": "ExternalTest"
+                  "type": "ExternalTest"
                 }
               }
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UndefinedValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UndefinedValue.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -13,8 +13,7 @@
                 "value": "1"
               },
               "this": {
-                "type": "UndefinedValue",
-                "value": "UndefinedValue"
+                "type": "UndefinedValue"
               }
             },
             "locals": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
@@ -1,10 +1,10 @@
-[
+﻿[
   {
     "ddsource": "dd_debugger",
     "debugger": {
       "diagnostics": {
         "exception": {
-          "message": "Placing line probes in async generic methods in Release builds is currently not supported.",
+          "message": "Probe location did not map out to a valid bytecode offset",
           "stacktrace": null,
           "type": "NO_TYPE"
         },


### PR DESCRIPTION
## Reason for change
The RFC says: value (optional) is the content of the captured data for primitives as a string literal

## Implementation details
Delete the value when the type is not primitive and it's not safe to call ToString on that type

## Test coverage
All existing snapshot tests