### PR TITLE
Replace DownloadPipelineArtifact by a pipeline step

### DIFF
--- a/.azure-pipelines/steps/download-artifact.yml
+++ b/.azure-pipelines/steps/download-artifact.yml
@@ -3,7 +3,6 @@ parameters:
   artifact: ''
   path: ''
   patterns: ''
-  displayName: ''
   condition: ''
   # Defaults
   timeoutInMinutes: 10

--- a/.azure-pipelines/steps/download-samples.yml
+++ b/.azure-pipelines/steps/download-samples.yml
@@ -14,5 +14,4 @@ steps:
     parameters:
       artifact: samples-multi-version-${{ parameters.framework }}
       path: $(outputDir)/publish
-      displayName: Download multi-version samples
       retryCountOnTaskFailure: 5

--- a/.azure-pipelines/steps/restore-working-directory-for-tests.yml
+++ b/.azure-pipelines/steps/restore-working-directory-for-tests.yml
@@ -18,12 +18,10 @@ steps:
 
 - template: download-artifact.yml
   parameters:
-    displayName: Download universal home binaries
     artifact: linux-universal-home-$(universalArtifactSuffix)
     path: $(monitoringHome)/${{ parameters.artifactSuffix }}
 
 - template: download-artifact.yml
   parameters:
-    displayName: Download profiler binaries
     artifact: linux-profiler-home-${{ parameters.artifactSuffix }}
     path: $(monitoringHome)

--- a/.azure-pipelines/steps/restore-working-directory.yml
+++ b/.azure-pipelines/steps/restore-working-directory.yml
@@ -9,5 +9,4 @@ steps:
     artifact: ${{ parameters.artifact }}
     patterns: "**/@(bin|obj|packages)/**"
     path: $(System.DefaultWorkingDirectory)
-    displayName: 'Download working dir'
     retryCountOnTaskFailure: 5

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -589,40 +589,34 @@ stages:
       parameters:
         artifact: linux-tracer-home-linux-x64
         path: $(monitoringHome)
-        displayName: Download tracer linux native binary (linux-x64)
         condition: eq(variables['artifactSuffix'], 'linux-x64')
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-profiler-home-linux-x64
         path: $(monitoringHome)
-        displayName: Download profiler linux native binary (linux-x64)
         condition: eq(variables['artifactSuffix'], 'linux-x64')
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: dd-dotnet-linux-x64
         path: $(monitoringHome)/linux-x64
-        displayName: Download dd-dotnet (linux-x64)
         condition: eq(variables['artifactSuffix'], 'linux-x64')
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-tracer-home-linux-musl-x64
         path: $(monitoringHome)
-        displayName: Download tracer linux native binary (linux-musl-x64)
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-profiler-home-linux-musl-x64
         path: $(monitoringHome)
-        displayName: Download profiler linux native binary (linux-musl-x64)
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: dd-dotnet-linux-musl-x64
         path: $(monitoringHome)/linux-musl-x64
-        displayName: Download dd-dotnet (linux-musl-x64)
 
     - script: |
         chmod +x $(monitoringHome)/linux-musl-x64/dd-dotnet
@@ -634,7 +628,6 @@ stages:
       parameters:
         artifact: linux-universal-home-linux-x64
         path: $(monitoringHome)/$(artifactSuffix)
-        displayName: Download universal native binaries
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -871,40 +864,34 @@ stages:
       parameters:
         artifact: linux-tracer-home-linux-arm64
         path: $(monitoringHome)
-        displayName: Download tracer arm64 native binary
         condition: eq(variables['artifactSuffix'], 'linux-arm64')
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-profiler-home-linux-arm64
         path: $(monitoringHome)
-        displayName: Download profiler arm64 native binary
         condition: eq(variables['artifactSuffix'], 'linux-arm64')
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: dd-dotnet-linux-arm64
         path: $(monitoringHome)/linux-arm64
-        displayName: Download dd-dotnet linux-arm64
         condition: eq(variables['artifactSuffix'], 'linux-arm64')
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-tracer-home-linux-musl-arm64
         path: $(monitoringHome)
