### PR TITLE
Move trimming file into buildTransitive

### DIFF
--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <None Include="..\..\..\docs\Datadog.Trace\README.md" Pack="true" PackagePath="\" />
     <None Include="Datadog.Trace.props" Pack="true" PackagePath="build;buildTransitive" Visible="false" />
-    <None Include="..\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" Pack="true" PackagePath="buildTransitive" Visible="false" />
+    <None Include="..\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" Pack="true" PackagePath="build;buildTransitive" Visible="false" />
   </ItemGroup>
 
 

--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <None Include="..\..\..\docs\Datadog.Trace\README.md" Pack="true" PackagePath="\" />
-    <None Include="Datadog.Trace.props" Pack="true" PackagePath="buildTransitive" Visible="false" />
+    <None Include="Datadog.Trace.props" Pack="true" PackagePath="build;buildTransitive" Visible="false" />
     <None Include="..\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" Pack="true" PackagePath="buildTransitive" Visible="false" />
   </ItemGroup>
 

--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
@@ -46,8 +46,8 @@
 
   <ItemGroup>
     <None Include="..\..\..\docs\Datadog.Trace\README.md" Pack="true" PackagePath="\" />
-    <None Include="Datadog.Trace.props" Pack="true" PackagePath="build" Visible="false" />
-    <None Include="..\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="Datadog.Trace.props" Pack="true" PackagePath="buildTransitive" Visible="false" />
+    <None Include="..\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" Pack="true" PackagePath="buildTransitive" Visible="false" />
   </ItemGroup>
 
 

--- a/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
+++ b/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
@@ -28,8 +28,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="build\Datadog.Trace.Trimming.props" target="build\Datadog.Trace.Trimming.props" />
-    <file src="build\Datadog.Trace.Trimming.xml" target="build\Datadog.Trace.Trimming.xml" />
+    <file src="build\Datadog.Trace.Trimming.props" target="buildTransitive\Datadog.Trace.Trimming.props" />
+    <file src="build\Datadog.Trace.Trimming.xml" target="buildTransitive\Datadog.Trace.Trimming.xml" />
     <file src="..\..\..\datadog-logo-256x256.png" target="datadog-logo-256x256.png" />
     <file src="README.md" target="README.md" />
   </files>

--- a/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
+++ b/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.nuspec
@@ -28,7 +28,9 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="build\Datadog.Trace.Trimming.props" target="build\Datadog.Trace.Trimming.props" />
     <file src="build\Datadog.Trace.Trimming.props" target="buildTransitive\Datadog.Trace.Trimming.props" />
+    <file src="build\Datadog.Trace.Trimming.xml" target="build\Datadog.Trace.Trimming.xml" />
     <file src="build\Datadog.Trace.Trimming.xml" target="buildTransitive\Datadog.Trace.Trimming.xml" />
     <file src="..\..\..\datadog-logo-256x256.png" target="datadog-logo-256x256.png" />
     <file src="README.md" target="README.md" />


### PR DESCRIPTION
## Summary of changes

Packs the trimming files into the `buildTransitive` folder

## Reason for change

If the package isn't referenced at top-level, it won't be added correctly

## Implementation details

build -> buildTransitive

## Test coverage

Need to see if we have tests for it, but will check the build output

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
