### PR TITLE
Create a `StringUtil` helper for correct nullable annotations on `string.IsNullOrEmpty`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/AwsKinesisCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/AwsKinesisCommon.cs
@@ -24,12 +24,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
 
         public static string? StreamNameFromARN(string? arn)
         {
-            if (string.IsNullOrEmpty(arn))
+            if (StringUtil.IsNullOrEmpty(arn))
             {
                 return null;
             }
 
-            var arnComponents = arn!.Split('/');
+            var arnComponents = arn.Split('/');
             if (arnComponents.Length != 2)
             {
                 return null;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/AwsSnsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/AwsSnsCommon.cs
@@ -65,12 +65,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
         [return: NotNullIfNotNull(nameof(topicArn))]
         public static string? GetTopicName(string? topicArn)
         {
-            if (string.IsNullOrEmpty(topicArn))
+            if (StringUtil.IsNullOrEmpty(topicArn))
             {
                 return topicArn;
             }
 
-            var lastSeparationIndex = topicArn!.LastIndexOf(':') + 1;
+            var lastSeparationIndex = topicArn.LastIndexOf(':') + 1;
             return topicArn.Substring(lastSeparationIndex);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
@@ -100,18 +100,18 @@ public static class SignInManagerPasswordSignInUserIntegration
 
                 var userId = UserEventsCommon.GetId(user);
                 var userLogin = UserEventsCommon.GetLogin(user);
-                if (!string.IsNullOrEmpty(userId))
+                if (!StringUtil.IsNullOrEmpty(userId))
                 {
                     foundUserId = true;
-                    userId = processPii?.Invoke(userId!) ?? userId;
-                    setTag(Tags.AppSec.EventsUsers.InternalUserId, userId!);
-                    setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId, userId!);
+                    userId = processPii?.Invoke(userId) ?? userId;
+                    setTag(Tags.AppSec.EventsUsers.InternalUserId, userId);
+                    setTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId, userId);
                 }
 
-                if (!string.IsNullOrEmpty(userLogin))
+                if (!StringUtil.IsNullOrEmpty(userLogin))
                 {
                     foundLogin = true;
-                    var login = processPii?.Invoke(userLogin!) ?? userLogin!;
+                    var login = processPii?.Invoke(userLogin) ?? userLogin;
                     setTag(Tags.AppSec.EventsUsers.InternalLogin, login);
                     tryAddTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserLogin, login);
                 }