-        displayName: Download tracer linux-musl-arm64 native binary
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-profiler-home-linux-musl-arm64
         path: $(monitoringHome)
-        displayName: Download profiler linux-musl-arm64 native binary
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: dd-dotnet-linux-musl-arm64
         path: $(monitoringHome)/linux-musl-arm64
-        displayName: Download dd-dotnet linux-musl-arm64
 
     - script: |
         chmod +x $(monitoringHome)/linux-musl-arm64/dd-dotnet
@@ -916,7 +903,6 @@ stages:
       parameters:
         artifact: linux-universal-home-linux-arm64
         path: $(monitoringHome)/$(artifactSuffix)
-        displayName: Download universal native binaries
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -1001,13 +987,11 @@ stages:
       parameters:
         artifact: build-macos-native_tracer
         path: $(monitoringHome)
-        displayName: Download native tracer
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: build-macos-native_loader
         path: $(monitoringHome)
-        displayName: Download native loader and managed
 
     - publish: $(monitoringHome)
       displayName: Uploading combined macos profiler artifact
@@ -1036,13 +1020,11 @@ stages:
 
       - template: steps/download-artifact.yml
         parameters:
-          displayName: Download windows profiler home
           artifact: windows-profiler-home
           path: $(monitoringHome)
 
       - template: steps/download-artifact.yml
         parameters:
-          displayName: Download dd-dotnet win-x64
           artifact: dd-dotnet-win-x64
           path: $(monitoringHome)/win-x64
 
@@ -1380,7 +1362,6 @@ stages:
         parameters:
           artifact: build-macos-native_tracer
           path: $(monitoringHome)
-          displayName: Download native tracer
 
       - script: ./tracer/build.sh BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build and Test
@@ -2046,7 +2027,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download MSI
         artifact: windows-msi-$(targetPlatform)
         path: $(System.DefaultWorkingDirectory)$(relativeMsiOutputDirectory)
         patterns: '**/*-$(targetPlatform).msi'
@@ -2646,7 +2626,6 @@ stages:
     # windows-tracer-home.zip file contains profiler, tracer...
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download monitoring home zip
         artifact: windows-tracer-home.zip
         path: $(Agent.TempDirectory)
         patterns: "windows-tracer-home.zip"
@@ -2724,13 +2703,11 @@ stages:
       parameters:
         artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
-        displayName: Download linux monitoring home
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-profiler-symbols-$(artifactSuffix)
         path: $(monitoringHome)
-        displayName: Download linux debug symbols
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -3381,7 +3358,6 @@ stages:
         artifact: build-windows-working-directory
         path: $(System.DefaultWorkingDirectory)
         retryCountOnTaskFailure: 5
-        displayName: Download working dir
 
     # Download everything to monitoring home
     # BuildBundleNuget moves everything to the required folders
@@ -3392,11 +3368,9 @@ stages:
           **/*.so
           **/loader.conf
         path: $(monitoringHome)
-        displayName: Download linux tracer home
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download alpine tracer home
         artifact: linux-tracer-home-linux-musl-x64
         patterns: |
           **/*.so
@@ -3405,7 +3379,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download arm64 tracer home
         artifact: linux-tracer-home-linux-arm64
         patterns: |
           **/*.so
@@ -3414,7 +3387,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download alpine arm64 tracer home
         artifact: linux-tracer-home-linux-musl-arm64
         patterns: |
           **/*.so
@@ -3423,7 +3395,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download osx tracer home
         artifact: macos-tracer-home
         patterns: |
           **/*.dylib
@@ -3432,14 +3403,12 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download windows profiler home
         artifact: windows-profiler-home
         patterns: "**/*.dll"
         path: $(monitoringHome)
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download linux profiler home
         artifact: linux-profiler-home-linux-x64
         patterns: |
           **/*.so
@@ -3448,7 +3417,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download alpine profiler home
         artifact: linux-profiler-home-linux-musl-x64
         patterns: |
           **/*.so
@@ -3457,7 +3425,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download arm64 profiler home
         artifact: linux-profiler-home-linux-arm64
         patterns: |
           **/*.so
@@ -3466,7 +3433,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download alpine arm64 profiler home
         artifact: linux-profiler-home-linux-musl-arm64
         patterns: |
           **/*.so
