### PR TITLE
Fix null reference exception in combine method

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -237,7 +237,6 @@ src/Datadog.Trace/Util/System.Diagnostics.CodeAnalysis.Attributes.cs
 src/Datadog.Trace/Util/System.Runtime.CompilerServices.Attributes.cs
 src/Datadog.Trace/Util/ThrowHelper.cs
 src/Datadog.Trace/Util/TimeHelpers.cs
-src/Datadog.Trace/Util/UriHelpers.cs
 src/Datadog.Trace/Activity/Handlers/ActivityMappingExtensions.cs
 src/Datadog.Trace/Agent/MessagePack/SpanFormatterResolver.cs
 src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactory.cs
@@ -24,7 +24,7 @@ internal class AwsApiGatewaySpanFactory : IInferredSpanFactory
     {
         try
         {
-            var resourceUrl = UriHelpers.GetCleanUriPath(data.Path).ToLowerInvariant();
+            var resourceUrl = UriHelpers.GetCleanUriPath(data.Path)?.ToLowerInvariant();
 
             var tags = new InferredProxyTags
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactory.cs
@@ -24,7 +24,7 @@ internal class AwsApiGatewaySpanFactory : IInferredSpanFactory
     {
         try
         {
-            var resourceUrl = UriHelpers.GetCleanUriPath(data.Path)?.ToLowerInvariant();
+            var resourceUrl = UriHelpers.GetCleanUriPath(data.Path).ToLowerInvariant();
 
             var tags = new InferredProxyTags
             {

--- a/tracer/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/UriHelpers.cs
@@ -34,13 +34,13 @@ namespace Datadog.Trace.Util
             return $"{uri.Scheme}{Uri.SchemeDelimiter}{uri.Authority}{path}";
         }
 
-        public static string? GetCleanUriPath(Uri uri)
+        public static string GetCleanUriPath(Uri uri)
             => GetCleanUriPath(uri.AbsolutePath);
 
-        public static string? GetCleanUriPath(Uri uri, string virtualPathToRemove)
+        public static string GetCleanUriPath(Uri uri, string virtualPathToRemove)
             => GetCleanUriPath(uri.AbsolutePath, virtualPathToRemove);
 
-        public static string? GetCleanUriPath(string? absolutePath)
+        public static string GetCleanUriPath(string? absolutePath)
             => GetCleanUriPath(absolutePath, null);
 
         /// <summary>
@@ -49,11 +49,11 @@ namespace Datadog.Trace.Util
         /// <param name="absolutePath">The path to clean</param>
         /// <param name="virtualPathToRemove">The optional virtual path to remove from the front of the path</param>
         /// <returns>The cleaned path</returns>
-        public static string? GetCleanUriPath(string? absolutePath, string? virtualPathToRemove)
+        public static string GetCleanUriPath(string? absolutePath, string? virtualPathToRemove)
         {
             if (absolutePath is null || absolutePath == string.Empty || (absolutePath.Length == 1 && absolutePath[0] == '/'))
             {
-                return absolutePath;
+                return absolutePath ?? string.Empty;
             }
 
             if (!string.IsNullOrEmpty(virtualPathToRemove) && string.Equals(absolutePath, virtualPathToRemove))
@@ -231,9 +231,6 @@ namespace Datadog.Trace.Util
                 return baseUri ?? string.Empty;
             }
 
-            // If the baseUri ends with a slash, we can just append the relativePath
-            // If the relativePath starts with a slash, we can just append it to the baseUri
-            // Otherwise, we need to add a slash between them
             return relativePath.StartsWith("/")
                 ? $"{baseUri.TrimEnd('/')}{relativePath}"
                 : $"{baseUri.TrimEnd('/')}/{relativePath.TrimStart('/')}";

--- a/tracer/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
@@ -102,9 +102,12 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("http://localhost/some/", "path")]
         [InlineData("http://localhost/some", "/path")]
         [InlineData("http://localhost/some/", "/path")]
-        public void CombineString_ShouldMergeCorrectly(string baseUri, string relativePath)
+        [InlineData(null, "some/path", "some/path")]
+        [InlineData("http://localhost/some/path", null)]
+        [InlineData(null, null, "")]
+        public void CombineString_ShouldMergeCorrectly(string baseUri, string relativePath, string result = "http://localhost/some/path")
         {
-            Trace.Util.UriHelpers.Combine(baseUri, relativePath).Should().Be("http://localhost/some/path");
+            Trace.Util.UriHelpers.Combine(baseUri, relativePath).Should().Be(result);
         }
 
         [Theory]
@@ -116,9 +119,10 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("http://localhost/some/", "path")]
         [InlineData("http://localhost/some", "/path")]
         [InlineData("http://localhost/some/", "/path")]
-        public void CombineString_ShouldMergeAbsolutePathCorrectly(string baseUri, string relativePath)
+        [InlineData("http://localhost/some/path", null)]
+        public void CombineString_ShouldMergeAbsolutePathCorrectly(string baseUri, string relativePath, string result = "/some/path")
         {
-            Trace.Util.UriHelpers.Combine(new Uri(baseUri).AbsolutePath, relativePath).Should().Be("/some/path");
+            Trace.Util.UriHelpers.Combine(new Uri(baseUri).AbsolutePath, relativePath).Should().Be(result);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

https://app.datadoghq.com/error-tracking?query=source%3Adotnet%20%2ARuntimePipelineInvokeAsyncIntegration%2A&order=total_count&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22f4abb06e-3aeb-11f0-a0f1-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&view=spans&from_ts=1749035433914&to_ts=1749121833914&live=true

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
