### PR TITLE
Activate runtime metrics by default on CI

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -249,16 +249,6 @@ profiler_cpu_timer_create:
     DD_PROFILING_CPU_ENABLED: 1
     COMPlus_EnableDiagnostics: 1
     ENDPOINT: "hello"
-    
-runtime-metrics:
-  extends: .benchmarks
-  variables:
-    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
-    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
-    COR_ENABLE_PROFILING: 1
-    CORECLR_ENABLE_PROFILING: 1
-    DD_RUNTIME_METRICS_ENABLED: 1
-    ENDPOINT: "hello"
 
 .benchmarks-arm64:
   stage: benchmarks
@@ -455,18 +445,6 @@ profiler_cpu_timer_create-arm64:
     COMPlus_EnableDiagnostics: 1
     ENDPOINT: "hello"
 
-runtime-metrics-arm64:
-  tags: ["runner:apm-k8s-arm-metal"]
-  extends: .benchmarks-arm64
-  variables:
-    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
-    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
-    COR_ENABLE_PROFILING: 1
-    CORECLR_ENABLE_PROFILING: 1
-    DD_RUNTIME_METRICS_ENABLED: 1
-    ENDPOINT: "hello"
-
-
 .benchmarks-win:
   stage: benchmarks-win
   needs: ["check_azure_pipeline"]
@@ -630,12 +608,4 @@ profiler_cpu_timer_create-win:
     DD_PROFILING_WALLTIME_ENABLED: 0
     DD_PROFILING_CPU_ENABLED: 1
     COMPlus_EnableDiagnostics: 1
-    ENDPOINT: "hello"
-    
-runtime-metrics-win:
-  extends: .benchmarks-win
-  variables:
-    COR_ENABLE_PROFILING: 1
-    CORECLR_ENABLE_PROFILING: 1
-    DD_RUNTIME_METRICS_ENABLED: 1
     ENDPOINT: "hello"

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -25,7 +25,7 @@ check_azure_pipeline:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
       - build-id.txt
     expire_in: 3 months
   tags: ["arch:amd64"]
@@ -90,11 +90,13 @@ update-bp-infra:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./steps/setup-sut.sh
     - bp-runner bp-runner.yml --debug
