### PR TITLE
test(trace-exporter): enable UDS transport test for .NET Core 3.1 or greater

### DIFF
--- a/tracer/test/Datadog.Trace.IntegrationTests/LibDatadog/TraceExporterTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/LibDatadog/TraceExporterTests.cs
@@ -21,7 +21,9 @@ public class TraceExporterTests
 {
     [SkippableTheory]
     [InlineData(TestTransports.Tcp)]
+#if NETCOREAPP3_1_OR_GREATER
     [InlineData(TestTransports.Uds)]
+#endif
     [InlineData(TestTransports.WindowsNamedPipe)]
     public async Task SendsTracesUsingDataPipeline(TestTransports transport)
     {


### PR DESCRIPTION
## Summary of changes

Run UDS tests for  .NET Core 3.1 or greater

## Reason for change

Because the test agent only supports UDS for .NET Core 3.1 or greater

https://github.com/DataDog/dd-trace-dotnet/blob/6f49ec92450f4ff977854d9b9904fbe612a19e79/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs#L117

## Implementation details

Wrapped UDS test under `#if NETCOREAPP3_1_OR_GREATER` preprocessor.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
