### PR TITLE
Print the generated snapshot in case of failures

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -12,12 +12,14 @@ using Newtonsoft.Json.Linq;
 using VerifyTests;
 using VerifyXunit;
 using Xunit;
+using Xunit.Abstractions;
+
 #pragma warning disable CS0414
 
 namespace Datadog.Trace.Tests.Debugger
 {
     [UsesVerify]
-    public class DebuggerSnapshotCreatorTests
+    public class DebuggerSnapshotCreatorTests(ITestOutputHelper output)
     {
         [Fact]
         public async Task Limits_LargeCollection()
@@ -96,6 +98,7 @@ namespace Datadog.Trace.Tests.Debugger
         {
             var snapshot = SnapshotHelper.GenerateSnapshot(local);
 
+            output.WriteLine("Snapshot: " + snapshot);
             var verifierSettings = new VerifySettings();
             verifierSettings.ScrubLinesContaining(new[] { "id", "timestamp", "duration" });
             var localVariableAsJson = JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return.locals");


### PR DESCRIPTION
## Summary of changes

Add debug statement for analyzing flaky debugger test

## Reason for change

It flaked with 

```
Failed Datadog.Trace.Tests.Debugger.DebuggerSnapshotCreatorTests.Limits_FieldsCount [1 s]
Error Message:
Newtonsoft.Json.JsonReaderException : Unexpected end of content while loading JObject. Path 'debugger', line 812, position 3.
Stack Trace:
    at Newtonsoft.Json.Linq.JContainer.ReadTokenFrom(JsonReader reader, JsonLoadSettings options)
at Newtonsoft.Json.Linq.JObject.Load(JsonReader reader, JsonLoadSettings settings)
at Newtonsoft.Json.Linq.JObject.Parse(String json, JsonLoadSettings settings)
at Newtonsoft.Json.Linq.JObject.Parse(String json)
at Datadog.Trace.Tests.Debugger.DebuggerSnapshotCreatorTests.ValidateSingleValue(Object local) in /project/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs:line 101
at Datadog.Trace.Tests.Debugger.DebuggerSnapshotCreatorTests.Limits_FieldsCount() in /project/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs:line 39
```

which is kinda weird

## Implementation details

Write the snapshot so we can see what it is if it fails again

## Test coverage

N/A

## Other details
