### PR TITLE
Try update `ProcessHelper` to fix flakiness

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -363,7 +363,6 @@ namespace Foo
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
-        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnEolFrameworkInSsi_WhenForwarderPathExists_CallsForwarderWithExpectedTelemetry()
         {
             var logDir = SetLogDirectory();
@@ -396,7 +395,6 @@ namespace Foo
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
-        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnEolFrameworkInSsi_WhenOverriden_CallsForwarderWithExpectedTelemetry()
         {
             var logDir = SetLogDirectory();
@@ -432,7 +430,6 @@ namespace Foo
         [Trait("RunOnWindows", "True")]
         [InlineData("1")]
         [InlineData("0")]
-        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnSupportedFrameworkInSsi_CallsForwarderWithExpectedTelemetry(string isOverriden)
         {
             var logDir = SetLogDirectory();

--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
@@ -104,12 +104,11 @@ namespace Datadog.Trace.TestHelpers
             if (timeout != Timeout.Infinite)
             {
                 // Split timeout between output, error, and process exit
-                timeout /= 3;
+                timeout /= 2;
             }
 
             return _outputTask.Task.Wait(timeout)
-                && _errorTask.Task.Wait(timeout)
-                && Process.WaitForExit(timeout);
+                && _errorTask.Task.Wait(timeout);
         }
 
         public virtual void Dispose()
@@ -125,10 +124,6 @@ namespace Datadog.Trace.TestHelpers
                     // Ignore exceptions when killing the process, as it may have already exited
                 }
             }
-
-            // Wait for output/error draining to complete
-            Task?.Wait();
-            Process?.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Updates the `ProcessHelper` used in tests to try to avoid deadlocks, and remove `[Flaky]` attribute to see if it works

## Reason for change

We often see deadlocks invoking the .NET SDK. Raised an issue about it [here](https://github.com/NuGet/Home/issues/14343), and they suggested our `ProcessHelper` implementation could cause deadlocks, so updating to the suggested version. It looks reasonable to me.

## Implementation details

- Replaced our existing version with the suggested version
- Removed the flaky attribute (to see if we see any deadlocks)

## Test coverage

Covered by existing tests

