### PR TITLE
[Profiler] Add ringbuffer

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2929,6 +2929,50 @@ stages:
       condition: always()
       continueOnError: false
 
+- stage: tsan_profiler_tests
+  #thread sanitizer tests
+  condition: >
+    and(
+      succeeded(), 
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
+    )
+  dependsOn: [merge_commit_id, generate_variables]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [Linux]
+      allowSkipped: true
+
+  - job: Linux
+    timeoutInMinutes: 60 #default value
+
+    pool:
+      name: azure-managed-linux-x64-1
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        targetShaId: $(targetShaId)
+        targetBranch: $(targetBranch)
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        target: builder
+        baseImage: centos7
+        useNativeSdkVersion: true
+        command: "BuildProfilerTsanTest -Framework net7.0"
+        apiKey: $(DD_LOGGER_DD_API_KEY)
+
+    - publish: profiler/build_data
+      displayName: Uploading Thread sanitizer test results
+      artifact: _$(System.StageName)_$(Agent.JobName)_test_results_$(System.JobAttempt)
+      condition: always()
+      continueOnError: false
+
 - stage: integration_tests_arm64
   dependsOn: [build_arm64_tracer, build_arm64_universal, build_arm64_profiler, generate_variables, merge_commit_id, build_samples]
   variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2964,7 +2964,7 @@ stages:
         target: builder
         baseImage: centos7
         useNativeSdkVersion: true
-        command: "BuildProfilerTsanTest -Framework net7.0"
+        command: "BuildProfilerTsanTest RunUnitTestsWithTsanLinux -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - publish: profiler/build_data

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -6,9 +6,11 @@ project("Datadog.Profiler.Native.Linux" VERSION 3.22.0)
 
 option(RUN_ASAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
 option(RUN_UBSAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
+option(RUN_TSAN "Build with Clang Thread Sanitizer" OFF)
 
 message(STATUS "Run Clang Address Sanitizer: " ${RUN_ASAN})
 message(STATUS "Run Clang Undefined-Behavior Sanitizer: " ${RUN_UBSAN})
+message(STATUS "Run Clang Thread Sanitizer: " ${RUN_TSAN})
 
 # ******************************************************
 # Compiler options
@@ -29,6 +31,10 @@ endif()
 
 if (RUN_UBSAN)
     add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all -DDD_SANITIZERS)
+endif()
+
+if (RUN_TSAN)
+    add_compile_options(-fsanitize=thread -g -fno-omit-frame-pointer -DDD_SANITIZERS)
 endif()
 
 if(ISLINUX)
@@ -119,7 +125,7 @@ if (RUN_ASAN)
     target_link_libraries(${PROFILER_STATIC_LIB_NAME} -fsanitize=address)
 endif()
 
-if (NOT RUN_ASAN AND NOT RUN_UBSAN)
+if (NOT RUN_ASAN AND NOT RUN_UBSAN AND NOT RUN_TSAN)
     target_link_libraries(${PROFILER_STATIC_LIB_NAME} -Wl,--no-undefined)
 endif()
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
@@ -344,6 +344,18 @@ void RingBuffer::Writer::Commit(Buffer buf)
     __atomic_store_n(&hdr->size, new_size, __ATOMIC_RELEASE);
 }
 
+void RingBuffer::Writer::Discard(Buffer buf)
+{
+    auto* hdr = reinterpret_cast<RingBufferHeader*>(buf.data()) - 1;
+
+    // Clear busy bit
+    std::uint64_t new_size = hdr->size ^ RingBufferHeader::k_busy_bit;
+    new_size |= RingBufferHeader::k_discard_bit;
+    // Needs release ordering to make sure that all previous writes are
+    // visible to the reader once reader acquires `hdr->size`.
+    __atomic_store_n(&hdr->size, new_size, __ATOMIC_RELEASE);
+}
+
 RingBuffer::Reader::Reader(RingBufferImpl* rb) :
     _rb(rb)
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
@@ -16,7 +16,6 @@
 #include <ostream>
 #include <tuple>
 
-#define _GNU_SOURCE
 #include <sys/mman.h>
 
 using namespace std::chrono_literals;
@@ -96,6 +95,10 @@ RingBuffer::RingBuffer(std::size_t size)
     }
 }
 
+static inline int memfd_create(const char *name, unsigned int flags) {
+  return syscall(SYS_memfd_create, name, flags);
+}
+
 std::pair<RingBuffer::RingBufferUniquePtr, std::string> RingBuffer::Create(std::size_t requestedSize)
 {
     // TODO debug log parameters
@@ -123,7 +126,7 @@ std::pair<RingBuffer::RingBufferUniquePtr, std::string> RingBuffer::Create(std::
         });
 
     // FUTURE @TODO: have a name that takes into account the number of ring buffers
-    rb->mapfd = memfd_create("dd_profiler_ring_buffer", MFD_CLOEXEC);
+    rb->mapfd = memfd_create("dd_profiler_ring_buffer", 1U /*MFD_CLOEXEC*/);
 
     std::stringstream errorBuff;
     if (rb->mapfd < 0)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
