### PR TITLE
Exclude release/2.x from scheduled build

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -81,8 +81,8 @@ schedules:
         - master
         - release/*
         - hotfix/*
-        - /benchmarks/*
       exclude:
+        - release/2.x
         - release/1.x
     always: true
 


### PR DESCRIPTION
## Summary of changes

Disables the scheduled build of `release/2.x` _in the `release/2.x` branch_.

## Reason for change

Whether a scheduled branch runs depends on whether it's defined as enabled _in that branch_. We disabled the `release/2.x` schedule on `master`, but that doesn't actually work, unless we _also_ remove it from the schedule in the `release/2.x` branch too.

## Implementation details

Fix the schedule in the `release/2.x` branch (note the target branch for this PR is _not_ `master`)

## Test coverage

Nah, YOLO

## Other details

We also have a scheduled job [running ](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178325)for the `benchmarks/3.11.1` branch which is _super_ confusing seeing as that branch doesn't exist 😅 