### PR TITLE
System.InvalidOperationException when calling System.Uri.get_Scheme()

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -357,7 +357,6 @@ src/Datadog.Trace/Telemetry/Metrics/IntegrationIdExtensions.cs
 src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
 src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
 src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
-src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
 src/Datadog.Trace/Util/Http/QueryStringManager.cs
 src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
 src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafConfigStruct.cs

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
@@ -17,7 +17,20 @@ namespace Datadog.Trace.Util.Http
         {
             if (!uri.IsAbsoluteUri)
             {
-                return uri.ToString();
+                var relativeUrl = uri.ToString();
+
+                if (queryStringManager != null)
+                {
+                    var queryStringIndex = relativeUrl.IndexOf('?');
+
+                    if (queryStringIndex >= 0)
+                    {
+                        var queryString = relativeUrl.Substring(queryStringIndex);
+                        relativeUrl = relativeUrl.Substring(0, queryStringIndex) + queryStringManager.TruncateAndObfuscate(queryString);
+                    }
+                }
+
+                return relativeUrl;
             }
 
             return GetUrl(

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
@@ -4,8 +4,8 @@
 // </copyright>
 
 using System;
-using Datadog.Trace.Configuration;
-using Datadog.Trace.Util.Http.QueryStringObfuscation;
+
+#nullable enable
 
 namespace Datadog.Trace.Util.Http
 {
@@ -13,8 +13,14 @@ namespace Datadog.Trace.Util.Http
     {
         private const string NoHostSpecified = "UNKNOWN_HOST";
 
-        internal static string GetUrl(Uri uri, QueryStringManager queryStringManager = null)
-            => GetUrl(
+        internal static string GetUrl(Uri uri, QueryStringManager? queryStringManager = null)
+        {
+            if (!uri.IsAbsoluteUri)
+            {
+                return uri.ToString();
+            }
+
+            return GetUrl(
                 uri.Scheme,
                 uri.Host,
                 uri.IsDefaultPort ? null : uri.Port,
@@ -22,8 +28,9 @@ namespace Datadog.Trace.Util.Http
                 uri.AbsolutePath,
                 uri.Query,
                 queryStringManager);
+        }
 
-        internal static string GetUrl(string scheme, string host, int? port, string pathBase, string path, string queryString, QueryStringManager queryStringManager = null)
+        internal static string GetUrl(string scheme, string host, int? port, string pathBase, string path, string queryString, QueryStringManager? queryStringManager = null)
         {
             if (queryStringManager != null)
             {
@@ -34,6 +41,6 @@ namespace Datadog.Trace.Util.Http
             return $"{scheme}://{GetNormalizedHost(host)}{(port.HasValue ? $":{port}" : string.Empty)}{pathBase}{path}";
         }
 
-        internal static string GetNormalizedHost(string host) => string.IsNullOrEmpty(host) ? NoHostSpecified : host;
+        internal static string GetNormalizedHost(string? host) => host is null || host == string.Empty ? NoHostSpecified : host;
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Util/HttpRequestUtilsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/HttpRequestUtilsTests.cs
@@ -51,4 +51,18 @@ public class HttpRequestUtilsTests
         // Assert
         Assert.Equal("/relative/path?query=123", result);
     }
+
+    [Fact]
+    public void GetUrl_WithRelativeUriAndQueryStringManager_ReturnsProcessedUrl()
+    {
+        // Arrange
+        var uri = new Uri("/relative/path?secret=ee123", UriKind.Relative);
+        var queryStringManager = new QueryStringManager(true, 1000, 1000, TracerSettingsConstants.DefaultObfuscationQueryStringRegex);
+
+        // Act
+        var result = HttpRequestUtils.GetUrl(uri, queryStringManager);
+
+        // Assert
+        Assert.Equal("/relative/path?<redacted>", result);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Util/HttpRequestUtilsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/HttpRequestUtilsTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="HttpRequestUtilsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Util.Http;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util
+{
+    public class HttpRequestUtilsTests
+    {
+        [Fact]
+        public void GetUrl_WithAbsoluteUri_ReturnsCorrectUrl()
+        {
+            // Arrange
+            var uri = new Uri("https://example.com:8080/path/to/resource?query=123");
+
+            // Act
+            var result = HttpRequestUtils.GetUrl(uri);
+
+            // Assert
+            Assert.Equal("https://example.com:8080/path/to/resource", result);
+        }
+
+        [Fact]
+        public void GetUrl_WithAbsoluteUriAndQueryStringManager_ReturnsProcessedUrl()
+        {
+            // Arrange
+            var uri = new Uri("https://example.com/path?secret=ee123");
+            var queryStringManager = new QueryStringManager(true, 1000, 1000, TracerSettingsConstants.DefaultObfuscationQueryStringRegex);
+
+            // Act
+            var result = HttpRequestUtils.GetUrl(uri, queryStringManager);
+
+            // Assert
+            Assert.Equal("https://example.com/path?<redacted>", result);
+        }
+
+        [Fact]
+        public void GetUrl_WithRelativeUri_ReturnsUriAsString()
+        {
+            // Arrange
+            var uri = new Uri("/relative/path?query=123", UriKind.Relative);
+
+            // Act
+            var result = HttpRequestUtils.GetUrl(uri);
+
+            // Assert
+            Assert.Equal("/relative/path?query=123", result);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/HttpRequestUtilsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/HttpRequestUtilsTests.cs
@@ -8,48 +8,47 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.Util.Http;
 using Xunit;
 
-namespace Datadog.Trace.Tests.Util
+namespace Datadog.Trace.Tests.Util;
+
+public class HttpRequestUtilsTests
 {
-    public class HttpRequestUtilsTests
+    [Fact]
+    public void GetUrl_WithAbsoluteUri_ReturnsCorrectUrl()
     {
-        [Fact]
-        public void GetUrl_WithAbsoluteUri_ReturnsCorrectUrl()
-        {
-            // Arrange
-            var uri = new Uri("https://example.com:8080/path/to/resource?query=123");
+        // Arrange
+        var uri = new Uri("https://example.com:8080/path/to/resource?query=123");
 
-            // Act
-            var result = HttpRequestUtils.GetUrl(uri);
+        // Act
+        var result = HttpRequestUtils.GetUrl(uri);
 
-            // Assert
-            Assert.Equal("https://example.com:8080/path/to/resource", result);
-        }
+        // Assert
+        Assert.Equal("https://example.com:8080/path/to/resource", result);
+    }
 
-        [Fact]
-        public void GetUrl_WithAbsoluteUriAndQueryStringManager_ReturnsProcessedUrl()
-        {
-            // Arrange
-            var uri = new Uri("https://example.com/path?secret=ee123");
-            var queryStringManager = new QueryStringManager(true, 1000, 1000, TracerSettingsConstants.DefaultObfuscationQueryStringRegex);
+    [Fact]
+    public void GetUrl_WithAbsoluteUriAndQueryStringManager_ReturnsProcessedUrl()
+    {
+        // Arrange
+        var uri = new Uri("https://example.com/path?secret=ee123");
+        var queryStringManager = new QueryStringManager(true, 1000, 1000, TracerSettingsConstants.DefaultObfuscationQueryStringRegex);
 
-            // Act
-            var result = HttpRequestUtils.GetUrl(uri, queryStringManager);
+        // Act
+        var result = HttpRequestUtils.GetUrl(uri, queryStringManager);
 
-            // Assert
-            Assert.Equal("https://example.com/path?<redacted>", result);
-        }
+        // Assert
+        Assert.Equal("https://example.com/path?<redacted>", result);
+    }
 
-        [Fact]
-        public void GetUrl_WithRelativeUri_ReturnsUriAsString()
-        {
-            // Arrange
-            var uri = new Uri("/relative/path?query=123", UriKind.Relative);
+    [Fact]
+    public void GetUrl_WithRelativeUri_ReturnsUriAsString()
+    {
+        // Arrange
+        var uri = new Uri("/relative/path?query=123", UriKind.Relative);
 
-            // Act
-            var result = HttpRequestUtils.GetUrl(uri);
+        // Act
+        var result = HttpRequestUtils.GetUrl(uri);
 
-            // Assert
-            Assert.Equal("/relative/path?query=123", result);
-        }
+        // Assert
+        Assert.Equal("/relative/path?query=123", result);
     }
 }


### PR DESCRIPTION
## Summary of changes

We are getting the following error:

```
System.InvalidOperationException
at System.Uri.get_Scheme()
at Datadog.Trace.Util.Http.HttpRequestUtils.GetUrl(Uri uri, QueryStringManager queryStringManager)
at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet.AspNetWebApi2Integration.UpdateSpan(IHttpControllerContext controllerContext, Span span, AspNetTags tags)
```

If we take a look at the code of at System.Uri.get_Scheme() and similar methods, we can see that a InvalidOperationException is thrown when a relative url is received (both netcore and .net framework).

```
    public string Scheme
    {
        [__DynamicallyInvokable]
        get
        {
            if (IsNotAbsoluteUri)
            {
                throw new InvalidOperationException(SR.GetString("net_uri_NotAbsolute"));
            }
            return m_Syntax.SchemeName;
        }
    }
```
In httpRequestUtils.GetUrl, we build a string representation of the Url. For relative urls, we cannot access the individual components of the URL, so we get a tring representation by calling the ToString() method.

## Reason for change

Discovered through telemetry: https://app.datadoghq.com/error-tracking?query=source%3Adotnet%20%40tracer_version%3A3.17%2A&et-side=activity&et-viz=events&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%2274a6d8ba-3d63-11f0-94e2-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&view=spans&from_ts=1748438263029&to_ts=1749043063029&live=true

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