@@ -1,0 +1,405 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "RingBuffer.h"
+
+#include "Log.h"
+#include "OpSysTools.h"
+#include "SpinningMutex.hpp"
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <cassert>
+#include <mutex>
+#include <new>
+#include <ostream>
+#include <tuple>
+
+#define _GNU_SOURCE
+#include <sys/mman.h>
+
+using namespace std::chrono_literals;
+
+struct RingBuffer::RingBufferImpl
+{
+public:
+    std::uint64_t mask;
+    std::size_t meta_size; // size of the metadata
+    std::size_t data_size; // size of data
+    std::byte* data;
+    void* base;
+
+    std::uint64_t* writer_pos;             // writer cursor
+    std::uint64_t* reader_pos;             // reader cursor
+    std::uint64_t intermediate_reader_pos; // intermediate_reader_pos > reader_pos,
+                                           // part read by reader but not yet reflected
+                                           // to the writer
+
+    SpinningMutex* spinlock;
+    int mapfd;
+};
+
+//  mimic: std::hardware_destructive_interference_size, C++17
+inline constexpr std::size_t hardware_destructive_interference_size = 128;
+
+struct RingBufferMetaDataPage
+{
+    alignas(hardware_destructive_interference_size) uint64_t writer_pos = 0;
+    alignas(hardware_destructive_interference_size) uint64_t reader_pos = 0;
+    alignas(hardware_destructive_interference_size) SpinningMutex spinlock;
+};
+
+std::size_t GetMetadataSize()
+{
+    // Use one page to store the metadata (RingBufferMetaDataPage)
+    // in case in the future sizeof(RingBufferMetaDataPage) changes
+    static_assert(sizeof(RingBufferMetaDataPage) <= DefaultPageSize);
+    return GetPageSize();
+}
+
+// Return `x` rounded up to next multiple of `pow2`
+// `pow2` must be a power of 2
+// Return 0 for x==0 or x > std::numeric_limits<uint64_t>::max() - pow2 + 1
+inline constexpr uint64_t align_up(uint64_t x, uint64_t pow2)
+{
+    assert(pow2 > 0 && (pow2 & (pow2 - 1)) == 0);
+    return ((x - 1) | (pow2 - 1)) + 1;
+}
+
+std::size_t next_power_of_two(std::size_t size)
+{
+    if (size == 0) return 1;
+    --size;
+    size |= size >> 1;
+    size |= size >> 2;
+    size |= size >> 4;
+    size |= size >> 8;
+    size |= size >> 16;
+    if (sizeof(size) == 8) size |= size >> 32;
+    return size + 1;
+}
+
+std::size_t get_mask_from_size(size_t size)
+{
+    //assert(is_power_of_two(size));
+    return (size - 1);
+}
+
+RingBuffer::RingBuffer(std::size_t size)
+{
+    std::string errorStr;
+    std::tie(_impl, errorStr) = Create(size);
+    if (_impl == nullptr)
+    {
+        Log::Error("Failed to create ring buffer: ", std::move(errorStr));
+    }
+}
+
+std::pair<RingBuffer::RingBufferUniquePtr, std::string> RingBuffer::Create(std::size_t requestedSize)
+{
+    // TODO debug log parameters
+    auto rb = RingBufferUniquePtr(
+        new RingBuffer::RingBufferImpl(),
+        [](RingBuffer::RingBufferImpl* rb) {
+            if (rb == nullptr)
+            {
+                return;
+            }
+
+            if (rb->mapfd >= 0)
+            {
+                close(rb->mapfd);
+            }
+
+            if (rb->base != nullptr)
+            {
+                auto const rbSize = rb->data_size + rb->meta_size;
+                auto* ptr = reinterpret_cast<std::byte*>(rb->base);
+                munmap(ptr + rbSize - rb->meta_size, rbSize);
+                munmap(ptr, rbSize);
+                munmap(ptr, 2 * rbSize - rb->meta_size);
+            }
+        });
+
+    // FUTURE @TODO: have a name that takes into account the number of ring buffers
+    rb->mapfd = memfd_create("dd_profiler_ring_buffer", MFD_CLOEXEC);
+
+    std::stringstream errorBuff;
+    if (rb->mapfd < 0)
+    {
+        auto currentErrno = errno;
+        errorBuff << "Failed to create file descriptor using memfd: " << strerror(currentErrno);
+        return {nullptr, errorBuff.str()};
+    }
+
+    auto dataSize = next_power_of_two(std::max(GetPageSize(), requestedSize));
+    auto const metadata_size = GetMetadataSize();
+    auto rbSize = dataSize + metadata_size;
+
+    if (ftruncate(rb->mapfd, rbSize) == -1)
+    {
+        auto currentErrno = errno;
+        errorBuff << "Failed to set the size of the file descriptor (size=" << rbSize << "): " << strerror(currentErrno);
+        return {nullptr, errorBuff.str()};
+    }
+
+    // Map in the region representing the ring buffer, map the buffer twice
+    // (minus metadata size) to avoid handling boundaries.
+    size_t const total_length = 2 * rbSize - metadata_size;
+    // Reserve twice the size of the buffer
+    void* base = mmap(nullptr, total_length, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    if (MAP_FAILED == base || !base)
+    {
+        auto currentErrno = errno;
+        errorBuff << "Failed to allocate virtual memory (" << total_length << " bytes): " << strerror(currentErrno);
+        return {nullptr, errorBuff.str()};
+    }
+
+    auto* ptr = static_cast<std::byte*>(base);
+
+    // Each mapping of fd must have a size of 2^n+1 pages
+    // That's why starts by mapping buffer on the second half of reserved
+    // space and ensure that metadata page overlaps on the first part
+    if (mmap(ptr + dataSize, rbSize,
+             PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, rb->mapfd,
+             0) == MAP_FAILED)
+    {
+        auto currentErrno = errno;
+        errorBuff << "Failed to map the second half of the virtual memory: " << strerror(currentErrno);
+        return {nullptr, errorBuff.str()};
+    }
+
+    // Map buffer a second time on the first half of reserved space
+    // It will overlap the metadata page of the previous mapping.
+    if (mmap(ptr, rbSize,
+             PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, rb->mapfd,
+             0) == MAP_FAILED)
+    {
+        auto currentErrno = errno;
+        errorBuff << "Failed to map the first half of the virtual memory: " << strerror(currentErrno);
+        return {nullptr, errorBuff.str()};
+    }
+
+    rb->meta_size = metadata_size;
+    rb->base = base;
+    rb->data = reinterpret_cast<std::byte*>(base) + rb->meta_size;
+    rb->data_size = dataSize;
+    rb->mask = get_mask_from_size(dataSize);
+    auto* meta = new (rb->base) RingBufferMetaDataPage();
+    rb->reader_pos = &meta->reader_pos;
+    rb->writer_pos = &meta->writer_pos;
+    rb->intermediate_reader_pos = 0;
+    rb->spinlock = new (&meta->spinlock) SpinningMutex();
+
+    return {std::move(rb), ""};
+}
+
+RingBuffer::Writer RingBuffer::GetWriter()
+{
+    return Writer(_impl.get());
+}
+
+RingBuffer::Reader RingBuffer::GetReader()
+{
+    return Reader(_impl.get());
+}
+
+#ifdef DD_TEST
+void RingBuffer::Reset()
+{
+    if (_impl == nullptr)
+    {
+        return;
+    }
+
+    // Reset the writer and reader positions
+    *_impl->writer_pos = 0;
+    *_impl->reader_pos = 0;
+    _impl->intermediate_reader_pos = 0;
+}
+
+std::size_t RingBuffer::GetSize() const
+{
+    if (_impl == nullptr)
+    {
+        return 0;
+    }
+    return _impl->data_size + _impl->meta_size;
+}
+
+SpinningMutex* RingBuffer::GetLock()
+{
+    return _impl->spinlock;
+}
+#endif // DD_TEST
+
+struct RingBufferHeader
+{
+    uint64_t size;
+    static constexpr uint64_t k_discard_bit = 1UL << 62;
+    static constexpr uint64_t k_busy_bit = 1UL << 63;
+
+    static bool is_busy(uint64_t size)
+    {
+        return size & k_busy_bit;
+    }
+    static bool is_discarded(uint64_t size)
+    {
+        return size & k_discard_bit;
+    }
+
+    [[nodiscard]] size_t get_size() const
+    {
+        return size & ~k_discard_bit;
+    }
+
+    void set_busy()
+    {
+        size |= k_busy_bit;
+    }
+    void set_discarded()
+    {
+        size |= k_discard_bit;
+    }
+    [[nodiscard]] bool is_busy() const
+    {
+        return size & k_busy_bit;
+    }
+    [[nodiscard]] bool is_discarded() const
+    {
+        return size & k_discard_bit;
+    }
+};
+
+inline constexpr size_t RingBufferAlignment{8};
+
+RingBuffer::Writer::Writer(RingBufferImpl* rb) :
+    _rb(rb)
+{
+    UpdateTail();
+}
+
+Buffer RingBuffer::Writer::Reserve(std::size_t size, bool* timeout) const
+{
+    std::size_t const n2 =
+        align_up(size + sizeof(RingBufferHeader), RingBufferAlignment);
+    if (n2 == 0)
+    {
+        return {};
+    }
+
+    auto* rb = _rb;
+    // \fixme{nsavoire} Not sure if spinlock is the best option here
+    std::unique_lock const lock{*rb->spinlock, ReserveTimeout};
+    if (!lock.owns_lock())
+    {
+        // timeout on lock
+        if (timeout)
+        {
+            *timeout = true;
+        }
+        return {};
+    }
+
+    // No need for atomic operation, since we hold the lock
+    std::uint64_t const writer_pos = *rb->writer_pos;
+
+    std::uint64_t const new_writer_pos = writer_pos + n2;
+    // Check that there is enough free space
+    if (rb->mask < new_writer_pos - _tail)
+    {
+        return {};
+    }
+
+    uint64_t const head_linear = writer_pos & rb->mask;
+    auto* hdr =
+        reinterpret_cast<RingBufferHeader*>(rb->data + head_linear);
+
+    // Mark the sample as busy
+    hdr->size = size | RingBufferHeader::k_busy_bit;
+
+    // Atomic operation required to synchronize with reader load_acquire
+    __atomic_store_n(rb->writer_pos, new_writer_pos, __ATOMIC_RELEASE);
+
+    return {reinterpret_cast<std::byte*>(hdr + 1), size};
+}
+
+void RingBuffer::Writer::Commit(Buffer buf)
+{
+    auto* hdr = reinterpret_cast<RingBufferHeader*>(buf.data()) - 1;
+
+    // Clear busy bit
+    std::uint64_t new_size = hdr->size ^ RingBufferHeader::k_busy_bit;
+    // Needs release ordering to make sure that all previous writes are
+    // visible to the reader once reader acquires `hdr->size`.
+    __atomic_store_n(&hdr->size, new_size, __ATOMIC_RELEASE);
+
+    UpdateTail();
+}
+
+inline void RingBuffer::Writer::UpdateTail()
+{
+    _tail = __atomic_load_n(_rb->reader_pos, __ATOMIC_ACQUIRE);
+}
+
+RingBuffer::Reader::Reader(RingBufferImpl* rb) :
+    _rb(rb)
+{
+    _head = __atomic_load_n(_rb->writer_pos, __ATOMIC_ACQUIRE);
+    assert(rb->intermediate_reader_pos <= _head);
+    assert(_rb->intermediate_reader_pos == *_rb->reader_pos);
+}
+
+RingBuffer::Reader::~Reader()
+{
+    if (_rb && *_rb->reader_pos < _rb->intermediate_reader_pos)
+    {
+        __atomic_store_n(_rb->reader_pos, _rb->intermediate_reader_pos,
+                         __ATOMIC_RELEASE);
+    }
+}
+
+std::size_t RingBuffer::Reader::AvailableSamples(std::size_t sampleSize) const
+{
+    return (_head - _rb->intermediate_reader_pos) / (sizeof(RingBufferHeader) + sampleSize);
+}
+
+ConstBuffer RingBuffer::Reader::Read()
+{
+    auto* rb = _rb;
+    auto const head = _head;
+    while (true)
+    {
+        auto tail = rb->intermediate_reader_pos;
+        if (head == tail)
+        {
+            return {};
+        }
+
+        uint64_t const tail_linear = tail & rb->mask;
+        std::byte* start = rb->data + tail_linear;
+        auto* hdr = reinterpret_cast<RingBufferHeader*>(start);
+        uint64_t const sz = __atomic_load_n(&hdr->size, __ATOMIC_ACQUIRE);
+
+        // Sample not committed yet, bail out
+        if (RingBufferHeader::is_busy(sz)) [[unlikely]]
+        {
+            return {};
+        }
+
+        rb->intermediate_reader_pos +=
+            align_up((sz & ~RingBufferHeader::k_discard_bit) +
+                         sizeof(RingBufferHeader),
+                     RingBufferAlignment);
+
+        if (RingBufferHeader::is_discarded(sz)) [[unlikely]]
+        {
+            continue;
+        }
+
+        return {reinterpret_cast<std::byte*>(hdr + 1), sz};
+    }
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.cpp
@@ -123,6 +123,8 @@ std::pair<RingBuffer::RingBufferUniquePtr, std::string> RingBuffer::Create(std::
                 munmap(ptr, rbSize);
                 munmap(ptr, 2 * rbSize - rb->meta_size);
             }
+
+            delete rb;
         });
 
     // FUTURE @TODO: have a name that takes into account the number of ring buffers

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
@@ -25,7 +25,7 @@ class RingBuffer
 private:
     struct RingBufferImpl;
 public:
