### PR TITLE
Remove flaky datapipeline tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             => from behaviour in (AgentBehaviour[])Enum.GetValues(typeof(AgentBehaviour))
                from transportType in Transports
                from metadataSchemaVersion in new[] { "v0", "v1" }
-               from dataPipelineEnabled in new[] { true, false }
+               from dataPipelineEnabled in new[] { false } // TODO: re-enable datapipeline tests - Currently it causes too much flake with duplicate spans
                select new object[] { behaviour, transportType, metadataSchemaVersion, dataPipelineEnabled };
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public static IEnumerable<object[]> Data =>
             from transport in Transports
-            from dataPipelineEnabled in new[] { true, false }
+            from dataPipelineEnabled in new[] { false } // TODO: re-enable datapipeline tests - Currently it causes too much flake with duplicate spans
             select new object[] { transport, dataPipelineEnabled };
 
         [SkippableTheory]


### PR DESCRIPTION
## Summary of changes

Remove datapipeline tests which are causing a lot of flakiness, particularly with named pipes

## Reason for change

These tests are failing a _lot_ due to duplicate spans in the payload. It needs investigating, and this PR should be reverted once the issue has been fixed.

## Implementation details

Delete the data pipeline tests. It's not easy to explicitly skip them, because of their usage in theory tests rather than facts

## Test coverage

Less now. This must be reverted before we enable datapipeline usage
