### PR TITLE
Fix usagae of `system_tests/agent`

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4610,9 +4610,6 @@ stages:
               # Save weblog variant image
               docker save system_tests/weblog:latest -o ../docker-images/$w.tar
             done < /tmp/weblogs_list.txt
-            
-            # Save agent image
-            docker save system_tests/agent:latest -o ../docker-images/agent.tar
 
           displayName: Build weblogs and agent & save Docker images
 


### PR DESCRIPTION
## Summary of changes

Fix the system test stage

## Reason for change

https://github.com/DataDog/system-tests/pull/4771 probably breaks it

## Implementation details

Remove the saving of the `system_tests/agent` docker image - it's not created any more

## Test coverage

This is the stest

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
