### PR TITLE
Add timeouts and retries to `LiveDebuggerTests` when debugger is disabled

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Assertions/MemoryAssertions.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Assertions/MemoryAssertions.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
 
 namespace Datadog.Trace.Debugger.IntegrationTests.Assertions;
 
@@ -32,15 +34,16 @@ internal class MemoryAssertions
     /// which can perform assertions on said snapshot.
     /// </summary>
     /// <param name="process">Process to capture snapshot of</param>
+    /// <param name="output">The test output helper</param>
     /// <returns>MemoryAssertions</returns>
-    public static MemoryAssertions CaptureSnapshotToAssertOn(Process process)
+    public static async Task<MemoryAssertions> CaptureSnapshotToAssertOn(Process process, ITestOutputHelper output)
     {
         if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
         {
             throw new NotSupportedException("Arm64 is not supported for memory assertions");
         }
 
-        var liveObjectsByTypes = DumpHeapLive.GetLiveObjectsByTypes(process);
+        var liveObjectsByTypes = await DumpHeapLive.GetLiveObjectsByTypes(process, output, TimeSpan.FromSeconds(30));
         return new MemoryAssertions(liveObjectsByTypes);
     }
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
@@ -39,6 +39,7 @@ public class LiveDebuggerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
+    [Flaky("The explicitly disabled tests often hang on x86 .NET and .NET 8, when the debugger is disabled. Needs investigation.")]
     public async Task LiveDebuggerDisabled_DebuggerDisabledByDefault_NoDebuggerTypesCreated()
     {
         await RunTest();
@@ -49,6 +50,7 @@ public class LiveDebuggerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
+    [Flaky("The explicitly disabled tests often hang on x86 .NET and .NET 8, when the debugger is disabled. Needs investigation.")]
     public async Task LiveDebuggerDisabled_DebuggerExplicitlyDisabled_NoDebuggerTypesCreated()
     {
         SetEnvironmentVariable(ConfigurationKeys.Debugger.Enabled, "0");
@@ -68,7 +70,7 @@ public class LiveDebuggerTests : TestHelper
 
         try
         {
-            var memoryAssertions = MemoryAssertions.CaptureSnapshotToAssertOn(sample);
+            var memoryAssertions = await MemoryAssertions.CaptureSnapshotToAssertOn(sample, Output);
 
             memoryAssertions.NoObjectsExist<SnapshotSink>();
             memoryAssertions.NoObjectsExist<LineProbeResolver>();


### PR DESCRIPTION
## Summary of changes

Adds a timeout to the `DataTarget.CreateSnapshotAndAttach()` call, and marks the `LiveDebuggerTests` as flaky

## Reason for change

The `LiveDebuggerTests` currently frequently hang, we need to understand why, and mitigate the issue.

## Implementation details

- Add overall timeout to the `GetLiveObjectsByTypes` method
- Add some logs to try to understand what's happening
- Mark the test as flaky

## Test coverage

N/A

Example failures: [Example1](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178295&view=logs&j=5bbbfeff-80c6-5e3a-ed15-df19bc2221a9&t=f97d6e34-8c18-5125-1e10-f8ff1691d2d4), [Example2](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178288&view=logs&j=5a1533ef-d5b3-5244-8177-90f592ad9a02&t=889462ef-7425-5ee6-c218-8225a4de53e7), [Example3](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178279&view=logs&j=5bbbfeff-80c6-5e3a-ed15-df19bc2221a9&t=f97d6e34-8c18-5125-1e10-f8ff1691d2d4), [Example4](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178274&view=logs&j=dfbb55d7-038c-5432-f154-c7f295998250&t=cde1f8e2-299e-52ab-e384-edcffbdbb58d),

## Other details

I suspect there's a race condition - maybe the app exists before the `DataTarget` can attach or something? _May_ want to rewrite to use the existing memory dump capabilities we have built in?

If this continues to fail, we will likely need to skip it completely.
