### PR TITLE
Fix error in DefaultModelBindingContext

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -429,7 +429,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BindingSource.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BindingSourceValueProvider.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/CompositeValueProvider.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/DefaultModelBindingContext.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/DefaultModelBindingContext_SetResult_Integration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/ModelBindingResult.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/MvcOptionsIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/AwsConstants.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/DefaultModelBindingContext_SetResult_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/DefaultModelBindingContext_SetResult_Integration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore
         /// </summary>
         private const string IntegrationName = nameof(IntegrationId.AspNetCore);
 
-        internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, System.Exception exception, in CallTargetState state)
+        internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, System.Exception? exception, in CallTargetState state)
         {
             var iast = Iast.Iast.Instance;
             var security = Security.Instance;


### PR DESCRIPTION
## Summary of changes

We are getting[ the following error](https://app.datadoghq.com/error-tracking?query=source%3Adotnet%20%40tracer_version%3A3.18%2A%20%2Anullreference%2A&et-side=activity&et-viz=events&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22404d80aa-3ade-11f0-814f-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%2C%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZdZDkv6Vo1koAAAABhBWmRaRGt2NkFBRDI1eDA0ekNfa0gxR0YAAAAkMDE5NzU5MTEtMmJkMy00N2RmLTkwNWQtNDhiZWZhMWQ2NGJiAAMAOQ%22%7D%2C%22i%22%3A%22error-tracking-error-event%22%7D%5D&view=spans&from_ts=1748943512401&to_ts=1749548312401&live=true):
```

Error : Exception occurred when calling the CallTarget integration continuation.
System.NullReferenceException
at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.DefaultModelBindingContext_SetResult_Integration.OnMethodEnd[TTarget](TTarget instance, Exception exception, CallTargetState& state)
at Microsoft.AspNetCore.Mvc.ModelBinding.DefaultModelBindingContext.set_Result(ModelBindingResult value)
```

While it's not clear in what exact part of the method the exception is thrown, this line could potentially throw it:

`var span = (state.Scope ?? state.PreviousScope).Span;`

Enabling nullable_enable, fixing the possible null references highlighted and checking for null spans could probably solve the issue. Anyway, it's a code improvement that will not harm.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