@@ -3475,55 +3441,46 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download dd-dotnet win-x64
         artifact: dd-dotnet-win-x64
         path: $(monitoringHome)/win-x64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download dd-dotnet linux-x64
         artifact: dd-dotnet-linux-x64
         path: $(monitoringHome)/linux-x64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download dd-dotnet linux-musl-x64
         artifact: dd-dotnet-linux-musl-x64
         path: $(monitoringHome)/linux-musl-x64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download dd-dotnet linux-arm64
         artifact: dd-dotnet-linux-arm64
         path: $(monitoringHome)/linux-arm64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download dd-dotnet linux-musl-arm64
         artifact: dd-dotnet-linux-musl-arm64
         path: $(monitoringHome)/linux-musl-arm64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download linux universal artifacts
         artifact: linux-universal-home-linux-x64
         path: $(monitoringHome)/linux-x64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download linux universal artifacts
         artifact: linux-universal-home-linux-x64
         path: $(monitoringHome)/linux-musl-x64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download linux universal artifacts
         artifact: linux-universal-home-linux-arm64
         path: $(monitoringHome)/linux-arm64
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download linux universal artifacts
         artifact: linux-universal-home-linux-arm64
         path: $(monitoringHome)/linux-musl-arm64
 
@@ -3612,25 +3569,21 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download windows profiler home
         artifact: windows-profiler-home
         path: $(monitoringHome)
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download tool runner
         artifact: runner-dotnet-tool
         path: $(runnerTool)
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download standalone runner
         artifact: runner-standalone-win-$(targetPlatform)
         path: $(Agent.TempDirectory)/runner
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download dd-dotnet win-x64
         artifact: dd-dotnet-win-x64
         path: $(monitoringHome)/win-x64
 
@@ -3724,31 +3677,26 @@ stages:
       parameters:
         artifact: linux-profiler-home-$(artifactSuffix)
         path: $(monitoringHome)
-        displayName: Download profiler linux native binary
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: runner-dotnet-tool
         path: $(runnerTool)
-        displayName: Download tool runner
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: runner-standalone-$(artifactSuffix)
         path: $(Agent.TempDirectory)/runner
-        displayName: Download standalone runner
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: dd-dotnet-$(artifactSuffix)
         path: $(monitoringHome)/$(artifactSuffix)
-        displayName: Download dd-dotnet $(artifactSuffix)
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: linux-universal-home-linux-$(targetArch)
         path: $(monitoringHome)/$(artifactSuffix)
-        displayName: Download universal native binaries
 
     - task: ExtractFiles@1
       inputs:
@@ -3812,21 +3760,18 @@ stages:
             artifact: linux-packages-linux-musl-x64
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download linux Alpine tar packages
 
         - template: steps/download-artifact.yml
           parameters:
               artifact: linux-packages-linux-x64
               patterns: "*.tar.gz"
               path: $(Build.ArtifactStagingDirectory)
-              displayName: Download linux x64 packages
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-packages-linux-arm64
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download linux Arm64 packages
 
         - bash: |
             TAR_NAME=$(basename $(Build.ArtifactStagingDirectory)/datadog-dotnet-apm-*.arm64.tar.gz)
@@ -3854,25 +3799,21 @@ stages:
           parameters:
             artifact: linux-tracer-home-linux-x64-r2r
             path: $(Build.ArtifactStagingDirectory)/x64
-            displayName: Download serverless tracer home x64
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-universal-home-linux-x64
             path: $(Build.ArtifactStagingDirectory)/x64
-            displayName: Download serverless universal home x64
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-tracer-home-linux-arm64-r2r
             path: $(Build.ArtifactStagingDirectory)/arm64
-            displayName: Download serverless tracer home arm64
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-universal-home-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/arm64
-            displayName: Download serverless universal home arm64
 
         # publish all tar files as single artifact
         - publish: "$(Build.ArtifactStagingDirectory)"
@@ -3899,7 +3840,6 @@ stages:
           parameters:
             artifact: nuget-packages
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download NuGet packages
 
         # set the version from the package name
         - bash: |
