### PR TITLE
Fix a `NullReferenceException` in AWS SDK `RuntimePipelineInvokeAsyncIntegration`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
@@ -81,9 +81,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                         var path = request.ResourcePath switch
                         {
                             null => absolutePath,
-                            string resourcePath when absolutePath == "/" => resourcePath,
-                            string resourcePath when absolutePath is not null => UriHelpers.Combine(absolutePath, resourcePath),
-                            string resourcePath => resourcePath, // absolutePath is null, use resourcePath directly
+                            string resourcePath when absolutePath is null or "/" => resourcePath,
+                            string resourcePath => UriHelpers.Combine(absolutePath, resourcePath),
                         };
 
                         // The request object is populated later by the Marshaller,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
@@ -82,7 +82,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                         {
                             null => absolutePath,
                             string resourcePath when absolutePath == "/" => resourcePath,
-                            string resourcePath => UriHelpers.Combine(absolutePath, resourcePath),
+                            string resourcePath when absolutePath is not null => UriHelpers.Combine(absolutePath, resourcePath),
+                            string resourcePath => resourcePath, // absolutePath is null, use resourcePath directly
                         };
 
                         // The request object is populated later by the Marshaller,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeSyncIntegration.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                         var path = request.ResourcePath switch
                         {
                             null => absolutePath,
-                            string resourcePath when absolutePath == "/" => resourcePath,
+                            string resourcePath when absolutePath is null or "/" => resourcePath,
                             string resourcePath => UriHelpers.Combine(absolutePath, resourcePath),
                         };
 


### PR DESCRIPTION
## Summary of changes

Fixes a `NullReferenceException` in `RuntimePipelineInvokeAsyncIntegration` for the AWS SDK instrumentation. May be related to V4 as I don't see prior errors from it.

## Reason for change

Error Tracking alerted on our dogfood test application

```
Error : Exception occurred when calling the CallTarget integration continuation.
System.NullReferenceException
   at Datadog.Trace.Util.UriHelpers.Combine(String baseUri, String relativePath)
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK.RuntimePipelineInvokeAsyncIntegration.OnAsyncMethodEnd[TTarget,TResponse](TTarget instance, TResponse response, Exception exception, CallTargetState& state)
   at REDACTED
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations.TaskContinuationGenerator`4.SyncCallbackHandler.ContinuationAction(Task`1 previousTask, TTarget target, CallTargetState state)
```

## Implementation details

Just adding a check for when `absolutePath is not null` to call prior to `UriHelpers.Combine`.

## Test coverageg

😬 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
