### PR TITLE
Mark some instrumentation tests flaky

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -251,6 +251,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
+        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnEolFrameworkInSsi_WhenForwarderPathExists_CallsForwarderWithExpectedTelemetry()
         {
             var logDir = SetLogDirectory();
@@ -283,6 +284,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
+        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnEolFrameworkInSsi_WhenOverriden_CallsForwarderWithExpectedTelemetry()
         {
             var logDir = SetLogDirectory();
@@ -318,6 +320,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [InlineData("1")]
         [InlineData("0")]
+        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnSupportedFrameworkInSsi_CallsForwarderWithExpectedTelemetry(string isOverriden)
         {
             var logDir = SetLogDirectory();


### PR DESCRIPTION
## Summary of changes

## Reason for change

The call to the .NET SDK sometimes hangs when building the dummy app (seen recently [in this run](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=178522&view=results)). We captured a memory dump, and the basic VS analysis flagged the use of sync-over-async as the cause of the hang as part of `dotnet restore`. Created an issue [about it here](https://github.com/NuGet/Home/issues/14343).

## Implementation details

Mark all the methods that call `_fixture.GetAppPath` as flaky.

## Test coverage

N/A

## Other details

If we _still_ get flake here, we could experiment with other approaches. e.g. explicitly called restore/build/publish separately, using shell execute etc, just incase there's something specific about how we're making the call. But it's not worth exploring otherwise IMO
