### PR TITLE
Check for nested Aggregate exceptions in CouchBase tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Couchbase/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase/Program.cs
@@ -23,7 +23,6 @@ namespace Samples.Couchbase
             { InnerException: { } inner } => ContainsAuthenticationException(inner),
             _ => false,
         }
-        }
 
         private static async Task<int> Main()
         {

--- a/tracer/test/test-applications/integrations/Samples.Couchbase/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase/Program.cs
@@ -16,15 +16,13 @@ namespace Samples.Couchbase
         ICluster _cluster;
         IBucket _bucket;
 
-        private static bool ContainsAuthenticationException(Exception ex)
+        private static bool ContainsAuthenticationException(Exception ex) => ex switch
         {
-            if (ex is AuthenticationException)
-                return true;
-
-            if (ex is AggregateException aggEx)
-                return aggEx.InnerExceptions.Any(ContainsAuthenticationException);
-
-            return ex.InnerException != null && ContainsAuthenticationException(ex.InnerException);
+            AuthenticationException => true,
+            AggregateException aggEx => aggEx.InnerExceptions.Any(ContainsAuthenticationException),
+            { InnerException: { } inner } => ContainsAuthenticationException(inner),
+            _ => false,
+        }
         }
 
         private static async Task<int> Main()

--- a/tracer/test/test-applications/integrations/Samples.Couchbase/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase/Program.cs
@@ -22,7 +22,7 @@ namespace Samples.Couchbase
             AggregateException aggEx => aggEx.InnerExceptions.Any(ContainsAuthenticationException),
             { InnerException: { } inner } => ContainsAuthenticationException(inner),
             _ => false,
-        }
+        };
 
         private static async Task<int> Main()
         {

--- a/tracer/test/test-applications/integrations/Samples.Couchbase3/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase3/Program.cs
@@ -16,7 +16,7 @@ namespace Samples.Couchbase3
             AggregateException aggEx => aggEx.InnerExceptions.Any(ContainsAuthenticationException),
             { InnerException: { } inner } => ContainsAuthenticationException(inner),
             _ => false,
-        }
+        };
 
         private static async Task<int> Main()
         {

--- a/tracer/test/test-applications/integrations/Samples.Couchbase3/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase3/Program.cs
@@ -10,15 +10,12 @@ namespace Samples.Couchbase3
 {
     internal class Program
     {
-        private static bool ContainsAuthenticationException(Exception ex)
+        private static bool ContainsAuthenticationException(Exception ex) => ex switch
         {
-            if (ex is AuthenticationException)
-                return true;
-
-            if (ex is AggregateException aggEx)
-                return aggEx.InnerExceptions.Any(ContainsAuthenticationException);
-
-            return ex.InnerException != null && ContainsAuthenticationException(ex.InnerException);
+            AuthenticationException => true,
+            AggregateException aggEx => aggEx.InnerExceptions.Any(ContainsAuthenticationException),
+            { InnerException: { } inner } => ContainsAuthenticationException(inner),
+            _ => false,
         }
 
         private static async Task<int> Main()


### PR DESCRIPTION
## Summary of changes

Some Couchbase [tests are failing](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178479&view=logs&j=0f9d53fb-31bd-5598-cee7-d26a1517a0ae&t=5a1b3050-c4bf-5d8f-ef1e-3e4f9384fdc4) because of authentication. These fails should be skipped. We were already protected against these failures, but, in this case, we are getting an AggregateException that contains a nested AggregateException that contains the authentication exception.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
