### PR TITLE
Update all Green job to the latest version

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -20,7 +20,7 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: DataDog/ensure-ci-success@727e7fe39ae2e1ce7ea336ec85a7369ab0731754
+      - uses: DataDog/ensure-ci-success@4a4b720e881d965254a9de2a4f14d1ec0c3d0d7c
         with:
           initial-delay-seconds: 10  # wait for this delay before starting
           max-retries: 120  # how many retries before stopping 


### PR DESCRIPTION
## Summary of changes

The all green task was failing on master, showing this message when all the rest of the tasks were green:
Error: This action must be run on a pull_request event.

After talking to @cbeauchesne, he [has updated the code](https://github.com/DataDog/ensure-ci-success/commit/4a4b720e881d965254a9de2a4f14d1ec0c3d0d7c) to allow this task to run in PRs. We need to update our pipeline as well.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
