### PR TITLE
Ensure that there is an ActiveScope for AWS SDK Http integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/HttpWebRequestMessageProcessHttpResponseMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/HttpWebRequestMessageProcessHttpResponseMessageIntegration.cs
@@ -35,7 +35,7 @@ public class HttpWebRequestMessageProcessHttpResponseMessageIntegration
         // so this is now the source of truth for the request data
         if (instance.Instance is not null
             && instance.RequestUri is not null
-            && Tracer.Instance.InternalActiveScope.Span.Tags is AwsSdkTags tags)
+            && Tracer.Instance.InternalActiveScope?.Span.Tags is AwsSdkTags tags)
         {
             tags.HttpUrl = instance.RequestUri.GetLeftPart(UriPartial.Path);
         }


### PR DESCRIPTION
## Summary of changes

Ensure that `InternalActiveScope` isn't `null` as it apparently can be.

## Reason for change

Error tracking alerted on a test app with a `NullReferenceException` for this.

## Implementation details

Added a `?`

## Test coverage

😬 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