-    RingBuffer(std::size_t size);
+    RingBuffer(std::size_t capacity, std::size_t sampleSize);
     ~RingBuffer() = default;
 
     RingBuffer(RingBuffer const&) = delete;
@@ -46,7 +46,7 @@ public:
         Writer(Writer&&) = default;
         Writer& operator=(Writer&&) = default;
 
-        Buffer Reserve(std::size_t size, bool* timeout = nullptr) const;
+        Buffer Reserve(bool* timeout = nullptr) const;
         void Commit(Buffer);
         void Discard(Buffer);
 
@@ -69,15 +69,15 @@ public:
         Reader& operator=(Reader&&) = default;
 
         // sampleSize allows to compute the number of samples hold by the reader
-        std::size_t AvailableSamples(std::size_t sampleSize) const;
-        ConstBuffer Read();
+        std::size_t AvailableSamples() const;
+        ConstBuffer GetNext();
 
     private:
         friend class RingBuffer;
         explicit Reader(RingBufferImpl* rb);
 
         RingBufferImpl* _rb;
-        uint64_t _head;
+        uint64_t _tail;
     };
 
     Writer GetWriter();
@@ -91,7 +91,7 @@ public:
 
 private:
     using RingBufferUniquePtr = std::unique_ptr<RingBufferImpl, std::function<void(RingBufferImpl*)>>;