@@ -3914,110 +3854,92 @@ stages:
           parameters:
             artifact: linux-packages-linux-musl-x64
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download linux Alpine packages
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-packages-linux-x64
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download linux x64 packages
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-packages-linux-arm64
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download linux Arm64 packages
 
         # Linux symbols
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-profiler-symbols-linux-musl-x64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux profiler Alpine symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-profiler-symbols-linux-x64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux profiler Alpine symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-profiler-symbols-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux profiler Arm64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-profiler-symbols-linux-musl-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux profiler Alpine Arm64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-tracer-symbols-linux-musl-x64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux tracer Alpine symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-tracer-symbols-linux-x64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux tracer x64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-tracer-symbols-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux tracer Arm64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-tracer-symbols-linux-musl-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols
-            displayName: Download linux tracer Alpine Arm64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-universal-symbols-linux-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
-            displayName: Download linux universal libraries linux x64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-universal-symbols-linux-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
-            displayName: Download linux universal libraries linux musl x64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-universal-symbols-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
-            displayName: Download linux universal libraries linux arm64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: linux-universal-symbols-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-arm64
-            displayName: Download linux universal libraries linux musl arm64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: dd-dotnet-symbols-linux-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
-            displayName: Download dd-dotnet linux-x64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: dd-dotnet-symbols-linux-musl-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
-            displayName: Download dd-dotnet linux-musl-x64 symbols
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: dd-dotnet-symbols-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
-            displayName: Download dd-dotnet linux-arm64 symbols
 
         - bash: |
             tar -zcf  $(Build.ArtifactStagingDirectory)/linux-native-symbols.tar.gz ./symbols
@@ -4032,7 +3954,6 @@ stages:
           parameters:
             artifact: bundle-nuget-package
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download bundle nuget package
 
 #        Don't include the Datadog.Trace.BenchmarkDotNet package in the release artifacts
 #        as it currently doesn't work with v3.
@@ -4048,42 +3969,36 @@ stages:
             artifact: runner-dotnet-tool
             patterns: "*.nupkg"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download runner dotnet tool
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: runner-standalone-win-x64
             patterns: "*.zip"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download standalone dotnet tool win-x64
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: runner-standalone-linux-x64
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download standalone dotnet tool linux-x64
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: runner-standalone-linux-musl-x64
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download standalone dotnet tool linux-musl-x64
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: runner-standalone-linux-arm64
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download standalone dotnet tool linux-arm64
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: runner-standalone-linux-musl-arm64
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download standalone dotnet tool linux-musl-arm64
 
         # release artifacts
         - publish: "$(Build.ArtifactStagingDirectory)"
@@ -4098,13 +4013,11 @@ stages:
           parameters:
             artifact: windows-tracer-home.zip
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download Windows tracer home
 
         - template: steps/download-artifact.yml
           parameters:
             artifact: windows-msi-x64
             path: $(Build.ArtifactStagingDirectory)
-            displayName: Download x64 MSI
 
         # Download the artifacts required by the serverless layer and create the zip file
         # This exapands the directory - but we want a zip file, so re-zip it!
@@ -4112,7 +4025,6 @@ stages:
           parameters:
             artifact: serverless-artifacts
             path: $(Agent.TempDirectory)/serverless-artifacts
-            displayName: Download serverless artifacts
 
         - bash: |
             cd $(Agent.TempDirectory)/serverless-artifacts
@@ -4225,7 +4137,6 @@ stages:
 
       - template: steps/download-artifact.yml
         parameters:
-          displayName: Download coverage report
           patterns: '**/coverage.cobertura.xml'
           path: $(Build.SourcesDirectory)/cover
 
@@ -4283,7 +4194,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download windows native binary
         artifact: windows-tracer-home
         path: $(monitoringHome)
         retryCountOnTaskFailure: 5
@@ -4338,13 +4248,11 @@ stages:
       parameters:
         artifact: execution_time_benchmarks_windows_x64_HttpMessageHandler_1 #only download the first lot, ignores retries
         path: $(System.DefaultWorkingDirectory)/artifacts/build_data/execution_benchmarks/current/execution_time_benchmarks_windows_x64_HttpMessageHandler_1
