### PR TITLE
fix(trace-exporter): add error handling when releasing handles in ErrorHandle, TraceExporter, and TraceExporterConfiguration

### DIFF
--- a/tracer/src/Datadog.Trace/LibDatadog/ErrorHandle.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/ErrorHandle.cs
@@ -7,11 +7,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.LibDatadog;
 
 internal class ErrorHandle : SafeHandle
 {
+    private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<ErrorHandle>();
+
     public ErrorHandle()
         : base(IntPtr.Zero, true)
     {
@@ -27,7 +30,15 @@ internal class ErrorHandle : SafeHandle
 
     protected override bool ReleaseHandle()
     {
-        NativeInterop.Exporter.FreeError(handle);
+        try
+        {
+            NativeInterop.Exporter.FreeError(handle);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "An error occurred while releasing the handle for ErrorHandle.");
+        }
+
         return true;
     }
 

--- a/tracer/src/Datadog.Trace/LibDatadog/TraceExporter.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/TraceExporter.cs
@@ -80,7 +80,16 @@ internal class TraceExporter : SafeHandle, IApi
 
     protected override bool ReleaseHandle()
     {
-        NativeInterop.Exporter.Free(handle);
+        try
+        {
+            NativeInterop.Exporter.Free(handle);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "An error occurred while releasing the handle for TraceExporter.");
+            return false;
+        }
+
         return true;
     }
 }

--- a/tracer/src/Datadog.Trace/LibDatadog/TraceExporterConfiguration.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/TraceExporterConfiguration.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.LibDatadog;
 
@@ -15,6 +16,8 @@ namespace Datadog.Trace.LibDatadog;
 /// </summary>
 internal class TraceExporterConfiguration : SafeHandle
 {
+    private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<TraceExporterConfiguration>();
+
     private IntPtr _telemetryConfigPtr;
 
     public TraceExporterConfiguration()
@@ -156,7 +159,15 @@ internal class TraceExporterConfiguration : SafeHandle
             _telemetryConfigPtr = IntPtr.Zero;
         }
 
-        NativeInterop.Config.Free(handle);
+        try
+        {
+            NativeInterop.Config.Free(handle);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "An error occurred while releasing the handle for TraceExporterConfiguration.");
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
## Summary of changes

Follow up of https://github.com/DataDog/dd-trace-dotnet/pull/6314#discussion_r2126069726

## Reason for change

These exceptions should never happen but given we are overly cautious about not breaking the customer app, I wrapped all handle releases.

## Implementation details

try-catch

## Test coverage

None

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