-    static std::pair<RingBufferUniquePtr, std::string> Create(std::size_t size);
+    static std::pair<RingBufferUniquePtr, std::string> Create(std::size_t capacity, std::size_t sampleSize);
 
     static std::atomic<std::uint8_t> NbRingBuffers;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
@@ -43,6 +43,7 @@ public:
 
         Buffer Reserve(std::size_t size, bool* timeout = nullptr) const;
         void Commit(Buffer);
+        void Discard(Buffer);
 
     private:
         friend class RingBuffer;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
@@ -33,10 +33,13 @@ public:
     public:
         ~Writer() = default;
 
+        #ifdef DD_TEST
+        Writer() = default;
+        #endif
         Writer(Writer const&) = delete;
         Writer& operator=(Writer const&) = delete;
-        Writer(Writer&&) = delete;
-        Writer& operator=(Writer&&) = delete;
+        Writer(Writer&&) = default;
+        Writer& operator=(Writer&&) = default;
 
         Buffer Reserve(std::size_t size, bool* timeout = nullptr) const;
         void Commit(Buffer);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
@@ -93,5 +93,7 @@ private:
     using RingBufferUniquePtr = std::unique_ptr<RingBufferImpl, std::function<void(RingBufferImpl*)>>;
     static std::pair<RingBufferUniquePtr, std::string> Create(std::size_t size);
 