-        displayName: Download HttpMessageHandler
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: execution_time_benchmarks_windows_x64_FakeDbCommand_1 #only download the first lot, ignores retries
         path: $(System.DefaultWorkingDirectory)/artifacts/build_data/execution_benchmarks/current/execution_time_benchmarks_windows_x64_FakeDbCommand_1
-        displayName: Download FakeDbCommand
 
     - script: tracer\build.cmd CompareExecutionTimeBenchmarkResults
       displayName: Compare execution-time results
@@ -4417,7 +4325,6 @@ stages:
       parameters:
         artifact: windows-profiler-home
         path: $(monitoringHome)
-        displayName: Download profiler windows native binary
         retryCountOnTaskFailure: 5
 
     - task: DotNetCoreCLI@2
@@ -4508,7 +4415,6 @@ stages:
       parameters:
         artifact: linux-profiler-home-linux-x64
         path: $(monitoringHome)
-        displayName: Download profiler linux native binary
         retryCountOnTaskFailure: 5
 
     - task: DotNetCoreCLI@2
@@ -4661,7 +4567,6 @@ stages:
           
         - template: steps/download-artifact.yml
           parameters:
-            displayName: Download linux-packages
             artifact: linux-packages-linux-x64
             patterns: '**/*tar.gz'
             path: $(Build.ArtifactStagingDirectory)
@@ -4724,7 +4629,6 @@ stages:
         
       - template: steps/download-artifact.yml
         parameters:
-          displayName: Download Docker images
           artifact: system-test-docker-images
           path: $(Build.SourcesDirectory)
 
@@ -4791,7 +4695,6 @@ stages:
       parameters:
         artifact: $(linuxArtifacts)
         path: $(smokeTestAppDir)/artifacts
-        displayName: Download artifacts to smoke test directory
 
     - script: |
         mkdir -p artifacts/build_data/snapshots
@@ -4875,7 +4778,6 @@ stages:
           parameters:
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
-            displayName: Download artifacts to smoke test directory
 
         # Run the "normal" installer smoke tests
         - script: |
@@ -4949,13 +4851,11 @@ stages:
       parameters:
         artifact: bundle-nuget-package
         path: $(smokeTestAppDir)/artifacts
-        displayName: Download bundle nuget
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: nuget-packages
         path: $(smokeTestAppDir)/artifacts
-        displayName: Download Datadog.Trace package
 
     - script: |
         mkdir -p artifacts/build_data/snapshots
@@ -5040,11 +4940,9 @@ stages:
           parameters:
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
-            displayName: Download installer artifacts to smoke test directory
 
         - template: steps/download-artifact.yml
           parameters:
-            displayName: Download $(packageName) package
             artifact: nuget-packages
             itemPattern: "$(packageName).$(ToolVersion)$(packageVersionSuffix).nupkg"
             path: $(smokeTestAppDir)/artifacts
@@ -5115,7 +5013,6 @@ stages:
       parameters:
         artifact: runner-dotnet-tool
         path: $(smokeTestAppDir)/artifacts
-        displayName: Download tool runner-dotnet-tool
 
     - script: |
         mkdir -p artifacts/build_data/snapshots
@@ -5181,7 +5078,6 @@ stages:
         artifact: runner-standalone-$(platformSuffix)
         patterns: "*.tar.gz"
         path: $(Agent.TempDirectory)
-        displayName: Download tool runner-standalone-$(platformSuffix)
 
     - script: |
         mkdir -p artifacts/build_data/snapshots
@@ -5253,14 +5149,12 @@ stages:
       parameters:
         artifact: $(linuxArtifacts)
         path: $(smokeTestAppDir)/artifacts
-        displayName: Download artifacts to smoke test directory
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: runner-standalone-$(platformSuffix)
         patterns: "*.tar.gz"
         path: $(Agent.TempDirectory)
-        displayName: Download tool runner-standalone-$(platformSuffix)
 
     - script: |
         mkdir -p artifacts/build_data/snapshots
@@ -5327,7 +5221,6 @@ stages:
           parameters:
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
-            displayName: Download artifacts to smoke test directory
 
         - script: |
             mkdir -p artifacts/build_data/snapshots
