### PR TITLE
chore: disable data pipeline by default

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -416,7 +416,7 @@ namespace Datadog.Trace.Configuration
 
             DataPipelineEnabled = config
                                   .WithKeys(ConfigurationKeys.TraceDataPipelineEnabled)
-                                  .AsBool(defaultValue: true);
+                                  .AsBool(defaultValue: false);
 
             if (DataPipelineEnabled)
             {


### PR DESCRIPTION
## Summary of changes

Disable data pipeline by default. We will use our phased rollout strategy to enable.

## Reason for change

Context https://github.com/DataDog/dd-trace-dotnet/pull/6314/files#r1995659318

## Implementation details

Flipped the config

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
