### PR TITLE
Avoid dlclose on glibc 2.34-2.36

### DIFF
--- a/shared/src/native-src/dynamic_library_base.cpp
+++ b/shared/src/native-src/dynamic_library_base.cpp
@@ -56,6 +56,83 @@ void* DynamicLibraryBase::GetFunction(const std::string& funcName)
 #endif
 }
 
+#if LINUX
+/// \brief Checks if the current system has a buggy implementation of dlclose (glibc 2.34-2.36).
+/// \return True if the system is affected by the buggy dlclose, false otherwise.
+bool DynamicLibraryBase::HasBuggyDlclose() const
+{
+    // In certain versions of glibc, there is a TLS-reuse bug that can cause crashes when unloading shared libraries.
+    // The bug was introduced in 2.34, fixed in 2.36 on x86-64, and fixed in 2.37 on aarch64.
+    // See https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=3921c5b40f293c57cb326f58713c924b0662ef59
+    // Explanation in Fedora where we spotted it: https://bugzilla.redhat.com/show_bug.cgi?id=2251557
+    //
+    // 2.34 shipped with a regression: after a dlclose() of a library that carried dynamic-TLS, the loader could reuse
+    // the same “module-ID” for a different library without first clearing the associated DTV (Dynamic Thread Vector)
+    // entry. The next time any code accessed that TLS slot it could read or write an unmapped address → SIGSEGV.
+    //
+    // This manifested as a crash in the WAF when we called `ddwaf_context_info` on arm64. It explicitly happens
+    // on arm64 when we unload the continuous profiler (because it's not supported).
+    //
+    // It manifests in this scenario, because ddwaf_context_init starts like this:
+    //   +128  bl   __tls_get_addr     ; ask glibc for the TLS slot for libddwaf
+    //   +136  mrs  x11, TPIDR_EL0     ; TLS base for this thread
+    //   +140  ldrb w9, [x11, x0]      ; <–– boom if x0 points to a stale DTV entry
+    //
+    // When we unload the continuous profiler and call dlcose, it causes the loader to hand out a recycled module-ID
+    // to libddwaf. When ddwaf_context_init tries to access TLS in the `ldrb` instruction, `x11 + x0` is outside
+    // every mapped version, and so crashes.
+    //
+    // Note that although calling dlclose with the continuous profiler may trigger the issue (the actual crash is flaky
+    // depending on load/unload timing and address layout), unloading _any_ library that is is built with
+    // `__thread`/`thread_local` data could trigger the crash. To minimize the risk of hitting this issue,
+
+    // Cache the value statically to avoid repeated checks
+    static bool result = []() {
+        // Need to check whether we can close libraries or not
+        // But we compile for both musl and glibc, so need to manually
+        // try to load the glibc function gnu_get_libc_version
+        void* handle = dlopen("libc.so.6", RTLD_LAZY);
+        if (!handle) {
+            // Likely not glibc (e.g. musl)
+            return false;
+        }
+
+        using gnu_get_libc_version_fn = const char* (*)();
+        auto func = (gnu_get_libc_version_fn)dlsym(handle, "gnu_get_libc_version");
+        if (!func) {
+            // We do have glibc, but the function is not available...
+            // This shouldn't happen given it's available since 2.1 and we require 2.17
+            // so overall, a bit weird... Don't close the handle, just in case, and
+            // treat it as faulty
+            // dlclose(handle);
+            return true;
+        }
+
+        // Check if it's one of the buggy versions
+        const auto version = std::string(func());
+        // Try to "Save" the valuea as en environment variable so that we can report it later if necessary
+        ::shared::SetEnvironmentValue(WStr("DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH"), version);
+
+#if ARM64
+        const auto is_buggy = (version == "2.34" || version == "2.35" || version == "2.36");
+#else
+        const auto is_buggy = (version == "2.34" || version == "2.35");
+#endif
+
+        if (!is_buggy) {
+            // Not buggy, so we can close the handle
+            dlclose(handle);
+            return false;
+        }
+
+        // buggy, so we can't close the handle
+        return true;
+    }();
+
+    return result;
+}
+#endif
+
 bool DynamicLibraryBase::Load()
 {
     _logger->Debug("Load: ", _filePath);
@@ -104,41 +181,18 @@ bool DynamicLibraryBase::Unload()
 #if _WIN32
     auto result = FreeLibrary((HMODULE) _instance);
 #else
-    // In certain versions of glibc, there is a TLS-reuse bug that can cause crashes when unloading shared libraries.
-    // The bug was introduced in 2.34, fixed in 2.36 on x86-64, and fixed in 2.37 on aarch64.
-    // See https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=3921c5b40f293c57cb326f58713c924b0662ef59
-    // Explanation in Fedora where we spotted it: https://bugzilla.redhat.com/show_bug.cgi?id=2251557
-    //
-    // 2.34 shipped with a regression: after a dlclose() of a library that carried dynamic-TLS, the loader could reuse
-    // the same “module-ID” for a different library without first clearing the associated DTV (Dynamic Thread Vector)
-    // entry. The next time any code accessed that TLS slot it could read or write an unmapped address → SIGSEGV.
-    //
-    // This manifested as a crash in the WAF when we called `ddwaf_context_info` on arm64. It explicitly happens
-    // on arm64 when we unload the continuous profiler (because it's not supported).
-    //
-    // It manifests in this scenario, because ddwaf_context_init starts like this:
-    //   +128  bl   __tls_get_addr     ; ask glibc for the TLS slot for libddwaf
-    //   +136  mrs  x11, TPIDR_EL0     ; TLS base for this thread
-    //   +140  ldrb w9, [x11, x0]      ; <–– boom if x0 points to a stale DTV entry
-    //
-    // When we unload the continuous profiler and call dlcose, it causes the loader to hand out a recycled module-ID
-    // to libddwaf. When ddwaf_context_init tries to access TLS in the `ldrb` instruction, `x11 + x0` is outside
-    // every mapped version, and so crashes.
-    //
-    // Note that although calling dlclose with the continuous profiler may trigger the issue (the actual crash is flaky
-    // depending on load/unload timing and address layout), unloading _any_ library that is is built with
-    // `__thread`/`thread_local` data could trigger the crash. To minimize the risk of hitting this issue,
+#if LINUX
+    if (HasBuggyDlclose())
+    {
+        _logger->Warn("Unload: Skipping unload of dynamic library '", _filePath,
+                      "' due to buggy dlclose implementation on this system. ",
+                      "GLIBC version is likely 2.34-2.36, which has a TLS-reuse bug that can cause ",
+                      "crashes when unloading shared libraries.");
+        return false;
+    }
 
-    // TODO: Just force block dlclose for testing - we will gate this on glibc later
-
-#if ARM64
-    auto requiredGlibcMinorVersion = 37;
-#else
-    auto requiredGlibcMinorVersion = 36;
-#endif
-
-    auto result = true;
-    // auto result = dlclose(_instance) == 0;
+#endif // if LINUX
+    auto result = dlclose(_instance) == 0;
 #endif
 
     if (!result)

--- a/shared/src/native-src/dynamic_library_base.cpp
+++ b/shared/src/native-src/dynamic_library_base.cpp
@@ -56,83 +56,6 @@ void* DynamicLibraryBase::GetFunction(const std::string& funcName)
 #endif
 }
 