--- a/tracer/src/Datadog.Trace/Util/StringUtil.cs
+++ b/tracer/src/Datadog.Trace/Util/StringUtil.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="StringUtil.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+// ReSharper disable once CheckNamespace - Putting this in system so we can do simple drop-in replacement
+namespace System;
+
+/// <summary>
+/// Provides some simple wrappers around string operations, primarily to provide nullable annotations for frameworks
+/// that don't support them i.e. .NET FX, .NET Standard 2.0.
+/// </summary>
+internal static class StringUtil
+{
+    /// <summary>
+    /// Indicates whether the specified string is null or an empty string ("").
+    /// A nullable-annotation wrapper for <see cref="string.IsNullOrEmpty"/>
+    /// that works on .NET Framework and .NET Standard 2.0.
+    /// </summary>
+    /// <param name="value">The string to test</param>
+    /// <returns>true if the value parameter is null or an empty string (""); otherwise, false.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsNullOrEmpty([NotNullWhen(false)] string? value)
+        => string.IsNullOrEmpty(value);
+
+    /// <summary>
+    /// Indicates whether a specified string is null, empty, or consists only of white-space characters.
+    /// A nullable-annotation wrapper for <see cref="string.IsNullOrWhiteSpace"/>
+    /// that works on .NET Framework and .NET Standard 2.0.
+    /// </summary>
+    /// <param name="value">The string to test</param>
+    /// <returns>true if the value parameter is null or Empty, or if value consists exclusively of white-space characters.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsNullOrWhiteSpace([NotNullWhen(false)] string? value)
+        => string.IsNullOrWhiteSpace(value);
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/HeadersUtil.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/HeadersUtil.cs
@@ -1,4 +1,4 @@
-// <copyright file="StringUtil.cs" company="Datadog">
+// <copyright file="HeadersUtil.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -11,7 +11,7 @@ using System.Text.RegularExpressions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
 {
-    internal static class StringUtil
+    internal static class HeadersUtil
     {
         private static readonly Regex HeaderRegex = new(
             @"^\[HttpListener\] request header: (?<name>.*?)=(?<value>.*?)\r?$",

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -125,7 +125,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 // parse http headers from stdout
-                var headers = StringUtil.GetAllHeaders(processResult.StandardOutput).ToList();
+                var headers = HeadersUtil.GetAllHeaders(processResult.StandardOutput).ToList();
 
                 var firstSpan = spans.First();
                 headers.FirstOrDefault(h => h.Key == HttpHeaderNames.TraceId).Value.Should().Be(firstSpan.TraceId.ToString(CultureInfo.InvariantCulture));
@@ -198,7 +198,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 agent.Spans.Should().NotContain(s => s.Type == SpanTypes.Http);
 
                 // parse http headers from stdout
-                var headers = StringUtil.GetAllHeaders(processResult.StandardOutput).ToList();
+                var headers = HeadersUtil.GetAllHeaders(processResult.StandardOutput).ToList();
                 headers.Where(h => h.Key == HttpHeaderNames.TracingEnabled).Should().AllSatisfy(h => h.Value.Should().Be("false"));
 
                 // when tracing is disabled, we should not see any trace context or baggage headers

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -54,9 +54,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
                 Assert.Empty(spans);
 
-                var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
-                var parentSpanId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
-                var tracingEnabled = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TracingEnabled);
+                var traceId = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
+                var parentSpanId = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
+                var tracingEnabled = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TracingEnabled);
 
                 Assert.Null(traceId);
                 Assert.Null(parentSpanId);
@@ -87,8 +87,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
                 var firstSpan = spans.First();
-                var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
-                var parentSpanId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
+                var traceId = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
+                var parentSpanId = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
 
                 Assert.Equal(firstSpan.TraceId.ToString(CultureInfo.InvariantCulture), traceId);
                 Assert.Equal(firstSpan.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -60,9 +60,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
                 Assert.Empty(spans);
 
-                var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
-                var parentSpanId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
-                var tracingEnabled = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TracingEnabled);
+                var traceId = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
+                var parentSpanId = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
+                var tracingEnabled = HeadersUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TracingEnabled);
 
                 Assert.Null(traceId);
                 Assert.Null(parentSpanId);

--- a/tracer/test/Datadog.Trace.Tests/Util/StringUtilTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/StringUtilTests.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="StringUtilTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util;
+
+public class StringUtilTests
+{
+    public static TheoryData<string?> Values => new()
+    {
+        null,
+        string.Empty,
+        "  ",
+        "\t",
+        "null",
+        "not null",
+    };
+
+    [Theory]
+    [MemberData(nameof(Values))]
+    public void StringUtil_IsNullOrEmpty_BehavesAsString(string? input)
+    {
+        var result = StringUtil.IsNullOrEmpty(input);
+        var expected = string.IsNullOrEmpty(input);
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(Values))]
+    public void StringUtil_IsNullOrWhiteSpace_BehavesAsString(string? input)
+    {
+        var result = StringUtil.IsNullOrWhiteSpace(input);
+        var expected = string.IsNullOrWhiteSpace(input);
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void StringUtil_Flow_Analysis_NoErrors()
+    {
+        string? input = null;
+        if (StringUtil.IsNullOrEmpty(input))
+        {
+            // This is (correctly) flagged as a warning in flow analysis
+            // var test = input.Length;
+        }
+        else
+        {
+            // This should not flag as a warning in flow analysis
+            // if you use string.IsNullOrEmpty() you (incorrectly) get a warning
+            var test = input.Length;
+        }
+
+        if (StringUtil.IsNullOrWhiteSpace(input))
+        {
+            // This is (correctly) flagged as a warning in flow analysis
+            // var test = input.Length;
+        }
+        else
+        {
+            // This should not flag as a warning in flow analysis
+            // if you use string.IsNullOrWhiteSpace() you (incorrectly) get a warning
+            var test = input.Length;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Instead of using `string.IsNullOrEmpty()` of `string.IsNullOrWhitespace()` use `StringUtil.IsNullOrEmpty()` etc.

## Reason for change

`string.IsNullOrEmpty()` _doesn't_ have the correctly nullable annotations for .NET FX and .NET Standard. That means that the flow analysis often says a string variable _could_ be null, when it really  couldn't. That in turn means you have to use `!` all over the place, which in turn makes it harder to spot when we're _actually_ making nullability assumptions vs. the cases where we're just trying to shut the compiler up. In other places, we actively avoid the method to avoid the noise. `StringUtil.IsNullOrEmpty` is simply a correctly annotated version which delegates to the real implementation.

## Implementation details

`StringUtil` is a thin wrapper around the `string` utilities, adding the correct annotations. I "fixed" a few places that had this problem as an example, but theoretically we should just be able to replace all usages.

## Test coverage

Added unit tests to confirm behaviour is unchanged, and that the warning is gone

## Other details
