### PR TITLE
Fix the system-tests parametric tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4627,6 +4627,20 @@ stages:
           artifact: system-test-docker-images
           path: $(Build.SourcesDirectory)
 
+      - template: steps/download-artifact.yml
+        parameters:
+          artifact: linux-packages-linux-x64
+          patterns: '**/*tar.gz'
+          path: $(Build.ArtifactStagingDirectory)
+          condition: eq(variables['SCENARIO'], 'PARAMETRIC')
+
+      - script: |
+          PACKAGE_NAME=$(basename $(Build.ArtifactStagingDirectory)/datadog-dotnet-apm-*.tar.gz)
+          echo Moving $PACKAGE_NAME to system-tests/binaries
+          mv $(Build.ArtifactStagingDirectory)/$PACKAGE_NAME system-tests/binaries/
+        displayName: Move dotnet binary to system test folder
+        condition: eq(variables['SCENARIO'], 'PARAMETRIC')
+
       - script: |
           echo "Loading images for variant: $(WEBLOG_VARIANT)"
           docker load -i "$(Build.SourcesDirectory)/$(WEBLOG_VARIANT).tar"


### PR DESCRIPTION
## Summary of changes

Fix the fact we're not running the parametric tests against the code in the branch

## Reason for change

For ~6 months, we've not been running the parametric tests against the code in the branch, we've been running it against the latest release 🙈 

## Implementation details

Download the artifact again in the parametric test stages. It's not required by the other scenarios, because they use the weblog, which already bakes it in. The parametric tests are different and don't use the weblog

## Test coverage

Ran a test [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=179057&view=logs&j=fa40fe21-a6c3-5cd1-322e-e17d6fd01752&t=9efec318-bc59-5db9-db95-e03f15f49cd3), and confirmed it's using the 3.19.0 version (instead of 3.18.0, the current release) which is what it was using before
