### PR TITLE
[Code Origin] DEBUG-3935 Fix type handle mismatch when resolving attribute type

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -181,21 +181,38 @@ internal static class EndpointDetector
         {
             string fullName;
             var attribute = reader.GetCustomAttribute(attributeHandle);
-            if (attribute.Constructor.Kind == HandleKind.MemberReference)
+            switch (attribute.Constructor.Kind)
             {
-                var ctor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
-                var attributeType = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
-                fullName = GetFullTypeName(attributeType.Namespace, attributeType.Name, reader);
-            }
-            else if (attribute.Constructor.Kind == HandleKind.MethodDefinition)
-            {
-                var ctor = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
-                var attributeType = reader.GetTypeDefinition(ctor.GetDeclaringType());
-                fullName = GetFullTypeName(attributeType.Namespace, attributeType.Name, reader);
-            }
-            else
-            {
-                continue;
+                case HandleKind.MemberReference:
+                    {
+                        var ctor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                        switch (ctor.Parent.Kind)
+                        {
+                            case HandleKind.TypeReference:
+                                var tr = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
+                                fullName = GetFullTypeName(tr.Namespace, tr.Name, reader);
+                                break;
+
+                            case HandleKind.TypeDefinition:
+                                var td = reader.GetTypeDefinition((TypeDefinitionHandle)ctor.Parent);
+                                fullName = GetFullTypeName(td.Namespace, td.Name, reader);
+                                break;
+
+                            default:
+                                continue;
+                        }
+
+                        break;
+                    }
+                case HandleKind.MethodDefinition:
+                    {
+                        var ctor = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                        var td = reader.GetTypeDefinition(ctor.GetDeclaringType());
+                        fullName = GetFullTypeName(td.Namespace, td.Name, reader);
+                        break;
+                    }
+                default:
+                    continue;
             }
 
             if (attributeNames.Contains(fullName))

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -204,6 +204,7 @@ internal static class EndpointDetector
 
                         break;
                     }
+
                 case HandleKind.MethodDefinition:
                     {
                         var ctor = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
@@ -211,6 +212,7 @@ internal static class EndpointDetector
                         fullName = GetFullTypeName(td.Namespace, td.Name, reader);
                         break;
                     }
+
                 default:
                     continue;
             }

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOriginManager.cs
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "Failed to load PDB info for assembly {AssemblyName}", asm.Location);
+                        Log.Error(ex, "Error while getting endpoints for assembly: {AssemblyName}", asm.Location);
                         return null;
                     }
                 });


### PR DESCRIPTION
## Summary of changes
Robust resolution of attribute types in `HasAttributeFromSet`

## Reason for change
InvliadCastException in case MemberReference.Parent is not TypeDefinition

## Implementation details
Checkin for MemberReference.Parent before getting the type

