### PR TITLE
Streamline release process by not explicitly creating a tag in `create_draft_release.yml`

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -104,6 +104,7 @@ jobs:
           draft: true
           name: "${{steps.versions.outputs.full_version}}"
           tag_name: "v${{steps.versions.outputs.full_version}}"
+          target_commitish: "${{steps.set_sha.outputs.sha}}"
           prerelease: ${{steps.versions.outputs.isprerelease}}
           body: ${{steps.release_notes.outputs.release_notes}}
           fail_on_unmatched_files: true

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -18,7 +18,11 @@ jobs:
       actions: read # read secrets
       issues: write # change milestones 
     env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      # Have to use external token with explicit workflow permissions because we are creating
+      # a release from an arbitrary SHA. For "reasons", the built-in token does not _always_
+      # work in that scenario, so using an external token is required. See issue
+      # https://github.com/cli/cli/issues/9514 for more details.
+      GITHUB_TOKEN: "${{ secrets.GH_EXTERNAL_TOKEN }}"
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
 
     steps:

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -98,11 +98,6 @@ jobs:
         env:
           Version: ${{steps.versions.outputs.full_version}}
 
-      - name: "Create and push git tag"
-        run: |
-          git tag "v${{steps.versions.outputs.full_version}}"
-          git push origin "v${{steps.versions.outputs.full_version}}"
-
       - name: Create Release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v1.0.0
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,8 +104,8 @@ download-single-step-artifacts:
   rules:
     - if: $DOTNET_PACKAGE_VERSION
       when: on_success
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/' # Manually triggered as artifacts are from the Github release
-      when: manual
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+      when: on_success # Artifacts are downloaded from the GitHub release, which creates the tag on publish
       allow_failure: false
     - when: on_success # Artifacts come from Azure pipeline, but as we already depend on build, we already have a delayed start
   script:
@@ -147,8 +147,8 @@ download-serverless-artifacts:
   rules:
     - if: $DOTNET_PACKAGE_VERSION
       when: on_success
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/' # Manually triggered as artifacts are from the Github release
-      when: manual
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+      when: on_success # Artifacts are downloaded from the GitHub release, which creates the tag on publish
       allow_failure: false
     - when: delayed # Artifacts come from Azure pipeline, wait a reasonable time before polling
       start_in: 15 minutes


### PR DESCRIPTION
## Summary of changes

Instead of manually creating a tag in `create_draft_release.yml`, create the tag when the release is _published_.

## Reason for change

Currently, the workflow creates the tag _before_ creating the release. I'm pretty sure that was because we thought a release had to be associated with an _existing_ tag. However, as long as you specify the release sha (we do, now), then you can pass a sha instead, and when you publish the release it _automatically_ creates the release.

![image](https://github.com/user-attachments/assets/70ff9c7f-2ecb-4b3f-b371-3b83602e8a85)

The advantage of this is that we no longer need to _manually_ start the gitlab pipeline after doing the release. We can have the publishing of the tag _automatically_ trigger the rest of the GitLab pipeline.

One annoying thing though is that we can no longer use the "built in" `GH_TOKEN`, because if workflow files have changed, the release fails (because you need the `workflows` permissions, and you can't grant it _from_ a workflow). Luckily we already have a token we use for invoking workflows, so we can switch to that one instead.

## Implementation details

- Use the external GH_TOKEN
- Remove the explicit git publish
- Pass the SHA into the create-release workflow
- Auto trigger the gitlab run when a tag is pushed

## Test coverage

I tested the create release process several times in a dummy repo to confirm it works as described above. It's also where I caught the external GH_TOKEN issue too.

## Other details

I'm about 90% sure the release process was actually _wrong_ before, and we would always tag the `HEAD` commit, even though we could use the _artifacts_ from a previous commit 😕 I don't think that's what we ever actually want to do, so that's also implicitly fixed 😅 