### PR TITLE
Set `DD_TRACING_ENABLED=tracing` for IIS based SSI

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/Commands/CommandBase.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/CommandBase.cs
@@ -20,7 +20,7 @@ internal abstract class CommandBase : Command
     {
     }
 
-    protected bool IsValidEnvironment(CommandResult commandResult)
+    protected static bool IsValidEnvironment(CommandResult commandResult)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -39,7 +39,7 @@ internal abstract class CommandBase : Command
         return true;
     }
 
-    protected bool HasValidIIsVersion(ILogger commandResult, [NotNullWhen(false)] out string? errorMessage)
+    protected static bool HasValidIIsVersion([NotNullWhen(false)] out string? errorMessage)
     {
         if (!RegistryHelper.TryGetIisVersion(Log.Instance, out var version))
         {

--- a/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
@@ -106,7 +106,7 @@ internal class EnableIisInstrumentationCommand : CommandBase
         }
 
         // We can't enable iis instrumentation if IIS is not available or is to low a version
-        if (!HasValidIIsVersion(Log.Instance, out var errorMessage))
+        if (!HasValidIIsVersion(out var errorMessage))
         {
             commandResult.ErrorMessage = errorMessage;
             return;

--- a/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
@@ -39,18 +39,14 @@ internal class EnableIisInstrumentationCommand : CommandBase
         var tracerValues = new TracerValues(versionedPath);
         var log = Log.Instance;
 
-        var result = Execute(log, tracerValues, Defaults.TracerLogDirectory, Defaults.CrashTrackingRegistryKey);
+        var result = Execute(log, tracerValues);
 
         context.ExitCode = (int)result;
         return Task.CompletedTask;
     }
 
     // Internal for testing
-    internal static ReturnCode Execute(
-        ILogger log,
-        TracerValues tracerValues,
-        string tracerLogDirectory,
-        string registryKeyName)
+    internal static ReturnCode Execute(ILogger log, TracerValues tracerValues)
     {
         log.WriteInfo("Enabling IIS instrumentation for .NET tracer");
 

--- a/tracer/src/Datadog.FleetInstaller/Commands/RemoveIisInstrumentation.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/RemoveIisInstrumentation.cs
@@ -36,11 +36,11 @@ internal class RemoveIisInstrumentation : CommandBase
     }
 
     // Internal for testing
-    internal ReturnCode Execute(ILogger log)
+    internal static ReturnCode Execute(ILogger log)
     {
         log.WriteInfo("Removing IIS instrumentation for .NET tracer");
 
-        if (!HasValidIIsVersion(log, out var errorMessage))
+        if (!HasValidIIsVersion(out var errorMessage))
         {
             // IIS isn't available, weird because it means they removed it _after_ successfully installing the product
             // but whatever, there's no variables there if that's the case!

--- a/tracer/src/Datadog.FleetInstaller/Program.cs
+++ b/tracer/src/Datadog.FleetInstaller/Program.cs
@@ -17,7 +17,7 @@ using Datadog.FleetInstaller.Commands;
 // args = ["uninstall-product"];
 // args = [];
 
-var rootCommand = new CommandWithExamples(CommandWithExamples.Command);
+var rootCommand = new CommandWithExamples(CommandWithExamples.Command, "Windows SSI fleet-installer command line tool");
 
 var builder = new CommandLineBuilder(rootCommand)
     .UseHelp()

--- a/tracer/src/Datadog.FleetInstaller/TracerValues.cs
+++ b/tracer/src/Datadog.FleetInstaller/TracerValues.cs
@@ -27,6 +27,7 @@ internal class TracerValues
             { "DD_DOTNET_TRACER_HOME", TracerHomeDirectory },
             { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
+            { "DD_INJECTION_ENABLED", "tracer" },
             { Defaults.InstrumentationInstallTypeKey, Defaults.InstrumentationInstallTypeValue },
         });
         FilesToAddToGac =


### PR DESCRIPTION
## Summary of changes

- Set `DD_INJECTION_ENABLED=tracer` when doing IIS-only SSI
- Minor cleanup

## Reason for change

This is still _technically_ SSI, so we should probably treat it as such.

## Implementation details

- Add the variable to the list of values we install
- Some minor refactoring

## Test coverage

Meh

## Other details

Stacked on: 
- https://github.com/DataDog/dd-trace-dotnet/pull/7063


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
