### PR TITLE
Use custom test framework in the debugger integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/CustomTestFramework.cs
@@ -1,0 +1,20 @@
+// <copyright file="CustomTestFramework.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Xunit;
+using Xunit.Abstractions;
+
+[assembly: TestFramework("Datadog.Trace.Debugger.IntegrationTests.CustomTestFramework", "Datadog.Trace.Debugger.IntegrationTests")]
+
+namespace Datadog.Trace.Debugger.IntegrationTests
+{
+    public class CustomTestFramework : TestHelpers.CustomTestFramework
+    {
+        public CustomTestFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Update the debugger integration tests to use our custom test framework

## Reason for change

Our custom test framework adds multiple features:
- Logging each method as it starts, so we know which test was running if we get a failure
- Warnings about long-running (likely hung) tests
- Randomizing test order execution to detect flake and reporting metrics to DD
- Handling automatic retry for tests marked `[Flaky]`

## Implementation details

Add the `CustomTestFramework` attribute and implementation

## Test coverage

This is the test - as long as the tests run, we're ok

## Other details

Hopefully this will help detect flake/hanging issues in the debugger tests 