### PR TITLE
fix: enable retries on failure due to script error

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -81,6 +81,7 @@ update-bp-infra:
       - runner_system_failure
       - scheduler_failure
       - api_failure
+      - script_failure
   rules:
     - when: on_success
   image: $MACROBENCHMARKS_CI_IMAGE
@@ -263,6 +264,7 @@ profiler_cpu_timer_create:
       - runner_system_failure
       - scheduler_failure
       - api_failure
+      - script_failure
   rules:
     - when: on_success
   image: $MACROBENCHMARKS_CI_IMAGE
@@ -450,7 +452,17 @@ profiler_cpu_timer_create-arm64:
   needs: ["check_azure_pipeline"]
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dotnet-macrobenchmarks
+  interruptible: true
   timeout: 2h
+  retry:
+    max: 2
+    when:
+      - unknown_failure
+      - data_integrity_failure
+      - runner_system_failure
+      - scheduler_failure
+      - api_failure
+      - script_failure
   rules:
     - when: on_success
   artifacts:


### PR DESCRIPTION
## Summary of changes
Enables retries on failure due to script error
## Reason for change
We need to diagnose errors from k6, we are enabling retiries on script failure
## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
