### PR TITLE
Fix exit code from `GacUninstallCommand` when the assembly is not in the GAC

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/GacUninstallCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/GacUninstallCommand.cs
@@ -46,8 +46,8 @@ internal class GacUninstallCommand : CommandWithExamples
         var installedAssemblyNames = gacMethods.GetAssemblyNames(assemblyName!);
         if (installedAssemblyNames.Count == 0)
         {
-            Utils.WriteWarning($"Assembly '{assemblyName}' is not installed the GAC.");
-            context.ExitCode = 1;
+            Utils.WriteSuccess($"Assembly '{assemblyName}' is not installed in the GAC.");
+            context.ExitCode = 0;
             return;
         }
 


### PR DESCRIPTION
## Summary of changes

Fixes the return code for the `GacUninstallCommand` when the assembly is not in the GAC

## Reason for change

If the assembly isn't in the GAC, we shouldn't return error when uninstalling it, because the desired state is correct. This was changed in #6995 but is an unintended behaviour change

## Implementation details

- Change the exit code `1` -> `0`
- Write a success message instead of a warning
- Fix typo 

## Test coverage

🙈 

## Other details

Currently some of the other "failure" messages are _effectively_ the same thing, so it might make change to change those too. However, their behaviour wasn't changed in #6995 so is non-critical