### PR TITLE
Revert "Revert 'Reapply "Revert Load the tracer/profiler after guardrails checks" (#6959)' (#6986)"

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
@@ -27,10 +27,6 @@ HRESULT STDMETHODCALLTYPE CorProfilerClassFactory::QueryInterface(REFIID riid, v
     {
         *ppvObject = this;
         this->AddRef();
-
-        // We try to load the class factory of all target cor profilers.
-        // Errors are already logged in the dispatcher.
-        m_dispatcher->LoadClassFactory(riid);
         return S_OK;
     }
 
@@ -68,13 +64,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerClassFactory::CreateInstance(IUnknown* pUnk
 
     auto profiler = new datadog::shared::nativeloader::CorProfiler(m_dispatcher);
     HRESULT res = profiler->QueryInterface(riid, ppvObject);
-    if (SUCCEEDED(res))
-    {
-        m_dispatcher->LoadInstance(pUnkOuter, riid);
-    }
-    else
+    if (FAILED(res))
     {
         delete profiler;
+        *ppvObject = nullptr;
     }
 
     Log::Debug("CorProfilerClassFactory::CreateInstance: ", res);

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -22,8 +22,41 @@ namespace datadog::shared::nativeloader
     DynamicDispatcherImpl::DynamicDispatcherImpl() :
         m_continuousProfilerInstance(nullptr),
         m_tracerInstance(nullptr),
-        m_customInstance(nullptr)
+        m_customInstance(nullptr),
+        m_initialized(false),
+        m_initializationResult(E_UNEXPECTED)
     {
+    }
+
+    HRESULT DynamicDispatcherImpl::Initialize()
+    {
+        if (m_initialized)
+        {
+            return m_initializationResult;
+        }
+
+        m_initialized = true;
+
+        LoadConfiguration(GetConfigurationFilePath());
+
+        m_initializationResult = LoadClassFactory(IID_IClassFactory);
+
+        if (FAILED(m_initializationResult))
+        {
+            Log::Error("Error loading all cor profiler class factories.");
+            return m_initializationResult;
+        }
+
+        m_initializationResult = LoadInstance();
+
+        if (FAILED(m_initializationResult))
+        {
+            Log::Error("Error loading all cor profiler instances.");
+            return m_initializationResult;
+        }
+
+        m_initializationResult = S_OK;
+        return m_initializationResult;
     }
 
     void DynamicDispatcherImpl::LoadConfiguration(fs::path&& configFilePath)
@@ -157,7 +190,8 @@ namespace datadog::shared::nativeloader
 
     HRESULT DynamicDispatcherImpl::LoadClassFactory(REFIID riid)
     {
-        HRESULT GHR = S_OK;
+        // We consider the loading a success if at least one class factory is properly loaded.
+        HRESULT GHR = E_FAIL;
 
         if (m_continuousProfilerInstance != nullptr)
         {
@@ -171,12 +205,20 @@ namespace datadog::shared::nativeloader
                 else
                 {
                     Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load continuous profiler class factory in: ",
-                        m_continuousProfilerInstance->GetFilePath());
+                        m_continuousProfilerInstance->GetFilePath(), ", error code: ", result);
                 }
 
                 // If we cannot load the class factory we release the instance.
-                m_continuousProfilerInstance.release();
-                GHR = result;
+                m_continuousProfilerInstance = nullptr;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
@@ -191,12 +233,21 @@ namespace datadog::shared::nativeloader
                 }
                 else
                 {
-                    Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ", m_tracerInstance->GetFilePath());
+                    Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ",
+                        m_tracerInstance->GetFilePath(), ", error code: ", result);
                 }
 
                 // If we cannot load the class factory we release the instance.
-                m_tracerInstance.release();
-                GHR = result;
+                m_tracerInstance = nullptr;
+                
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
@@ -205,58 +256,95 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_customInstance->LoadClassFactory(riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load custom class factory in: ", m_customInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load custom class factory in: ",
+                    m_customInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
-                m_customInstance.release();
-                GHR = result;
+                m_customInstance = nullptr;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
         return GHR;
     }
 
