### PR TITLE
Skip flaky debugger tests on x86

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
@@ -39,9 +39,12 @@ public class LiveDebuggerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
-    [Flaky("The explicitly disabled tests often hang on x86 .NET and .NET 8, when the debugger is disabled. Needs investigation.")]
     public async Task LiveDebuggerDisabled_DebuggerDisabledByDefault_NoDebuggerTypesCreated()
     {
+#if NET8_0_OR_GREATER
+        // These tests often hang on x86 on .NET 8+. Needs investigation
+        Skip.If(!EnvironmentTools.IsTestTarget64BitProcess());
+#endif
         await RunTest();
     }
 
@@ -50,9 +53,12 @@ public class LiveDebuggerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
-    [Flaky("The explicitly disabled tests often hang on x86 .NET and .NET 8, when the debugger is disabled. Needs investigation.")]
     public async Task LiveDebuggerDisabled_DebuggerExplicitlyDisabled_NoDebuggerTypesCreated()
     {
+#if NET8_0_OR_GREATER
+        // These tests often hang on x86 on .NET 8+. Needs investigation
+        Skip.If(!EnvironmentTools.IsTestTarget64BitProcess());
+#endif
         SetEnvironmentVariable(ConfigurationKeys.Debugger.Enabled, "0");
         await RunTest();
     }


### PR DESCRIPTION
## Summary of changes

Skips the `LiveDebugger` tests on x86 as they hang

## Reason for change

The tests very frequently hang on x86 on .NET 8 and .NET 9. Tried to mitigate in #7010, but that apparently didn't work.

## Implementation details

Skip the tests explicitly on x86 on .NET 8+

## Test coverage

Less now, but hopefully also less flake