-#if LINUX
-/// \brief Checks if the current system has a buggy implementation of dlclose (glibc 2.34-2.36).
-/// \return True if the system is affected by the buggy dlclose, false otherwise.
-bool DynamicLibraryBase::HasBuggyDlclose() const
-{
-    // In certain versions of glibc, there is a TLS-reuse bug that can cause crashes when unloading shared libraries.
-    // The bug was introduced in 2.34, fixed in 2.36 on x86-64, and fixed in 2.37 on aarch64.
-    // See https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=3921c5b40f293c57cb326f58713c924b0662ef59
-    // Explanation in Fedora where we spotted it: https://bugzilla.redhat.com/show_bug.cgi?id=2251557
-    //
-    // 2.34 shipped with a regression: after a dlclose() of a library that carried dynamic-TLS, the loader could reuse
-    // the same “module-ID” for a different library without first clearing the associated DTV (Dynamic Thread Vector)
-    // entry. The next time any code accessed that TLS slot it could read or write an unmapped address → SIGSEGV.
-    //
-    // This manifested as a crash in the WAF when we called `ddwaf_context_info` on arm64. It explicitly happens
-    // on arm64 when we unload the continuous profiler (because it's not supported).
-    //
-    // It manifests in this scenario, because ddwaf_context_init starts like this:
-    //   +128  bl   __tls_get_addr     ; ask glibc for the TLS slot for libddwaf
-    //   +136  mrs  x11, TPIDR_EL0     ; TLS base for this thread
-    //   +140  ldrb w9, [x11, x0]      ; <–– boom if x0 points to a stale DTV entry
-    //
-    // When we unload the continuous profiler and call dlcose, it causes the loader to hand out a recycled module-ID
-    // to libddwaf. When ddwaf_context_init tries to access TLS in the `ldrb` instruction, `x11 + x0` is outside
-    // every mapped version, and so crashes.
-    //
-    // Note that although calling dlclose with the continuous profiler may trigger the issue (the actual crash is flaky
-    // depending on load/unload timing and address layout), unloading _any_ library that is is built with
-    // `__thread`/`thread_local` data could trigger the crash. To minimize the risk of hitting this issue,
-
-    // Cache the value statically to avoid repeated checks
-    static bool result = []() {
-        // Need to check whether we can close libraries or not
-        // But we compile for both musl and glibc, so need to manually
-        // try to load the glibc function gnu_get_libc_version
-        void* handle = dlopen("libc.so.6", RTLD_LAZY);
-        if (!handle) {
-            // Likely not glibc (e.g. musl)
-            return false;
-        }
-
-        using gnu_get_libc_version_fn = const char* (*)();
-        auto func = (gnu_get_libc_version_fn)dlsym(handle, "gnu_get_libc_version");
-        if (!func) {
-            // We do have glibc, but the function is not available...
-            // This shouldn't happen given it's available since 2.1 and we require 2.17
-            // so overall, a bit weird... Don't close the handle, just in case, and
-            // treat it as faulty
-            // dlclose(handle);
-            return true;
-        }
-
-        // Check if it's one of the buggy versions
-        const auto version = std::string(func());
-        // Try to "Save" the valuea as en environment variable so that we can report it later if necessary
-        ::shared::SetEnvironmentValue(WStr("DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH"), version);
-
-#if ARM64
-        const auto is_buggy = (version == "2.34" || version == "2.35" || version == "2.36");
-#else
-        const auto is_buggy = (version == "2.34" || version == "2.35");
-#endif
-
-        if (!is_buggy) {
-            // Not buggy, so we can close the handle
-            dlclose(handle);
-            return false;
-        }
-
-        // buggy, so we can't close the handle
-        return true;
-    }();
-
-    return result;
-}
-#endif
-
 bool DynamicLibraryBase::Load()
 {
     _logger->Debug("Load: ", _filePath);
@@ -182,12 +105,13 @@ bool DynamicLibraryBase::Unload()
     auto result = FreeLibrary((HMODULE) _instance);
 #else
 #if LINUX
-    if (HasBuggyDlclose())
+    auto [is_buggy, glibc_version] = ::shared::HasBuggyDlclose();
+    if (is_buggy)
     {
         _logger->Warn("Unload: Skipping unload of dynamic library '", _filePath,
-                      "' due to buggy dlclose implementation on this system. ",
-                      "GLIBC version is likely 2.34-2.36, which has a TLS-reuse bug that can cause ",
-                      "crashes when unloading shared libraries.");
+                      "' due to buggy dlclose implementation on this system.",
+                      "GLIBC version 2.34-2.36 has a TLS-reuse bug that can cause crashes when unloading"
+                      " shared libraries. Consider updating the installed version of glibc. Found GLIBC version: ", glibc_version);
         return false;
     }
 

