### PR TITLE
[Dynamic Instrumentation] DEBUG-3959 Guard against undefined value expression

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -116,7 +116,7 @@ internal partial class ProbeExpressionParser<T>
         return left;
     }
 
-    private static Expression Combine(Expression leftOperand, Expression rightOperand, Combiner combiner)
+    private Expression Combine(Expression leftOperand, Expression rightOperand, Combiner combiner)
     {
         return leftOperand is null ? AsBoolean(rightOperand) : combiner(AsBoolean(leftOperand), AsBoolean(rightOperand));
 


### PR DESCRIPTION
## Summary of changes
This PR makes sure that combined conditional expression win't throw exceotion when one of the operands is not a boolean.

## Implementation details
We are checking for undifined expression only for the right operand. 
We need to make sure that both operands treated as booleans.

## Test coverage
All existing EL tests.