@@ -5411,7 +5304,6 @@ stages:
           parameters:
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
-            displayName: Download artifacts to smoke test directory
 
         # Run the "normal" installer smoke tests 
         - script: |
@@ -5485,13 +5377,11 @@ stages:
       parameters:
         artifact: bundle-nuget-package
         path: $(smokeTestAppDir)/artifacts
-        displayName: Download bundle nuget
 
     - template: steps/download-artifact.yml
       parameters:
         artifact: nuget-packages
         path: $(smokeTestAppDir)/artifacts
-        displayName: Download Datadog.Trace package
 
     - script: |
         mkdir -p artifacts/build_data/snapshots
@@ -5573,7 +5463,6 @@ stages:
         artifact: runner-standalone-$(platformSuffix)
         patterns: "*.tar.gz"
         path: $(Agent.TempDirectory)
-        displayName: Download dotnet tool
 
     - script: |
         mkdir -p artifacts/build_data/snapshots
@@ -5644,13 +5533,11 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download bundle nuget
         artifact: bundle-nuget-package
         path: $(smokeTestAppDir)/artifacts
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download Datadog.Trace package
         artifact: nuget-packages
         path: $(smokeTestAppDir)/artifacts
 
@@ -5743,7 +5630,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download dotnet tool
         artifact: runner-standalone-win-x64
         patterns: "dd-trace-win-x64.zip"
         path: $(Agent.TempDirectory)
@@ -5817,7 +5703,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download MSI to temp directory
         artifact: windows-msi-$(targetPlatform)
         patterns: '**/*-$(targetPlatform).msi'
         path: $(Agent.TempDirectory)
@@ -5891,7 +5776,6 @@ stages:
 
         - template: steps/download-artifact.yml
           parameters:
-            displayName: Download MSI to temp directory
             artifact: windows-msi-$(targetPlatform)
             patterns: '**/*-$(targetPlatform).msi'
             path: $(Agent.TempDirectory)
@@ -5969,7 +5853,6 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        displayName: Download tracer home zip
         artifact: windows-tracer-home.zip
         path: $(smokeTestAppDir)/artifacts
 
@@ -6034,13 +5917,11 @@ stages:
 
         - template: steps/download-artifact.yml
           parameters:
-            displayName: Download tracer home zip
             artifact: windows-tracer-home.zip
             path: $(smokeTestAppDir)/artifacts
 
         - template: steps/download-artifact.yml
           parameters:
-            displayName: Download fleet installer to temp directory
             artifact: fleet-installer
             path: $(smokeTestAppDir)/artifacts/installer
 
@@ -6114,7 +5995,6 @@ stages:
 
         - template: steps/download-artifact.yml
           parameters:
-            displayName: Download tool runner-dotnet-tool
             artifact: runner-dotnet-tool
             path: $(smokeTestAppDir)/artifacts
 


### PR DESCRIPTION
## Summary of changes

There has been spoted [a failure](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/178255/logs/21117) related to this task in installer_smoke_tests_arm64 in this [pipeline](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178255&view=logs&j=bbdc603e-ef18-5321-0b7f-6323e91d4dee) due to timeout:

```
        - task: DownloadPipelineArtifact@2
          displayName: Download artifacts to smoke test directory
          inputs:
            artifact: $(linuxArtifacts)
            path: $(smokeTestAppDir)/artifacts

2025-05-23T12:21:16.3318668Z Downloaded 59.9 MB out of 66.8 MB (90%).
2025-05-23T12:21:19.0682015Z Downloaded 59.9 MB out of 66.8 MB (90%).
2025-05-23T12:21:19.7992375Z ##[error]The Operation will be canceled. The next steps may not contain expected logs.
```           
While this task usually completes in around 10 seconds, this time, it failed after 45 mins. Seems like the error is not related to us but more to Azure.  It's interesting that the artifact download succeeded for the other jobs of this stage.
Setting timeoutInMinutes and retryCountOnTaskFailure could help to prevent these issues, but this could potentially happen with any DownloadPipelineArtifact task, so this PR adds some default values for every DownloadPipelineArtifact used in the pipeline. These default values can optionally be overridden.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
