### PR TITLE
Differentiate between error states

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartActiveImplementationIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartActiveImplementationIntegration.cs
@@ -40,17 +40,7 @@ public class StartActiveImplementationIntegration
 
         if (instance.AutomaticTracer is not Datadog.Trace.Tracer tracer)
         {
-            if (instance.AutomaticTracer is null)
-            {
-                Log.Error("Error: instance.AutomaticTracer is null. This should never happen, and indicates a problem with automatic instrumentation.");
-            }
-            else
-            {
-                Log.Error(
-                    "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
-                    instance.AutomaticTracer?.GetType());
-            }
-
+            LogInvalidAutomaticTracer(instance.AutomaticTracer);
             return CallTargetState.GetDefault();
         }
 
@@ -72,5 +62,28 @@ public class StartActiveImplementationIntegration
                             ? scope.DuckCast<TReturn>()
                             : returnValue;
         return new CallTargetReturn<TReturn>(duckScope);
+    }
+
+    internal static void LogInvalidAutomaticTracer(object? autoTracer)
+    {
+        try
+        {
+            // Throwing and catching to grab to call stack and redact it for telemetry
+            throw new Exception("instance.AutomaticTracer is null");
+        }
+        catch (Exception ex)
+        {
+            if (autoTracer is null)
+            {
+                Log.Error(ex, "Error: instance.AutomaticTracer is null. This should never happen, and indicates a problem with automatic instrumentation.");
+            }
+            else
+            {
+                Log.Error(
+                    ex,
+                    "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
+                    autoTracer.GetType());
+            }
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartActiveImplementationIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartActiveImplementationIntegration.cs
@@ -69,7 +69,7 @@ public class StartActiveImplementationIntegration
         try
         {
             // Throwing and catching to grab to call stack and redact it for telemetry
-            throw new Exception("instance.AutomaticTracer is null");
+            throw new Exception("instance.AutomaticTracer was not a Datadog.Trace.Tracer");
         }
         catch (Exception ex)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartActiveImplementationIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartActiveImplementationIntegration.cs
@@ -40,9 +40,17 @@ public class StartActiveImplementationIntegration
 
         if (instance.AutomaticTracer is not Datadog.Trace.Tracer tracer)
         {
-            Log.Error(
-                "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
-                instance.AutomaticTracer?.GetType());
+            if (instance.AutomaticTracer is null)
+            {
+                Log.Error("Error: instance.AutomaticTracer is null. This should never happen, and indicates a problem with automatic instrumentation.");
+            }
+            else
+            {
+                Log.Error(
+                    "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
+                    instance.AutomaticTracer?.GetType());
+            }
+
             return CallTargetState.GetDefault();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
@@ -37,17 +37,7 @@ public class StartSpanIntegration
         // This is only used by the OpenTracing public API
         if (instance.AutomaticTracer is not Datadog.Trace.Tracer tracer)
         {
-            if (instance.AutomaticTracer is null)
-            {
-                Log.Error("Error: instance.AutomaticTracer is null. This should never happen, and indicates a problem with automatic instrumentation.");
-            }
-            else
-            {
-                Log.Error(
-                    "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
-                    instance.AutomaticTracer?.GetType());
-            }
-
+            StartActiveImplementationIntegration.LogInvalidAutomaticTracer(instance.AutomaticTracer);
             return CallTargetState.GetDefault();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/StartSpanIntegration.cs
@@ -37,9 +37,17 @@ public class StartSpanIntegration
         // This is only used by the OpenTracing public API
         if (instance.AutomaticTracer is not Datadog.Trace.Tracer tracer)
         {
-            Log.Error(
-                "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
-                instance.AutomaticTracer?.GetType());
+            if (instance.AutomaticTracer is null)
+            {
+                Log.Error("Error: instance.AutomaticTracer is null. This should never happen, and indicates a problem with automatic instrumentation.");
+            }
+            else
+            {
+                Log.Error(
+                    "Error: instance.AutomaticTracer is not a Datadog.Trace.Tracer: {TracerType}. This should never happen, and indicates a problem with automatic instrumentation.",
+                    instance.AutomaticTracer?.GetType());
+            }
+
             return CallTargetState.GetDefault();
         }
 


### PR DESCRIPTION
## Summary of changes

Write a different error for `null` in error condition

## Reason for change

We're trying to work out what's happening here. Having the extra information would be handy.

## Implementation details

The logs are redacted, so we don't get the type, but the stack and telling whether it's `null` or something else would be useful

## Test coverage

🙈 

## Other Details

[Error logs](https://app.datadoghq.com/error-tracking/issue/50236f8e-3ae4-11f0-8ccb-da7ad0900002?query=source%3Adotnet%20service%3Ainstrumentation-telemetry-data%20version%3A3.17.0.0&index=&from_ts=1748425654941&to_ts=1748440054941&live=true)