### PR TITLE
Mark a couple of tests as flaky

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -58,6 +58,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
         [CombinatorialOrPairwiseData]
+        [Flaky("This test often fails with an ObjectDisposedException on shutdown. It seems tied to the HttpListener/WebServer implementation, but I couldn't figure out why")]
         public async Task HttpClient_SubmitsTraces(
             [CombinatorialMemberData(nameof(GetInstrumentationOptions))] InstrumentationOptions instrumentation,
             bool socketsHandlerEnabled,

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -304,6 +304,7 @@ public class DiscoveryServiceTests
     }
 
     [Fact]
+    [Flaky("This is an inherently flaky test as it relies on time periods")]
     public async Task HandlesFailuresInApiWithBackoff()
     {
         var mutex = new ManualResetEventSlim(initialState: false, spinCount: 0);


### PR DESCRIPTION
## Summary of changes

Marks a couple of tests as flaky

## Reason for change

They're flaky.
- The discovery service one is inherently flaky, as it's time-based
- The HttpMessageHandler is notoriously flaky. It throws a crashing `ObjectDisposedException` from the `HttpListener`. This has been about for ages, and we never figured it out, so just marking it

## Implementation details

Mark them as flaky

## Test coverage

Indeed
