### PR TITLE
[AAP][ApiSec] Add response body parse switch in API Security

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -138,6 +138,11 @@ internal static class SecurityCoordinatorHelpers
 
     internal static object? CheckBody(this Security security, HttpContext context, Span span, object body, bool response)
     {
+        if (response && !security.Settings.ApiSecurityParseResponseBody)
+        {
+            return null;
+        }
+
         var transport = new SecurityCoordinator.HttpTransport(context);
         if (!transport.IsBlocked)
         {

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -138,6 +138,10 @@ namespace Datadog.Trace.AppSec
                                            .AsInt32(300, val => val >= 0)
                                            .Value;
 
+            ApiSecurityParseResponseBody = config
+                                .WithKeys(ConfigurationKeys.AppSec.ApiSecurityParseResponseBody)
+                                .AsBool(true);
+
             UseUnsafeEncoder = config.WithKeys(ConfigurationKeys.AppSec.UseUnsafeEncoder)
                                      .AsBool(false);
 
@@ -275,6 +279,8 @@ namespace Datadog.Trace.AppSec
         public bool? ScaEnabled { get; }
 
         public bool NoCustomLocalRules { get; }
+
+        public bool ApiSecurityParseResponseBody { get; }
 
         public static SecuritySettings FromDefaultSources()
         {

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -132,6 +132,11 @@ namespace Datadog.Trace.Configuration
             internal const string ApiSecurityEndpointCollectionMessageLimit = "DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT";
 
             /// <summary>
+            /// Enables the parsing of the response body in the API Security module. Defaults to true
+            /// </summary>
+            internal const string ApiSecurityParseResponseBody = "DD_API_SECURITY_PARSE_RESPONSE_BODY";
+
+            /// <summary>
             /// Use new unsafe encoder for the waf
             /// </summary>
             internal const string UseUnsafeEncoder = "DD_EXPERIMENTAL_APPSEC_USE_UNSAFE_ENCODER";

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5ApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5ApiSecurity.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +20,7 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity
     public class AspNetCore5ApiSecurityEnabled : AspNetCoreApiSecurity
     {
         public AspNetCore5ApiSecurityEnabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base(fixture, outputHelper, true, "AspNetCore5")
+            : base(fixture, outputHelper, true, true, sampleName: "AspNetCore5")
         {
         }
     }
@@ -27,7 +28,15 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity
     public class AspNetCore5ApiSecurityDisabled : AspNetCoreApiSecurity
     {
         public AspNetCore5ApiSecurityDisabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base(fixture, outputHelper, false, sampleName: "AspNetCore5")
+            : base(fixture, outputHelper, false, true, sampleName: "AspNetCore5")
+        {
+        }
+    }
+
+    public class AspNetCore5ApiSecurityParseResponseBodyDisabled : AspNetCoreApiSecurity
+    {
+        public AspNetCore5ApiSecurityParseResponseBodyDisabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+            : base(fixture, outputHelper, true, false, "AspNetCore5")
         {
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
@@ -22,8 +22,8 @@ public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCo
 {
     private readonly AspNetCoreTestFixture _fixture;
 
-    protected AspNetCoreApiSecurity(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableApiSecurity, string sampleName)
-        : base(sampleName, outputHelper, "/shutdown", testName: $"ApiSecurity.{sampleName}.{(enableApiSecurity ? "ApiSecOn" : "ApiSecOff")}")
+    protected AspNetCoreApiSecurity(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableApiSecurity, bool enableResponseBdyParsing, string sampleName)
+        : base(sampleName, outputHelper, "/shutdown", testName: $"ApiSecurity.{sampleName}.{(enableApiSecurity ? "ApiSecOn" : "ApiSecOff")}{(enableApiSecurity && !enableResponseBdyParsing ? ".BodyParseOff" : string.Empty)}")
     {
         _fixture = fixture;
         _fixture.SetOutput(outputHelper);
@@ -31,6 +31,10 @@ public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCo
         EnvironmentHelper.CustomEnvironmentVariables.Add(ConfigurationKeys.AppSec.Rules, Path.Combine("ApiSecurity", "ruleset-with-block.json"));
         SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
         SetEnvironmentVariable(ConfigurationKeys.AppSec.ApiSecurityEnabled, enableApiSecurity.ToString());
+        if (!enableResponseBdyParsing)
+        {
+            SetEnvironmentVariable(ConfigurationKeys.AppSec.ApiSecurityParseResponseBody, "false");
+        }
     }
 
     public override void Dispose()

--- a/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.BodyParseOff.__url=_dataapi_empty-model_body={-property_expectedStatusCode=NoContent_containsAttack=False.verified.txt
+++ b/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.BodyParseOff.__url=_dataapi_empty-model_body={-property_expectedStatusCode=NoContent_containsAttack=False.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: POST /dataapi/empty-model,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: emptymodel,
+      aspnet_core.controller: dataapi,
+      aspnet_core.route: dataapi/empty-model,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: POST /dataapi/empty-model,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.DataApiController.EmptyModel (Samples.Security.AspNetCore5),
+      aspnet_core.route: dataapi/empty-model,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: POST,
+      http.request.headers.host: localhost:00000,
+      http.route: dataapi/empty-model,
+      http.status_code: 204,
+      http.url: http://localhost:00000/dataapi/empty-model,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.s.req.body: [{"Property":[8],"Property2":[8],"Property3":[4],"Property4":[4]}],
+      _dd.appsec.s.req.headers: [{"content-length":[8],"content-type":[8],"host":[8],"user-agent":[8],"x-forwarded-for":[8]}],
+      _dd.appsec.s.req.params: [{"action":[8],"controller":[8]}],
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.BodyParseOff.__url=_dataapi_model_body={-property_expectedStatusCode=Forbidden_containsAttack=True.verified.txt
+++ b/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.BodyParseOff.__url=_dataapi_model_body={-property_expectedStatusCode=Forbidden_containsAttack=True.verified.txt
@@ -1,0 +1,74 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: POST /dataapi/model,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: model,
+      aspnet_core.controller: dataapi,
+      aspnet_core.route: dataapi/model,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      _dd.origin: appsec
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: POST /dataapi/model,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.blocked: true,
+      appsec.event: true,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.DataApiController.Model (Samples.Security.AspNetCore5),
+      aspnet_core.route: dataapi/model,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.endpoint: dataapi/model,
+      http.method: POST,
+      http.request.headers.content-length: 76,
+      http.request.headers.content-type: application/json; charset=utf-8,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.response.headers.content-type: application/json,
+      http.route: dataapi/model,
+      http.status_code: 403,
+      http.url: http://localhost:00000/dataapi/model,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-932-160","name":"Remote Command Execution: Unix Shell Code Found","tags":{"category":"attack_attempt","type":"command_injection"}},"rule_matches":[{"operator":"phrase_match","operator_value":"","parameters":[{"address":"server.request.body","highlight":["dev/zero"],"key_path":["Property"],"value":"dev/zero"}]}]}]},
+      _dd.appsec.s.req.body: [{"Property":[8],"Property2":[8],"Property3":[4],"Property4":[4]}],
+      _dd.appsec.s.req.headers: [{"content-length":[8],"content-type":[8],"host":[8],"user-agent":[8],"x-forwarded-for":[8]}],
+      _dd.appsec.s.req.params: [{"action":[8],"controller":[8]}],
+      _dd.appsec.s.res.headers: [{"content-type":[8]}],
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    },
+    MetaStruct: {
+      appsec: 
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.BodyParseOff.__url=_dataapi_model_body={-property_expectedStatusCode=OK_containsAttack=False.verified.txt
+++ b/tracer/test/snapshots/Security.ApiSecurity.AspNetCore5.ApiSecOn.BodyParseOff.__url=_dataapi_model_body={-property_expectedStatusCode=OK_containsAttack=False.verified.txt
@@ -1,0 +1,57 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: POST /dataapi/model,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: model,
+      aspnet_core.controller: dataapi,
+      aspnet_core.route: dataapi/model,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: POST /dataapi/model,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.DataApiController.Model (Samples.Security.AspNetCore5),
+      aspnet_core.route: dataapi/model,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: POST,
+      http.request.headers.host: localhost:00000,
+      http.route: dataapi/model,
+      http.status_code: 200,
+      http.url: http://localhost:00000/dataapi/model,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.s.req.body: [{"Property":[8],"Property2":[8],"Property3":[4],"Property4":[4]}],
+      _dd.appsec.s.req.headers: [{"content-length":[8],"content-type":[8],"host":[8],"user-agent":[8],"x-forwarded-for":[8]}],
+      _dd.appsec.s.req.params: [{"action":[8],"controller":[8]}],
+      _dd.appsec.s.res.headers: [{"content-type":[8]}],
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes
Disable response body parsing in API Security calls with the env var `DD_API_SECURITY_PARSE_RESPONSE_BODY`

## Reason for change
[Jira](https://datadoghq.atlassian.net/browse/APPSEC-57415)

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