-    HRESULT DynamicDispatcherImpl::LoadInstance(IUnknown* pUnkOuter, REFIID riid)
+    HRESULT DynamicDispatcherImpl::LoadInstance()
     {
-        HRESULT GHR = S_OK;
+        // We consider the loading a success if at least one class factory is properly loaded.
+        HRESULT GHR = E_FAIL;
 
         if (m_continuousProfilerInstance != nullptr)
         {
-            HRESULT result = m_continuousProfilerInstance->LoadInstance(pUnkOuter, riid);
+            HRESULT result = m_continuousProfilerInstance->LoadInstance();
+
             if (FAILED(result))
             {
-                    Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
-                     m_continuousProfilerInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
+                     m_continuousProfilerInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
-                m_continuousProfilerInstance.release();
-                GHR = result;
+                m_continuousProfilerInstance = nullptr;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
         if (m_tracerInstance != nullptr)
         {
-            HRESULT result = m_tracerInstance->LoadInstance(pUnkOuter, riid);
+            HRESULT result = m_tracerInstance->LoadInstance();
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the tracer instance in: ", m_tracerInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the tracer instance in: ",
+                    m_tracerInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
-                m_tracerInstance.release();
-                GHR = result;
+                m_tracerInstance = nullptr;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
         if (m_customInstance != nullptr)
         {
-            HRESULT result = m_customInstance->LoadInstance(pUnkOuter, riid);
+            HRESULT result = m_customInstance->LoadInstance();
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the custom instance in: ", m_customInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the custom instance in: ",
+                    m_customInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
-                m_customInstance.release();
-                GHR = result;
+                m_customInstance = nullptr;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
@@ -20,9 +20,10 @@ namespace datadog::shared::nativeloader
     {
     public:
         virtual ~IDynamicDispatcher() = default;
+        virtual HRESULT Initialize() = 0;
         virtual void LoadConfiguration(fs::path&& configFilePath) = 0;
         virtual HRESULT LoadClassFactory(REFIID riid) = 0;
-        virtual HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) = 0;
+        virtual HRESULT LoadInstance() = 0;
         virtual HRESULT STDMETHODCALLTYPE DllCanUnloadNow() = 0;
         virtual IDynamicInstance* GetContinuousProfilerInstance() = 0;
         virtual IDynamicInstance* GetTracerInstance() = 0;
@@ -41,13 +42,18 @@ namespace datadog::shared::nativeloader
 
     public:
         DynamicDispatcherImpl();
+        HRESULT Initialize() override;
         void LoadConfiguration(fs::path&& configFilePath) override;
         HRESULT LoadClassFactory(REFIID riid) override;
-        HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override;
+        HRESULT LoadInstance() override;
         HRESULT STDMETHODCALLTYPE DllCanUnloadNow() override;
         IDynamicInstance* GetContinuousProfilerInstance() override;
         IDynamicInstance* GetTracerInstance() override;
         IDynamicInstance* GetCustomInstance() override;
+
+    private:
+        bool m_initialized;
+        HRESULT m_initializationResult;
     };
 
 } // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
@@ -72,7 +72,7 @@ namespace datadog::shared::nativeloader
         return res;
     }
 
-    HRESULT DynamicInstanceImpl::LoadInstance(IUnknown* pUnkOuter, REFIID riid)
+    HRESULT DynamicInstanceImpl::LoadInstance()
     {
         Log::Debug("DynamicInstanceImpl::LoadInstance");
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.h
@@ -20,7 +20,7 @@ namespace datadog::shared::nativeloader
     public:
         virtual ~IDynamicInstance() = default;
         virtual HRESULT LoadClassFactory(REFIID riid) = 0;
-        virtual HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) = 0;
+        virtual HRESULT LoadInstance() = 0;
         virtual HRESULT STDMETHODCALLTYPE DllCanUnloadNow() = 0;
         virtual ICorProfilerCallback10* GetProfilerCallback() = 0;
         virtual std::string GetFilePath() = 0;
@@ -42,7 +42,7 @@ namespace datadog::shared::nativeloader
         DynamicInstanceImpl(const std::string& filePath, const std::string& clsid);
         ~DynamicInstanceImpl() override;
         HRESULT LoadClassFactory(REFIID riid) override;
-        HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override;
+        HRESULT LoadInstance() override;
         HRESULT STDMETHODCALLTYPE DllCanUnloadNow() override;
         ICorProfilerCallback10* GetProfilerCallback() override;
         std::string GetFilePath() override;

--- a/shared/src/native-src/dynamic_library_base.cpp
+++ b/shared/src/native-src/dynamic_library_base.cpp
@@ -93,7 +93,7 @@ bool DynamicLibraryBase::Load()
 
 bool DynamicLibraryBase::Unload()
 {
-    _logger->Debug("Unload");
+    _logger->Debug("Unloading ", _filePath);
     if (_instance == nullptr)
     {
         _logger->Warn("Unload: Unable to unload dynamic library '", _filePath,

--- a/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_dynamic_instance.h
+++ b/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_dynamic_instance.h
@@ -34,10 +34,10 @@ public:
         return m_loadClassFactory;
     }
 
-    HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override
+    HRESULT LoadInstance() override
     {
         if (GetFilePath() != "Test")
-            return DynamicInstanceImpl::LoadInstance(pUnkOuter, riid);
+            return DynamicInstanceImpl::LoadInstance();
         return m_loadInstance;
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
@@ -182,7 +182,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             if (libName != null && runtimeIds != null)
             {
                 var paths = LibraryLocationHelper.GetDatadogNativeFolders(fd, runtimeIds);
-                if (!LibraryLocationHelper.TryLoadLibraryFromPaths(libName, paths, out libraryHandle))
+                if (!LibraryLocationHelper.TryLoadLibraryFromPaths(fd, libName, paths, out libraryHandle))
                 {
                     return new LibraryInitializationResult(LibraryInitializationResult.LoadStatus.LibraryLoad);
                 }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ProcessBasicChecksTests.cs
@@ -214,6 +214,8 @@ namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks
         public async Task WorkingWithContinuousProfiler(string enabled, bool? ssiInjectionEnabled)
         {
             SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+            // The continuous profiler isn't currently supported on ARM
+            SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
 
             var ssiInjection = ssiInjectionEnabled is null
                                    ? null

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -230,6 +230,9 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     public async Task WorkingWithContinuousProfiler()
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+        // The continuous profiler isn't currently supported on ARM
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
+
         string archFolder;
 
         if (FrameworkDescription.Instance.ProcessArchitecture == ProcessArchitecture.Arm64)


### PR DESCRIPTION
## Summary of changes

Reapply the loading the tracer/profiler after guardrails etc checks

## Reason for change

We want to make sure we bail out before loading the tracer/profiler dlls to limit memory footprint.

## Implementation details

Revert the revert that reverted the revert

Also apply @daniel-romano-DD's "turn it off and back on again" fix from #6982 when on linux arm64. This seems to resolve the issue (that we could only repro on fedora 35 on arm64) where the WAF would crash the installer smoke tests. 

## Test coverage

I've run both the arm64 installer tests 3 times with this PR, and not seen any crashes. Similarly, we ran the #6982 fix version several times with this fix and it always worked. 

## Other details

We're still trying to understand the source of the issue. Initial consideration was something tied to glibc or kernel issues, but there's no difference between the faulty and successful images (which makes sense given they're running in docker I _think_). @gleocadie is investigating further


| Distro        | Glibc Version   | Kernel version    |
| ------------- | --------------- | ----------------- |
| Fedora 35     | 2.36-9+deb12u10 | 5.15.0-1088-azure |
| Fedora 34     | 2.36-9+deb12u10 | 5.15.0-1088-azure |
| Fedora 40     | 2.36-9+deb12u10 | 5.15.0-1088-azure |
| Debian focal  | 2.36-9+deb12u10 | 5.15.0-1088-azure |
