### PR TITLE
[Test Optimization] Improve git commands

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitCommandGitInfoProvider.cs
@@ -15,8 +15,6 @@ namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class GitCommandGitInfoProvider : GitInfoProvider
 {
-    private static readonly char[] GitOutputTrimChars = ['\n', '\r', ' '];
-
     private GitCommandGitInfoProvider()
     {
     }
@@ -55,7 +53,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
                     useWhereIsIfFileNotFound: true));
             if (repositoryOutput?.ExitCode == 0)
             {
-                localGitInfo.Repository = repositoryOutput.Output.Trim(GitOutputTrimChars);
+                localGitInfo.Repository = repositoryOutput.Output.Trim();
             }
             else
             {
@@ -69,7 +67,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
                     arguments: "rev-parse --abbrev-ref HEAD",
                     workingDirectory: gitDirectory.FullName,
                     useWhereIsIfFileNotFound: true));
-            if (branchOutput?.ExitCode == 0 && branchOutput.Output.Trim(GitOutputTrimChars) is { Length: > 0 } branchName && branchName != "HEAD")
+            if (branchOutput?.ExitCode == 0 && branchOutput.Output.Trim() is { Length: > 0 } branchName && branchName != "HEAD")
             {
                 localGitInfo.Branch = branchName;
             }
@@ -91,7 +89,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
                 return false;
             }
 
-            var gitLogDataArray = gitLogOutput.Output.Trim(GitOutputTrimChars).Split(["|,|"], StringSplitOptions.None);
+            var gitLogDataArray = gitLogOutput.Output.Trim().Split(["|,|"], StringSplitOptions.None);
             if (gitLogDataArray.Length < 8)
             {
                 localGitInfo.Errors.Add($"Git log output does not contain the expected number of fields: {gitLogOutput.Output}");
@@ -119,7 +117,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
             localGitInfo.CommitterDate = DateTimeOffset.FromUnixTimeSeconds(committerUnixDate);
             localGitInfo.CommitterName = gitLogDataArray[5];
             localGitInfo.CommitterEmail = gitLogDataArray[6];
-            localGitInfo.Message = string.Join("|,|", gitLogDataArray.Skip(7)).Trim(GitOutputTrimChars);
+            localGitInfo.Message = string.Join("|,|", gitLogDataArray.Skip(7)).Trim();
             if (localGitInfo.Commit.StartsWith("'"))
             {
                 localGitInfo.Commit = localGitInfo.Commit.Substring(1);
@@ -127,7 +125,7 @@ internal sealed class GitCommandGitInfoProvider : GitInfoProvider
 
             if (localGitInfo.Message.EndsWith("'"))
             {
-                localGitInfo.Message = localGitInfo.Message.Substring(0, localGitInfo.Message.Length - 1).Trim(GitOutputTrimChars);
+                localGitInfo.Message = localGitInfo.Message.Substring(0, localGitInfo.Message.Length - 1).Trim();
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary of changes

This PR improves some git commands and removes the ones inside the http client.

## Reason for change

Basic git information should be retrieved only from the CIEnvironmentValues classes. When creating the http client, the CIEnvironmentValues instance is already filled with all the git metadata, we don't need to run any extra command.

[SDTEST-2037](https://datadoghq.atlassian.net/browse/SDTEST-2037)

## Implementation details

## Test coverage

There shouldn't be any change of behavior, so curernt tests should pass.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->


[SDTEST-2037]: https://datadoghq.atlassian.net/browse/SDTEST-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