### PR TITLE
Remove scheduled SSI run

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -99,7 +99,6 @@ steps:
         --env DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID \
         --env DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH \
         --env DD_LOGGER_DD_TAGS \
-        --env IS_SSI_RUN \
         --env RANDOM_SEED \
         ${{ parameters.extraArgs }} \
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }}:$sdkVersion \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -53,13 +53,6 @@ schedules:
         - master
     always: true
 
-  - cron: "0 4 * * *"
-    displayName: Daily SSI Run
-    branches:
-      include:
-        - master
-    always: true
-
 # Global variables
 variables:
   buildConfiguration: Release
@@ -126,8 +119,6 @@ variables:
   DD_LOGGER_DD_TAGS: test.configuration.job:$(System.JobDisplayName)
   DD_LOGGER_ENABLED: true
   DD_COLLECTOR_CPU_USAGE: true
-  # If we're doing an SSI run, set the indicator, the rest need to be set in the stage
-  IS_SSI_RUN: $[ or(eq(variables['Build.CronSchedule.DisplayName'], 'Daily SSI Run'), eq(variables['force_ssi_run'], 'true')) ]
   ToolVersion: 3.17.0
   # .NET SDK performance optimization variables
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -69,7 +69,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
 
   IntegrationTests.IIS.MultipleAppsInDomain:
     build:
@@ -114,7 +113,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
 
   smoke-tests.windows:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,7 +372,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
       - LDAP_SERVER=openldap-server:389
     hostname: integrationtests
     depends_on:
@@ -451,7 +450,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
       - RANDOM_SEED
     hostname: integrationtests
     depends_on:
@@ -522,7 +520,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
       - RANDOM_SEED
     hostname: integrationtests
 
@@ -579,7 +576,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
       - RANDOM_SEED
     hostname: integrationtests
 
@@ -630,7 +626,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
 
   StartDependencies:
     image: andrewlock/wait-for-dependencies
@@ -722,7 +717,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
       - RANDOM_SEED
     depends_on:
       - servicestackredis_arm64
@@ -801,7 +795,6 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
-      - IS_SSI_RUN
       - RANDOM_SEED
 
   start-test-agent:

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2777,17 +2777,6 @@ partial class Build
             }
         }
 
-        // set variables for subsequent tests
-        var isSsiRun = Environment.GetEnvironmentVariable("IS_SSI_RUN");
-        if (!string.IsNullOrEmpty(isSsiRun) && string.Equals(isSsiRun, "true", StringComparison.OrdinalIgnoreCase))
-        {
-            Logger.Information("Setting environment variables for SSI run");
-
-            // Not setting telemetry forwarder path because we don't have one to point to
-            Environment.SetEnvironmentVariable("DD_INJECT_FORCE", "true");
-            Environment.SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
-        }
-
         base.OnTargetRunning(target);
 
         static string PrettyPrint(long bytes)


### PR DESCRIPTION
## Summary of changes

Removes the scheduled SSI run

## Reason for change

A recent PR https://github.com/DataDog/dd-trace-dotnet/pull/6961 resulted in the SSI run failing. We're not convinced this run provides a lot of value now anyway, now that we have the dedicated onboarding tests, so removing the run to unblock `master`

## Implementation details

Delete the scheduled SSI run and associated `IS_SSI_RUN` variable

## Test coverage

N/A

## Other details

We will likely advise other languages to do the same