### PR TITLE
Fix timeout exception

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -493,8 +493,8 @@ partial class Build
 
         using var client = new HttpClient();
 
-        const int maxRetries = 3;
-        const int timeoutSeconds = 5;
+        const int maxRetries = 5;
+        const int timeoutSeconds = 15;
 
         for (int attempt = 1; attempt <= maxRetries; attempt++)
         {


### PR DESCRIPTION
## Summary of changes

We are getting some timeout errors when downloading one of the libdwaf versions. It seems that one of the sync http calls can hang for minutes before returning anything.

This update improves the robustness of the DownloadWafVersion method by:
* Introducing a short timeout (5 seconds) per HTTP request using CancellationTokenSource to prevent the method from hanging indefinitely.
* Adding exponential backoff (2 * attempt seconds) between retries to reduce pressure on the remote server and increase the chances of success in case of transient network issues.
* Replacing the previous retry loop with a bounded for loop using a maximum of 3 attempts.
* Ensuring that appropriate exceptions are thrown if all attempts fail, to surface meaningful build errors.

These changes aim to prevent long build hangs and improve stability when downloading libddwaf from NuGet.

From https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/178278/logs/10816
```
2025-05-23T18:19:35.7804568Z Recursively copying from[36;1mD:\a\_work\1\s\shared\bin\monitoring-home\win-x64 to[36;1mD:\a\_work\1\s\tracer\test\Datadog.Trace.Security.Unit.Tests\bin\Release\net9.0\win-x64...
2025-05-23T18:19:35.7891568Z Copying file C:\Users\AzDevOps\AppData\Local\Temp\libddwaf.1.10.0\runtimes\win-x64\native\ddwaf.dll to[36;1mD:\a\_work\1\s\tracer\test\Datadog.Trace.Security.Unit.Tests\bin\Release\net9.0\win-x64\ddwaf-1.10.0.dll...
2025-05-23T18:21:15.7957028Z ##[error]Target "CopyNativeFilesForAppSecUnitTests" has thrown an exception
2025-05-23T18:21:15.8039566Z CopyNativeFilesForAppSecUnitTests has thrown an exception
2025-05-23T18:21:15.8040136Z System.Threading.Tasks.TaskCanceledException: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
2025-05-23T18:21:15.8040401Z  ---> System.TimeoutException: The operation was canceled.
2025-05-23T18:21:15.8040732Z  ---> System.Threading.Tasks.TaskCanceledException: The operation was canceled.
2025-05-23T18:21:15.8041136Z  ---> System.IO.IOException: Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request..
2025-05-23T18:21:15.8041564Z  ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
2025-05-23T18:21:15.8041989Z[90m   --- End of inner exception stack trace ---
2025-05-23T18:21:15.8042445Z[90m   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
2025-05-23T18:21:15.8043042Z[90m   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
2025-05-23T18:21:15.8043378Z[90m   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](CancellationToken cancellationToken, Int32 estimatedSize)
2025-05-23T18:21:15.8043743Z[90m   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
2025-05-23T18:21:15.8044091Z[90m   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](Memory`1 buffer, CancellationToken cancellationToken)
2025-05-23T18:21:15.8044452Z[90m   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
2025-05-23T18:21:15.8044754Z[90m   at System.Net.Http.HttpConnection.InitialFillAsync(Boolean async)
2025-05-23T18:21:15.8045042Z[90m   at System.Net.Http.HttpConnection.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
2025-05-23T18:21:15.8046002Z[90m   --- End of inner exception stack trace ---
2025-05-23T18:21:15.8046285Z[90m   at System.Net.Http.HttpConnection.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
2025-05-23T18:21:15.8046649Z[90m   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
2025-05-23T18:21:15.8046990Z[90m   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
2025-05-23T18:21:15.8047439Z[90m   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
2025-05-23T18:21:15.8047775Z[90m   --- End of inner exception stack trace ---
2025-05-23T18:21:15.8047969Z[90m   --- End of inner exception stack trace ---
2025-05-23T18:21:15.8048329Z[90m   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
2025-05-23T18:21:15.8048822Z[90m   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
2025-05-23T18:21:15.8049236Z[90m   at Build.DownloadWafVersion(String libddwafVersion, String uncompressFolderTarget) in D:\a\_work\1\s\tracer\build\_build\Build.Steps.cs:line 503
2025-05-23T18:21:15.8049572Z[90m   at Build.<get_CopyNativeFilesForAppSecUnitTests>b__470_1() in D:\a\_work\1\s\tracer\build\_build\Build.Steps.cs:line 651
2025-05-23T18:21:15.8049913Z[90m   at Nuke.Common.Execution.TargetDefinition.<>c__DisplayClass77_0.<Executes>b__0() in /_/source/Nuke.Common/Execution/TargetDefinition.cs:line 71
2025-05-23T18:21:15.8050249Z[90m   at Nuke.Common.Execution.BuildExecutor.<>c.<Execute>b__4_2(Action x) in /_/source/Nuke.Common/Execution/BuildExecutor.cs:line 112
2025-05-23T18:21:15.8050750Z[90m   at Nuke.Common.Utilities.Collections.EnumerableExtensions.ForEach[T](IEnumerable`1 enumerable, Action`1 action) in /_/source/Nuke.Common/Utilities/Collections/Enumerable.ForEach.cs:line 17
2025-05-23T18:21:15.8051947Z[90m   at Nuke.Common.Execution.BuildExecutor.Execute(NukeBuild build, ExecutableTarget target, IReadOnlyCollection`1 previouslyExecutedTargets, Boolean failureMode) in /_/source/Nuke.Common/Execution/BuildExecutor.cs:line 112
2025-05-23T18:21:15.8052789Z ##[endgroup]CopyNativeFilesForAppSecUnitTests
```

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
