### PR TITLE
Do not run Datadog Static Analyzer on PR from dependabot

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -3,6 +3,7 @@ on: [push]
 
 jobs:
   check-quality:
+    if: github.actor != 'dependabot[bot]'  # secrets are not available to dependabot
     runs-on: ubuntu-latest
     name: Datadog Static Analyzer
     permissions:


### PR DESCRIPTION
## Summary of changes

Skip  Datadog Static Analyzer on PR from  from dependabot.

## Reason for change

https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions

This jobs requires DD_API_KEY, but PR created by dependabot does not have access to secrets.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