+    static std::atomic<std::uint8_t> NbRingBuffers;
+
     RingBufferUniquePtr _impl;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "shared/src/native-src/dd_span.hpp"
+
+using Buffer = shared::span<std::byte>;
+using ConstBuffer = shared::span<const std::byte>;
+
+using namespace std::chrono_literals;
+
+class SpinningMutex;
+
+class RingBuffer
+{
+private:
+    struct RingBufferImpl;
+public:
+    RingBuffer(std::size_t size);
+    ~RingBuffer() = default;
+
+    class Writer
+    {
+    public:
+        ~Writer() = default;
+
+        Writer(Writer const&) = delete;
+        Writer& operator=(Writer const&) = delete;
+        Writer(Writer&&) = delete;
+        Writer& operator=(Writer&&) = delete;
+
+        Buffer Reserve(std::size_t size, bool* timeout = nullptr) const;
+        void Commit(Buffer);
+
+    private:
+        friend class RingBuffer;
+        explicit Writer(RingBufferImpl* rb);
+        inline void UpdateTail();
+
+        static constexpr std::chrono::milliseconds ReserveTimeout{100ms};
+        RingBufferImpl* _rb;
+        std::uint64_t _tail;
+    };
+
+    class Reader
+    {
+    public:
+        ~Reader();
+
+        Reader(const Reader&) = delete;
+        Reader& operator=(const Reader&) = delete;
+        Reader(Reader&&) = default;
+        Reader& operator=(Reader&&) = default;
+
+        // sampleSize allows to compute the number of samples hold by the reader
+        std::size_t AvailableSamples(std::size_t sampleSize) const;
+        ConstBuffer Read();
+
+    private:
+        friend class RingBuffer;
+        explicit Reader(RingBufferImpl* rb);
+
+        RingBufferImpl* _rb;
+        uint64_t _head;
+    };
+
+    Writer GetWriter();
+    Reader GetReader();
+
+#ifdef DD_TEST
+    void Reset();
+    std::size_t GetSize() const;
+    SpinningMutex* GetLock();
+#endif // DD_TEST
+
+private:
+    using RingBufferUniquePtr = std::unique_ptr<RingBufferImpl, std::function<void(RingBufferImpl*)>>;
+    static std::pair<RingBufferUniquePtr, std::string> Create(std::size_t size);
+
+    RingBufferUniquePtr _impl;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
@@ -44,11 +44,9 @@ public:
     private:
         friend class RingBuffer;
         explicit Writer(RingBufferImpl* rb);
-        inline void UpdateTail();
 
         static constexpr std::chrono::milliseconds ReserveTimeout{100ms};
         RingBufferImpl* _rb;
-        std::uint64_t _tail;
     };
 
     class Reader

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RingBuffer.h
@@ -28,6 +28,11 @@ public:
     RingBuffer(std::size_t size);
     ~RingBuffer() = default;
 
