### PR TITLE
Change the primary logger configuration to a sub-logger configuration

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -107,14 +107,16 @@ internal static class DatadogLoggingFactory
             var managedLogPath = Path.Combine(fileConfig.LogDirectory, $"dotnet-tracer-managed-{domainMetadata.ProcessName}-{domainMetadata.ProcessId.ToString(CultureInfo.InvariantCulture)}.log");
 
             loggerConfiguration
-               .Enrich.With(new RemovePropertyEnricher(LogEventLevel.Error, DatadogSerilogLogger.SkipTelemetryProperty))
-               .WriteTo.File(
-                    managedLogPath,
-                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception} {Properties}{NewLine}",
-                    rollingInterval: RollingInterval.Infinite, // don't do daily rolling, rely on the file size limit for rolling instead
-                    rollOnFileSizeLimit: true,
-                    fileSizeLimitBytes: fileConfig.MaxLogFileSizeBytes,
-                    shared: true);
+               .WriteTo.Logger(
+                    lc => lc
+                          .Enrich.With(new RemovePropertyEnricher(LogEventLevel.Error, DatadogSerilogLogger.SkipTelemetryProperty))
+                          .WriteTo.File(
+                               managedLogPath,
+                               outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception} {Properties}{NewLine}",
+                               rollingInterval: RollingInterval.Infinite, // don't do daily rolling, rely on the file size limit for rolling instead
+                               rollOnFileSizeLimit: true,
+                               fileSizeLimitBytes: fileConfig.MaxLogFileSizeBytes,
+                               shared: true));
         }
 
         try


### PR DESCRIPTION
## Summary of changes

This changes the primary file logging configuration to be a sub logging configuration.

## Reason for change

We added `ErrorSkipTelemetry` in https://github.com/DataDog/dd-trace-dotnet/pull/7028, but it doesn't seem to work.
From what I can tell the `Enrich.With(new RemovePropertyEnricher(LogEventLevel.Error, DatadogSerilogLogger.SkipTelemetryProperty))` was added to the main logging configuration and it would hit first and then remove the skip telemetry property, so now it is it's own sub-logging configuration to try to not do that.

## Implementation details

Copied the redacted error logging

## Test coverage

They still pass so I think that is both good and bad as it means we aren't testing the interaction between the two logging configurations, but I don't really know how important this is.

## Other details

I don't know if this is the right move
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