+  after_script:
+    - mv /var/log/datadog/dotnet/* platform/artifacts
   artifacts:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
     K6_OPTIONS_WARMUP_RATE: 14000
@@ -123,7 +125,7 @@ baseline:
     COR_ENABLE_PROFILING: 0
     CORECLR_ENABLE_PROFILING: 0
     ENDPOINT: "hello"
-
+    
 calltarget_ngen:
   extends: .benchmarks
   variables:
@@ -247,6 +249,16 @@ profiler_cpu_timer_create:
     DD_PROFILING_CPU_ENABLED: 1
     COMPlus_EnableDiagnostics: 1
     ENDPOINT: "hello"
+    
+runtime-metrics:
+  extends: .benchmarks
+  variables:
+    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_RUNTIME_METRICS_ENABLED: 1
+    ENDPOINT: "hello"
 
 .benchmarks-arm64:
   stage: benchmarks
@@ -272,11 +284,12 @@ profiler_cpu_timer_create:
     - git clone --branch dd-trace-dotnet/macro https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - ./steps/setup-sut.sh
     - bp-runner bp-runner.arm.yml --debug
+  after_script: !reference [.benchmarks, after_script]
   artifacts:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
     K6_OPTIONS_WARMUP_RATE: 14000
@@ -442,6 +455,18 @@ profiler_cpu_timer_create-arm64:
     COMPlus_EnableDiagnostics: 1
     ENDPOINT: "hello"
 
+runtime-metrics-arm64:
+  tags: ["runner:apm-k8s-arm-metal"]
+  extends: .benchmarks-arm64
+  variables:
+    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_RUNTIME_METRICS_ENABLED: 1
+    ENDPOINT: "hello"
+
+
 .benchmarks-win:
   stage: benchmarks-win
   needs: ["check_azure_pipeline"]
@@ -464,7 +489,7 @@ profiler_cpu_timer_create-arm64:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
     # Whether to cleanup ephemeral instances after benchmarks are run
@@ -605,4 +630,12 @@ profiler_cpu_timer_create-win:
     DD_PROFILING_WALLTIME_ENABLED: 0
     DD_PROFILING_CPU_ENABLED: 1
     COMPlus_EnableDiagnostics: 1
+    ENDPOINT: "hello"
+    
+runtime-metrics-win:
+  extends: .benchmarks-win
+  variables:
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_RUNTIME_METRICS_ENABLED: 1
     ENDPOINT: "hello"

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -1030,6 +1030,7 @@
       <type fullname="System.Threading.EventWaitHandle" />
       <type fullname="System.Threading.Interlocked" />
       <type fullname="System.Threading.LazyInitializer" />
+      <type fullname="System.Threading.ManualResetEvent" />
       <type fullname="System.Threading.ManualResetEventSlim" />
       <type fullname="System.Threading.Monitor" />
       <type fullname="System.Threading.Mutex" />

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
         private TimeSpan _previousUserCpu;
         private TimeSpan _previousSystemCpu;
-        private bool _disposed;
+        private int _disposed;
 
         public RuntimeMetricsWriter(IDogStatsd statsd, TimeSpan delay, bool inAzureAppServiceContext)
             : this(statsd, delay, inAzureAppServiceContext, InitializeListenerFunc)
@@ -130,13 +130,13 @@ namespace Datadog.Trace.RuntimeMetrics
 
         public void Dispose()
         {
-            if (_disposed)
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 1)
             {
+                Log.Debug("Disposing Runtime Metrics but it was already disposed");
                 return;
             }
 
             Log.Debug("Disposing Runtime Metrics");
-            _disposed = true;
             _timer.Dispose();
             AppDomain.CurrentDomain.FirstChanceException -= FirstChanceException;
             // We don't dispose runtime metrics on .NET Core because of https://github.com/dotnet/runtime/issues/103480
@@ -149,7 +149,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
         internal void PushEvents()
         {
-            if (_disposed)
+            if (Volatile.Read(ref _disposed) == 1)
             {
                 Log.Debug("Runtime metrics is disposed and can't push new events");
                 return;

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -144,7 +144,6 @@ namespace Datadog.Trace.RuntimeMetrics
             _listener?.Dispose();
 #endif
             _exceptionCounts.Clear();
-            _statsd.Dispose();
         }
 
         internal void PushEvents()

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -741,7 +741,7 @@ namespace Datadog.Trace
                     }
 
                     instance.RuntimeMetrics?.Dispose();
-                    instance.Statsd.Dispose();
+                    instance.Statsd?.Dispose();
 
                     Log.Debug("Finished waiting for disposals.");
                 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -741,6 +741,7 @@ namespace Datadog.Trace
                     }
 
                     instance.RuntimeMetrics?.Dispose();
+                    instance.Statsd.Dispose();
 
                     Log.Debug("Finished waiting for disposals.");
                 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -740,11 +740,7 @@ namespace Datadog.Trace
                         await instance.Telemetry.DisposeAsync().ConfigureAwait(false);
                     }
 
-                    // We don't dispose runtime metrics on .NET Core because of https://github.com/dotnet/runtime/issues/103480
-#if NETFRAMEWORK
-                    Log.Debug("Disposing Runtime Metrics");
                     instance.RuntimeMetrics?.Dispose();
-#endif
 
                     Log.Debug("Finished waiting for disposals.");
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -69,10 +69,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SkipOn.Platform(SkipOn.PlatformValue.MacOs);
 
+            var canUseStatsD = EnvironmentHelper.CanUseStatsD(transportType);
+            if (!canUseStatsD)
+            {
+                SetEnvironmentVariable(ConfigurationKeys.RuntimeMetricsEnabled, "0");
+            }
+
             EnvironmentHelper.EnableTransport(transportType);
             SetEnvironmentVariable(ConfigurationKeys.TraceDataPipelineEnabled, dataPipelineEnabled.ToString());
 
-            using var agent = EnvironmentHelper.GetMockAgent();
+            using var agent = EnvironmentHelper.GetMockAgent(useStatsD: canUseStatsD);
             var customResponse = behaviour switch
             {
                 AgentBehaviour.Return404 => new MockTracerResponse { StatusCode = 404 },

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -68,17 +68,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         private async Task SubmitsTraces(AgentBehaviour behaviour, TestTransports transportType, string metadataSchemaVersion, bool dataPipelineEnabled)
         {
             SkipOn.Platform(SkipOn.PlatformValue.MacOs);
-
-            var canUseStatsD = EnvironmentHelper.CanUseStatsD(transportType);
-            if (!canUseStatsD)
-            {
-                SetEnvironmentVariable(ConfigurationKeys.RuntimeMetricsEnabled, "0");
-            }
-
             EnvironmentHelper.EnableTransport(transportType);
             SetEnvironmentVariable(ConfigurationKeys.TraceDataPipelineEnabled, dataPipelineEnabled.ToString());
 
-            using var agent = EnvironmentHelper.GetMockAgent(useStatsD: canUseStatsD);
+            using var agent = EnvironmentHelper.GetMockAgent(useStatsD: EnvironmentHelper.CanUseStatsD(transportType));
             var customResponse = behaviour switch
             {
                 AgentBehaviour.Return404 => new MockTracerResponse { StatusCode = 404 },

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -177,7 +177,7 @@ public abstract class AzureFunctionsTests : TestHelper
         [Trait("RunOnWindows", "True")]
         public async Task SubmitsTraces()
         {
-            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true, useStatsD: true);
             using (await RunAzureFunctionAndWaitForExit(agent, framework: "net6.0"))
             {
                 const int expectedSpanCount = 21;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkEvpTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkEvpTest.cs
@@ -431,8 +431,7 @@ public abstract class TestingFrameworkEvpTest : TestHelper
         {
             using var logsIntake = new MockLogsIntakeForCiVisibility();
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.XUnit), nameof(XUnitTests));
-
-            using var agent = EnvironmentHelper.GetMockAgent();
+            using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
             agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains(evpVersionToRemove)).ToArray();
 
             const string correlationId = "2e8a36bda770b683345957cc6c15baf9";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -279,7 +279,7 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         using var logsIntake = new MockLogsIntakeForCiVisibility();
         EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.XUnit), nameof(XUnitTests));
 
-        using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+        using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true, useStatsD: true);
         agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains(evpVersionToRemove)).ToArray();
 
         const string correlationId = "2e8a36bda770b683345957cc6c15baf9";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.XUnit), nameof(XUnitTests));
             SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Logs, "1");
 
-            using var agent = EnvironmentHelper.GetMockAgent();
+            using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
 
             // We remove the evp_proxy endpoint to force the APM protocol compatibility
             agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -186,7 +186,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             EnvironmentHelper.EnableUnixDomainSockets();
             EnableDependencies(enableDependencies);
-            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true, useStatsD: true);
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
@@ -35,8 +35,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             EnvironmentHelper.EnableTransport(transport);
             SetEnvironmentVariable(ConfigurationKeys.TraceDataPipelineEnabled, dataPipelineEnabled.ToString());
+            var canUseStatsD = EnvironmentHelper.CanUseStatsD(transport);
+            if (!canUseStatsD)
+            {
+                SetEnvironmentVariable(ConfigurationKeys.RuntimeMetricsEnabled, "0");
+            }
 
-            using (var agent = EnvironmentHelper.GetMockAgent())
+            using (var agent = EnvironmentHelper.GetMockAgent(useStatsD: canUseStatsD))
             {
                 using (var sample = await RunSampleAndWaitForExit(agent, arguments: $" -t {TracesToTrigger} -s {SpansPerTrace} -f {FillerTagLength}"))
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -141,6 +141,12 @@ namespace Datadog.Trace.TestHelpers
             var executable = EnvironmentHelper.IsCoreClr() && !usePublishWithRID ? EnvironmentHelper.GetSampleExecutionSource() : sampleAppPath;
             var args = EnvironmentHelper.IsCoreClr() && !usePublishWithRID ? $"{runtimeArgs}{sampleAppPath} {arguments ?? string.Empty}" : arguments;
 
+            // on windows in uds , not supported
+            if (!EnvironmentHelper.CanUseStatsD(agent.TransportType))
+            {
+                SetEnvironmentVariable(ConfigurationKeys.RuntimeMetricsEnabled, "0");
+            }
+
             var process = await ProfilerHelper.StartProcessWithProfiler(
                 executable,
                 EnvironmentHelper,

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.TestHelpers
             return RuntimeFrameworkDescription.Contains("core") || IsNet5();
         }
 
-        public static bool CanUseStatsD(TestTransports transport) => transport != TestTransports.Uds || !EnvironmentTools.IsWindows();
+        public static bool CanUseStatsD(TestTransports transport) => !(transport == TestTransports.Uds && !EnvironmentTools.IsWindows());
 
         public static bool IsAlpine() => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsAlpine"));
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.TestHelpers
             return RuntimeFrameworkDescription.Contains("core") || IsNet5();
         }
 
-        public static bool CanUseStatsD(TestTransports transport) => !(transport == TestTransports.Uds && !EnvironmentTools.IsWindows());
+        public static bool CanUseStatsD(TestTransports transport) => !(transport == TestTransports.Uds && EnvironmentTools.IsWindows());
 
         public static bool IsAlpine() => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsAlpine"));
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -92,6 +92,8 @@ namespace Datadog.Trace.TestHelpers
             return RuntimeFrameworkDescription.Contains("core") || IsNet5();
         }
 
+        public static bool CanUseStatsD(TestTransports transport) => transport != TestTransports.Uds || !EnvironmentTools.IsWindows();
+
         public static bool IsAlpine() => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsAlpine"));
 
         public static string GetMonitoringHomePath()

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -280,6 +280,14 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables["DD_APPSEC_WAF_TIMEOUT"] = 10_000_000.ToString();
             }
 
+#if NET9_0_OR_GREATER || NETFRAMEWORK
+            if (!environmentVariables.ContainsKey(ConfigurationKeys.RuntimeMetricsEnabled))
+            {
+                // enable runtime metrics by default on CI first
+                environmentVariables[ConfigurationKeys.RuntimeMetricsEnabled] = "1";
+            }
+#endif
+
             foreach (var name in new[] { "SERVICESTACK_REDIS_HOST", "STACKEXCHANGE_REDIS_HOST" })
             {
                 var value = Environment.GetEnvironmentVariable(name);

--- a/tracer/test/Datadog.Trace.TestHelpers/TestTracer/ScopedTracer.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestTracer/ScopedTracer.cs
@@ -24,5 +24,5 @@ internal class ScopedTracer(
     IDiscoveryService discoveryService = null)
     : Tracer(settings, agentWriter, sampler, scopeManager, statsd, telemetry: telemetryController, discoveryService: discoveryService), IAsyncDisposable
 {
-    public async ValueTask DisposeAsync() => await TracerManager.ShutdownAsync();
+    public ValueTask DisposeAsync() => new(TracerManager.ShutdownAsync());
 }

--- a/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -237,6 +237,7 @@ namespace Datadog.Trace.Tests
                 {
                     { ConfigurationKeys.AgentUri, $"http://127.0.0.1:{agent.Port}" },
                     { ConfigurationKeys.TracerMetricsEnabled, tracerMetricsEnabled },
+                    { ConfigurationKeys.RuntimeMetricsEnabled, tracerMetricsEnabled },
                     { ConfigurationKeys.StartupDiagnosticLogEnabled, false },
                     { ConfigurationKeys.TraceDataPipelineEnabled, false },
                 });

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -181,7 +181,13 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             var writer = new RuntimeMetricsWriter(statsd.Object, TimeSpan.FromMilliseconds(Timeout.Infinite), false, (statsd, timeSpan, inAppContext) => listener.Object);
             writer.Dispose();
 
+#if  NETFRAMEWORK
             listener.Verify(l => l.Dispose(), Times.Once);
+#else
+            listener.Verify(l => l.Dispose(), Times.Never);
+#endif
+            writer.PushEvents();
+            listener.Verify(l => l.Refresh(), Times.Never);
 
             // Make sure that the writer unsubscribed from the global exception handler
             try


### PR DESCRIPTION
## Summary of changes

Activate runtime metrics by default on CI for net 9 or netfx. Easier to review per commit
- Change the way we dispose, to dispose more things in .net core, except for the `EventListener` itself because [of this runtime issue.
](https://github.com/dotnet/runtime/issues/103480)
- Use scoped tracer wherever possible in CI (most modified files)
- add macro benchmarks scenarios

## Reason for change

to prepare for activation by default of runtime metrics

## Implementation details

## Test coverage

Change tests accordingly

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
