### PR TITLE
Mark Span ID generation tests as flaky

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Util/RandomIdGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RandomIdGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RandomIdGeneratorTests.cs" company="Datadog">
+// <copyright file="RandomIdGeneratorTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -11,6 +11,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
@@ -127,6 +128,7 @@ public class RandomIdGeneratorTests
     }
 
     [Theory]
+    [Flaky("This test can rarely fail because it does not, intentionally, rely on predictable behaviour")]
     [InlineData(true)]
     [InlineData(false)]
     public void NextSpanId_Are_Evenly_Distributed(bool useAllBits)
@@ -138,6 +140,7 @@ public class RandomIdGeneratorTests
 
     [Theory]
     [InlineData(true)]
+    [Flaky("This test can rarely fail because it does not, intentionally, rely on predictable behaviour")]
     [InlineData(false)]
     public void NextTraceId_Lower_Are_Evenly_Distributed(bool useAllBits)
     {


### PR DESCRIPTION
## Summary of changes

The test NextSpanId_Are_Evenly_Distributed(bool useAllBits) [has failed](https://app.datadoghq.com/error-tracking?query=source%3Adotnet%20%40tracer_version%3A3.17%2A%20%2Anullreference%2A&et-side=data&et-viz=events&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22f8b0d70e-3ae4-11f0-bd0d-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&view=spans&from_ts=1749126737994&to_ts=1749731537994&live=true) because it generates ids randomly and it can happen from time to time that the generated ids don't comply the test expectations regarding distribution. Since the test behavior is not predictable, the involved tests have been marked as flaky.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
