### PR TITLE
[Dynamic Instrumentation] DEBUG-3961 Enable SymDB by default

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Configuration
 
             /// <summary>
             /// Configuration key for allowing upload of symbol data (such as method names, parameter names, etc) to Datadog.
-            /// Default value is false (disabled).
+            /// Default value is true (enabled).
             /// </summary>
             /// <seealso cref="DebuggerSettings.SymbolDatabaseUploadEnabled"/>
             public const string SymbolDatabaseUploadEnabled = "DD_SYMBOL_DATABASE_UPLOAD_ENABLED";

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Debugger
             var config = new ConfigurationBuilder(source, telemetry);
 
             Enabled = config.WithKeys(ConfigurationKeys.Debugger.Enabled).AsBool(false);
-            SymbolDatabaseUploadEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled).AsBool(false);
+            SymbolDatabaseUploadEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled).AsBool(true);
 
             MaximumDepthOfMembersToCopy = config
                                          .WithKeys(ConfigurationKeys.Debugger.MaxDepthToSerialize)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -56,9 +56,8 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
         [InlineData("false")]
+        [InlineData("0")]
         public void SymbolsDisabled(string enabled)
         {
             var settings = new DebuggerSettings(
@@ -66,6 +65,20 @@ namespace Datadog.Trace.Tests.Debugger
                 NullConfigurationTelemetry.Instance);
 
             settings.SymbolDatabaseUploadEnabled.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("1")]
+        [InlineData("true")]
+        public void SymbolsEnabled(string enabled)
+        {
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled, enabled }, }),
+                NullConfigurationTelemetry.Instance);
+
+            settings.SymbolDatabaseUploadEnabled.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes
SymbDB was accidentally disabled by default. This PR changes that behavior to enable it by default.

## Test coverage
DebuggerSettingsTest
