### PR TITLE
[Exception Replay] Groundwork to support Test Optimization

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplaySettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplaySettings.cs
@@ -41,8 +41,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
             var seconds = config
                          .WithKeys(ConfigurationKeys.Debugger.RateLimitSeconds)
-                         .AsInt32(DefaultRateLimitSeconds, x => x > 0)
-                         .Value;
+                         .AsInt32(DefaultRateLimitSeconds);
 
             RateLimit = TimeSpan.FromSeconds(seconds);
 

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -46,6 +46,8 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         private static Task? _exceptionProcessorTask;
         private static bool _isInitialized;
 
+        internal static event Action<ExceptionIdentifier>? ExceptionCaseInstrumented;
+
         internal static bool IsEditAndContinueFeatureEnabled { get; private set; }
 
         private static async Task StartExceptionProcessingAsync(CancellationToken cancellationToken)
@@ -484,6 +486,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             {
                 Log.Information("New exception case occurred, initiating data collection for exception: {Name}, Message: {Message}, StackTrace: {StackTrace}", exception.GetType().Name, exception.Message, exception.StackTrace);
                 trackedExceptionCase.Instrument();
+                ExceptionCaseInstrumented?.Invoke(trackedExceptionCase.ExceptionIdentifier);
 
                 if (rootSpan != null)
                 {

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedExceptionCase.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedExceptionCase.cs
@@ -91,6 +91,12 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
         public bool Revert(int normalizedExceptionHash)
         {
+            if (ExceptionDebugging.Settings.RateLimit.TotalMilliseconds == 0)
+            {
+                // No rate limit, avoid reverting
+                return false;
+            }
+
             if (BeginTeardown())
             {
                 NormalizedExceptionHash = normalizedExceptionHash;


### PR DESCRIPTION
## Summary of changes
CI Test Optimization starts to utilize Exception Replay to capture debug information for failing tests. If a test fails in CI, the test will run multiple times - with Exception Replay enabled - and that will surface the variable values of the methods participating in the stack trace of the exception that has failed the test. This is only true for tests that fail due to _exception_ and not logical failures. 

## Reason for change
Added a few helpers for Test Optimization to use Exception Replay optimally:
1. Avoid reverting exception cases. Exception Replay by default captures only 1 occurrence of an exception and then avoid capturing it for certain amount of time. For Test Optimization we want to capture several occurrences at the same time. Rate limit is now able to be 0 - meaning, skip reverting & re-instrumenting.
2. Test Optimization needs to be notified when Exception Replay started to track an exception - meaning, instrumentation is underway and capturing is possible - so it will trigger the failing test repeatedly.