### PR TITLE
Revert "Benchmarks: Update microbenchmarks to customize BenchmarkDotNet command line arguments"

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -545,11 +545,10 @@ partial class Build : NukeBuild
         .Description("Runs the Benchmarks project")
         .Executes(() =>
         {
-            var benchmarkProjectsWithSettings = new Tuple<string, string, Func<DotNetRunSettings, DotNetRunSettings>>[] {
-                new(Projects.BenchmarksTrace, "--iterationTime 200", s => s),
-                // new(Projects.BenchmarksOpenTelemetryApi, "--iterationTime 100", s => s),
+            var benchmarkProjectsWithSettings = new Tuple<string, Func<DotNetRunSettings, DotNetRunSettings>>[] {
+                new(Projects.BenchmarksTrace, s => s),
+                // new(Projects.BenchmarksOpenTelemetryApi, s => s),
                 new(Projects.BenchmarksOpenTelemetryInstrumentedApi,
-                    "--iterationTime 100",
                     s => s.SetProcessEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true")
                           .SetProcessEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false")
                           .SetProcessEnvironmentVariable("DD_INTERNAL_AGENT_STANDALONE_MODE_ENABLED", "true")
@@ -559,8 +558,7 @@ partial class Build : NukeBuild
             foreach (var tuple in benchmarkProjectsWithSettings)
             {
                 var benchmarkProjectName = tuple.Item1;
-                var benchmarkSettings = tuple.Item2;
-                var configureDotNetRunSettings = tuple.Item3;
+                var configureDotNetRunSettings = tuple.Item2;
 
                 var benchmarksProject = Solution.GetProject(benchmarkProjectName);
                 var resultsDirectory = benchmarksProject.Directory / "BenchmarkDotNet.Artifacts" / "results";
@@ -587,7 +585,7 @@ partial class Build : NukeBuild
                         .SetFramework(framework)
                         .EnableNoRestore()
                         .EnableNoBuild()
-                        .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} {benchmarkSettings ?? string.Empty}")
+                        .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 200")
                         .SetProcessEnvironmentVariable("DD_SERVICE", "dd-trace-dotnet")
                         .SetProcessEnvironmentVariable("DD_ENV", "CI")
                         .SetProcessEnvironmentVariable("DD_DOTNET_TRACER_HOME", MonitoringHome)


### PR DESCRIPTION
## Summary of changes
Reverts #6990

This reverts commit 95ee281081f6c9f7cdca708ada134f2fb45061e4.

## Reason for change
The iteration time that was updated in the previous change caused instability in the OpenTelemetry Tracing API benchmarks and other issues with collecting `Benchmarks.Trace` results.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
