### PR TITLE
Allow unsigned commits from specific workflows

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -2,3 +2,11 @@
 schema-version: v1
 kind: mergequeue
 enable: false
+---
+schema-version: v1
+kind: mergegate
+rules:
+  - require: commit-signatures
+    excluded_emails:
+      - '49699333+dependabot[bot]@users.noreply.github.com' # dependabot
+      - '41898282+github-actions[bot]@users.noreply.github.com' # version-bump bots


### PR DESCRIPTION
## Summary of changes

Allow unsigned commits from our dependabot and version-bump bots

## Reason for change

Unsigned commits are going to be blocked soon

## Implementation details

Follow [the instructions](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5105058311/Commit+Signing+Enforcement+FAQ#I-have-bots-that-are-not-signing-commits-yet%2C-will-this-block-merges%3F)

## Test coverage

I guess we'll find out if it works soon 🤷‍♂️ 

## Other details

I updated the admin settings already