+    RingBuffer(RingBuffer const&) = delete;
+    RingBuffer& operator=(RingBuffer const&) = delete;
+    RingBuffer(RingBuffer&&) = default;
+    RingBuffer& operator=(RingBuffer&&) = default;
+
     class Writer
     {
     public:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "Log.h"
+
 #include "shared/src/native-src/string.h"
 
 #include <chrono>
@@ -229,5 +231,24 @@ inline HANDLE OpSysTools::GetCurrentProcess()
     return ::GetCurrentProcess();
 #else
     return nullptr;
+#endif
+}
+
+constexpr size_t DefaultPageSize{4096}; // Concerned about hugepages?
+inline std::size_t GetPageSize()
+{
+#ifdef _WINDOWS
+    throw std::runtime_error("GetPageSize() is not implemented for Windows.");
+#else
+    static std::size_t page_size = 0;
+    if (page_size == 0)
+    {
+        page_size = sysconf(_SC_PAGESIZE);
+        if (page_size != DefaultPageSize)
+        {
+            Log::Warn("Page size is ", page_size, " expected ", DefaultPageSize);
+        }
+    }
+    return page_size;
 #endif
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SpinningMutex.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SpinningMutex.hpp
@@ -4,11 +4,29 @@
 #pragma once
 
 #include <atomic>
+
 #include <signal.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <thread>
 #include <unistd.h>
+
+#ifdef DD_SANITIZE_THREAD
+#include <sanitizer/tsan_interface.h>
+#define TSAN_MUTEX_CREATE __tsan_mutex_create
+#define TSAN_MUTEX_DESTROY __tsan_mutex_destroy
+#define TSAN_MUTEX_PRE_LOCK __tsan_mutex_pre_lock
+#define TSAN_MUTEX_POST_LOCK __tsan_mutex_post_lock
+#define TSAN_MUTEX_PRE_UNLOCK __tsan_mutex_pre_unlock
+#define TSAN_MUTEX_POST_UNLOCK __tsan_mutex_post_unlock
+#else
+#define TSAN_MUTEX_CREATE(...)
+#define TSAN_MUTEX_DESTROY(...)
+#define TSAN_MUTEX_PRE_LOCK(...)
+#define TSAN_MUTEX_POST_LOCK(...)
+#define TSAN_MUTEX_PRE_UNLOCK(...)
+#define TSAN_MUTEX_POST_UNLOCK(...)
+#endif
 
 // /!\ For now, this class is simple enough to replace the std::mutex used for the
 // /!\ stack walk lock. If in the future we need it to be on critical paths,
@@ -24,61 +42,120 @@
 class SpinningMutex
 {
 public:
-    SpinningMutex() :
-        _ownerTid{0}
+    SpinningMutex() : _flag(false)
     {
+        TSAN_MUTEX_CREATE(this, __tsan_mutex_not_static);
     }
-    ~SpinningMutex() = default;
 
-    SpinningMutex(SpinningMutex const&) = delete;
-    SpinningMutex& operator=(SpinningMutex const&) = delete;
+    ~SpinningMutex()
+    {
+        TSAN_MUTEX_DESTROY(this, __tsan_mutex_not_static);
+    }
 
-    SpinningMutex(SpinningMutex&&) = delete;
-    SpinningMutex& operator=(SpinningMutex&&) = delete;
-
-    // make it usable with std::unique_lock
-    // so naming will be different from the rest of the code
-    //
-    // Taken from https://github.com/skarupke/mutex_benchmarks/blob/master/BenchmarkMutex.cpp#L442
+public:
     void lock()
     {
-        for (;;)
-        {
-            if (try_lock())
-            {
-                break;
-            }
-#ifdef __x86_64__
-            asm volatile("pause");
-#else
-            std::this_thread::yield();
-#endif
-            if (try_lock())
-            {
-                break;
-            }
-            std::this_thread::yield();
-        }
+        try_lock_until_slow(std::chrono::steady_clock::time_point::max());
     }
 
-    void unlock()
+    template <typename Rep, typename Period>
+    bool try_lock_for(std::chrono::duration<Rep, Period> timeout_duration)
     {
-        _ownerTid = 0;
-        _locked.clear(std::memory_order_release);
+        return lock_fast() ? true
+                           : try_lock_until_slow(std::chrono::steady_clock::now() +
+                                                 timeout_duration);
     }
 
     bool try_lock()
     {
-        auto acquired = !_locked.test_and_set(std::memory_order_acquire);
-        if (acquired)
+        TSAN_MUTEX_PRE_LOCK(this, __tsan_mutex_try_lock);
+        auto result = !_flag.exchange(true, std::memory_order_acquire);
+        if (result)
         {
-            _ownerTid = syscall(SYS_gettid);
+            TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock, 0);
         }
-        return acquired;
+        else
+        {
+            TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock_failed, 0);
+        }
+        return result;
+    }
+
+    void unlock()
+    {
+        TSAN_MUTEX_PRE_UNLOCK(this, __tsan_mutex_try_lock);
+        _flag.store(false, std::memory_order_release);
+        TSAN_MUTEX_POST_UNLOCK(this, __tsan_mutex_try_lock);
     }
 
 private:
-    std::atomic_flag _locked = ATOMIC_FLAG_INIT;
-    // mainly for debug reason
-    pid_t _ownerTid;
+    static constexpr uint32_t k_max_active_spin = 4000;
+    static constexpr std::chrono::nanoseconds k_yield_sleep =
+        std::chrono::microseconds(500);
+
+    bool lock_fast()
+    {
+        // Taken from
+        // https://probablydance.com/2019/12/30/measuring-mutexes-spinlocks-and-how-bad-the-linux-scheduler-really-is/
+        uint32_t spincount = 0;
+
+        for (;;)
+        {
+            TSAN_MUTEX_PRE_LOCK(this, __tsan_mutex_try_lock);
+            if (!_flag.exchange(true, std::memory_order_acquire))
+            {
+                TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock, 0);
+                break;
+            }
+            TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock_failed, 0);
+            do
+            {
+                if (spincount < k_max_active_spin)
+                {
+                    ++spincount;
+#ifdef __x86_64__
+                    asm volatile("pause");
+#else
+                    asm volatile("yield");
+#endif
+                }
+                else
+                {
+                    return false;
+                }
+                // Wait for lock to be released without generating cache misses
+            } while (_flag.load(std::memory_order_relaxed));
+        }
+        return true;
+    }
+
+    __attribute__((noinline)) bool
+    try_lock_until_slow(std::chrono::steady_clock::time_point timeout_time)
+    {
+        for (;;)
+        {
+            TSAN_MUTEX_PRE_LOCK(this, __tsan_mutex_try_lock);
+            if (!_flag.exchange(true, std::memory_order_acquire))
+            {
+                TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock, 0);
+                break;
+            }
+
+            TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock_failed, 0);
+            do
+            {
+                if (std::chrono::steady_clock::now() > timeout_time)
+                {
+                    // timeout
+                    return false;
+                }
+                // If active spin fails, yield
+                std::this_thread::sleep_for(k_yield_sleep);
+
+            } while (_flag.load(std::memory_order_relaxed));
+        }
+        return true;
+    }
+
+    std::atomic_bool _flag;
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -11,6 +11,8 @@ add_compile_options(-fPIC -fms-extensions)
 add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
 add_compile_options(-Wno-invalid-noreturn -Wno-macro-redefined -Wc++20-extensions -DDD_TEST)
 