--- a/shared/src/native-src/dynamic_library_base.cpp
+++ b/shared/src/native-src/dynamic_library_base.cpp
@@ -104,7 +104,41 @@ bool DynamicLibraryBase::Unload()
 #if _WIN32
     auto result = FreeLibrary((HMODULE) _instance);
 #else
-    auto result = dlclose(_instance) == 0;
+    // In certain versions of glibc, there is a TLS-reuse bug that can cause crashes when unloading shared libraries.
+    // The bug was introduced in 2.34, fixed in 2.36 on x86-64, and fixed in 2.37 on aarch64.
+    // See https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=3921c5b40f293c57cb326f58713c924b0662ef59
+    // Explanation in Fedora where we spotted it: https://bugzilla.redhat.com/show_bug.cgi?id=2251557
+    //
+    // 2.34 shipped with a regression: after a dlclose() of a library that carried dynamic-TLS, the loader could reuse
+    // the same “module-ID” for a different library without first clearing the associated DTV (Dynamic Thread Vector)
+    // entry. The next time any code accessed that TLS slot it could read or write an unmapped address → SIGSEGV.
+    //
+    // This manifested as a crash in the WAF when we called `ddwaf_context_info` on arm64. It explicitly happens
+    // on arm64 when we unload the continuous profiler (because it's not supported).
+    //
+    // It manifests in this scenario, because ddwaf_context_init starts like this:
+    //   +128  bl   __tls_get_addr     ; ask glibc for the TLS slot for libddwaf
+    //   +136  mrs  x11, TPIDR_EL0     ; TLS base for this thread
+    //   +140  ldrb w9, [x11, x0]      ; <–– boom if x0 points to a stale DTV entry
+    //
+    // When we unload the continuous profiler and call dlcose, it causes the loader to hand out a recycled module-ID
+    // to libddwaf. When ddwaf_context_init tries to access TLS in the `ldrb` instruction, `x11 + x0` is outside
+    // every mapped version, and so crashes.
+    //
+    // Note that although calling dlclose with the continuous profiler may trigger the issue (the actual crash is flaky
+    // depending on load/unload timing and address layout), unloading _any_ library that is is built with
+    // `__thread`/`thread_local` data could trigger the crash. To minimize the risk of hitting this issue,
+
+    // TODO: Just force block dlclose for testing - we will gate this on glibc later
+
+#if ARM64
+    auto requiredGlibcMinorVersion = 37;
+#else
+    auto requiredGlibcMinorVersion = 36;
+#endif
+
+    auto result = true;
+    // auto result = dlclose(_instance) == 0;
 #endif
 
     if (!result)

