### PR TITLE
Bump one pipeline version

### DIFF
--- a/.gitlab/one-pipeline.locked.yaml
+++ b/.gitlab/one-pipeline.locked.yaml
@@ -1,2 +1,2 @@
 include:
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/05e116339b9780a138a474d0348e97debfca97f27bbc4ca489cf4e4c90d9cc94/one-pipeline.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/f2050f53c1f5aed62a24e6b406c746e7d593230ce02b5d56d2a2296db763ebf4/one-pipeline.yml


### PR DESCRIPTION
## Summary of changes

Bumps the one-pipeline to the latest version

## Reason for change

A recent [DataDog/auto_inject](https://github.com/DataDog/auto_inject) update changed the required version of Go, which breaks the pipeline.

## Implementation details

Multi-stage fix
- https://github.com/DataDog/images/pull/7200
- https://github.com/DataDog/libdatadog-build/pull/117
- https://github.com/DataDog/libdatadog-build/pull/118

## Test coverage

If the build is fixed with this change, we're good

## Other details

Injector team have [a follow-up ticket](https://datadoghq.atlassian.net/browse/INPLAT-647?atlOrigin=eyJpIjoiMDI5YWJiM2ExMzU4NGU3N2IyZTk1NjQwNDJhYzFiZDciLCJwIjoiamlyYS1zbGFjay1pbnQifQ) to stop this happening again