### PR TITLE
[AAP] Reduce waf config diagnostics log levels

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -143,7 +143,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
 
                             if (!_wafLibraryInvoker.BuilderRemoveConfig(wafBuilderHandle, path))
                             {
-                                Log.Error("DDAS-0005-00: WAF builder: Config failed to be removed : {0}", path); // Check were all these error codes are defined
+                                Log.Debug("WAF builder: Config failed to be removed : {0}", path); // Check were all these error codes are defined
                             }
                         }
                     }
@@ -160,7 +160,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                                 var path = config.Key;
                                 if (!_wafLibraryInvoker.BuilderAddOrUpdateConfig(wafBuilderHandle, path, ref configObj, ref diagnostics))
                                 {
-                                    Log.Error("DDAS-0005-00: WAF builder: Config failed to load : {0}", path); // Check were all these error codes are defined
+                                    Log.Debug("WAF builder: Config failed to load : {0}", path); // Check were all these error codes are defined
                                 }
                             }
                         }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -191,7 +191,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
 
                 if (diags.HasErrors)
                 {
-                    // This message should go to telemetry logs only, skipping the regular logs
+                    // TODO: This message should go to telemetry logs only, skipping the regular logs
                     Log.Debug("Some errors were found while applying waf configuration (RulesFile: {RulesFile})", rulesFile);
                 }
                 else

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -214,7 +214,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                             var message = $"{item.Key}: [{string.Join(", ", item.Value)}]";
                             if (isError)
                             {
-                                // This message should go to telemetry logs only, skipping the regular logs
+                                // TODO: This message should go to telemetry logs only, skipping the regular logs
                                 Log.Debug("rc::asm_dd::diagnostic Error: {Err}", message);
                             }
                             else

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResultUtils.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResultUtils.cs
@@ -125,6 +125,8 @@ internal struct ReportedDiagnostics
     {
         Rules.Errors = errors;
     }
+
+    public bool HasErrors => Rules.Errors is { Count: > 0 } || Rest.Errors is { Count: > 0 };
 }
 
 internal struct WafStats


### PR DESCRIPTION
## Summary of changes
Waf config diagnostics log levels were being logged as Warnings, but should be Debug level

## Reason for change
Specified in this [RFC](https://docs.google.com/document/d/1t6U7WXko_QChhoNIApn0-CRNe6SAKuiiAQIyCRPUXP4/edit?tab=t.0)

> Note that aside from through telemetry logs, none of the diagnostics presented here should be logged to a regular logger using a level above debug, as it will inevitably result in customer complaints.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
