### PR TITLE
Add `-ApiVersion` Nuke parameter for specific NuGet version testing

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1522,13 +1522,30 @@ partial class Build
               var samples = GetSamplesToBuild();
               Logger.Information("Building {SampleName}", samples);
 
-              // TODO: set Samples.Trimming as don't build, as we have to explicitly build that on every platform anyway
-              DotNetBuild(config => config
-                                   .SetConfiguration(BuildConfiguration)
-                                   .SetProperty("BuildInParallel", "true")
-                                   .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
-                                   .When(Framework is not null, x => x.SetFramework(Framework))
-                                   .SetProjectFile(samples));
+              // If we are building a specific sample, with a specific NuGet version, we can target just that one with MSBuild
+              // Windows only at the moment as I couldn't get `dotnet build` to work with the ApiVersion parameter
+              // As it needs to be restored first, but when it did it couldn't find the assets file
+              if (IsWin && !string.IsNullOrEmpty(ApiVersion) && !string.IsNullOrEmpty(SampleName))
+              {
+                  Logger.Information($"Building sample '{SampleName}' with ApiVersion '{ApiVersion}' using MSBuild");
+
+                  MSBuild(x => x.SetTargetPath(samples)
+                                .SetTargets("Restore", "Build")
+                                .SetConfiguration(BuildConfiguration)
+                                .SetProperty("ApiVersion", ApiVersion)
+                                .When(Framework is not null, o => o.SetProperty("TargetFramework", Framework.ToString()))
+                                .SetProperty("BuildInParallel", "true")
+                                .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701")));
+              }
+              else
+              {
+                  // TODO: set Samples.Trimming as don't build, as we have to explicitly build that on every platform anyway
+                  DotNetBuild(config => config.SetConfiguration(BuildConfiguration)
+                                              .SetProperty("BuildInParallel", "true")
+                                              .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
+                                              .When(Framework is not null, x => x.SetFramework(Framework))
+                                              .SetProjectFile(samples));
+              }
 
               string GetSamplesToBuild()
               {

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1527,7 +1527,7 @@ partial class Build
               // As it needs to be restored first, but when it did it couldn't find the assets file
               if (IsWin && !string.IsNullOrEmpty(ApiVersion) && !string.IsNullOrEmpty(SampleName))
               {
-                  Logger.Information($"Building sample '{SampleName}' with ApiVersion '{ApiVersion}' using MSBuild");
+                  Logger.Information("Building sample {SampleName} with ApiVersion {ApiVersion} using MSBuild", SampleName, ApiVersion);
 
                   MSBuild(x => x.SetTargetPath(samples)
                                 .SetTargets("Restore", "Build")

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -63,6 +63,9 @@ partial class Build
     [LazyLocalExecutable(@"C:\Program Files\IIS Express\iisexpress.exe")]
     readonly Lazy<Tool> IisExpress;
 
+    [Parameter("The (overridden) API version to use when building sample projects (e.g. '4.7.1')")]
+    readonly string ApiVersion;
+
     AbsolutePath IisExpressApplicationConfig =>
         RootDirectory / ".vs" / Solution.Name / "config" / "applicationhost.config";
 


### PR DESCRIPTION
## Summary of changes

Adds an `-ApiVersion` Nuke parameter so that when running integration tests locally we can just do something like `-ApiVersion "1.2.3"` to build the sample project against the "1.2.3" NuGet. This is instead of having to edit the `.csproj` directly or having to run `-TestAllPackageVersions` which takes longer.

## Reason for change

Small improvement to local developer experience so that we don't need to change NuGet versions in the `.csproj`. Unfortunately, Windows only as I couldn't figure out how to get `dotnet` commands to work with it and MSBuild worked right away.

## Implementation details

Added new parameter `ApiVersion`
Added logic to the `CompileSamples` target that will set that version when specifying a specific Sample to test.

Example usage:

` tracer/build.ps1 BuildAndRunWindowsIntegrationTests -BuildConfiguration Debug -Filter "Datadog.Trace.ClrProfiler.IntegrationTests.CosmosTests" -SampleName "Samples.CosmosDb" -Framework net8.0 -ApiVersion "3.52.0"`

This will build the `Samples.CosmosDb` project with `3.52.0` as the ApiVersion, which in turn will cause 3.52.0 to be restored instead of the default 3.18.0

`<ApiVersion Condition="'$(ApiVersion)' == ''">3.18.0</ApiVersion>`
`<PackageReference Include="Microsoft.Azure.Cosmos" Version="$(ApiVersion)" />` 



## Test coverage

Ran it locally with a few versions seems to work (I think)

## Other details

Note that `ApiVersion` doesn't necessarily equal _one_ NuGet or the NuGet that we want to target in the csproj, but that is usually the case.

Additionally, there are typically constraints around `ApiVersion` (e.g., specific .NET Framework versions). This doesn't account for those it's just a simple property set.
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
