### PR TITLE
Allow specifying `SampleName` filter and comprehensive version testing

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1493,6 +1493,7 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    performComprehensiveTesting: $[eq(variables.perform_comprehensive_testing, 'true')]
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -1560,7 +1561,7 @@ stages:
           retryCountOnTaskFailure: 1
           env:
             SampleName: $(IntegrationTestSampleName)
-            IncludeMinorPackageVersions: $[eq(variables.perform_comprehensive_testing, 'true')]
+            IncludeMinorPackageVersions: $(performComprehensiveTesting)
 
         - publish: $(outputDir)/publish
           displayName: Upload artifact samples (publish only)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -251,6 +251,7 @@ partial class Build
             EnsureExistingDirectory(BuildDataDirectory);
             EnsureExistingDirectory(ProfilerBuildDataDirectory);
             EnsureExistingDirectory(SymbolsDirectory);
+            EnsureExistingDirectory(BuildArtifactsDirectory / "publish");
         });
 
     Target Restore => _ => _


### PR DESCRIPTION
## Summary of changes

Fix the `BuildSamples` stage so that it respects the `SampleName` and `perform_comprehensive_testing` CI variables.

## Reason for change

We use these variables to be able to perform testing against _all_ package versions when we make risky modifications to an integration. After the refactor to `BuildSamples` this functionality was broken.

## Implementation details

Add the variables back

## Test coverage

I'll do a dedicated run to make sure it's working as expected

## Other details

Required for #6989