+target_compile_options(Datadog.Profiler.Native.static PRIVATE -DDD_TEST)
+
 if (IS_ALPINE)
     add_compile_options(-DDD_ALPINE)
 endif()

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -25,6 +25,10 @@ if (RUN_UBSAN)
     add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all)
 endif()
 
+if (RUN_TSAN)
+    add_compile_options(-fsanitize=thread -g -fno-omit-frame-pointer -DDD_SANITIZERS)
+endif()
+
 if(ISLINUX)
     add_compile_options(-stdlib=libstdc++ -DLINUX -Wno-pragmas)
 endif()
@@ -73,6 +77,10 @@ endif()
 
 if (RUN_UBSAN)
     target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=undefined)
+endif()
+
+if (RUN_TSAN)
+    target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=thread)
 endif()
 
 target_link_libraries(${TEST_EXECUTABLE_NAME}

--- a/profiler/test/Datadog.Profiler.Native.Tests/RingBufferTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/RingBufferTest.cpp
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#ifdef LINUX
+
+#include "gtest/gtest.h"
+
+#include "RingBuffer.h"
+#include "SpinningMutex.hpp"
+
+#include "OpSysTools.h"
+
+TEST(RingBufferTest, CheckRingBufferSizing)
+{
+    // RingBuffer size = data size + metadata size
+    // Metdatasize = page size
+
+    //
+    // for size < 4096, the ring buffer data size will be 4096
+    auto pageSize = GetPageSize();
+    auto metadataSize = GetPageSize();
+    for (int i = 0; i <= pageSize; i++)
+    {
+        auto rb = RingBuffer(i);
+        ASSERT_EQ(rb.GetSize(), pageSize + metadataSize);
+    }
+
+    // if requested size for the ring buffer is power of 2,
+    // check that we keep that size
+    for (int i = pageSize; i < 1 << 15; i *= 2)
+    {
+        auto rb = RingBuffer(i);
+        ASSERT_EQ(rb.GetSize(), metadataSize + i);
+    }
+
+    // if request size is between 2 power of 2 integers,
+    // check we use the bigger one
+    for (int i = 4097, j = 8192; i < 1 << 15; i *= 2, j *= 2)
+    {
+        auto rb = RingBuffer(i);
+        ASSERT_EQ(rb.GetSize(), metadataSize + j);
+    }
+}
+
+TEST(RingBufferTest, CheckByteBuffer)
+{
+    auto rb = RingBuffer(1);
+    auto w = rb.GetWriter();
+
+    auto sampleSize = 25;
+    auto buffer = w.Reserve(sampleSize);
+    ASSERT_EQ(buffer.size(), sampleSize);
+    ASSERT_NE(buffer.data(), nullptr);
+
+    for (std::uint8_t i = 0; i < sampleSize; i++)
+        buffer[i] = (std::byte)i;
+
+    w.Commit(buffer);
+
+    auto r = rb.GetReader();
+    ASSERT_EQ(r.AvailableSamples(sampleSize), 1);
+
+    auto readBuffer = r.Read();
+    ASSERT_EQ(readBuffer.size(), sampleSize);
+    ASSERT_NE(readBuffer.data(), nullptr);
+
+    for (std::uint8_t i = 0; i < sampleSize; i++)
+        ASSERT_EQ(readBuffer[i], (std::byte)i);
+}
+
+TEST(RingBufferTest, AddFakeSamplesAsMuchAsPossible)
+{
+    struct FakeSample
+    {
+    public:
+        std::uint16_t _first;
+        std::uint64_t _second;
+        std::string _third;
+        double _fourth;
+    };
+
+    // in a page we can store 102 samples (one sample = sizeof(FakeSample) + header size, all
+    // of this aligned on 8 bytes)
+    auto nbSamples = 102;
+    auto rb = RingBuffer(4096);
+
+    for (int i = 0, j = 0; i < nbSamples; i++, j = 0)
+    {
+        auto w = rb.GetWriter();
+        auto buffer = w.Reserve(sizeof(FakeSample));
+        ASSERT_FALSE(buffer.empty());
+
+        auto sample = new (buffer.data()) FakeSample();
+
+        auto rank = i * 10;
+        sample->_first = rank + j++;
+        sample->_second = rank + j++;
+        sample->_third = std::to_string(rank + j++);
+        sample->_fourth = rank + j++;
+
+        {
+            auto r = rb.GetReader();
+            // even though the writer did not commit, the current sample
+            // exist in the ring buffer but marked as 'busy'
+            ASSERT_EQ(r.AvailableSamples(sizeof(FakeSample)), i + 1);
+        }
+
+        w.Commit(buffer);
+    }
+
+    // make sure we cannot add more sample
+    {
+        auto w = rb.GetWriter();
+        auto buffer = w.Reserve(sizeof(FakeSample));
+        ASSERT_TRUE(buffer.empty());
+    }
+
+    auto r = rb.GetReader();
+    ASSERT_EQ(r.AvailableSamples(sizeof(FakeSample)), nbSamples);
+
+    for (int i = 0, j = 0; i < nbSamples; i++, j = 0)
+    {
+        auto buffer = r.Read();
+        auto const* sample = reinterpret_cast<FakeSample const*>(buffer.data());
+
+        auto rank = i * 10;
+        ASSERT_EQ(sample->_first, rank + j++);
+        ASSERT_EQ(sample->_second, rank + j++);
+        ASSERT_EQ(sample->_third, std::to_string(rank + j++));
+        ASSERT_EQ(sample->_fourth, rank + j++);
+    }
+
+    ASSERT_EQ(r.AvailableSamples(sizeof(FakeSample)), 0);
+}
+
+TEST(RingBufferTest, StaleLock)
+{
+    auto rb = RingBuffer(42);
+    auto w = rb.GetWriter();
+
+    rb.GetLock()->lock();
+    auto timeout = false;
+
+    ASSERT_TRUE(w.Reserve(4, &timeout).empty());
+    ASSERT_TRUE(timeout);
+}
+#endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/RingBufferTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/RingBufferTest.cpp
@@ -128,6 +128,8 @@ TEST(RingBufferTest, AddFakeSamplesAsMuchAsPossible)
         ASSERT_EQ(sample->_second, rank + j++);
         ASSERT_EQ(sample->_third, std::to_string(rank + j++));
         ASSERT_EQ(sample->_fourth, rank + j++);
+        // we have to release memory allocate by std::string
+        std::destroy_at(const_cast<FakeSample*>(sample));
     }
 
     ASSERT_EQ(r.AvailableSamples(sizeof(FakeSample)), 0);

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -801,7 +801,11 @@ partial class Build
         .OnlyWhenStatic(() => IsLinux)
         .Executes(() =>
         {
-            RunProfilerUnitTests("Datadog.Profiler.Native.Tests", Configuration.Release, MSBuildTargetPlatform.x64, SanitizerKind.Tsan);
+            // Filtering tests is temporary.
+            // For now, false negatives are reported by the tool because dependencies are not built
+            // against thread sanitizer lib (ex: libdatadog).
+            // For now we focus on the ring buffer unit tests.
+            RunProfilerUnitTests("Datadog.Profiler.Native.Tests", Configuration.Release, MSBuildTargetPlatform.x64, SanitizerKind.Tsan, testsFilter: "*RingBuffer*");
         });
 
     Target BuildProfilerSampleForSanitiserTests => _ => _