--- a/shared/src/native-src/dynamic_library_base.h
+++ b/shared/src/native-src/dynamic_library_base.h
@@ -23,9 +23,6 @@ protected:
 
 private:
     virtual void OnInitialized() = 0;
-#if LINUX
-    bool HasBuggyDlclose() const;
-#endif
 
     std::string _filePath;
     void* _instance;

--- a/shared/src/native-src/dynamic_library_base.h
+++ b/shared/src/native-src/dynamic_library_base.h
@@ -23,6 +23,9 @@ protected:
 
 private:
     virtual void OnInitialized() = 0;
+#if LINUX
+    bool HasBuggyDlclose() const;
+#endif
 
     std::string _filePath;
     void* _instance;

--- a/shared/src/native-src/util.h
+++ b/shared/src/native-src/util.h
@@ -105,6 +105,13 @@ namespace shared
 
     std::string GenerateRuntimeId();
 
+#if LINUX
+    /// \brief Checks if the current system has a buggy implementation of dlclose (glibc 2.34-2.36).
+    /// \return A tuple with a boolean that is True if the system is affected by the buggy dlclose, false otherwise.
+    /// The string is the version of glibc found, if any
+    std::tuple<bool, WSTRING> HasBuggyDlclose();
+#endif
+
     bool WStringStartWithCaseInsensitive(const WSTRING& longer, const WSTRING& shorter);
 
     template <class Container>

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2476,6 +2476,9 @@ partial class Build
            knownPatterns.Add(new(@".*TestOptimization: .*", RegexOptions.Compiled));
            knownPatterns.Add(new(@".*TestOptimizationClient: .*", RegexOptions.Compiled));
 
