### PR TITLE
Fix Exception in AspNetMvcIntegration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         resourceName = httpContext.Items[SharedItems.HttpContextPropagatedResourceNameKey] as string;
                     }
 
-                    if (route == null && routeData?.Route.GetType().FullName == RouteCollectionRouteTypeName)
+                    if (route == null && routeData?.Route?.GetType().FullName == RouteCollectionRouteTypeName)
                     {
                         var routeMatches = routeValues?.GetValueOrDefault("MS_DirectRouteMatches") as List<RouteData>;
 


### PR DESCRIPTION
## Summary of changes

We are getting [the following ](https://app.datadoghq.com/error-tracking?query=source%3Adotnet%20%40tracer_version%3A3.18%2A%20%2Anullreference%2A&et-side=activity&et-viz=events&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22d3511666-3ae6-11f0-9092-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%2C%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZdZJLaQlqs2SAAAABhBWmRaSkxhUUFBQ0g1WklFZkUtNGphRFkAAAAkMDE5NzU5MmEtODQ1NS00NjU5LWI3NjMtOTdlZmRmNDg4NjdmAAJinQ%22%7D%2C%22i%22%3A%22error-tracking-error-event%22%7D%5D&view=spans&from_ts=1748943512401&to_ts=1749548312401&live=true)exception:

```
System.NullReferenceException
at System.Object.GetType()
at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet.AspNetMvcIntegration.CreateScope(ControllerContextStruct controllerContext)
```

In this method, this is the only call to GetType():
`if (route == null && routeData?.Route.GetType().FullName == RouteCollectionRouteTypeName)`

It seems to be the source of the exception.

it's interesting to note that previously it's defined:
`Route route = routeData?.Route as Route;`

Still, route could be null and not routeData?.Route if routeData?.Route is not a Route but, for instance, this:
`RouteCollectionRoute : RouteBase, IReadOnlyCollection<RouteBase>`

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