@@ -950,7 +954,7 @@ partial class Build
         }
     }
 
-    void RunProfilerUnitTests(string testLibrary, Configuration configuration, MSBuildTargetPlatform platform, SanitizerKind sanitizer = SanitizerKind.None, string[] additionalEnvVars = null)
+    void RunProfilerUnitTests(string testLibrary, Configuration configuration, MSBuildTargetPlatform platform, SanitizerKind sanitizer = SanitizerKind.None, string[] additionalEnvVars = null, string testsFilter = null)
     {
         var intermediateDirPath =
             IsWin
@@ -997,8 +1001,14 @@ partial class Build
 
         AddExtraEnvVariables(envVars, additionalEnvVars);
 
+        // This is temporary and used only by the thread sanitizer
+        // In reality we would like to run all tests with the thread sanitizer.
+        // But the thread sanitizer reports false positive or fails because dependencies are
+        // not built against thread sanitizer library (ex: libdatadog)
+        var testsFilterOption = string.IsNullOrWhiteSpace(testsFilter) ? string.Empty : $"--gtest_filter=\"{testsFilter}\"";
+
         var testsResultFile = ProfilerBuildDataDirectory / "tests" / $"{testLibrary}.Results.{Platform}.{configuration}.{platform}.xml";
         var testExe = ToolResolver.GetLocalTool(exePath);
-        testExe($"--gtest_output=xml:{testsResultFile}", workingDirectory: workingDirectory, environmentVariables: envVars);
+        testExe($"--gtest_output=xml:{testsResultFile} {testsFilterOption}", workingDirectory: workingDirectory, environmentVariables: envVars);
     }
 }

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -784,7 +784,6 @@ partial class Build
         .Unlisted()
         .OnlyWhenStatic(() => IsLinux)
         .Before(PublishProfiler)
-        .Triggers(RunUnitTestsWithTsanLinux)
         .Executes(() =>
         {
             EnsureExistingDirectory(ProfilerBuildDataDirectory);

--- a/tracer/test/snapshots/native-profiler-symbols-alpine-arm64.verified.txt
+++ b/tracer/test/snapshots/native-profiler-symbols-alpine-arm64.verified.txt
@@ -85,6 +85,7 @@ free
 fseeko
 fstat
 ftello
+ftruncate
 fwrite
 get_nprocs
 getauxval
@@ -175,7 +176,6 @@ readlink
 realloc
 remove
 rename
-sched_yield
 sendto
 setenv
 setlocale

--- a/tracer/test/snapshots/native-profiler-symbols-alpine-x64.verified.txt
+++ b/tracer/test/snapshots/native-profiler-symbols-alpine-x64.verified.txt
@@ -88,6 +88,7 @@ free
 fseeko
 fstat
 ftello
+ftruncate
 fwrite
 get_nprocs
 getauxval
@@ -178,7 +179,6 @@ readlink
 realloc
 remove
 rename
-sched_yield
 sendto
 setenv
 setlocale


### PR DESCRIPTION
## Summary of changes


[Add a ring buffer implementation](https://datadoghq.atlassian.net/browse/PROF-11984) (taken from https://github.com/DataDog/ddprof and adjusted to our needs a bit)

## Reason for change

This PR is the beginning to fix the `timer_create` issue (crash the process if a timer ticks while the thread is being destroyed)

## Implementation details

## Test coverage
- [x] Unit tests
- [x] Add multithread tests + TSAN run in CI
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
