### PR TITLE
Add fix for race condition in `InitResult`

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
@@ -152,7 +152,6 @@ internal partial class SecurityReporter
     {
         if (initResult is { Reported: false })
         {
-            initResult.Reported = true;
             _span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             _span.SetMetric(Metrics.AppSecWafInitRulesLoaded, initResult.LoadedRules);
             _span.SetMetric(Metrics.AppSecWafInitRulesErrorCount, initResult.FailedToLoadRules);

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitResult.cs
@@ -6,16 +6,13 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using Datadog.Trace.AppSec.Waf.NativeBindings;
-using Datadog.Trace.AppSec.WafEncoding;
-using Datadog.Trace.Logging;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
+using System.Threading;
 
 namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
 {
     internal class InitResult
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(InitResult));
+        private int _firstReport = 0;
 
         private InitResult(ref UpdateResult updateResult)
         {
@@ -51,7 +48,11 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
 
         internal string RuleFileVersion => UpdateResult.RuleFileVersion;
 
-        internal bool Reported { get; set; }
+        /// <summary>
+        /// Gets a value indicating whether the WAF init info been reported to the WAF. Only returns true on the first report.
+        /// </summary>
+        /// <returns>True if this is the first invocation of the method on the InitResult. False for subsequent calls</returns>
+        internal bool Reported => Interlocked.Exchange(ref _firstReport, 1) == 1;
 
         internal static InitResult From(ref UpdateResult result)
         {

--- a/tracer/test/Datadog.Trace.Tests/AppSec/InitResultTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AppSec/InitResultTests.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="InitResultTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.AppSec;
+
+public class InitResultTests
+{
+    [Fact]
+    public void InitResult_Reported_ChangesToFalseAfterFirstCall()
+    {
+        var updateResult = UpdateResult.FromFailed("error");
+        var initResult = InitResult.From(ref updateResult);
+        initResult.Reported.Should().BeFalse();
+        initResult.Reported.Should().BeTrue();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Web;
 using System.Web.Hosting;
 using Datadog.Trace.Agent;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast;
@@ -266,7 +267,7 @@ public class RequestDataHelperTests
 
         var writerMock = new Mock<IAgentWriter>();
         var samplerMock = new Mock<ITraceSampler>();
-        var security = new AppSec.Security(null, null, null);
+        var security = new Security(null, null, null);
         var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         var scope = (Scope)tracer.StartActive("Root");
         scope.Span.ServiceName = "service";


### PR DESCRIPTION
## Summary of changes

Fixes a race condition, that could cause the WAF tags to be added more than once

## Reason for change

Saw some flake in the fleet_installer smoke tests where the `_dd.waf.version` tag was added to subsequent spans. The existing code has a race condition which could explain the issue

## Implementation details

Use an atomic update of `Reported` to ensure we only run once

## Test coverage

Added a small unit test to confirm the fix