+           // glibc TLS-reuse bug warnings
+           knownPatterns.Add(new(@".*GLIBC version 2.34-2.36 has a TLS-reuse bug.*", RegexOptions.Compiled));
+
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
@@ -125,7 +125,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
             }
         }
 
-        internal static bool TryLoadLibraryFromPaths(FrameworkDescription frameworkDescription, string libName, List<string> paths, out IntPtr handle)
+        internal static bool TryLoadLibraryFromPaths(string libName, List<string> paths, out IntPtr handle)
         {
             var success = false;
             handle = IntPtr.Zero;
@@ -137,15 +137,6 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                 if (!File.Exists(libFullPath))
                 {
                     continue;
-                }
-
-                if (IsLinuxArm64(frameworkDescription))
-                {
-                    // This is really bizare, but if we don't do this, we see crashes on Fedora 35 only, on arm64
-                    if (NativeLibrary.TryLoad(libFullPath, out handle))
-                    {
-                        NativeLibrary.CloseLibrary(handle);
-                    }
                 }
 
                 var loaded = NativeLibrary.TryLoad(libFullPath, out handle);
@@ -167,8 +158,6 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
             }
 
             return success;
-            static bool IsLinuxArm64(FrameworkDescription description)
-                => description.OSPlatform == OSPlatformName.Linux && description.ProcessArchitecture == ProcessArchitecture.Arm64;
         }
 
         internal static string GetLibName(FrameworkDescription fwk, string libVersion = null)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
@@ -182,7 +182,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             if (libName != null && runtimeIds != null)
             {
                 var paths = LibraryLocationHelper.GetDatadogNativeFolders(fd, runtimeIds);
-                if (!LibraryLocationHelper.TryLoadLibraryFromPaths(fd, libName, paths, out libraryHandle))
+                if (!LibraryLocationHelper.TryLoadLibraryFromPaths(libName, paths, out libraryHandle))
                 {
                     return new LibraryInitializationResult(LibraryInitializationResult.LoadStatus.LibraryLoad);
                 }

--- a/tracer/src/Datadog.Tracer.Native/interop.cpp
+++ b/tracer/src/Datadog.Tracer.Native/interop.cpp
@@ -286,6 +286,18 @@ EXTERN_C void *dddlsym (void *__restrict __handle, const char *__restrict __name
 
 EXTERN_C int dddlclose (void *handle)
 {
+#if LINUX
+    auto [is_buggy, glibc_version] = ::shared::HasBuggyDlclose();
+    if (is_buggy)
+    {
+        trace::Logger::Warn("Skipping dddlclose for handle '", handle,
+                      "' due to buggy dlclose implementation on this system.",
+                      "GLIBC version 2.34-2.36 has a TLS-reuse bug that can cause crashes when unloading"
+                      " shared libraries. Consider updating the installed version of glibc. Found GLIBC version: ", glibc_version);
+        return 1;
+    }
+#endif
+
     return dlclose(handle);
 }
 #endif


### PR DESCRIPTION
## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
