### PR TITLE
Add flaky attribute

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyResolveMscorlibResourcesInfiniteRecursionCrashSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyResolveMscorlibResourcesInfiniteRecursionCrashSmokeTest.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,6 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         {
         }
 
+        [Flaky("Flaky test: App shutdown")]
         [SkippableFact]
         [Trait("Category", "Smoke")]
         public async Task NoExceptions()


### PR DESCRIPTION
## Summary of changes

The test Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests.AssemblyResolveMscorlibResourcesInfiniteRecursionCrashSmokeTest.NoExceptions have been failing lately. It was considered a flaky test and in the recent days [it is failing more frequently](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40git.branch%3Amaster%20%40test.status%3Afail%20%40ci.pipeline.name%3Aconsolidated-pipeline%20%40test.full_name%3ADatadog.Trace.ClrProfiler.IntegrationTests.Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests.AssemblyResolveMscorlibResourcesInfiniteRecursionCrashSmokeTest.NoExceptions&agg_m=%40ci.pipeline.id&agg_m_source=base&agg_q=%40os.platform%2C%40os.architecture%2C%40runtime.version&agg_q_source=base%2Cbase%2Cbase&agg_t=cardinality&currentTab=trace&eventStack=&fromUser=false&graphType=flamegraph&index=citest&sort_m=%2C%2C&sort_m_source=%2C%2C&sort_t=%2C%2C&spanViewType=metadata&top_n=5%2C5%2C10&top_o=top%2Ctop%2Ctop&viz=stream&x_missing=true%2Ctrue%2Ctrue&start=1741074559757&end=1748850559757&paused=false).

The test has been labeled as flaky.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
