### PR TITLE
Try to fallback to adding registry keys if IIS installation fails

### DIFF
--- a/tracer/src/Datadog.FleetInstaller/Commands/AvailableCommandsCommand.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/AvailableCommandsCommand.cs
@@ -1,0 +1,80 @@
+// <copyright file="AvailableCommandsCommand.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Datadog.FleetInstaller.Commands;
+
+/// <summary>
+/// Installs a new version of the .NET Tracer. Could be the first version, or simply a new version
+/// </summary>
+internal class AvailableCommandsCommand : CommandBase
+{
+    private const string Command = "available-commands";
+    private const string CommandDescription = "Prints the list of available commands in this version of the .NET Fleet Installer to stdout";
+    private readonly Command _rootCommand;
+
+    public AvailableCommandsCommand(Command rootCommand)
+        : base(Command, CommandDescription)
+    {
+        _rootCommand = rootCommand;
+        this.SetHandler(ExecuteAsync);
+    }
+
+    public Task ExecuteAsync(InvocationContext context)
+    {
+        // We write directly to stdout, instead of the logger
+
+        var result = Execute(Console.Out, _rootCommand);
+
+        context.ExitCode = (int)result;
+        return Task.CompletedTask;
+    }
+
+    // Internal for testing
+#pragma warning disable SA1005 // Comment must not begin with a space (required for lang injection)
+    internal static ReturnCode Execute(TextWriter writer, Command rootCommand)
+    {
+        //language=JSON
+        var json = $$"""
+                     {
+                       "commands": [
+                         {{string.Join(",\n    ", GetCommandsJson(rootCommand))}}
+                       ]
+                     }
+                     """;
+
+        writer.WriteLine(json);
+        return ReturnCode.Success;
+
+        static IEnumerable<string> GetCommandsJson(Command rootCommand)
+        {
+            foreach (var command in rootCommand.Subcommands)
+            {
+                if (command.IsHidden)
+                {
+                    continue;
+                }
+
+                //language=JSON
+                yield return $$"""{ "name": "{{command.Name}}", "options": [{{string.Join(", ", GetOptionsJson(command))}}] }""";
+            }
+        }
+
+        static IEnumerable<string> GetOptionsJson(Command command)
+        {
+            foreach (var option in command.Options)
+            {
+                //language=JSON
+                yield return $$"""{ "name": "{{option.Name}}"}""";
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.FleetInstaller/Commands/CommandBase.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/CommandBase.cs
@@ -20,7 +20,7 @@ internal abstract class CommandBase : Command
     {
     }
 
-    protected bool IsValidEnvironment(CommandResult commandResult)
+    protected static bool IsValidEnvironment(CommandResult commandResult)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -39,7 +39,7 @@ internal abstract class CommandBase : Command
         return true;
     }
 
-    protected bool HasValidIIsVersion(ILogger commandResult, [NotNullWhen(false)] out string? errorMessage)
+    protected static bool HasValidIIsVersion([NotNullWhen(false)] out string? errorMessage)
     {
         if (!RegistryHelper.TryGetIisVersion(Log.Instance, out var version))
         {

--- a/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
@@ -106,7 +106,7 @@ internal class EnableIisInstrumentationCommand : CommandBase
         }
 
         // We can't enable iis instrumentation if IIS is not available or is to low a version
-        if (!HasValidIIsVersion(Log.Instance, out var errorMessage))
+        if (!HasValidIIsVersion(out var errorMessage))
         {
             commandResult.ErrorMessage = errorMessage;
             return;

--- a/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/EnableIisInstrumentationCommand.cs
@@ -39,18 +39,14 @@ internal class EnableIisInstrumentationCommand : CommandBase
         var tracerValues = new TracerValues(versionedPath);
         var log = Log.Instance;
 
-        var result = Execute(log, tracerValues, Defaults.TracerLogDirectory, Defaults.CrashTrackingRegistryKey);
+        var result = Execute(log, tracerValues);
 
         context.ExitCode = (int)result;
         return Task.CompletedTask;
     }
 
     // Internal for testing
-    internal static ReturnCode Execute(
-        ILogger log,
-        TracerValues tracerValues,
-        string tracerLogDirectory,
-        string registryKeyName)
+    internal static ReturnCode Execute(ILogger log, TracerValues tracerValues)
     {
         log.WriteInfo("Enabling IIS instrumentation for .NET tracer");
 

--- a/tracer/src/Datadog.FleetInstaller/Commands/RemoveIisInstrumentation.cs
+++ b/tracer/src/Datadog.FleetInstaller/Commands/RemoveIisInstrumentation.cs
@@ -36,11 +36,11 @@ internal class RemoveIisInstrumentation : CommandBase
     }
 
     // Internal for testing
-    internal ReturnCode Execute(ILogger log)
+    internal static ReturnCode Execute(ILogger log)
     {
         log.WriteInfo("Removing IIS instrumentation for .NET tracer");
 
-        if (!HasValidIIsVersion(log, out var errorMessage))
+        if (!HasValidIIsVersion(out var errorMessage))
         {
             // IIS isn't available, weird because it means they removed it _after_ successfully installing the product
             // but whatever, there's no variables there if that's the case!

--- a/tracer/src/Datadog.FleetInstaller/Defaults.cs
+++ b/tracer/src/Datadog.FleetInstaller/Defaults.cs
@@ -11,6 +11,8 @@ namespace Datadog.FleetInstaller;
 internal class Defaults
 {
     public const string CrashTrackingRegistryKey = @"Software\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules";
+    public const string IisW3SvcRegistryKey = @"System\CurrentControlSet\Services\W3SVC";
+    public const string IisWasRegistryKey = @"System\CurrentControlSet\Services\WAS";
     public const string InstrumentationInstallTypeKey = "DD_INSTRUMENTATION_INSTALL_TYPE";
     public const string InstrumentationInstallTypeValue = "windows_fleet_installer";
 

--- a/tracer/src/Datadog.FleetInstaller/Program.cs
+++ b/tracer/src/Datadog.FleetInstaller/Program.cs
@@ -21,6 +21,7 @@ var rootCommand = new CommandWithExamples(CommandWithExamples.Command);
 
 var builder = new CommandLineBuilder(rootCommand)
     .UseHelp()
+    .UseVersionOption()
     .UseCustomErrorReporting()
     .CancelOnProcessTermination();
 

--- a/tracer/src/Datadog.FleetInstaller/Program.cs
+++ b/tracer/src/Datadog.FleetInstaller/Program.cs
@@ -37,11 +37,15 @@ rootCommand.AddExample("""
 rootCommand.AddExample("""
                        remove-iis-instrumentation"
                        """);
+rootCommand.AddExample("""
+                       available-commands"
+                       """);
 
 rootCommand.AddCommand(new InstallVersionCommand());
 rootCommand.AddCommand(new UninstallVersionCommand());
 rootCommand.AddCommand(new EnableIisInstrumentationCommand());
 rootCommand.AddCommand(new RemoveIisInstrumentation());
+rootCommand.AddCommand(new AvailableCommandsCommand(rootCommand));
 
 return builder.Build().Invoke(args);
 

--- a/tracer/src/Datadog.FleetInstaller/Program.cs
+++ b/tracer/src/Datadog.FleetInstaller/Program.cs
@@ -17,7 +17,7 @@ using Datadog.FleetInstaller.Commands;
 // args = ["uninstall-product"];
 // args = [];
 
-var rootCommand = new CommandWithExamples(CommandWithExamples.Command);
+var rootCommand = new CommandWithExamples(CommandWithExamples.Command, "Windows SSI fleet-installer command line tool");
 
 var builder = new CommandLineBuilder(rootCommand)
     .UseHelp()

--- a/tracer/src/Datadog.FleetInstaller/RegistryHelper.cs
+++ b/tracer/src/Datadog.FleetInstaller/RegistryHelper.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.Win32;
 
 namespace Datadog.FleetInstaller;
@@ -12,56 +13,10 @@ namespace Datadog.FleetInstaller;
 internal class RegistryHelper
 {
     public static bool AddCrashTrackingKey(ILogger log, TracerValues values, string registryKeyName)
-    {
-        var crashHandlerPath = values.NativeLoaderX64Path;
-        log.WriteInfo($"Adding crash tracking key to registry: '{registryKeyName}'");
-
-        try
-        {
-            var key = Registry.LocalMachine.OpenSubKey(registryKeyName, writable: true);
-            if (key is null)
-            {
-                log.WriteInfo($"Creating registry subkey: '{registryKeyName}'");
-
-                key = Registry.LocalMachine.CreateSubKey(registryKeyName, writable: true);
-                if (key is null)
-                {
-                    log.WriteError($"Registry key '{registryKeyName}' could not be created ");
-                    return false;
-                }
-            }
-
-            // This overwrites the key if it is already there
-            key.SetValue(crashHandlerPath, value: 1, RegistryValueKind.DWord);
-            log.WriteInfo($"Crash tracking handler path '{crashHandlerPath}' added to '{registryKeyName}'");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            log.WriteError(ex, $"Failed to add crash tracking handler to registry key '{registryKeyName}'");
-            return false;
-        }
-    }
+        => AddOrUpdateValueForRegistryKey(log, registryKeyName, values.NativeLoaderX64Path, 1, RegistryValueKind.DWord, "crash tracking handler");
 
     public static bool RemoveCrashTrackingKey(ILogger log, TracerValues values, string registryKeyName)
-    {
-        var crashHandlerPath = values.NativeLoaderX64Path;
-        log.WriteInfo($"Removing crash tracking key from registry: '{registryKeyName}'");
-
-        try
-        {
-            var key = Registry.LocalMachine.OpenSubKey(registryKeyName, writable: true);
-            key?.DeleteValue(crashHandlerPath, throwOnMissingValue: false);
-            log.WriteInfo($"Crash tracking handler path '{crashHandlerPath}' removed from '{registryKeyName}'");
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            log.WriteError(ex, $"Failed to remove crash tracking handler from registry key '{registryKeyName}'");
-            return false;
-        }
-    }
+        => RemoveValueForRegistryKey(log, registryKeyName, values.NativeLoaderX64Path, "crash tracking handler");
 
     public static bool TryGetIisVersion(ILogger log, [NotNullWhen(true)] out Version? version)
     {
@@ -91,6 +46,101 @@ internal class RegistryHelper
         {
             log.WriteError(ex, $"Error reading the IIS Version from the registry key '{registryKeyName}'");
             version = null;
+            return false;
+        }
+    }
+
+    public static bool SetIisRegistrySettings(ILogger log, TracerValues values, string w3SvcKey, string wasKey)
+    {
+        var keyValues = values.RequiredEnvVariables.Select(kvp => kvp + "=" + kvp.Value).ToArray();
+        if (!SetIisRegistrySettings(log, w3SvcKey, keyValues))
+        {
+            return false;
+        }
+
+        if (SetIisRegistrySettings(log, wasKey, keyValues))
+        {
+            return true;
+        }
+
+        // we assume we _didn't_ set the key for WAS seeing as that stage failed
+        log.WriteError($"Rolling back IIS registry settings for {w3SvcKey}");
+        RemoveIisRegistrySettings(log, w3SvcKey);
+        return false;
+    }
+
+    public static bool RemoveIisRegistrySettings(ILogger log, string w3SvcKey, string wasKey)
+    {
+        // Always try to remove both keys, even if one fails
+        var success1 = RemoveIisRegistrySettings(log, w3SvcKey);
+        var success2 = RemoveIisRegistrySettings(log, wasKey);
+        return success1 && success2;
+    }
+
+    private static bool SetIisRegistrySettings(ILogger log, string registryKeyName, string[] keyValues)
+        => AddOrUpdateValueForRegistryKey(
+            log,
+            registryKeyName,
+            valueName: "Environment",
+            keyValues,
+            RegistryValueKind.MultiString,
+            "IIS fallback variables");
+
+    private static bool RemoveIisRegistrySettings(ILogger log, string registryKeyName)
+        => RemoveValueForRegistryKey(log, registryKeyName, valueName: "Environment", "IIS fallback variables");
+
+    private static bool AddOrUpdateValueForRegistryKey(
+        ILogger log,
+        string registryKeyName,
+        string valueName,
+        object valueValue,
+        RegistryValueKind valueKind,
+        string description)
+    {
+        log.WriteInfo($"Adding {description} key to registry: '{registryKeyName}'");
+
+        try
+        {
+            var key = Registry.LocalMachine.OpenSubKey(registryKeyName, writable: true);
+            if (key is null)
+            {
+                log.WriteInfo($"Creating registry subkey: '{registryKeyName}'");
+
+                key = Registry.LocalMachine.CreateSubKey(registryKeyName, writable: true);
+                if (key is null)
+                {
+                    log.WriteError($"Registry key '{registryKeyName}' could not be created ");
+                    return false;
+                }
+            }
+
+            // This overwrites the key if it is already there
+            key.SetValue(valueName, value: valueValue, valueKind);
+            log.WriteInfo($"'{valueName}' added to {description} key '{registryKeyName}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.WriteError(ex, $"Failed to add {description} to registry key '{registryKeyName}'");
+            return false;
+        }
+    }
+
+    private static bool RemoveValueForRegistryKey(ILogger log, string registryKeyName, string valueName, string description)
+    {
+        log.WriteInfo($"Removing {description} from registry: '{registryKeyName}'");
+
+        try
+        {
+            var key = Registry.LocalMachine.OpenSubKey(registryKeyName, writable: true);
+            key?.DeleteValue(valueName, throwOnMissingValue: false);
+            log.WriteInfo($"Value '{valueName}' for {description} removed from '{registryKeyName}'");
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.WriteError(ex, $"Failed to remove {description} from registry key '{registryKeyName}'");
             return false;
         }
     }

--- a/tracer/src/Datadog.FleetInstaller/ReturnCode.cs
+++ b/tracer/src/Datadog.FleetInstaller/ReturnCode.cs
@@ -18,4 +18,6 @@ internal enum ReturnCode
     ErrorRemovingAppPoolVariables,
     ErrorRemovingCrashTrackerKey,
     ErrorReadingIisConfiguration,
+    ErrorSettingIisFallbackVariables,
+    ErrorRemovingIisFallbackVariables,
 }

--- a/tracer/src/Datadog.FleetInstaller/TracerValues.cs
+++ b/tracer/src/Datadog.FleetInstaller/TracerValues.cs
@@ -27,6 +27,7 @@ internal class TracerValues
             { "DD_DOTNET_TRACER_HOME", TracerHomeDirectory },
             { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
+            { "DD_TRACING_ENABLED", "tracing" },
             { Defaults.InstrumentationInstallTypeKey, Defaults.InstrumentationInstallTypeValue },
         });
         FilesToAddToGac =

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/RegistryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/RegistryHelperTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Datadog.FleetInstaller;
 using FluentAssertions;
 using Microsoft.Win32;
@@ -16,6 +17,7 @@ namespace Datadog.Trace.IntegrationTests.FleetInstaller;
 
 public class RegistryHelperTests(ITestOutputHelper output) : FleetInstallerTestsBase(output)
 {
+    private const string IisRegKeyValueName = "Environment";
     private readonly List<string> _keysToDelete = [];
 
     public override void Dispose()
@@ -194,6 +196,159 @@ public class RegistryHelperTests(ITestOutputHelper output) : FleetInstallerTests
 
         // Needs to be run on a machine that has IIS installed
         RegistryHelper.TryGetIisVersion(Log, out var version).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public void SetIisRegistrySettings_AddsKeyIfItDoesntExist()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key1 = GetRegistryKey();
+        var key2 = GetRegistryKey();
+
+        RegistryHelper.SetIisRegistrySettings(Log, values, key1, key2)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key is there with expected value
+        var expected = values.RequiredEnvVariables.Select(kvp => kvp + "=" + kvp.Value).ToArray();
+        expected.Should().HaveSameCount(values.RequiredEnvVariables);
+        VerifyIisRegKey(key1, expected);
+        VerifyIisRegKey(key2, expected);
+    }
+
+    [SkippableFact]
+    public void SetIisRegistrySettings_AddsKeyIfItAlreadyExists()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key1 = GetRegistryKey();
+        var key2 = GetRegistryKey();
+        Registry.LocalMachine.CreateSubKey(key1).Should().NotBeNull();
+        Registry.LocalMachine.CreateSubKey(key2).Should().NotBeNull();
+
+        RegistryHelper.SetIisRegistrySettings(Log, values, key1, key2)
+                      .Should()
+                      .BeTrue();
+
+        var expected = values.RequiredEnvVariables.Select(kvp => kvp + "=" + kvp.Value).ToArray();
+        expected.Should().HaveSameCount(values.RequiredEnvVariables);
+        VerifyIisRegKey(key1, expected);
+        VerifyIisRegKey(key2, expected);
+    }
+
+    [SkippableFact]
+    public void SetIisRegistrySettings_OverwritesExistingValueIfSet()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var home = CreateMonitoringHomeCopy();
+        var values = new TracerValues(home);
+        var key1 = GetRegistryKey();
+        var key2 = GetRegistryKey();
+
+        // First key with the "wrong" value
+        var regKey1 = Registry.LocalMachine.CreateSubKey(key1);
+        regKey1.Should().NotBeNull();
+        regKey1!.SetValue(IisRegKeyValueName, 0, RegistryValueKind.DWord);
+
+        // This one has a different wrong value
+        var regKey2 = Registry.LocalMachine.CreateSubKey(key2);
+        regKey2.Should().NotBeNull();
+        regKey2!.SetValue(IisRegKeyValueName, "Blah=Blip", RegistryValueKind.String);
+
+        RegistryHelper.SetIisRegistrySettings(Log, values, key1, key2)
+                      .Should()
+                      .BeTrue();
+
+        var expected = values.RequiredEnvVariables.Select(kvp => kvp + "=" + kvp.Value).ToArray();
+        expected.Should().HaveSameCount(values.RequiredEnvVariables);
+        VerifyIisRegKey(key1, expected);
+        VerifyIisRegKey(key2, expected);
+    }
+
+    [SkippableFact]
+    public void RemoveIisRegistrySettings_RemovesValueIfSet()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var key1 = GetRegistryKey();
+        var key2 = GetRegistryKey();
+
+        // Add keys with real values for now
+        var regKey1 = Registry.LocalMachine.CreateSubKey(key1);
+        regKey1!.SetValue(IisRegKeyValueName, new[] { "Blah=blip", "Bleep=bloop" }, RegistryValueKind.MultiString);
+        var regKey2 = Registry.LocalMachine.CreateSubKey(key2);
+        regKey2!.SetValue(IisRegKeyValueName, new[] { "Blah=blip", "Bleep=bloop" }, RegistryValueKind.MultiString);
+
+        RegistryHelper.RemoveIisRegistrySettings(Log, key1, key2)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key value is no longer there
+        Registry.LocalMachine.OpenSubKey(key1)?.GetValue(IisRegKeyValueName).Should().BeNull();
+        Registry.LocalMachine.OpenSubKey(key2)?.GetValue(IisRegKeyValueName).Should().BeNull();
+    }
+
+    [SkippableFact]
+    public void RemoveIisRegistrySettings_ReturnsTrueIfKeyDoesntExist()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var key1 = GetRegistryKey();
+        var key2 = GetRegistryKey();
+
+        // Add keys with real values for now
+        Registry.LocalMachine.CreateSubKey(key1).Should().NotBeNull();
+        Registry.LocalMachine.CreateSubKey(key2).Should().NotBeNull();
+
+        RegistryHelper.RemoveIisRegistrySettings(Log, key1, key2)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key value is no longer there
+        Registry.LocalMachine.OpenSubKey(key1)?.GetValue(IisRegKeyValueName).Should().BeNull();
+        Registry.LocalMachine.OpenSubKey(key2)?.GetValue(IisRegKeyValueName).Should().BeNull();
+    }
+
+    [SkippableFact]
+    public void RemoveIisRegistrySettings_ReturnsTrueIfKeyIsNotThere()
+    {
+        // We skip the test if we don't have permissions
+        Skip.IfNot(IsRunningAsAdministrator);
+
+        var key1 = GetRegistryKey();
+        var key2 = GetRegistryKey();
+
+        // Keys should not exist
+        Registry.LocalMachine.OpenSubKey(key1).Should().BeNull();
+        Registry.LocalMachine.OpenSubKey(key2).Should().BeNull();
+
+        RegistryHelper.RemoveIisRegistrySettings(Log, key1, key2)
+                      .Should()
+                      .BeTrue();
+
+        // verify the key value is no longer there
+        Registry.LocalMachine.OpenSubKey(key1)?.GetValue(IisRegKeyValueName).Should().BeNull();
+        Registry.LocalMachine.OpenSubKey(key2)?.GetValue(IisRegKeyValueName).Should().BeNull();
+    }
+
+    private static void VerifyIisRegKey(string key1, string[] expected)
+    {
+        Registry.LocalMachine.OpenSubKey(key1)
+               ?.GetValue(IisRegKeyValueName)
+                .Should()
+                .BeOfType<string[]>()
+                .Which.Should().BeEquivalentTo(expected);
     }
 
     private string GetRegistryKey()


### PR DESCRIPTION
## Summary of changes

If a server doesn't have IIS installed (or doesn't have a sufficiently high version) then set the keys in the registry instead

## Reason for change

Currently, if customers try to enable the IIS instrumentation on servers which do _not_ have IIS, then the installation fails. This is problematic for some customers, as it means they need to tailor their installation script based on the features enabled on the host. As a result, we now want to _not_ fail the installation in this scenario. 

Coupled to this, if we _don't_ fail the installation, then we have an issue where if a customer _subsequently_ installs IIS they wouldn't get tracing, which may be surprising. 

As a workaround for the second point, when our "standard" IIS installation fails, we install all our variables into the same W3SVC and WAS registry keys that we use with the MSI.

## Implementation details

For install:
- Don't check `HasValidIIsVersion()` in the initial validation (this would previously immediately fail)
- Instead, check it as part of the standard installation
  - If `true`, run the same steps as before
  - If `false`, run the "fallback" path
    - This sets [the same registry keys](https://github.com/DataDog/dd-trace-dotnet/blob/master/shared/src/msi-installer/shared/EnvironmentVariables.wxs#L30-L44) that we set in the MSI
    - I set _all_ the keys in here. The MSI assumes we set some globally, and some locally for IIS, but for this "IIS only" install, we don't set the values globally, so this seemed simpler

For uninstall:
- If `HasValidIIsVersion()` is true, run the same steps as before
- If `false`, run the "fallback" path, and remove the registry keys if set

Additionally:
- Refactored the `RegistryHelper` slightly to reuse the "set value" and "remove value" code


## Test coverage

Added some additional tests for the `RegistryHelper`. 

Will run a manual test for the specific behaviour of IIS not-installed and then subsequently installed. I think it's probably too much of a PITA to have end-to-end/smoke tests for that scenario ATM. 

## Other details

Note that if a "real" error occurs, we still return an error . This is specifically about handling the case where IIS is not available.

One aspect not yet handled is:
- IIS not installed - so we add the reg keys
- They install IIS
- tracer updated, IIS is available, so we add the app host values
- Uninstall - as IIS is available, we remove the app host values
  - The fallback keys are left there

We could remove them _either_ on install or uninstall. Will discuss and update the PR as appropriate

Stacked on: 
- https://github.com/DataDog/dd-trace-dotnet/pull/7063
- https://github.com/DataDog/dd-trace-dotnet/pull/7068

