### PR TITLE
Disable data pipeline if libdatadog is not available

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -427,10 +427,7 @@ namespace Datadog.Trace.Configuration
                 {
                     DataPipelineEnabled = false;
                     Log.Warning(
-                        "{ConfigurationKey} is enabled, but {StatsComputationEnabled} is enabled. Disabling {TraceDataPipelineEnabled}.",
-                        ConfigurationKeys.TraceDataPipelineEnabled,
-                        ConfigurationKeys.StatsComputationEnabled,
-                        ConfigurationKeys.TraceDataPipelineEnabled);
+                        $"{ConfigurationKeys.TraceDataPipelineEnabled} is enabled, but {ConfigurationKeys.StatsComputationEnabled} is enabled. Disabling data pipeline.");
                     _telemetry.Record(ConfigurationKeys.TraceDataPipelineEnabled, false, ConfigurationOrigins.Calculated);
                 }
 
@@ -440,9 +437,15 @@ namespace Datadog.Trace.Configuration
                 {
                     DataPipelineEnabled = false;
                     Log.Warning(
-                        "{ConfigurationKey} is enabled, but TracesTransport is set to UnixDomainSocket which is not supported on Windows. Disabling {TraceDataPipelineEnabled}.",
-                        ConfigurationKeys.TraceDataPipelineEnabled,
-                        ConfigurationKeys.TraceDataPipelineEnabled);
+                        $"{ConfigurationKeys.TraceDataPipelineEnabled} is enabled, but TracesTransport is set to UnixDomainSocket which is not supported on Windows. Disabling data pipeline.");
+                    _telemetry.Record(ConfigurationKeys.TraceDataPipelineEnabled, false, ConfigurationOrigins.Calculated);
+                }
+
+                if (!LibDatadog.NativeInterop.IsLibDatadogAvailable)
+                {
+                    DataPipelineEnabled = false;
+                    Log.Warning(
+                        $"{ConfigurationKeys.TraceDataPipelineEnabled} is enabled, but Libddatadog is not available. Disabling data pipeline.");
                     _telemetry.Record(ConfigurationKeys.TraceDataPipelineEnabled, false, ConfigurationOrigins.Calculated);
                 }
             }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -445,7 +445,7 @@ namespace Datadog.Trace.Configuration
                 {
                     DataPipelineEnabled = false;
                     Log.Warning(
-                        $"{ConfigurationKeys.TraceDataPipelineEnabled} is enabled, but Libddatadog is not available. Disabling data pipeline.");
+                        $"{ConfigurationKeys.TraceDataPipelineEnabled} is enabled, but libdatadog is not available. Disabling data pipeline.");
                     _telemetry.Record(ConfigurationKeys.TraceDataPipelineEnabled, false, ConfigurationOrigins.Calculated);
                 }
             }


### PR DESCRIPTION
## Summary of changes

Disabled data pipeline if libdatadog is not available

## Reason for change

Libdatadog is not available in all scenarios e.g. serverless scenarios, `dd-trace ci run` ([as in this recent issue](https://github.com/DataDog/dd-trace-dotnet/pull/7122)). We should not enable data pipeline in these scenarios

## Implementation details

Do not allow enabling data pipeline if libdatadog isn't available

## Test coverage

We have a unit test for IsLibDatadogAvailable, I don't think we need tests for the value here

## Other details
Fixes some other log messages to remove structured logging variables as not really necessary.