### PR TITLE
Replacing Thread.Sleep usage in async methods

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsDynamoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsDynamoDbTests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 17;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 var dynamoDbSpans = spans.Where(
                     span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 await VerifyHelper.VerifySpans(spans, settings);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsDynamoDb);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsDynamoDb);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsEventBridgeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsEventBridgeTests.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 4;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 var eventBridgeSpans = spans.Where(span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
                 eventBridgeSpans.Should().NotBeEmpty();
@@ -88,7 +88,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 // (Only PutEvents and PutEventsAsync are supported right now)
                 await VerifyHelper.VerifySpans(spans, settings);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsEventBridge);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsEventBridge);
             }
         }
 
@@ -105,11 +105,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
             using var agent = EnvironmentHelper.GetMockAgent();
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(1, returnAllOperations: true);
+                var spans = await agent.WaitForSpansAsync(1, returnAllOperations: true);
 
                 Assert.NotEmpty(spans);
                 Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-                telemetry.AssertIntegrationDisabled(IntegrationId.AwsEventBridge);
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.AwsEventBridge);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 5;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 var kinesisSpans = spans.Where(
                     span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 await VerifyHelper.VerifySpans(spans, settings);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsKinesis);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsKinesis);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 var expectedSpans = requests * 2; // we manually instrument each request too
 
-                var spans = agent.WaitForSpans(expectedSpans, 15_000).ToArray();
+                var spans = (await agent.WaitForSpansAsync(expectedSpans, 15_000)).ToArray();
 
                 // Verify all the "with context" end invocations have a corresponding start context
                 using var s = new AssertionScope();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsS3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsS3Tests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 16;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 spans.Count().Should().Be(expectedCount);
                 var s3Spans = spans.Where(span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
@@ -83,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 // Note: http.request spans are expected for the S3 APIs that don't have explicit support
                 await VerifyHelper.VerifySpans(spans, settings);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsS3);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsS3);
             }
         }
 
@@ -100,11 +100,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
             using var agent = EnvironmentHelper.GetMockAgent();
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(1, returnAllOperations: true);
+                var spans = await agent.WaitForSpansAsync(1, returnAllOperations: true);
 
                 Assert.NotEmpty(spans);
                 Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-                telemetry.AssertIntegrationDisabled(IntegrationId.AwsS3);
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.AwsS3);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 5;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 var snsSpans = spans.Where(span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
                 snsSpans.Should().NotBeEmpty();
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 // - SetTopicAttributes
                 await VerifyHelper.VerifySpans(spans, settings);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsSns);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsSns);
 
                 static string GetSnapshotSuffix(string packageVersion)
                     => packageVersion switch

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 28;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 var sqsSpans = spans.Where(
                     span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 // - PurgeQueue
                 await VerifyHelper.VerifySpans(spans, settings);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsSqs);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsSqs);
 
                 static string GetSnapshotSuffix(string packageVersion)
                     => packageVersion switch

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsStepFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsStepFunctionsTests.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 4;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 var stepFunctionsSpans = spans.Where(span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
                 stepFunctionsSpans.Should().NotBeEmpty();
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 await VerifyHelper.VerifySpans(spans, settings);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsStepFunctions);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsStepFunctions);
             }
         }
 
@@ -112,11 +112,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
             using var agent = EnvironmentHelper.GetMockAgent();
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(1, returnAllOperations: true);
+                var spans = await agent.WaitForSpansAsync(1, returnAllOperations: true);
 
                 Assert.NotEmpty(spans);
                 Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-                telemetry.AssertIntegrationDisabled(IntegrationId.AwsStepFunctions);
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.AwsStepFunctions);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var expectedCount = 5;
                 var frameworkName = "NetCore";
 #endif
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 var kinesisSpans = spans.Where(
                     span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var taggedSpans = kinesisSpans.Where(s => s.Tags.ContainsKey("pathway.hash"));
                 taggedSpans.Should().HaveCount(expected: 2); // a send and a receive
 
-                var dsPoints = agent.WaitForDataStreamsPoints(statsCount: 2);
+                var dsPoints = await agent.WaitForDataStreamsPointsAsync(statsCount: 2);
 
                 var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
 
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 await Verifier.Verify(MockDataStreamsPayload.Normalize(dsPoints), settings)
                           .DisableRequireUniquePrefix();
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.AwsKinesis);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsKinesis);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSnsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSnsTests.cs
@@ -52,7 +52,7 @@ public class DataStreamsMonitoringAwsSnsTests : TestHelper
             var expectedTaggedCount = 2;
             var frameworkName = "NetCore";
 #endif
-            var spans = agent.WaitForSpans(expectedCount);
+            var spans = await agent.WaitForSpansAsync(expectedCount);
             spans.Should().HaveCount(expectedCount);
             var sqsSpans = spans.Where(
                 span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
@@ -62,7 +62,7 @@ public class DataStreamsMonitoringAwsSnsTests : TestHelper
             var taggedSpans = spans.Where(s => s.Tags.ContainsKey("pathway.hash"));
             taggedSpans.Should().HaveCount(expected: expectedTaggedCount);
 
-            var dsPoints = agent.WaitForDataStreamsPoints(statsCount: expectedTaggedCount);
+            var dsPoints = await agent.WaitForDataStreamsPointsAsync(statsCount: expectedTaggedCount);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.UseParameters(packageVersion);
@@ -72,7 +72,7 @@ public class DataStreamsMonitoringAwsSnsTests : TestHelper
                           .UseFileName(fileName)
                           .DisableRequireUniquePrefix();
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.AwsSns);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsSns);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSqsTests.cs
@@ -79,7 +79,7 @@ public class DataStreamsMonitoringAwsSqsTests : TestHelper
 #else
             var expectedCount = 9;
 #endif
-            var spans = agent.WaitForSpans(expectedCount);
+            var spans = await agent.WaitForSpansAsync(expectedCount);
             var sqsSpans = spans.Where(
                 span => span.Tags.TryGetValue("component", out var component) && component == "aws-sdk");
 
@@ -88,7 +88,7 @@ public class DataStreamsMonitoringAwsSqsTests : TestHelper
             var taggedSpans = spans.Where(s => s.Tags.ContainsKey("pathway.hash"));
             taggedSpans.Should().HaveCount(expected: 2); // a send and a receive
 
-            var dsPoints = agent.WaitForDataStreamsPoints(statsCount: 2);
+            var dsPoints = await agent.WaitForDataStreamsPointsAsync(statsCount: 2);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.UseParameters(packageVersion);
@@ -101,7 +101,7 @@ public class DataStreamsMonitoringAwsSqsTests : TestHelper
                           .UseFileName(fileName)
                           .DisableRequireUniquePrefix();
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.AwsSqs);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsSqs);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             await VerifyHelper.VerifySpans(spans, settings)
                                   .UseFileName(nameof(FakeCommandTests) + $"_{metadataSchemaVersion}");
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.AdoNet);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AdoNet);
         }
 
         private async Task RunDisabledFakeCommandTest(string metadataSchemaVersion)
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(expectedSpanCount);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount);
             int actualSpanCount = spans.Count();
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
@@ -108,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                                   .UseFileName(nameof(FakeCommandTests) + $"_{metadataSchemaVersion}_disabledFakeCommand");
 
             // We should have created 0 spans from ADO.NET integration - spans created are from RelationaTestHarness and are manual spans
-            telemetry.AssertIntegrationDisabled(IntegrationId.AdoNet);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.AdoNet);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -76,12 +76,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
             var actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
-            telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.SqlClient);
         }
 
         [SkippableFact]
@@ -98,11 +98,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.SqlClient);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.SqlClient);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -59,12 +59,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.Sqlite);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Sqlite);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(new Regex("Sqlite-Test-[a-zA-Z0-9]{32}"), "System-Data-SqlClient-Test-GUID");
@@ -98,11 +98,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             string packageVersion = PackageVersions.MicrosoftDataSqlite.First()[0] as string;
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.Sqlite);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Sqlite);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -73,11 +73,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // use the default package version for the sample, currently 8.0.17.
             // string packageVersion = PackageVersions.MySqlData.First()[0] as string;
             using var process = await RunSampleAndWaitForExit(agent /* , packageVersion: packageVersion */);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.MySql);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.MySql);
         }
 
         private async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion, string dbmPropagation)
@@ -111,12 +111,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
             var filteredSpans = spans.Where(s => s.ParentId.HasValue && !s.Resource.Equals("SHOW WARNINGS", StringComparison.OrdinalIgnoreCase)).ToList();
 
             filteredSpans.Count.Should().Be(expectedSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
-            telemetry.AssertIntegrationEnabled(IntegrationId.MySql);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.MySql);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(new Regex("MySql-Test-[a-zA-Z0-9]{32}"), "MySql-Test-GUID");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -61,12 +61,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue && !s.Resource.Equals("SHOW WARNINGS", StringComparison.OrdinalIgnoreCase)); // Remove unexpected DB spans from the calculation
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
-            telemetry.AssertIntegrationEnabled(IntegrationId.MySql);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.MySql);
         }
 
         [SkippableFact]
@@ -82,11 +82,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             string packageVersion = PackageVersions.MySqlConnector.First()[0] as string;
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.MySql);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.MySql);
         }
 
         private static int GetSpanCount(string packageVersionString)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -65,14 +65,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
             var filteredSpans = spans.Where(s => s.ParentId.HasValue).ToList();
 
             // Assert an exact match once we can correctly instrument the generic constraint case
             actualSpanCount.Should().Be(expectedSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
-            telemetry.AssertIntegrationEnabled(IntegrationId.Npgsql);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Npgsql);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(new Regex("Npgsql-Test-[a-zA-Z0-9]{32}"), "Npgsql-Test-GUID");
@@ -107,11 +107,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.Npgsql);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Npgsql);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/OracleTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/OracleTests.cs
@@ -48,10 +48,10 @@ public class OracleTests : TracingIntegrationTest
         using var agent = EnvironmentHelper.GetMockAgent();
         using var process = await RunSampleAndWaitForExit(agent);
 
-        var spans = agent.WaitForSpans(expectedSpanCount);
+        var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
         spans.Count.Should().Be(expectedSpanCount);
-        telemetry.AssertIntegrationEnabled(IntegrationId.Oracle);
+        await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Oracle);
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
         // database name is generated with a random suffix

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -47,11 +47,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.SqlClient);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.SqlClient);
         }
 
         private async Task RunTest(string metadataSchemaVersion)
@@ -67,11 +67,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
-            telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.SqlClient);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -75,11 +75,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
 
             spans.Count.Should().Be(expectedSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
-            telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.SqlClient);
 
             // Testing that spans yield the expected output when using DBM
 
@@ -132,11 +132,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.SqlClient);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.SqlClient);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -50,11 +50,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.Sqlite);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Sqlite);
         }
 
         private async Task RunTest(string metadataSchemaVersion)
@@ -70,11 +70,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
-            telemetry.AssertIntegrationEnabled(IntegrationId.Sqlite);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Sqlite);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(new Regex("SQLite-Test-[a-zA-Z0-9]{32}"), "System-Data-SqlClient-Test-GUID");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 const int expectedSpanCount = 10 + 9; // Sync + async
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .DisableRequireUniquePrefix()
                                   .UseFileName(nameof(AerospikeTests) + $".Schema{metadataSchemaVersion.ToUpper()}");
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.Aerospike);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Aerospike);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var process = await RunSampleAndWaitForExit(agent);
 
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName, timeoutInMilliseconds: 40000);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName, timeoutInMilliseconds: 40000);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(StackRegex, string.Empty);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AppTrimmingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AppTrimmingTests.cs
@@ -31,7 +31,7 @@ public class AppTrimmingTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         var aspnetPort = TcpPortProvider.GetOpenPort();
         using var processResult = await RunSampleAndWaitForExit(agent, aspNetCorePort: aspnetPort, usePublishWithRID: true);
-        var spans = agent.WaitForSpans(30);
+        var spans = await agent.WaitForSpansAsync(30);
 
         // Target app does 10 request, so it generates 30 spans (Http Request + AspNetCore + AspNetCore.Mvc)
         spans.Where(s => s.Name == "http.request").Should().HaveCount(10);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -184,7 +184,7 @@ Expect: 100-continue
             Output.WriteLine($"[http] {Encoding.ASCII.GetString(bytes)}");
             Encoding.ASCII.GetString(bytes).Should().StartWith("HTTP/1.1 100 Continue");
 
-            var spans = _iisFixture.Agent.WaitForSpans(
+            var spans = await _iisFixture.Agent.WaitForSpansAsync(
                 count: isClassicMode ? 0 : 1, // classic mode doesn't generate any spans in this scenario
                 minDateTime: testStart,
                 returnAllOperations: true);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
 
-            var allSpans = _iisFixture.Agent.WaitForSpans(3, minDateTime: testStart)
+            var allSpans = (await _iisFixture.Agent.WaitForSpansAsync(3, minDateTime: testStart))
                                    .OrderBy(s => s.Start)
                                    .ToList();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -203,7 +203,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var testStart = DateTimeOffset.UtcNow;
 
                 await SubmitRequest(output, path);
-                return Agent.WaitForSpans(count: expectedSpanCount, minDateTime: testStart, returnAllOperations: true);
+                return await Agent.WaitForSpansAsync(count: expectedSpanCount, minDateTime: testStart, returnAllOperations: true);
             }
 
             private async Task EnsureServerStarted(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -258,7 +258,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         break;
                     }
 
-                    Thread.Sleep(intervalMilliseconds);
+                    await Task.Delay(intervalMilliseconds);
                 }
 
                 if (!serverReady)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31InferredProxySpansTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31InferredProxySpansTests.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
             // don't call Fixture.WaitForSpans() directly so we can override span count and start date
             await Fixture.SendHttpRequest(request);
-            var spans = Fixture.Agent.WaitForSpans(count: spanCount, minDateTime: start, returnAllOperations: true);
+            var spans = await Fixture.Agent.WaitForSpansAsync(count: spanCount, minDateTime: start, returnAllOperations: true);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode, spanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
                     (s.Tags.TryGetValue("otel.library.name", out var value) && value == "Samples.AzureServiceBus")
                     || (s.Tags.TryGetValue("messaging.system", out value) && value == "servicebus") // Exclude the Admin requests
                     || (s.Tags.TryGetValue("message_bus.destination", out _))); // Include older versions of the library
-                var spans = agent.WaitForSpans(expectedProcessorSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedProcessorSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count().Should().Be(expectedProcessorSpanCount);
@@ -92,7 +92,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
                                   .UseFileName(filename)
                                   .DisableRequireUniquePrefix();
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.OpenTelemetry);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
@@ -48,7 +48,7 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
         using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
         {
             agent.SpanFilters.Add(s => s.Tags.TryGetValue("messaging.system", out var value) && value == "servicebus"); // Exclude the Admin requests
-            var spans = agent.WaitForSpans(23);
+            var spans = await agent.WaitForSpansAsync(23);
             spans.Should().HaveCount(23);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
@@ -77,7 +77,7 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
         using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
         {
             agent.SpanFilters.Add(s => s.Tags.TryGetValue("messaging.system", out var value) && value == "servicebus"); // Exclude the Admin requests
-            var spans = agent.WaitForSpans(23);
+            var spans = await agent.WaitForSpansAsync(23);
             spans.Should().HaveCount(23);
             var taggedSpans = spans.Where(s => s.Tags.ContainsKey("pathway.hash"));
             taggedSpans.Should().HaveCount(9); // 4 messages published, 5 messages consumed

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -149,7 +149,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using (await RunAzureFunctionAndWaitForExit(agent))
             {
                 const int expectedSpanCount = 21;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
@@ -181,7 +181,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using (await RunAzureFunctionAndWaitForExit(agent, framework: "net6.0"))
             {
                 const int expectedSpanCount = 21;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
                 var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
 
                 using var s = new AssertionScope();
@@ -214,7 +214,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 21;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
 
@@ -243,7 +243,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 26;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 var filteredSpans = FilterOutSocketsHttpHandler(spans);
 
@@ -278,7 +278,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 21;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
 
@@ -309,7 +309,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 26;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 // There are _additional_ spans created for these compared to the non-AspNetCore version
                 // These are http-client-handler-type: System.Net.Http.SocketsHttpHandler that come in around

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
                     using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1))
                     {
-                        spans = agent.WaitForSpans(expectedSpanCount)
+                        spans = (await agent.WaitForSpansAsync(expectedSpanCount))
                                      .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))
                                      .ToList();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
                     using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1))
                     {
-                        spans = agent.WaitForSpans(ExpectedSpanCount)
+                        spans = (await agent.WaitForSpansAsync(ExpectedSpanCount))
                                      .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))
                                      .ToList();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
@@ -176,7 +176,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         break;
                     }
 
-                    Thread.Sleep(500);
+                    await Task.Delay(500).ConfigureAwait(false);
                 }
 
                 // Sort and aggregate

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
@@ -176,7 +176,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         break;
                     }
 
-                    await Task.Delay(500).ConfigureAwait(false);
+                    await Task.Delay(500);
                 }
 
                 // Sort and aggregate

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -554,7 +554,7 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         Assert.Contains(messages, m => m.StartsWith("Test:SimpleErrorParameterizedTest"));
 
         // Smoke check telemetry
-        agent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
+        await agent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
         var allData = agent.Telemetry.Cast<TelemetryData>().ToArray();
 
         // we will have multiple app closing events

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
@@ -565,7 +565,7 @@ public class XUnitEvpTestsV3 : TestingFrameworkEvpTest
         Assert.Contains(messages, m => m.StartsWith("Test:SimpleErrorParameterizedTest"));
 
         // Smoke check telemetry
-        agent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
+        await agent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
         var allData = agent.Telemetry.Cast<TelemetryData>().ToArray();
 
         // we will have multiple app closing events

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             // We remove the evp_proxy endpoint to force the APM protocol compatibility
             agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
             using var processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion, expectedExitCode: 1);
-            var spans = agent.WaitForSpans(ExpectedSpanCount)
+            var spans = (await agent.WaitForSpansAsync(ExpectedSpanCount))
                          .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))
                          .ToList();
             var spansCopy = JsonConvert.DeserializeObject<List<MockSpan>>(JsonConvert.SerializeObject(spans));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(expectedSpanCount, operationName: ExpectedOperationName);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: ExpectedOperationName);
                 spans.Count.Should().BeGreaterOrEqualTo(expectedSpanCount, $"Expecting at least {expectedSpanCount} spans, only received {spans.Count}");
 
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseTextForParameters($"Schema{metadataSchemaVersion.ToUpper()}")
                                   .DisableRequireUniquePrefix();
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.CosmosDb);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.CosmosDb);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(10, 500)
+                var spans = (await agent.WaitForSpansAsync(10, 500))
                                  .Where(s => s.Type == "db")
                                  .ToList();
 
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 ValidateSpans(spans, (span) => span.Resource, expected);
-                telemetry.AssertIntegrationEnabled(IntegrationId.Couchbase);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Couchbase);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(13, 500);
+                var spans = await agent.WaitForSpansAsync(13, 500);
                 Assert.True(spans.Count >= 13, $"Expecting at least 13 spans, only received {spans.Count}");
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 };
 
                 ValidateSpans(spans, (span) => span.Resource, expected);
-                telemetry.AssertIntegrationEnabled(IntegrationId.Couchbase);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Couchbase);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringKafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringKafkaTests.cs
@@ -141,7 +141,7 @@ public class DataStreamsMonitoringKafkaTests : TestHelper
 
         using var assertionScope = new AssertionScope();
         // We don't expect any streams here, so no point waiting for ages
-        var dataStreams = agent.WaitForDataStreams(2, timeoutInMilliseconds: 2_000);
+        var dataStreams = await agent.WaitForDataStreamsAsync(2, timeoutInMilliseconds: 2_000);
         dataStreams.Should().BeEmpty();
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringManualApiTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringManualApiTest.cs
@@ -32,11 +32,11 @@ public class DataStreamsMonitoringManualApiTest : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         using var processResult = await RunSampleAndWaitForExit(agent);
 
-        var spans = agent.WaitForSpans(count: 2);
+        var spans = await agent.WaitForSpansAsync(count: 2);
         spans.Should().HaveCount(expected: 2);
         spans[1].TraceId.Should().Be(spans[0].TraceId); // trace context propagation
 
-        var dsPoints = agent.WaitForDataStreamsPoints(statsCount: 2);
+        var dsPoints = await agent.WaitForDataStreamsPointsAsync(statsCount: 2);
         // using span verifier to add all the default scrubbers
         var settings = VerifyHelper.GetSpanVerifierSettings();
         settings.AddDataStreamsScrubber();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
@@ -41,7 +41,7 @@ public class DataStreamsMonitoringRabbitMQTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
         {
-            var spans = agent.WaitForSpans(31);
+            var spans = await agent.WaitForSpansAsync(31);
             spans.Should().HaveCount(31);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
@@ -65,7 +65,7 @@ public class DataStreamsMonitoringRabbitMQTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
         {
-            var spans = agent.WaitForSpans(31);
+            var spans = await agent.WaitForSpansAsync(31);
             spans.Should().HaveCount(31);
             var taggedSpans = spans.Where(s => s.Tags.ContainsKey("pathway.hash"));
             taggedSpans.Should().HaveCount(13);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     });
                 }
 
-                var spans = agent.WaitForSpans(expected.Count)
+                var spans = (await agent.WaitForSpansAsync(expected.Count))
                                  .Where(s => s.Type == "elasticsearch")
                                  .OrderBy(s => s.Start)
                                  .ToList();
@@ -170,7 +170,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
                 ValidateSpans(spans, (span) => span.Resource, expected);
-                telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.ElasticsearchNet);
             }
         }
 
@@ -185,10 +185,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
+            var spans = (await agent.WaitForSpansAsync(1)).Where(s => s.Type == "elasticsearch").ToList();
 
             Assert.Empty(spans);
-            telemetry.AssertIntegrationDisabled(IntegrationId.ElasticsearchNet);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.ElasticsearchNet);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -154,7 +154,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     }
                 }
 
-                var spans = agent.WaitForSpans(expected.Count)
+                var spans = (await agent.WaitForSpansAsync(expected.Count))
                                  .Where(s => s.Type == "elasticsearch")
                                  .OrderBy(s => s.Start)
                                  .ToList();
@@ -187,7 +187,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
                 ValidateSpans(spans, (span) => span.Resource, expected);
-                telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.ElasticsearchNet);
             }
         }
 
@@ -201,10 +201,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.ElasticsearchNet)}_ENABLED", "false");
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
+            var spans = (await agent.WaitForSpansAsync(1)).Where(s => s.Type == "elasticsearch").ToList();
 
             Assert.Empty(spans);
-            telemetry.AssertIntegrationDisabled(IntegrationId.ElasticsearchNet);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.ElasticsearchNet);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -149,7 +149,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     }
                 }
 
-                var spans = agent.WaitForSpans(expected.Count)
+                var spans = (await agent.WaitForSpansAsync(expected.Count))
                                  .Where(s => s.Type == "elasticsearch")
                                  .OrderBy(s => s.Start)
                                  .ToList();
@@ -175,7 +175,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
                 ValidateSpans(spans, (span) => span.Resource, expected);
-                telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.ElasticsearchNet);
             }
         }
 
@@ -189,10 +189,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.ElasticsearchNet)}_ENABLED", "false");
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
+            var spans = (await agent.WaitForSpansAsync(1)).Where(s => s.Type == "elasticsearch").ToList();
 
             Assert.Empty(spans);
-            telemetry.AssertIntegrationDisabled(IntegrationId.ElasticsearchNet);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.ElasticsearchNet);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GoogleProtobufTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GoogleProtobufTests.cs
@@ -50,7 +50,7 @@ public class GoogleProtobufTests : TracingIntegrationTest
         using (await RunSampleAndWaitForExit(agent, "AddressBook", packageVersion))
         {
             using var assertionScope = new AssertionScope();
-            var spans = agent.WaitForSpans(2);
+            var spans = await agent.WaitForSpansAsync(2);
 
             ValidateIntegrationSpans(spans, metadataSchemaVersion, "Samples.GoogleProtobuf", isExternalSpan: true);
             var settings = VerifyHelper.GetSpanVerifierSettings();
@@ -82,7 +82,7 @@ public class GoogleProtobufTests : TracingIntegrationTest
         using var agent = EnvironmentHelper.GetMockAgent();
         using (await RunSampleAndWaitForExit(agent, "TimeStamp"))
         {
-            var spans = agent.WaitForSpans(2);
+            var spans = await agent.WaitForSpansAsync(2);
             foreach (var span in spans)
             {
                 span.Tags.Should().NotContain(t => t.Key.StartsWith("schema."));
@@ -99,7 +99,7 @@ public class GoogleProtobufTests : TracingIntegrationTest
         using var agent = EnvironmentHelper.GetMockAgent();
         using (await RunSampleAndWaitForExit(agent, "AddressBook"))
         {
-            var spans = agent.WaitForSpans(2);
+            var spans = await agent.WaitForSpansAsync(2);
             foreach (var span in spans)
             {
                 span.Tags.Should().NotContain(t => t.Key.StartsWith("schema."));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -220,7 +220,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var testStart = DateTime.UtcNow;
             var expectedSpans = await SubmitRequests(fixture.HttpPort, usingWebsockets);
 
-            var spans = fixture.Agent.WaitForSpans(count: expectedSpans, minDateTime: testStart, returnAllOperations: true);
+            var spans = await fixture.Agent.WaitForSpansAsync(count: expectedSpans, minDateTime: testStart, returnAllOperations: true);
 
             var graphQLSpans = spans.Where(span => span.Type == "graphql");
             ValidateIntegrationSpans(graphQLSpans, _metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -301,14 +301,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 using (processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
                 {
-                    var spans = agent.WaitForSpans(totalExpectedSpans, 500, assertExpectedCount: false);
+                    var spans = await agent.WaitForSpansAsync(totalExpectedSpans, 500, assertExpectedCount: false);
 
                     using var scope = new AssertionScope();
 
                     if (!isGrpcSupported)
                     {
                         Output.WriteLine($"Package version {packageVersion} is not supported in Grpc, skipping snapshot verification");
-                        telemetry.AssertIntegrationDisabled(IntegrationId.Grpc);
+                        await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Grpc);
                         return;
                     }
 
@@ -413,7 +413,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     }
                 }
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.Grpc);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Grpc);
             }
             catch (ExitCodeException)
             {
@@ -451,10 +451,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 using (processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
                 {
-                    var spans = agent.WaitForSpans(1, timeoutInMilliseconds: 500).Where(s => s.Type == "grpc.request").ToList();
+                    var spans = (await agent.WaitForSpansAsync(1, timeoutInMilliseconds: 500)).Where(s => s.Type == "grpc.request").ToList();
 
                     Assert.Empty(spans);
-                    telemetry.AssertIntegrationDisabled(IntegrationId.Grpc);
+                    await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Grpc);
                 }
             }
             catch (ExitCodeException)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -38,23 +38,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return telemetry;
         }
 
-        public static ValueTask AssertIntegrationEnabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+        public static Task AssertIntegrationEnabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
         {
             return telemetry.AssertIntegrationAsync(integrationId, enabled: true, autoEnabled: true);
         }
 
-        public static ValueTask AssertIntegrationDisabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+        public static Task AssertIntegrationDisabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
         {
             return telemetry.AssertIntegrationAsync(integrationId, enabled: false, autoEnabled: true);
         }
 
-        public static ValueTask AssertIntegrationEnabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
+        public static Task AssertIntegrationEnabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
             => mockAgent.AssertIntegrationAsync(integrationId, enabled: true, autoEnabled: true);
 
-        public static ValueTask AssertIntegrationDisabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
+        public static Task AssertIntegrationDisabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
             => mockAgent.AssertIntegrationAsync(integrationId, enabled: false, autoEnabled: true);
 
-        public static async ValueTask AssertIntegrationAsync(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+        public static async Task AssertIntegrationAsync(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -62,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-        public static async ValueTask AssertIntegrationAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+        public static async Task AssertIntegrationAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-        public static async ValueTask AssertConfigurationAsync(this MockTracerAgent mockAgent, string key, object value = null)
+        public static async Task AssertConfigurationAsync(this MockTracerAgent mockAgent, string key, object value = null)
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertConfiguration(allData, key, value);
         }
 
-        public static async ValueTask AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key, object value)
+        public static async Task AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key, object value)
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -86,10 +86,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertConfiguration(allData, key, value);
         }
 
-        public static ValueTask AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key)
+        public static Task AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key)
             => telemetry.AssertConfigurationAsync(key, value: null);
 
-        internal static async ValueTask<IEnumerable<(string[] Tags, int Value, long Timestamp)>> GetMetricDataPointsAsync(this MockTelemetryAgent telemetry, string metric, string tag1 = null, string tag2 = null, string tag3 = null)
+        internal static async Task<IEnumerable<(string[] Tags, int Value, long Timestamp)>> GetMetricDataPointsAsync(this MockTelemetryAgent telemetry, string metric, string tag1 = null, string tag2 = null, string tag3 = null)
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return GetMetricData(allData, metric, tag1, tag2, tag3);
         }
 
-        internal static async ValueTask<IEnumerable<DistributionMetricData>> GetDistributionsAsync(this MockTelemetryAgent telemetry, string distribution, string tag1 = null, string tag2 = null, string tag3 = null)
+        internal static async Task<IEnumerable<DistributionMetricData>> GetDistributionsAsync(this MockTelemetryAgent telemetry, string distribution, string tag1 = null, string tag2 = null, string tag3 = null)
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -38,43 +38,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return telemetry;
         }
 
-#if NETFRAMEWORK
-        public static Task AssertIntegrationEnabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
-#else
         public static ValueTask AssertIntegrationEnabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
-#endif
         {
             return telemetry.AssertIntegrationAsync(integrationId, enabled: true, autoEnabled: true);
         }
 
-#if NETFRAMEWORK
-        public static Task AssertIntegrationDisabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
-#else
         public static ValueTask AssertIntegrationDisabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
-#endif
         {
             return telemetry.AssertIntegrationAsync(integrationId, enabled: false, autoEnabled: true);
         }
 
-#if NETFRAMEWORK
-        public static Task AssertIntegrationEnabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
-#else
         public static ValueTask AssertIntegrationEnabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
-#endif
             => mockAgent.AssertIntegrationAsync(integrationId, enabled: true, autoEnabled: true);
 
-#if NETFRAMEWORK
-        public static Task AssertIntegrationDisabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
-#else
         public static ValueTask AssertIntegrationDisabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
-#endif
             => mockAgent.AssertIntegrationAsync(integrationId, enabled: false, autoEnabled: true);
 
-#if NETFRAMEWORK
-        public static async Task AssertIntegrationAsync(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
-#else
         public static async ValueTask AssertIntegrationAsync(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
-#endif
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -82,11 +62,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-#if NETFRAMEWORK
-        public static async Task AssertIntegrationAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)
-#else
         public static async ValueTask AssertIntegrationAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)
-#endif
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -94,11 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-#if NETFRAMEWORK
-        public static async Task AssertConfigurationAsync(this MockTracerAgent mockAgent, string key, object value = null)
-#else
         public static async ValueTask AssertConfigurationAsync(this MockTracerAgent mockAgent, string key, object value = null)
-#endif
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -106,11 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertConfiguration(allData, key, value);
         }
 
-#if NETFRAMEWORK
-        public static async Task AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key, object value)
-#else
         public static async ValueTask AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key, object value)
-#endif
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -118,18 +86,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             AssertConfiguration(allData, key, value);
         }
 
-#if NETFRAMEWORK
-        public static Task AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key)
-#else
         public static ValueTask AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key)
-#endif
             => telemetry.AssertConfigurationAsync(key, value: null);
 
-#if NETFRAMEWORK
-        internal static async Task<IEnumerable<(string[] Tags, int Value, long Timestamp)>> GetMetricDataPointsAsync(this MockTelemetryAgent telemetry, string metric, string tag1 = null, string tag2 = null, string tag3 = null)
-#else
         internal static async ValueTask<IEnumerable<(string[] Tags, int Value, long Timestamp)>> GetMetricDataPointsAsync(this MockTelemetryAgent telemetry, string metric, string tag1 = null, string tag2 = null, string tag3 = null)
-#endif
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
@@ -137,11 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return GetMetricData(allData, metric, tag1, tag2, tag3);
         }
 
-#if NETFRAMEWORK
-        internal static async Task<IEnumerable<DistributionMetricData>> GetDistributionsAsync(this MockTelemetryAgent telemetry, string distribution, string tag1 = null, string tag2 = null, string tag3 = null)
-#else
         internal static async ValueTask<IEnumerable<DistributionMetricData>> GetDistributionsAsync(this MockTelemetryAgent telemetry, string distribution, string tag1 = null, string tag2 = null, string tag3 = null)
-#endif
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
@@ -37,67 +38,112 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return telemetry;
         }
 
-        public static void AssertIntegrationEnabled(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+#if NETFRAMEWORK
+        public static Task AssertIntegrationEnabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+#else
+        public static ValueTask AssertIntegrationEnabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+#endif
         {
-            telemetry.AssertIntegration(integrationId, enabled: true, autoEnabled: true);
+            return telemetry.AssertIntegrationAsync(integrationId, enabled: true, autoEnabled: true);
         }
 
-        public static void AssertIntegrationDisabled(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+#if NETFRAMEWORK
+        public static Task AssertIntegrationDisabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+#else
+        public static ValueTask AssertIntegrationDisabledAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId)
+#endif
         {
-            telemetry.AssertIntegration(integrationId, enabled: false, autoEnabled: true);
+            return telemetry.AssertIntegrationAsync(integrationId, enabled: false, autoEnabled: true);
         }
 
-        public static void AssertIntegrationEnabled(this MockTracerAgent mockAgent, IntegrationId integrationId)
-            => mockAgent.AssertIntegration(integrationId, enabled: true, autoEnabled: true);
+#if NETFRAMEWORK
+        public static Task AssertIntegrationEnabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
+#else
+        public static ValueTask AssertIntegrationEnabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
+#endif
+            => mockAgent.AssertIntegrationAsync(integrationId, enabled: true, autoEnabled: true);
 
-        public static void AssertIntegrationDisabled(this MockTracerAgent mockAgent, IntegrationId integrationId)
-            => mockAgent.AssertIntegration(integrationId, enabled: false, autoEnabled: true);
+#if NETFRAMEWORK
+        public static Task AssertIntegrationDisabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
+#else
+        public static ValueTask AssertIntegrationDisabledAsync(this MockTracerAgent mockAgent, IntegrationId integrationId)
+#endif
+            => mockAgent.AssertIntegrationAsync(integrationId, enabled: false, autoEnabled: true);
 
-        public static void AssertIntegration(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+#if NETFRAMEWORK
+        public static async Task AssertIntegrationAsync(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+#else
+        public static async ValueTask AssertIntegrationAsync(this MockTracerAgent mockAgent, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+#endif
         {
-            mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
+            await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
             var allData = mockAgent.Telemetry.Cast<TelemetryData>().ToArray();
             AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-        public static void AssertIntegration(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+#if NETFRAMEWORK
+        public static async Task AssertIntegrationAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+#else
+        public static async ValueTask AssertIntegrationAsync(this MockTelemetryAgent telemetry, IntegrationId integrationId, bool enabled, bool? autoEnabled)
+#endif
         {
-            telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
+            await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
             var allData = telemetry.Telemetry.Cast<TelemetryData>().ToArray();
             AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-        public static void AssertConfiguration(this MockTracerAgent mockAgent, string key, object value = null)
+#if NETFRAMEWORK
+        public static async Task AssertConfigurationAsync(this MockTracerAgent mockAgent, string key, object value = null)
+#else
+        public static async ValueTask AssertConfigurationAsync(this MockTracerAgent mockAgent, string key, object value = null)
+#endif
         {
-            mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
+            await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
             var allData = mockAgent.Telemetry.Cast<TelemetryData>().ToArray();
             AssertConfiguration(allData, key, value);
         }
 
-        public static void AssertConfiguration(this MockTelemetryAgent telemetry, string key, object value)
+#if NETFRAMEWORK
+        public static async Task AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key, object value)
+#else
+        public static async ValueTask AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key, object value)
+#endif
         {
-            telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
+            await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
             var allData = telemetry.Telemetry.Cast<TelemetryData>().ToArray();
             AssertConfiguration(allData, key, value);
         }
 
-        public static void AssertConfiguration(this MockTelemetryAgent telemetry, string key) => telemetry.AssertConfiguration(key, value: null);
+#if NETFRAMEWORK
+        public static Task AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key)
+#else
+        public static ValueTask AssertConfigurationAsync(this MockTelemetryAgent telemetry, string key)
+#endif
+            => telemetry.AssertConfigurationAsync(key, value: null);
 
-        internal static IEnumerable<(string[] Tags, int Value, long Timestamp)> GetMetricDataPoints(this MockTelemetryAgent telemetry, string metric, string tag1 = null, string tag2 = null, string tag3 = null)
+#if NETFRAMEWORK
+        internal static async Task<IEnumerable<(string[] Tags, int Value, long Timestamp)>> GetMetricDataPointsAsync(this MockTelemetryAgent telemetry, string metric, string tag1 = null, string tag2 = null, string tag3 = null)
+#else
+        internal static async ValueTask<IEnumerable<(string[] Tags, int Value, long Timestamp)>> GetMetricDataPointsAsync(this MockTelemetryAgent telemetry, string metric, string tag1 = null, string tag2 = null, string tag3 = null)
+#endif
         {
-            telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
+            await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
             var allData = telemetry.Telemetry.Cast<TelemetryData>().ToArray();
             return GetMetricData(allData, metric, tag1, tag2, tag3);
         }
 
-        internal static IEnumerable<DistributionMetricData> GetDistributions(this MockTelemetryAgent telemetry, string distribution, string tag1 = null, string tag2 = null, string tag3 = null)
+#if NETFRAMEWORK
+        internal static async Task<IEnumerable<DistributionMetricData>> GetDistributionsAsync(this MockTelemetryAgent telemetry, string distribution, string tag1 = null, string tag2 = null, string tag3 = null)
+#else
+        internal static async ValueTask<IEnumerable<DistributionMetricData>> GetDistributionsAsync(this MockTelemetryAgent telemetry, string distribution, string tag1 = null, string tag2 = null, string tag3 = null)
+#endif
         {
-            telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
+            await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
             var allData = telemetry.Telemetry.Cast<TelemetryData>().ToArray();
             return GetDistributions(allData, distribution, tag1, tag2, tag3);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var testStart = DateTime.UtcNow;
             var expectedSpans = await SubmitRequests(fixture.HttpPort, usingWebsockets);
 
-            var spans = fixture.Agent.WaitForSpans(count: expectedSpans, minDateTime: testStart, returnAllOperations: true);
+            var spans = await fixture.Agent.WaitForSpansAsync(count: expectedSpans, minDateTime: testStart, returnAllOperations: true);
 
             var graphQLSpans = spans.Where(span => span.Type == "graphql");
             ValidateIntegrationSpans(graphQLSpans, metadataSchemaVersion: "v0", expectedServiceName: clientSpanServiceName, isExternalSpan);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}");
 
                 agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
                 spans.Should().HaveCount(expectedSpanCount);
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
@@ -157,11 +157,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 using var scope = new AssertionScope();
-                telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.HttpMessageHandler);
                 // ignore for now auto enabled for simplicity
-                telemetry.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: IsUsingSocketHandler(instrumentation), autoEnabled: null);
-                telemetry.AssertIntegration(IntegrationId.WinHttpHandler, enabled: IsUsingWinHttpHandler(instrumentation), autoEnabled: null);
-                telemetry.AssertIntegration(IntegrationId.CurlHandler, enabled: IsUsingCurlHandler(instrumentation), autoEnabled: null);
+                await telemetry.AssertIntegrationAsync(IntegrationId.HttpSocketsHandler, enabled: IsUsingSocketHandler(instrumentation), autoEnabled: null);
+                await telemetry.AssertIntegrationAsync(IntegrationId.WinHttpHandler, enabled: IsUsingWinHttpHandler(instrumentation), autoEnabled: null);
+                await telemetry.AssertIntegrationAsync(IntegrationId.CurlHandler, enabled: IsUsingCurlHandler(instrumentation), autoEnabled: null);
                 VerifyInstrumentation(processResult.Process);
             }
             catch (ExitCodeException)
@@ -227,10 +227,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 using var scope = new AssertionScope();
                 // ignore auto enabled for simplicity
-                telemetry.AssertIntegrationDisabled(IntegrationId.HttpMessageHandler);
-                telemetry.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: false, autoEnabled: null);
-                telemetry.AssertIntegration(IntegrationId.WinHttpHandler, enabled: false, autoEnabled: null);
-                telemetry.AssertIntegration(IntegrationId.CurlHandler, enabled: false, autoEnabled: null);
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.HttpMessageHandler);
+                await telemetry.AssertIntegrationAsync(IntegrationId.HttpSocketsHandler, enabled: false, autoEnabled: null);
+                await telemetry.AssertIntegrationAsync(IntegrationId.WinHttpHandler, enabled: false, autoEnabled: null);
+                await telemetry.AssertIntegrationAsync(IntegrationId.CurlHandler, enabled: false, autoEnabled: null);
                 VerifyInstrumentation(processResult.Process);
             }
             catch (ExitCodeException)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/LoaderOptimizationStartup.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/LoaderOptimizationStartup.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.IIS
                     break;
                 }
 
-                Thread.Sleep(intervalMilliseconds);
+                await Task.Delay(intervalMilliseconds);
             }
 
             // Server is ready to receive requests

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/MultipleAppsInDomainWithCustomConfigBuilder.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/MultipleAppsInDomainWithCustomConfigBuilder.cs
@@ -59,7 +59,7 @@ public class MultipleAppsInDomainWithCustomConfigBuilder(ITestOutputHelper outpu
                 break;
             }
 
-            Thread.Sleep(intervalMilliseconds);
+            await Task.Delay(intervalMilliseconds);
         }
 
         // Send request to app 1

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 spans.Should().HaveCountGreaterOrEqualTo(1);
 
                 ValidateLogCorrelation(spans, _logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion: packageVersion, use128Bits: enable128BitInjection);
@@ -201,7 +201,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 .HaveCount(expectedLogCount);
 
             VerifyInstrumentation(processResult.Process);
-            telemetry.AssertIntegrationEnabled(IntegrationId.ILogger);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.ILogger);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = EnvironmentHelper.GetMockAgent();
             using var processResult = await RunSampleAndWaitForExit(agent, arguments: topic, packageVersion: packageVersion);
 
-            var allSpans = agent.WaitForSpans(TotalExpectedSpanCount, timeoutInMilliseconds: 10_000);
+            var allSpans = await agent.WaitForSpansAsync(TotalExpectedSpanCount, timeoutInMilliseconds: 10_000);
             using var assertionScope = new AssertionScope();
             // We use HaveCountGreaterOrEqualTo because _both_ consumers may handle the message
             // Due to manual/autocommit behaviour
@@ -169,7 +169,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                    .And.OnlyContain(x => x.Tags[Tags.ErrorType] == "Confluent.Kafka.ConsumeException");
             }
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.Kafka);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Kafka);
         }
 
         private void VerifyProducerSpanProperties(List<MockSpan> producerSpans, string serviceName, string resourceName, int expectedCount)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -92,18 +92,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 IImmutableList<MockSpan> spans = null;
                 if (EnvironmentTools.IsWindows())
                 {
-                    spans = agent.WaitForSpans(1, 2500);
+                    spans = await agent.WaitForSpansAsync(1, 2500);
                 }
                 else if (!string.IsNullOrEmpty(packageVersion) && new Version(packageVersion) >= new Version("3.1.0"))
                 {
                     // if we are not on Windows and we are above 3.1.0, an additional span is made
                     // from log4net to determine if we are on Android.
                     // This is a Process span, we can ultimately just ignore it
-                    spans = agent.WaitForSpans(2, 2500);
+                    spans = await agent.WaitForSpansAsync(2, 2500);
                 }
                 else
                 {
-                    spans = agent.WaitForSpans(1, 2500);
+                    spans = await agent.WaitForSpansAsync(1, 2500);
                 }
 
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -152,18 +152,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 IImmutableList<MockSpan> spans = null;
                 if (EnvironmentTools.IsWindows())
                 {
-                    spans = agent.WaitForSpans(1, 2500);
+                    spans = await agent.WaitForSpansAsync(1, 2500);
                 }
                 else if (!string.IsNullOrEmpty(packageVersion) && new Version(packageVersion) >= new Version("3.1.0"))
                 {
                     // if we are not on Windows and we are above 3.1.0, an additional span is made
                     // from log4net to determine if we are on Android.
                     // This is a Process span, we can ultimately just ignore it
-                    spans = agent.WaitForSpans(2, 2500);
+                    spans = await agent.WaitForSpansAsync(2, 2500);
                 }
                 else
                 {
-                    spans = agent.WaitForSpans(1, 2500);
+                    spans = await agent.WaitForSpansAsync(1, 2500);
                 }
 
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -237,7 +237,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             VerifyInstrumentation(processResult.Process);
-            telemetry.AssertIntegrationEnabled(IntegrationId.Log4Net);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Log4Net);
         }
 
         private static bool PackageSupportsLogsInjection(string packageVersion)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -89,7 +89,7 @@ public class ManualInstrumentationTests : TestHelper
         using var assert = new AssertionScope();
         using var process = await RunSampleAndWaitForExit(agent);
 
-        var spans = agent.WaitForSpans(0, timeoutInMilliseconds: 500);
+        var spans = await agent.WaitForSpansAsync(0, timeoutInMilliseconds: 500);
         spans.Should().BeEmpty();
     }
 
@@ -102,7 +102,7 @@ public class ManualInstrumentationTests : TestHelper
         using var assert = new AssertionScope();
         using var process = await RunSampleAndWaitForExit(agent, usePublishWithRID: usePublishWithRID);
 
-        var spans = agent.WaitForSpans(expectedSpans);
+        var spans = await agent.WaitForSpansAsync(expectedSpans);
         spans.Should().HaveCount(expectedSpans);
 
         var settings = VerifyHelper.GetSpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(3, 500);
+                var spans = await agent.WaitForSpansAsync(3, 500);
 
                 var version = string.IsNullOrEmpty(packageVersion) ? null : new Version(packageVersion);
                 var snapshotSuffix = version switch
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateIntegrationSpans(allMongoSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.MongoDb);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.MongoDb);
 
                 // do some basic verification on the "admin" spans
                 using var scope = new AssertionScope();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = EnvironmentHelper.GetMockAgent();
             using var processResult = await RunSampleAndWaitForExit(agent, arguments: $"5 5");
 
-            var spans = agent.WaitForSpans(totalTransactions);
+            var spans = await agent.WaitForSpansAsync(totalTransactions);
             Assert.True(spans.Count >= totalTransactions, $"Expecting at least {totalTransactions} spans, only received {spans.Count}");
             var msmqSpans = spans.Where(span => string.Equals(span.GetTag("component"), "msmq", StringComparison.OrdinalIgnoreCase));
             ValidateIntegrationSpans(msmqSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
@@ -124,7 +124,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             purgeCount.Should().Be(expectedPurgeCount);
             receiveCount.Should().Be(expectedReceiveCount);
             peekCount.Should().Be(expectedPeekCount);
-            telemetry.AssertIntegrationEnabled(IntegrationId.Msmq);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Msmq);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -286,7 +286,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType })))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var testFiles = GetTestFiles(packageVersion, true, configType);
@@ -323,7 +323,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType })))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var testFiles = GetTestFiles(packageVersion, logsInjectionEnabled: false, configType);
@@ -391,7 +391,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 logs.Should().Contain(x => hasProperty(x, CustomContextKey, CustomContextValue));
             }
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.NLog);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.NLog);
         }
 
         private void VerifyContextProperties(LogFileTest[] testFiles, string packageVersion, string context)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent))
             {
                 const int expectedSpanCount = 53;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseFileName(nameof(NetActivitySdkTests));
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.OpenTelemetry);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 const int expectedSpanCount = 38;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
@@ -130,7 +130,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseFileName(filename)
                                   .DisableRequireUniquePrefix();
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.OpenTelemetry);
             }
         }
 
@@ -148,7 +148,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 const int expectedSpanCount = 38;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 var otelSpans = spans.Where(s => s.Service == "MyServiceName");
@@ -175,7 +175,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseFileName(filename)
                                   .DisableRequireUniquePrefix();
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.OpenTelemetry);
             }
         }
 
@@ -193,7 +193,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 using var s = new AssertionScope();
                 spans.Should().BeEmpty();
-                telemetry.AssertIntegrationDisabled(IntegrationId.OpenTelemetry);
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.OpenTelemetry);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTracingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTracingTests.cs
@@ -33,11 +33,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, arguments: nameof(MinimalSpan)))
             {
                 const int expectedSpanCount = 1;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 await VerifyHelper.VerifySpans(spans, settings);
-                telemetry.AssertIntegrationEnabled(IntegrationId.DatadogTraceManual);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.DatadogTraceManual);
             }
         }
 
@@ -51,11 +51,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, arguments: nameof(CustomServiceName)))
             {
                 const int expectedSpanCount = 1;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 await VerifyHelper.VerifySpans(spans, settings);
-                telemetry.AssertIntegrationEnabled(IntegrationId.DatadogTraceManual);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.DatadogTraceManual);
             }
         }
 
@@ -69,11 +69,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, arguments: nameof(Utf8Everywhere)))
             {
                 const int expectedSpanCount = 1;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 await VerifyHelper.VerifySpans(spans, settings);
-                telemetry.AssertIntegrationEnabled(IntegrationId.DatadogTraceManual);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.DatadogTraceManual);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);
 
                 foreach (var span in spans)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var spans = agent.Spans; // no spans expected
 
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
-            telemetry.AssertIntegrationDisabled(IntegrationId.Process);
+            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Process);
         }
 
         protected async Task RunTest(string metadataSchemaVersion, string testName, int expectedSpanCount, bool collectCommands = false)
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = EnvironmentHelper.GetMockAgent();
 
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             VerifyInstrumentation(process.Process);
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.Process);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Process);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = await RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(1);
+            var spans = await agent.WaitForSpansAsync(1);
 
             // could snapshot this, but really doesn't seem worth it, as all we
             // really want to test is that we don't get _2_ spans

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
             {
                 using var assertionScope = new AssertionScope();
-                var spans = agent.WaitForSpans(expectedSpanCount); // Do not filter on operation name because they will vary depending on instrumented method
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount); // Do not filter on operation name because they will vary depending on instrumented method
 
                 var rabbitmqSpans = spans.Where(span => string.Equals(span.GetTag("component"), "RabbitMQ", StringComparison.OrdinalIgnoreCase));
 
@@ -99,7 +99,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .DisableRequireUniquePrefix();
             }
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.RabbitMQ);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.RabbitMQ);
         }
 
         private string GetPackageVersionSuffix(string packageVersion)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RemotingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RemotingTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=http"))
             {
                 const int expectedSpanCount = 8;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseFileName(nameof(RemotingTests) + ".http" + $".Schema{metadataSchemaVersion.ToUpper()}");
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.Remoting);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Remoting);
             }
         }
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=tcp"))
             {
                 const int expectedSpanCount = 6;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
@@ -109,7 +109,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseFileName(nameof(RemotingTests) + ".tcp" + $".Schema{metadataSchemaVersion.ToUpper()}");
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.Remoting);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Remoting);
             }
         }
 
@@ -129,7 +129,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (await RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=ipc"))
             {
                 const int expectedSpanCount = 6;
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
@@ -147,7 +147,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseFileName(nameof(RemotingTests) + ".ipc" + $".Schema{metadataSchemaVersion.ToUpper()}");
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.Remoting);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Remoting);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -141,7 +141,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var logFiles = GetLogFiles(packageVersion, logsInjectionEnabled: true);
@@ -168,7 +168,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var logFiles = GetLogFiles(packageVersion, logsInjectionEnabled: false);
@@ -216,7 +216,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.TraceId))
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.SpanId));
             VerifyInstrumentation(processResult.Process);
-            telemetry.AssertIntegrationEnabled(IntegrationId.Serilog);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.Serilog);
         }
 
         private void SetSerilogConfiguration(bool loadFromConfig)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);
 
                 foreach (var span in spans)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using var assertionScope = new AssertionScope();
                 var expectedSpansPerRun = 13;
                 var expectedSpans = numberOfRuns * expectedSpansPerRun;
-                var spans = agent.WaitForSpans(expectedSpans)
+                var spans = (await agent.WaitForSpansAsync(expectedSpans))
                                  .OrderBy(s => s.Start)
                                  .ToList();
                 spans.Count.Should().Be(expectedSpans);
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                             .ThenBy(x => x.Duration));
                 }
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.ServiceStackRedis);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.ServiceStackRedis);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs
@@ -30,7 +30,7 @@ public class SourceCodeIntegrationGitMetadataTests : TestHelper
         using var assert = new AssertionScope();
         using var process = await RunSampleAndWaitForExit(agent);
 
-        var spans = agent.WaitForSpans(expectedSpans);
+        var spans = await agent.WaitForSpansAsync(expectedSpans);
         spans.Should().HaveCount(expectedSpans);
 
         // Let's separate the traces
@@ -57,7 +57,7 @@ public class SourceCodeIntegrationGitMetadataTests : TestHelper
         using var assert = new AssertionScope();
         using var process = await RunSampleAndWaitForExit(agent);
 
-        var spans = agent.WaitForSpans(0, timeoutInMilliseconds: 500);
+        var spans = await agent.WaitForSpansAsync(0, timeoutInMilliseconds: 500);
         spans.Should().BeEmpty();
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -74,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     _ => 202,
                 };
 
-                var spans = agent.WaitForSpans(expectedCount);
+                var spans = await agent.WaitForSpansAsync(expectedCount);
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
                 var host = Environment.GetEnvironmentVariable("STACKEXCHANGE_REDIS_HOST") ?? "localhost:6389";
@@ -113,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         .ThenBy(x => x.Duration));
             }
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.StackExchangeRedis);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.StackExchangeRedis);
         }
 
         private static PackageVersion GetPackageVersion(string packageVersionString)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -371,13 +371,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 });
         }
 
-        private static async ValueTask AssertServiceAsync(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
+        private static async Task AssertServiceAsync(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppStarted));
             AssertService(mockAgent.Telemetry.Cast<TelemetryData>(), expectedServiceName, expectedServiceVersion);
         }
 
-        private static async ValueTask AssertServiceAsync(MockTelemetryAgent telemetry, string expectedServiceName, string expectedServiceVersion)
+        private static async Task AssertServiceAsync(MockTelemetryAgent telemetry, string expectedServiceName, string expectedServiceVersion)
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppStarted));
             AssertService(telemetry.Telemetry, expectedServiceName, expectedServiceVersion);
@@ -392,13 +392,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             appClosing.Application.ServiceVersion.Should().Be(expectedServiceVersion);
         }
 
-        private static async ValueTask AssertDependenciesAsync(MockTracerAgent mockAgent, bool? enableDependencies)
+        private static async Task AssertDependenciesAsync(MockTracerAgent mockAgent, bool? enableDependencies)
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
             AssertDependencies(mockAgent.Telemetry.Cast<TelemetryData>(), enableDependencies);
         }
 
-        private static async ValueTask AssertDependenciesAsync(MockTelemetryAgent telemetry, bool? enableDependencies)
+        private static async Task AssertDependenciesAsync(MockTelemetryAgent telemetry, bool? enableDependencies)
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
             AssertDependencies(telemetry.Telemetry, enableDependencies);
@@ -428,19 +428,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                               .UseFileName("TelemetryTests");
         }
 
-        private static ValueTask<object> WaitForAllTelemetryAsync(MockTracerAgent mockAgent)
+        private static Task<object> WaitForAllTelemetryAsync(MockTracerAgent mockAgent)
             => mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
-        private static ValueTask<TelemetryData> WaitForAllTelemetryAsync(MockTelemetryAgent telemetry)
+        private static Task<TelemetryData> WaitForAllTelemetryAsync(MockTelemetryAgent telemetry)
             => telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
-        private static async ValueTask AssertNoRedactedErrorLogsAsync(MockTracerAgent mockAgent)
+        private static async Task AssertNoRedactedErrorLogsAsync(MockTracerAgent mockAgent)
         {
             await WaitForAllTelemetryAsync(mockAgent);
             AssertNoRedactedErrorLogs(mockAgent.Telemetry.Cast<TelemetryData>());
         }
 
-        private static async ValueTask AssertNoRedactedErrorLogsAsync(MockTelemetryAgent telemetry)
+        private static async Task AssertNoRedactedErrorLogsAsync(MockTelemetryAgent telemetry)
         {
             await WaitForAllTelemetryAsync(telemetry);
             AssertNoRedactedErrorLogs(telemetry.Telemetry);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -61,19 +61,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
 
                 await AssertExpectedSpans(spans);
             }
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
-            telemetry.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
-            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext,baggage");
-            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext,baggage");
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.HttpMessageHandler);
+            await telemetry.AssertConfigurationAsync(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+            await telemetry.AssertConfigurationAsync(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext,baggage");
+            await telemetry.AssertConfigurationAsync(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext,baggage");
 
-            AssertService(telemetry, "Samples.Telemetry", ServiceVersion);
-            AssertDependencies(telemetry, enableDependencies);
-            AssertNoRedactedErrorLogs(telemetry);
+            await AssertServiceAsync(telemetry, "Samples.Telemetry", ServiceVersion);
+            await AssertDependenciesAsync(telemetry, enableDependencies);
+            await AssertNoRedactedErrorLogsAsync(telemetry);
             agent.Telemetry.Should().BeEmpty();
         }
 
@@ -94,18 +94,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
                 await AssertExpectedSpans(spans);
             }
 
-            agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
-            agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
-            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext,baggage");
-            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext,baggage");
+            await agent.AssertIntegrationEnabledAsync(IntegrationId.HttpMessageHandler);
+            await agent.AssertConfigurationAsync(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+            await agent.AssertConfigurationAsync(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext,baggage");
+            await agent.AssertConfigurationAsync(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext,baggage");
 
-            AssertService(agent, "Samples.Telemetry", ServiceVersion);
-            AssertDependencies(agent, enableDependencies);
-            AssertNoRedactedErrorLogs(agent);
+            await AssertServiceAsync(agent, "Samples.Telemetry", ServiceVersion);
+            await AssertDependenciesAsync(agent, enableDependencies);
+            await AssertNoRedactedErrorLogsAsync(agent);
         }
 
         [SkippableFact]
@@ -125,14 +125,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
                 await AssertExpectedSpans(spans);
             }
 
             // Shouldn't have any, but wait for 5s
-            agent.WaitForLatestTelemetry(x => true);
+            await agent.WaitForLatestTelemetryAsync(x => true);
             agent.Telemetry.Should().BeEmpty();
-            AssertNoRedactedErrorLogs(agent);
+            await AssertNoRedactedErrorLogsAsync(agent);
         }
 
         [SkippableTheory]
@@ -160,15 +160,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
                 await AssertExpectedSpans(spans);
             }
 
-            agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
-            agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
-            AssertService(agent, "Samples.Telemetry", ServiceVersion);
-            AssertDependencies(agent, enableDependencies);
-            AssertNoRedactedErrorLogs(agent);
+            await agent.AssertIntegrationEnabledAsync(IntegrationId.HttpMessageHandler);
+            await agent.AssertConfigurationAsync(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+            await AssertServiceAsync(agent, "Samples.Telemetry", ServiceVersion);
+            await AssertDependenciesAsync(agent, enableDependencies);
+            await AssertNoRedactedErrorLogsAsync(agent);
         }
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -194,14 +194,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
                 await AssertExpectedSpans(spans);
             }
 
-            agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
-            AssertService(agent, "Samples.Telemetry", ServiceVersion);
-            AssertDependencies(agent, enableDependencies);
-            AssertNoRedactedErrorLogs(agent);
+            await agent.AssertIntegrationEnabledAsync(IntegrationId.HttpMessageHandler);
+            await AssertServiceAsync(agent, "Samples.Telemetry", ServiceVersion);
+            await AssertDependenciesAsync(agent, enableDependencies);
+            await AssertNoRedactedErrorLogsAsync(agent);
         }
 #endif
 
@@ -226,31 +226,31 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
                 await AssertExpectedSpans(spans);
             }
 
             // The numbers here may change, but we should have _some_
-            telemetry.GetDistributions(DistributionShared.InitTime.GetName()).Sum(x => x.Points.Count).Should().BeGreaterThan(4);
+            (await telemetry.GetDistributionsAsync(DistributionShared.InitTime.GetName())).Sum(x => x.Points.Count).Should().BeGreaterThan(4);
 
-            telemetry.GetMetricDataPoints(Count.TraceChunkEnqueued.GetName()).Sum(x => x.Value).Should().Be(ExpectedTraces);
+            (await telemetry.GetMetricDataPointsAsync(Count.TraceChunkEnqueued.GetName())).Sum(x => x.Value).Should().Be(ExpectedTraces);
 
             // The exact number of logs aren't important, but we should have some
-            telemetry.GetMetricDataPoints(Count.LogCreated.GetName(), "level:info")
+            (await telemetry.GetMetricDataPointsAsync(Count.LogCreated.GetName(), "level:info"))
                      .Sum(x => x.Value).Should().BeGreaterThan(10);
 
             // Should have at least 1 call to the Agentless telemetry API and no errors
-            var telemetryRequests = telemetry.GetMetricDataPoints(Count.TelemetryApiRequests.GetName(), "endpoint:agentless")
+            var telemetryRequests = (await telemetry.GetMetricDataPointsAsync(Count.TelemetryApiRequests.GetName(), "endpoint:agentless"))
                                              .Sum(x => x.Value);
             telemetryRequests.Should().BeGreaterThan(0);
-            telemetry.GetMetricDataPoints(Count.TelemetryApiResponses.GetName(), "endpoint:agentless")
+            (await telemetry.GetMetricDataPointsAsync(Count.TelemetryApiResponses.GetName(), "endpoint:agentless"))
                      .Sum(x => x.Value).Should().Be(telemetryRequests);
-            telemetry.GetMetricDataPoints(Count.TelemetryApiRequests.GetName(), "endpoint:agent").Should().BeEmpty();
-            telemetry.GetMetricDataPoints(Count.TelemetryApiErrors.GetName()).Should().BeEmpty();
+            (await telemetry.GetMetricDataPointsAsync(Count.TelemetryApiRequests.GetName(), "endpoint:agent")).Should().BeEmpty();
+            (await telemetry.GetMetricDataPointsAsync(Count.TelemetryApiErrors.GetName())).Should().BeEmpty();
 
             // we inject and extract headers once
             // avoiding checking the specific tag + count here so this doesn't need updating if we change the defaults
-            telemetry.GetMetricDataPoints(Count.ContextHeaderStyleInjected.GetName())
+            (await telemetry.GetMetricDataPointsAsync(Count.ContextHeaderStyleInjected.GetName()))
                      .Should()
                      .NotBeEmpty()
                      .And.OnlyContain(x => x.Tags.Length > 0)
@@ -260,21 +260,21 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                      .HaveCountGreaterOrEqualTo(1);
 
             // hopefully no errors
-            telemetry.GetMetricDataPoints(CountShared.IntegrationsError.GetName()).Should().BeEmpty();
-            telemetry.GetMetricDataPoints(Count.VersionConflictTracerCreated.GetName()).Should().BeEmpty();
+            (await telemetry.GetMetricDataPointsAsync(CountShared.IntegrationsError.GetName())).Should().BeEmpty();
+            (await telemetry.GetMetricDataPointsAsync(Count.VersionConflictTracerCreated.GetName())).Should().BeEmpty();
 
-            telemetry.GetMetricDataPoints(Gauge.Instrumentations.GetName()).Sum(x => x.Value).Should().BeGreaterThan(1);
+            (await telemetry.GetMetricDataPointsAsync(Gauge.Instrumentations.GetName())).Sum(x => x.Value).Should().BeGreaterThan(1);
 
-            telemetry.GetMetricDataPoints(Count.SpanCreated.GetName()).Sum(x => x.Value).Should().Be(ExpectedSpans);
-            telemetry.GetMetricDataPoints(Count.SpanFinished.GetName()).Sum(x => x.Value).Should().Be(ExpectedSpans);
-            telemetry.GetMetricDataPoints(Count.SpanEnqueuedForSerialization.GetName()).Sum(x => x.Value).Should().Be(ExpectedSpans);
-            telemetry.GetMetricDataPoints(Count.TraceSegmentCreated.GetName()).Sum(x => x.Value).Should().Be(ExpectedTraces);
-            telemetry.GetMetricDataPoints(Count.TraceChunkEnqueued.GetName()).Sum(x => x.Value).Should().Be(ExpectedTraces);
-            telemetry.GetMetricDataPoints(Count.TraceChunkSent.GetName()).Sum(x => x.Value).Should().Be(ExpectedTraces);
+            (await telemetry.GetMetricDataPointsAsync(Count.SpanCreated.GetName())).Sum(x => x.Value).Should().Be(ExpectedSpans);
+            (await telemetry.GetMetricDataPointsAsync(Count.SpanFinished.GetName())).Sum(x => x.Value).Should().Be(ExpectedSpans);
+            (await telemetry.GetMetricDataPointsAsync(Count.SpanEnqueuedForSerialization.GetName())).Sum(x => x.Value).Should().Be(ExpectedSpans);
+            (await telemetry.GetMetricDataPointsAsync(Count.TraceSegmentCreated.GetName())).Sum(x => x.Value).Should().Be(ExpectedTraces);
+            (await telemetry.GetMetricDataPointsAsync(Count.TraceChunkEnqueued.GetName())).Sum(x => x.Value).Should().Be(ExpectedTraces);
+            (await telemetry.GetMetricDataPointsAsync(Count.TraceChunkSent.GetName())).Sum(x => x.Value).Should().Be(ExpectedTraces);
 
-            telemetry.GetMetricDataPoints(Count.TraceApiRequests.GetName()).Sum(x => x.Value).Should().BeGreaterThan(0);
-            telemetry.GetMetricDataPoints(Count.TraceApiResponses.GetName()).Sum(x => x.Value).Should().BeGreaterThan(0);
-            telemetry.GetMetricDataPoints(Count.TraceApiErrors.GetName()).Should().BeEmpty();
+            (await telemetry.GetMetricDataPointsAsync(Count.TraceApiRequests.GetName())).Sum(x => x.Value).Should().BeGreaterThan(0);
+            (await telemetry.GetMetricDataPointsAsync(Count.TraceApiResponses.GetName())).Sum(x => x.Value).Should().BeGreaterThan(0);
+            (await telemetry.GetMetricDataPointsAsync(Count.TraceApiErrors.GetName())).Should().BeEmpty();
         }
 
         [SkippableFact]
@@ -302,11 +302,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
                 await AssertExpectedSpans(spans);
             }
 
-            WaitForAllTelemetry(telemetry);
+            await WaitForAllTelemetryAsync(telemetry);
             telemetry.Telemetry
                      .Where(x => x.IsRequestType(TelemetryRequestTypes.RedactedErrorLogs))
                      .Should()
@@ -349,11 +349,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(ExpectedSpans);
+                var spans = await agent.WaitForSpansAsync(ExpectedSpans);
                 await AssertExpectedSpans(spans);
             }
 
-            telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppStarted));
+            await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppStarted));
 
             var appStarted = telemetry.Telemetry.Should()
                 .ContainSingle(x => x.IsRequestType(TelemetryRequestTypes.AppStarted))
@@ -371,15 +371,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 });
         }
 
-        private static void AssertService(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
+#if NETFRAMEWORK
+        private static async Task AssertServiceAsync(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
+#else
+        private static async ValueTask AssertServiceAsync(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
+#endif
         {
-            mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppStarted));
+            await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppStarted));
             AssertService(mockAgent.Telemetry.Cast<TelemetryData>(), expectedServiceName, expectedServiceVersion);
         }
 
-        private static void AssertService(MockTelemetryAgent telemetry, string expectedServiceName, string expectedServiceVersion)
+#if NETFRAMEWORK
+        private static async Task AssertServiceAsync(MockTelemetryAgent telemetry, string expectedServiceName, string expectedServiceVersion)
+#else
+        private static async ValueTask AssertServiceAsync(MockTelemetryAgent telemetry, string expectedServiceName, string expectedServiceVersion)
+#endif
         {
-            telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppStarted));
+            await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppStarted));
             AssertService(telemetry.Telemetry, expectedServiceName, expectedServiceVersion);
         }
 
@@ -392,15 +400,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             appClosing.Application.ServiceVersion.Should().Be(expectedServiceVersion);
         }
 
-        private static void AssertDependencies(MockTracerAgent mockAgent, bool? enableDependencies)
+#if NETFRAMEWORK
+        private static async Task AssertDependenciesAsync(MockTracerAgent mockAgent, bool? enableDependencies)
+#else
+        private static async ValueTask AssertDependenciesAsync(MockTracerAgent mockAgent, bool? enableDependencies)
+#endif
         {
-            mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
+            await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
             AssertDependencies(mockAgent.Telemetry.Cast<TelemetryData>(), enableDependencies);
         }
 
-        private static void AssertDependencies(MockTelemetryAgent telemetry, bool? enableDependencies)
+#if NETFRAMEWORK
+        private static async Task AssertDependenciesAsync(MockTelemetryAgent telemetry, bool? enableDependencies)
+#else
+        private static async ValueTask AssertDependenciesAsync(MockTelemetryAgent telemetry, bool? enableDependencies)
+#endif
         {
-            telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
+            await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
             AssertDependencies(telemetry.Telemetry, enableDependencies);
         }
 
@@ -428,21 +444,37 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                               .UseFileName("TelemetryTests");
         }
 
-        private static void WaitForAllTelemetry(MockTracerAgent mockAgent)
-            => mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
+#if NETFRAMEWORK
+        private static Task WaitForAllTelemetryAsync(MockTracerAgent mockAgent)
+#else
+        private static ValueTask<object> WaitForAllTelemetryAsync(MockTracerAgent mockAgent)
+#endif
+            => mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
-        private static void WaitForAllTelemetry(MockTelemetryAgent telemetry)
-            => telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
+#if NETFRAMEWORK
+        private static Task WaitForAllTelemetryAsync(MockTelemetryAgent telemetry)
+#else
+        private static ValueTask<TelemetryData> WaitForAllTelemetryAsync(MockTelemetryAgent telemetry)
+#endif
+            => telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
-        private static void AssertNoRedactedErrorLogs(MockTracerAgent mockAgent)
+#if NETFRAMEWORK
+        private static async Task AssertNoRedactedErrorLogsAsync(MockTracerAgent mockAgent)
+#else
+        private static async ValueTask AssertNoRedactedErrorLogsAsync(MockTracerAgent mockAgent)
+#endif
         {
-            WaitForAllTelemetry(mockAgent);
+            await WaitForAllTelemetryAsync(mockAgent);
             AssertNoRedactedErrorLogs(mockAgent.Telemetry.Cast<TelemetryData>());
         }
 
-        private static void AssertNoRedactedErrorLogs(MockTelemetryAgent telemetry)
+#if NETFRAMEWORK
+        private static async Task AssertNoRedactedErrorLogsAsync(MockTelemetryAgent telemetry)
+#else
+        private static async ValueTask AssertNoRedactedErrorLogsAsync(MockTelemetryAgent telemetry)
+#endif
         {
-            WaitForAllTelemetry(telemetry);
+            await WaitForAllTelemetryAsync(telemetry);
             AssertNoRedactedErrorLogs(telemetry.Telemetry);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -371,21 +371,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 });
         }
 
-#if NETFRAMEWORK
-        private static async Task AssertServiceAsync(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
-#else
         private static async ValueTask AssertServiceAsync(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
-#endif
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppStarted));
             AssertService(mockAgent.Telemetry.Cast<TelemetryData>(), expectedServiceName, expectedServiceVersion);
         }
 
-#if NETFRAMEWORK
-        private static async Task AssertServiceAsync(MockTelemetryAgent telemetry, string expectedServiceName, string expectedServiceVersion)
-#else
         private static async ValueTask AssertServiceAsync(MockTelemetryAgent telemetry, string expectedServiceName, string expectedServiceVersion)
-#endif
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppStarted));
             AssertService(telemetry.Telemetry, expectedServiceName, expectedServiceVersion);
@@ -400,21 +392,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             appClosing.Application.ServiceVersion.Should().Be(expectedServiceVersion);
         }
 
-#if NETFRAMEWORK
-        private static async Task AssertDependenciesAsync(MockTracerAgent mockAgent, bool? enableDependencies)
-#else
         private static async ValueTask AssertDependenciesAsync(MockTracerAgent mockAgent, bool? enableDependencies)
-#endif
         {
             await mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
             AssertDependencies(mockAgent.Telemetry.Cast<TelemetryData>(), enableDependencies);
         }
 
-#if NETFRAMEWORK
-        private static async Task AssertDependenciesAsync(MockTelemetryAgent telemetry, bool? enableDependencies)
-#else
         private static async ValueTask AssertDependenciesAsync(MockTelemetryAgent telemetry, bool? enableDependencies)
-#endif
         {
             await telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
             AssertDependencies(telemetry.Telemetry, enableDependencies);
@@ -444,35 +428,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                               .UseFileName("TelemetryTests");
         }
 
-#if NETFRAMEWORK
-        private static Task WaitForAllTelemetryAsync(MockTracerAgent mockAgent)
-#else
         private static ValueTask<object> WaitForAllTelemetryAsync(MockTracerAgent mockAgent)
-#endif
             => mockAgent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
 
-#if NETFRAMEWORK
-        private static Task WaitForAllTelemetryAsync(MockTelemetryAgent telemetry)
-#else
         private static ValueTask<TelemetryData> WaitForAllTelemetryAsync(MockTelemetryAgent telemetry)
-#endif
             => telemetry.WaitForLatestTelemetryAsync(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
 
-#if NETFRAMEWORK
-        private static async Task AssertNoRedactedErrorLogsAsync(MockTracerAgent mockAgent)
-#else
         private static async ValueTask AssertNoRedactedErrorLogsAsync(MockTracerAgent mockAgent)
-#endif
         {
             await WaitForAllTelemetryAsync(mockAgent);
             AssertNoRedactedErrorLogs(mockAgent.Telemetry.Cast<TelemetryData>());
         }
 
-#if NETFRAMEWORK
-        private static async Task AssertNoRedactedErrorLogsAsync(MockTelemetryAgent telemetry)
-#else
         private static async ValueTask AssertNoRedactedErrorLogsAsync(MockTelemetryAgent telemetry)
-#endif
         {
             await WaitForAllTelemetryAsync(telemetry);
             AssertNoRedactedErrorLogs(telemetry.Telemetry);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
@@ -37,6 +37,6 @@ public class TracerTests : TestHelper
 
         // Tracing is disabled, we shouldn't have spans, even though they wrote some
         agent.Spans.Should().BeEmpty();
-        agent.AssertConfiguration("DD_TRACE_ENABLED", false);
+        await agent.AssertConfigurationAsync("DD_TRACE_ENABLED", false);
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -89,14 +89,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 await VerifyHelper.VerifySpans(spans, VerifyHelper.GetSpanVerifierSettings())
                                   .DisableRequireUniquePrefix()
                                   .UseFileName("TransportTests");
             }
 
-            telemetry.AssertConfiguration(ConfigTelemetryData.AgentTraceTransport, transportType.ToString());
+            await telemetry.AssertConfigurationAsync(ConfigTelemetryData.AgentTraceTransport, transportType.ToString());
 
             MockTracerAgent GetAgent(TracesTransportType type)
                 => type switch

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 {
                     // Extra long time out because big payloads
                     var timeoutInMilliseconds = 60_000;
-                    var spans = agent.WaitForSpans(ExpectedSpans, timeoutInMilliseconds: timeoutInMilliseconds);
+                    var spans = await agent.WaitForSpansAsync(ExpectedSpans, timeoutInMilliseconds: timeoutInMilliseconds);
                     AssertLargePayloadExpectations(spans);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -183,7 +183,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK, $"server returned an error: {content}");
 
-            var spans = _iisFixture.Agent.WaitForSpans(expectedSpans, minDateTime: testStart, returnAllOperations: true);
+            var spans = await _iisFixture.Agent.WaitForSpansAsync(expectedSpans, minDateTime: testStart, returnAllOperations: true);
 
             spans.Should().HaveCount(expectedSpans);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, aspNetCorePort: 0))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 spans.Should().HaveCountGreaterOrEqualTo(1);
 
                 ValidateLogCorrelation(spans, _logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, use128Bits: false);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = MockTracerAgent.Create(Output, agentPort))
             using (await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = MockTracerAgent.Create(Output, agentPort))
             using (await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = MockTracerAgent.Create(Output, agentPort))
             using (await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = MockTracerAgent.Create(Output, agentPort))
             using (await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 ValidateLogCorrelation(spans, _nlog40LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = MockTracerAgent.Create(Output, agentPort))
             using (await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 ValidateLogCorrelation(spans, _log200FileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = MockTracerAgent.Create(Output, agentPort))
             using (await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(1, 2500);
+                var spans = await agent.WaitForSpansAsync(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 ValidateLogCorrelation(spans, _log200FileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 spans.Should().HaveCount(expectedSpanCount);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = await RunSampleAndWaitForExit(agent))
             {
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 foreach (var span in spans)
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -114,7 +114,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 // The test adds a custom span to show that propagation works with WCF headers
                 agent.SpanFilters.Add(s => s.Type == SpanTypes.Web || s.Type == SpanTypes.Custom);
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
                 ValidateIntegrationSpans(spans.Where(s => s.Type == SpanTypes.Web), metadataSchemaVersion, expectedServiceName: "Samples.Wcf", isExternalSpan: false);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings(metadataSchemaVersion, binding, enableNewWcfInstrumentation, enableWcfObfuscation);
@@ -123,7 +123,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseMethodName("_");
 
                 // The custom binding doesn't trigger the integration
-                telemetry.AssertIntegration(IntegrationId.Wcf, enabled: binding != "Custom", autoEnabled: true);
+                await telemetry.AssertIntegrationAsync(IntegrationId.Wcf, enabled: binding != "Custom", autoEnabled: true);
             }
         }
 
@@ -156,7 +156,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 agent.SpanFilters.Add(s => !s.Resource.Contains("schemas.xmlsoap.org") && !s.Resource.Contains("www.w3.org"));
                 // The test adds a custom span to show that propagation works with WCF headers
                 agent.SpanFilters.Add(s => s.Type == SpanTypes.Web || s.Type == SpanTypes.Custom);
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
                 ValidateIntegrationSpans(spans.Where(s => s.Type == SpanTypes.Web), metadataSchemaVersion, expectedServiceName: "Samples.Wcf", isExternalSpan: false);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
@@ -168,7 +168,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseTextForParameters(fileSuffix);
 
                 // The custom binding doesn't trigger the integration
-                telemetry.AssertIntegration(IntegrationId.Wcf, enabled: true, autoEnabled: true);
+                await telemetry.AssertIntegrationAsync(IntegrationId.Wcf, enabled: true, autoEnabled: true);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Null(traceId);
                 Assert.Null(parentSpanId);
                 Assert.Equal("false", tracingEnabled);
-                telemetry.AssertIntegrationDisabled(IntegrationId.WebRequest);
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.WebRequest);
                 VerifyInstrumentation(processResult.Process);
             }
         }
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                var spans = agent.WaitForSpans(expectedSpanCount);
+                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
                 Assert.Equal(expectedSpanCount, spans.Count);
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Equal(firstSpan.TraceId.ToString(CultureInfo.InvariantCulture), traceId);
                 Assert.Equal(firstSpan.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);
 
-                telemetry.AssertIntegrationEnabled(IntegrationId.WebRequest);
+                await telemetry.AssertIntegrationEnabledAsync(IntegrationId.WebRequest);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Null(traceId);
                 Assert.Null(parentSpanId);
                 Assert.Equal("false", tracingEnabled);
-                telemetry.AssertIntegrationDisabled(IntegrationId.WebRequest);
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.WebRequest);
                 VerifyInstrumentation(processResult.Process);
             }
         }
@@ -89,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = EnvironmentHelper.GetMockAgent();
             using ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}");
 
-            var allSpans = agent.WaitForSpans(expectedAllSpansCount, assertExpectedCount: false).OrderBy(s => s.Start).ToList();
+            var allSpans = (await agent.WaitForSpansAsync(expectedAllSpansCount, assertExpectedCount: false)).OrderBy(s => s.Start).ToList();
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
 #if NET9_0_OR_GREATER
@@ -129,7 +129,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var httpSpans = allSpans.Where(s => s.Type == SpanTypes.Http).ToList();
             ValidateIntegrationSpans(httpSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
-            telemetry.AssertIntegrationEnabled(IntegrationId.WebRequest);
+            await telemetry.AssertIntegrationEnabledAsync(IntegrationId.WebRequest);
             VerifyInstrumentation(processResult.Process);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
             {
-                var spans = agent.WaitForSpans(expectedSpans, 1_000);
+                var spans = await agent.WaitForSpansAsync(expectedSpans, 1_000);
                 spans.Count.Should().Be(expectedSpans);
 
                 // All Datadog spans should be in the same trace

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.IntegrationTests
 
                 await tracer.FlushAsync();
 
-                var spans = agent.WaitForSpans(count: 1);
+                var spans = await agent.WaitForSpansAsync(count: 1);
                 Assert.Equal(expected: 1, spans.Count);
 
                 var headers = agent.TraceRequestHeaders.Should().ContainSingle().Subject;

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -459,7 +459,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
                         break;
                     }
 
-                    Thread.Sleep(200);
+                    await Task.Delay(200);
                 }
             }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -459,7 +459,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
                         break;
                     }
 
-                    await Task.Delay(200);
+                    await Task.Delay(200).ConfigureAwait(false);
                 }
             }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -459,7 +459,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
                         break;
                     }
 
-                    await Task.Delay(200).ConfigureAwait(false);
+                    await Task.Delay(200);
                 }
             }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/LibDatadog/TraceExporterTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/LibDatadog/TraceExporterTests.cs
@@ -74,7 +74,7 @@ public class TraceExporterTests
         }
 
         await tracer.TracerManager.ShutdownAsync();
-        var recordedSpans = agent.WaitForSpans(1);
+        var recordedSpans = await agent.WaitForSpansAsync(1);
         recordedSpans.Should().ContainSingle();
 
         var recordedSpan = recordedSpans.Should().ContainSingle().Subject;

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -108,8 +108,8 @@ namespace Datadog.Trace.IntegrationTests
 
             await tracer.TracerManager.ShutdownAsync(); // Flushes and closes both traces and stats
 
-            var statsPayload = agent.WaitForStats(1);
-            var spans = agent.WaitForSpans(13);
+            var statsPayload = await agent.WaitForStatsAsync(1);
+            var spans = await agent.WaitForSpansAsync(13);
 
             statsPayload.Should().HaveCount(1);
             statsPayload[0].Stats.Should().HaveCount(1);
@@ -220,8 +220,8 @@ namespace Datadog.Trace.IntegrationTests
 
             await tracer.TracerManager.ShutdownAsync(); // Flushes and closes both traces and stats
 
-            var statsPayload = agent.WaitForStats(1);
-            var spans = agent.WaitForSpans(6);
+            var statsPayload = await agent.WaitForStatsAsync(1);
+            var spans = await agent.WaitForSpansAsync(6);
 
             statsPayload.Should().HaveCount(1);
             statsPayload[0].Stats.Should().HaveCount(1);
@@ -470,7 +470,7 @@ namespace Datadog.Trace.IntegrationTests
 
             if (expectStats)
             {
-                var payload = agent.WaitForStats(1);
+                var payload = await agent.WaitForStatsAsync(1);
                 payload.Should().HaveCount(1);
 
                 var stats1 = payload[0];
@@ -489,7 +489,7 @@ namespace Datadog.Trace.IntegrationTests
             if (finishSpansOnClose)
             {
                 var numberOfSpans = expectAllTraces ? spansCount : spansCount - p0DroppedSpansCount;
-                var payload = agent.WaitForSpans(numberOfSpans);
+                var payload = await agent.WaitForSpansAsync(numberOfSpans);
                 payload.Should().HaveCount(numberOfSpans);
 
                 AssertTraces(payload, expectStats);

--- a/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.IntegrationTests
             var result = await transport.PushTelemetry(data);
 
             result.Should().Be(TelemetryPushResult.Success);
-            var received = agent.WaitForLatestTelemetry(x => x.SeqId == data.SeqId);
+            var received = await agent.WaitForLatestTelemetryAsync(x => x.SeqId == data.SeqId);
 
             received.Should().NotBeNull();
 
@@ -70,7 +70,7 @@ namespace Datadog.Trace.IntegrationTests
             var result = await transport.PushTelemetry(data);
 
             result.Should().Be(TelemetryPushResult.Success);
-            var received = agent.WaitForLatestTelemetry(x => x.SeqId == data.SeqId);
+            var received = await agent.WaitForLatestTelemetryAsync(x => x.SeqId == data.SeqId);
 
             received.Should().NotBeNull();
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
@@ -57,7 +57,7 @@ public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCo
         var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedUrl, body.Substring(0, 10), expectedStatusCode, containsAttack);
         var dateTime = DateTime.UtcNow;
         await SubmitRequest(url, body, "application/json");
-        var spans = agent.WaitForSpans(2, minDateTime: dateTime);
+        var spans = await agent.WaitForSpansAsync(2, minDateTime: dateTime);
 #if !NET8_O_OR_GREATER
         // Simple scrubber for the response content type in .NET 8
         // .NET 8 doesn't add the content-length header, whereas previous versions do

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreEndpoints.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreEndpoints.cs
@@ -58,7 +58,7 @@ public abstract class AspNetCoreEndpoints : AspNetBase, IClassFixture<AspNetCore
         await TryStartApp();
 
         var agent = _fixture.Agent;
-        agent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppEndpoints));
+        await agent.WaitForLatestTelemetryAsync(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppEndpoints));
 
         var allData = agent.Telemetry.Cast<TelemetryData>().ToArray();
         var telemetryData = allData.Where(x => x.IsRequestType(TelemetryRequestTypes.AppEndpoints)).ToArray().FirstOrDefault();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetFxWebApiApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetFxWebApiApiSecurity.cs
@@ -56,7 +56,7 @@ public abstract class AspNetFxWebApiApiSecurity : AspNetBase, IClassFixture<IisF
         settings.UseTextForParameters($"scenario={scenario}");
         var dateTime = DateTime.UtcNow;
         var res = await SubmitRequest(url, body, "application/json");
-        var spans = agent.WaitForSpans(2, minDateTime: dateTime);
+        var spans = await agent.WaitForSpansAsync(2, minDateTime: dateTime);
         await VerifySpans(spans, settings);
     }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetMvc5ApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetMvc5ApiSecurity.cs
@@ -67,7 +67,7 @@ public abstract class AspNetMvc5ApiSecurity : AspNetBase, IClassFixture<IisFixtu
         settings.UseTextForParameters($"scenario={scenario}");
         var dateTime = DateTime.UtcNow;
         var result = await SubmitRequest(url, body, "application/json");
-        var spans = agent.WaitForSpans(2, minDateTime: dateTime);
+        var spans = await agent.WaitForSpansAsync(2, minDateTime: dateTime);
         await VerifySpans(spans, settings);
     }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -444,7 +444,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             return await WaitForSpansAsync(agent, expectedSpans, phase, minDateTime, url);
         }
 
-        protected async ValueTask<IImmutableList<MockSpan>> WaitForSpansAsync(MockTracerAgent agent, int expectedSpans, string phase, DateTime minDateTime, string url)
+        protected async Task<IImmutableList<MockSpan>> WaitForSpansAsync(MockTracerAgent agent, int expectedSpans, string phase, DateTime minDateTime, string url)
         {
             agent.SpanFilters.Clear();
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -444,11 +444,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             return await WaitForSpansAsync(agent, expectedSpans, phase, minDateTime, url);
         }
 
-        #if NETFRAMEWORK
-        protected async Task<IImmutableList<MockSpan>> WaitForSpansAsync(MockTracerAgent agent, int expectedSpans, string phase, DateTime minDateTime, string url)
-        #else
         protected async ValueTask<IImmutableList<MockSpan>> WaitForSpansAsync(MockTracerAgent agent, int expectedSpans, string phase, DateTime minDateTime, string url)
-        #endif
         {
             agent.SpanFilters.Clear();
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var url = "/null-action/test/test";
             var dateTime = DateTime.UtcNow;
             await SubmitRequest(url, null, null);
-            var spans = agent.WaitForSpans(1, minDateTime: dateTime);
+            var spans = await agent.WaitForSpansAsync(1, minDateTime: dateTime);
             var settings = VerifyHelper.GetSpanVerifierSettings();
             await VerifyHelper.VerifySpans(spans, settings).UseFileName($"{GetTestName()}.test-null-action");
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5BlockingTemplates.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5BlockingTemplates.cs
@@ -78,7 +78,7 @@ public class AspNetCore5BlockingTemplatesHtml : AspNetCore5BlockingTemplates
         var (x, page) = await SubmitRequest(url, body: null, contentType: null, accept: "text/html");
         var normalizedPage = page.Replace("\r\n", "\n");
         normalizedPage.Should().Be($"""<!DOCTYPE html>{"\n"}<html lang="en"></html>""");
-        var spans = WaitForSpans(agent, 1, string.Empty, minDateTime, url);
+        var spans = await WaitForSpansAsync(agent, 1, string.Empty, minDateTime, url);
         await VerifySpans(spans, settings);
     }
 }
@@ -104,7 +104,7 @@ public class AspNetCore5BlockingTemplatesJson : AspNetCore5BlockingTemplates
         var minDateTime = DateTime.UtcNow;
         var (x, page) = await SubmitRequest(url, body: null, contentType: null);
         page.Should().Be("{}");
-        var spans = WaitForSpans(agent, 1, string.Empty, minDateTime, url);
+        var spans = await WaitForSpansAsync(agent, 1, string.Empty, minDateTime, url);
         await VerifySpans(spans, settings);
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var (statusCode, _) = await SubmitRequest(url, body: null, contentType: null, userAgent: userAgent);
             ((int)statusCode).Should().Be(returnedStatusCode);
 
-            var spans = WaitForSpans(agent, 1, string.Empty, minDateTime, url);
+            var spans = await WaitForSpansAsync(agent, 1, string.Empty, minDateTime, url);
             await VerifySpans(spans, settings);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                                  new("Akamai-User-Risk", "Test"),
                                  new("X-SigSci-RequestID", "Test")
                              });
-            var spans = WaitForSpans(agent, 1, string.Empty, now, url);
+            var spans = await WaitForSpansAsync(agent, 1, string.Empty, now, url);
             var settings = VerifyHelper.GetSpanVerifierSettings();
             await VerifyHelper.VerifySpans(spans, settings)
                               .UseFileName($"{GetTestName()}.test-external-waf-headers");

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
@@ -139,8 +139,8 @@ namespace Datadog.Trace.Security.IntegrationTests
             var dateTime = DateTime.UtcNow;
             var res = await SubmitRequest(url, null, null);
             var res2 = await SubmitRequest(url2, null, null);
-            var spans = WaitForSpans(_iisFixture.Agent, 2, null, minDateTime: dateTime, url: url);
-            var spans2 = WaitForSpans(_iisFixture.Agent, 2, null, minDateTime: dateTime, url: url2);
+            var spans = await WaitForSpansAsync(_iisFixture.Agent, 2, null, minDateTime: dateTime, url: url);
+            var spans2 = await WaitForSpansAsync(_iisFixture.Agent, 2, null, minDateTime: dateTime, url: url2);
             await VerifySpans(spans.Concat(spans2).ToImmutableList(), settings);
         }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var (statusCode, _) = await SubmitRequest(url, body: null, contentType: null, userAgent: userAgent);
             ((int)statusCode).Should().Be(returnedStatusCode);
 
-            var spans = WaitForSpans(agent, 1, string.Empty, minDateTime, url);
+            var spans = await WaitForSpansAsync(agent, 1, string.Empty, minDateTime, url);
             await VerifySpans(spans, settings);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -669,7 +669,7 @@ public class AspNetCore5IastTestsRestartedSampleIastEnabled : AspNetCore5IastTes
         await TryStartApp(newFixture, new MockTracerAgent.AgentConfiguration { SpanMetaStructs = false });
 
         var agent = newFixture.Agent;
-        var spans = agent.WaitForSpans(1, minDateTime: datetimeOffset);
+        var spans = await agent.WaitForSpansAsync(1, minDateTime: datetimeOffset);
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
         settings.AddIastScrubbing();
@@ -697,7 +697,7 @@ public class AspNetCore5IastTestsRestartedSampleIastEnabled : AspNetCore5IastTes
         await TryStartApp(newFixture, new MockTracerAgent.AgentConfiguration { SpanMetaStructs = false });
 
         var agent = newFixture.Agent;
-        var spans = agent.WaitForSpans(1, minDateTime: datetimeOffset);
+        var spans = await agent.WaitForSpansAsync(1, minDateTime: datetimeOffset);
 
         // Add a scrubber for "Session idle timeout is configured with: options.IdleTimeout, with a value of x minutes" and also for the hash value
         (Regex RegexPattern, string Replacement) sessionIdleTimeoutRegex = (new Regex(@"Session idle timeout is configured with: options.IdleTimeout, with a value of \d+ minutes"), "Session idle timeout is configured with: options.IdleTimeout, with a value of XXX minutes");

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
@@ -60,10 +60,10 @@ public class DeduplicationTests : TestHelper
         agent.Configuration.SpanMetaStructs = false;
 
         using var process = await RunSampleAndWaitForExit(agent, "5");
-        var spans =
+        var spans = await (
             onlyWeakHash ?
-                agent.WaitForSpans(expectedSpanCount, operationName: ExpectedOperationName) :
-                agent.WaitForSpans(expectedSpanCount);
+                agent.WaitForSpansAsync(expectedSpanCount, operationName: ExpectedOperationName) :
+                agent.WaitForSpansAsync(expectedSpanCount));
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
         settings.AddIastScrubbing();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Grpc/GrpcDotNetTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Grpc/GrpcDotNetTests.cs
@@ -54,7 +54,7 @@ public class GrpcDotNetTests : TestHelper
         agent.Configuration.SpanMetaStructs = false;
         using var process = await RunSampleAndWaitForExit(agent);
 
-        var spans = agent.WaitForSpans(expectedSpanCount);
+        var spans = await agent.WaitForSpansAsync(expectedSpanCount);
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
 
         var settings = VerifyHelper.GetSpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
@@ -47,7 +47,7 @@ public class WeakCipherTests : TestHelper
         agent.Configuration.SpanMetaStructs = false;
 
         using var process = await RunSampleAndWaitForExit(agent);
-        var spans = agent.WaitForSpans(expectedSpanCount, operationName: ExpectedOperationName);
+        var spans = await agent.WaitForSpansAsync(expectedSpanCount, operationName: ExpectedOperationName);
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
         settings.AddIastScrubbing();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/RASP/AspNetMvc5Rasp.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/RASP/AspNetMvc5Rasp.cs
@@ -112,7 +112,7 @@ public abstract class AspNetMvc5RaspTests : AspNetBase, IClassFixture<IisFixture
         var testName = _enableIast ? "RaspIast.AspNetMvc5" : "Rasp.AspNetMvc5";
         testName += _classicMode ? ".Classic" : ".Integrated";
         await SubmitRequest(url, null, "application/json");
-        var spans = agent.WaitForSpans(2, minDateTime: dateTime);
+        var spans = await agent.WaitForSpansAsync(2, minDateTime: dateTime);
         await VerifySpans(spans, settings, testName: testName, methodNameOverride: exploit);
     }
 
@@ -130,12 +130,12 @@ public abstract class AspNetMvc5RaspTests : AspNetBase, IClassFixture<IisFixture
         var dateTime = DateTime.UtcNow;
         var answer = await SubmitRequest("/Iast/PopulateDDBB", null, string.Empty);
         _iisFixture.Agent.SpanFilters.Add(s => !s.Resource.Contains("/Iast/PopulateDDBB"));
-        agent.WaitForSpans(2, minDateTime: dateTime);
+        await agent.WaitForSpansAsync(2, minDateTime: dateTime);
         dateTime = DateTime.UtcNow;
         var testName = _enableIast ? "RaspIast.AspNetMvc5" : "Rasp.AspNetMvc5";
         testName += _classicMode ? ".Classic" : ".Integrated";
         await SubmitRequest(url, body, "application/json");
-        var spans = agent.WaitForSpans(2, minDateTime: dateTime);
+        var spans = await agent.WaitForSpansAsync(2, minDateTime: dateTime);
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
         await VerifySpans(spansFiltered.ToImmutableList(), settings, testName: testName, methodNameOverride: exploit);
     }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -231,7 +231,7 @@ namespace Datadog.Trace.TestHelpers
 
                         if (responseCode == HttpStatusCode.OK)
                         {
-                            await Agent.WaitForSpansAsync(1, minDateTime: dateTime).ConfigureAwait(false);
+                            await Agent.WaitForSpansAsync(1, minDateTime: dateTime);
                             serverReady = true;
                         }
                     }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -237,7 +237,7 @@ namespace Datadog.Trace.TestHelpers
                     }
                     else
                     {
-                        serverReady = IsPortListening(HttpPort);
+                        serverReady = await IsPortListeningAsync(HttpPort);
                     }
                 }
                 catch
@@ -254,7 +254,7 @@ namespace Datadog.Trace.TestHelpers
 
                 if (milisecondsElapsed < intervalMilliseconds)
                 {
-                    await Task.Delay((int)(intervalMilliseconds - milisecondsElapsed))
+                    await Task.Delay((int)(intervalMilliseconds - milisecondsElapsed));
                 }
             }
 
@@ -264,14 +264,14 @@ namespace Datadog.Trace.TestHelpers
             }
         }
 
-        private bool IsPortListening(int port)
+        private async Task<bool> IsPortListeningAsync(int port)
         {
             try
             {
                 using (var client = new TcpClient())
                 {
                     var task = client.ConnectAsync("127.0.0.1", port);
-                    if (task.Wait(1000))
+                    if (await Task.WhenAny(task, Task.Delay(1000)) == task)
                     {
                         return client.Connected;
                     }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -254,7 +254,7 @@ namespace Datadog.Trace.TestHelpers
 
                 if (milisecondsElapsed < intervalMilliseconds)
                 {
-                    Thread.Sleep((int)(intervalMilliseconds - milisecondsElapsed));
+                    await Task.Delay((int)(intervalMilliseconds - milisecondsElapsed));
                 }
             }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -202,10 +202,10 @@ namespace Datadog.Trace.TestHelpers
 
             await SendHttpRequest(request);
 
-            return Agent.WaitForSpans(
-                count: 1,
-                minDateTime: now,
-                returnAllOperations: true);
+            return await Agent.WaitForSpansAsync(
+                       count: 1,
+                       minDateTime: now,
+                       returnAllOperations: true);
         }
 
         private async Task EnsureServerStarted(bool sendHealthCheck)
@@ -231,7 +231,7 @@ namespace Datadog.Trace.TestHelpers
 
                         if (responseCode == HttpStatusCode.OK)
                         {
-                            Agent.WaitForSpans(1, minDateTime: dateTime);
+                            await Agent.WaitForSpansAsync(1, minDateTime: dateTime).ConfigureAwait(false);
                             serverReady = true;
                         }
                     }
@@ -254,7 +254,7 @@ namespace Datadog.Trace.TestHelpers
 
                 if (milisecondsElapsed < intervalMilliseconds)
                 {
-                    await Task.Delay((int)(intervalMilliseconds - milisecondsElapsed));
+                    await Task.Delay((int)(intervalMilliseconds - milisecondsElapsed))
                 }
             }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -519,10 +519,10 @@ namespace Datadog.Trace.TestHelpers
                 agent.SpanFilters.Add(IsServerSpan);
             }
 
-            return agent.WaitForSpans(
-                count: expectedSpanCount,
-                minDateTime: testStart,
-                returnAllOperations: true);
+            return await agent.WaitForSpansAsync(
+                       count: expectedSpanCount,
+                       minDateTime: testStart,
+                       returnAllOperations: true);
         }
 
         protected async Task AssertWebServerSpan(
@@ -556,10 +556,10 @@ namespace Datadog.Trace.TestHelpers
 
                 agent.SpanFilters.Add(IsServerSpan);
 
-                spans = agent.WaitForSpans(
-                    count: 2,
-                    minDateTime: testStart,
-                    returnAllOperations: true);
+                spans = await agent.WaitForSpansAsync(
+                            count: 2,
+                            minDateTime: testStart,
+                            returnAllOperations: true);
 
                 Assert.True(spans.Count == 2, $"expected two span, saw {spans.Count}");
             }
@@ -629,11 +629,11 @@ namespace Datadog.Trace.TestHelpers
                 Output.WriteLine($"[http] {response.StatusCode} {content}");
                 Assert.Equal(expectedHttpStatusCode, response.StatusCode);
 
-                spans = agent.WaitForSpans(
-                    count: 1,
-                    minDateTime: testStart,
-                    operationName: "aspnet.request",
-                    returnAllOperations: true);
+                spans = await agent.WaitForSpansAsync(
+                            count: 1,
+                            minDateTime: testStart,
+                            operationName: "aspnet.request",
+                            returnAllOperations: true);
 
                 Assert.True(spans.Count == 1, $"expected two span, saw {spans.Count}");
             }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="timeoutInMilliseconds">The timeout</param>
         /// <param name="sleepTime">The time between checks</param>
         /// <returns>The telemetry that satisfied <paramref name="hasExpectedValues"/></returns>
-        public async ValueTask<TelemetryData> WaitForLatestTelemetryAsync(
+        public async Task<TelemetryData> WaitForLatestTelemetryAsync(
             Func<TelemetryData, bool> hasExpectedValues,
             int timeoutInMilliseconds = 10_000,
             int sleepTime = 500)
@@ -118,7 +118,7 @@ namespace Datadog.Trace.TestHelpers
                     }
                 }
 
-                await Task.Delay(sleepTime).ConfigureAwait(false);
+                await Task.Delay(sleepTime);
             }
 
             return null;

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
@@ -100,11 +100,7 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="timeoutInMilliseconds">The timeout</param>
         /// <param name="sleepTime">The time between checks</param>
         /// <returns>The telemetry that satisfied <paramref name="hasExpectedValues"/></returns>
-#if NETFRAMEWORK
-        public async Task<TelemetryData> WaitForLatestTelemetryAsync(
-#else
         public async ValueTask<TelemetryData> WaitForLatestTelemetryAsync(
-#endif
             Func<TelemetryData, bool> hasExpectedValues,
             int timeoutInMilliseconds = 10_000,
             int sleepTime = 500)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
@@ -100,7 +100,11 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="timeoutInMilliseconds">The timeout</param>
         /// <param name="sleepTime">The time between checks</param>
         /// <returns>The telemetry that satisfied <paramref name="hasExpectedValues"/></returns>
-        public TelemetryData WaitForLatestTelemetry(
+#if NETFRAMEWORK
+        public async Task<TelemetryData> WaitForLatestTelemetryAsync(
+#else
+        public async ValueTask<TelemetryData> WaitForLatestTelemetryAsync(
+#endif
             Func<TelemetryData, bool> hasExpectedValues,
             int timeoutInMilliseconds = 10_000,
             int sleepTime = 500)
@@ -118,7 +122,7 @@ namespace Datadog.Trace.TestHelpers
                     }
                 }
 
-                Thread.Sleep(sleepTime);
+                await Task.Delay(sleepTime).ConfigureAwait(false);
             }
 
             return null;

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -130,7 +130,11 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="returnAllOperations">When true, returns every span regardless of operation name</param>
         /// <param name="assertExpectedCount">When true, asserts that the number of spans to return matches the count</param>
         /// <returns>The list of spans.</returns>
-        public IImmutableList<MockSpan> WaitForSpans(
+#if NETFRAMEWORK
+        public async Task<IImmutableList<MockSpan>> WaitForSpansAsync(
+#else
+        public async ValueTask<IImmutableList<MockSpan>> WaitForSpansAsync(
+#endif
             int count,
             int timeoutInMilliseconds = 20000,
             string operationName = null,
@@ -174,7 +178,7 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                Thread.Sleep(500);
+                await Task.Delay(500).ConfigureAwait(false);
             }
 
             if (assertExpectedCount)
@@ -234,7 +238,11 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="timeoutInMilliseconds">The timeout</param>
         /// <param name="sleepTime">The time between checks</param>
         /// <returns>The telemetry that satisfied <paramref name="hasExpectedValues"/></returns>
-        public object WaitForLatestTelemetry(
+#if NETFRAMEWORK
+        public async Task<object> WaitForLatestTelemetryAsync(
+#else
+        public async ValueTask<object> WaitForLatestTelemetryAsync(
+#endif
             Func<object, bool> hasExpectedValues,
             int timeoutInMilliseconds = 5000,
             int sleepTime = 200)
@@ -252,13 +260,17 @@ namespace Datadog.Trace.TestHelpers
                     }
                 }
 
-                Thread.Sleep(sleepTime);
+                await Task.Delay(sleepTime).ConfigureAwait(false);
             }
 
             return null;
         }
 
-        public IImmutableList<MockClientStatsPayload> WaitForStats(
+#if NETFRAMEWORK
+        public async Task<IImmutableList<MockClientStatsPayload>> WaitForStatsAsync(
+#else
+        public async ValueTask<IImmutableList<MockClientStatsPayload>> WaitForStatsAsync(
+#endif
             int count,
             int timeoutInMilliseconds = 20000)
         {
@@ -275,13 +287,17 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                Thread.Sleep(500);
+                await Task.Delay(500).ConfigureAwait(false);
             }
 
             return stats;
         }
 
-        public IImmutableList<MockDataStreamsPayload> WaitForDataStreams(
+#if NETFRAMEWORK
+        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
+#else
+        public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
+#endif
             int timeoutInMilliseconds,
             Func<IImmutableList<MockDataStreamsPayload>, bool> waitFunc)
         {
@@ -298,17 +314,21 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                Thread.Sleep(500);
+                await Task.Delay(500).ConfigureAwait(false);
             }
 
             return stats;
         }
 
-        public IImmutableList<MockDataStreamsPayload> WaitForDataStreamsPoints(
+#if NETFRAMEWORK
+        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsPointsAsync(
+#else
+        public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsPointsAsync(
+#endif
             int statsCount,
             int timeoutInMilliseconds = 20000)
         {
-            return WaitForDataStreams(
+            return await WaitForDataStreamsAsync(
                 timeoutInMilliseconds,
                 (stats) =>
                 {
@@ -316,11 +336,15 @@ namespace Datadog.Trace.TestHelpers
                 });
         }
 
-        public IImmutableList<MockDataStreamsPayload> WaitForDataStreams(
+#if NETFRAMEWORK
+        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
+#else
+        public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
+#endif
             int payloadCount,
             int timeoutInMilliseconds = 20000)
         {
-            return WaitForDataStreams(
+            return await WaitForDataStreamsAsync(
                 timeoutInMilliseconds,
                 (stats) => stats.Count == payloadCount);
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -130,11 +130,7 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="returnAllOperations">When true, returns every span regardless of operation name</param>
         /// <param name="assertExpectedCount">When true, asserts that the number of spans to return matches the count</param>
         /// <returns>The list of spans.</returns>
-#if NETFRAMEWORK
-        public async Task<IImmutableList<MockSpan>> WaitForSpansAsync(
-#else
         public async ValueTask<IImmutableList<MockSpan>> WaitForSpansAsync(
-#endif
             int count,
             int timeoutInMilliseconds = 20000,
             string operationName = null,
@@ -178,7 +174,7 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                await Task.Delay(500).ConfigureAwait(false);
+                await Task.Delay(250).ConfigureAwait(false);
             }
 
             if (assertExpectedCount)
@@ -238,11 +234,7 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="timeoutInMilliseconds">The timeout</param>
         /// <param name="sleepTime">The time between checks</param>
         /// <returns>The telemetry that satisfied <paramref name="hasExpectedValues"/></returns>
-#if NETFRAMEWORK
-        public async Task<object> WaitForLatestTelemetryAsync(
-#else
         public async ValueTask<object> WaitForLatestTelemetryAsync(
-#endif
             Func<object, bool> hasExpectedValues,
             int timeoutInMilliseconds = 5000,
             int sleepTime = 200)
@@ -266,11 +258,7 @@ namespace Datadog.Trace.TestHelpers
             return null;
         }
 
-#if NETFRAMEWORK
-        public async Task<IImmutableList<MockClientStatsPayload>> WaitForStatsAsync(
-#else
         public async ValueTask<IImmutableList<MockClientStatsPayload>> WaitForStatsAsync(
-#endif
             int count,
             int timeoutInMilliseconds = 20000)
         {
@@ -287,17 +275,13 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                await Task.Delay(500).ConfigureAwait(false);
+                await Task.Delay(250).ConfigureAwait(false);
             }
 
             return stats;
         }
 
-#if NETFRAMEWORK
-        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
-#else
         public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
-#endif
             int timeoutInMilliseconds,
             Func<IImmutableList<MockDataStreamsPayload>, bool> waitFunc)
         {
@@ -314,17 +298,13 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                await Task.Delay(500).ConfigureAwait(false);
+                await Task.Delay(250).ConfigureAwait(false);
             }
 
             return stats;
         }
 
-#if NETFRAMEWORK
-        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsPointsAsync(
-#else
         public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsPointsAsync(
-#endif
             int statsCount,
             int timeoutInMilliseconds = 20000)
         {
@@ -336,11 +316,7 @@ namespace Datadog.Trace.TestHelpers
                 });
         }
 
-#if NETFRAMEWORK
-        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
-#else
         public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
-#endif
             int payloadCount,
             int timeoutInMilliseconds = 20000)
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -130,7 +130,7 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="returnAllOperations">When true, returns every span regardless of operation name</param>
         /// <param name="assertExpectedCount">When true, asserts that the number of spans to return matches the count</param>
         /// <returns>The list of spans.</returns>
-        public async ValueTask<IImmutableList<MockSpan>> WaitForSpansAsync(
+        public async Task<IImmutableList<MockSpan>> WaitForSpansAsync(
             int count,
             int timeoutInMilliseconds = 20000,
             string operationName = null,
@@ -174,7 +174,7 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                await Task.Delay(250).ConfigureAwait(false);
+                await Task.Delay(250);
             }
 
             if (assertExpectedCount)
@@ -234,7 +234,7 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="timeoutInMilliseconds">The timeout</param>
         /// <param name="sleepTime">The time between checks</param>
         /// <returns>The telemetry that satisfied <paramref name="hasExpectedValues"/></returns>
-        public async ValueTask<object> WaitForLatestTelemetryAsync(
+        public async Task<object> WaitForLatestTelemetryAsync(
             Func<object, bool> hasExpectedValues,
             int timeoutInMilliseconds = 5000,
             int sleepTime = 200)
@@ -252,13 +252,13 @@ namespace Datadog.Trace.TestHelpers
                     }
                 }
 
-                await Task.Delay(sleepTime).ConfigureAwait(false);
+                await Task.Delay(sleepTime);
             }
 
             return null;
         }
 
-        public async ValueTask<IImmutableList<MockClientStatsPayload>> WaitForStatsAsync(
+        public async Task<IImmutableList<MockClientStatsPayload>> WaitForStatsAsync(
             int count,
             int timeoutInMilliseconds = 20000)
         {
@@ -275,13 +275,13 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                await Task.Delay(250).ConfigureAwait(false);
+                await Task.Delay(250);
             }
 
             return stats;
         }
 
-        public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
+        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
             int timeoutInMilliseconds,
             Func<IImmutableList<MockDataStreamsPayload>, bool> waitFunc)
         {
@@ -298,13 +298,13 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                await Task.Delay(250).ConfigureAwait(false);
+                await Task.Delay(250);
             }
 
             return stats;
         }
 
-        public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsPointsAsync(
+        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsPointsAsync(
             int statsCount,
             int timeoutInMilliseconds = 20000)
         {
@@ -316,7 +316,7 @@ namespace Datadog.Trace.TestHelpers
                 });
         }
 
-        public async ValueTask<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
+        public async Task<IImmutableList<MockDataStreamsPayload>> WaitForDataStreamsAsync(
             int payloadCount,
             int timeoutInMilliseconds = 20000)
         {

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -75,7 +75,7 @@ public class DataStreamsMonitoringTransportTests
 
         await writer.DisposeAsync();
 
-        var result = agent.WaitForDataStreams(1);
+        var result = await agent.WaitForDataStreamsAsync(1);
 
         // we can't guarantee only having a single payload due to race conditions in the flushing code
         result.Should().OnlyContain(payload => payload.Env == "env");

--- a/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -248,7 +248,7 @@ namespace Datadog.Trace.Tests
                     await Task.Delay(5);
                 }
 
-                spans = agent.WaitForSpans(1);
+                spans = await agent.WaitForSpansAsync(1);
             }
 
             return spans;

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -236,11 +236,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             sink.Batches.Should().BeEmpty();
         }
 
-#if NETFRAMEWORK
-        private static async Task<ConcurrentStack<IList<DirectSubmissionLogEvent>>> WaitForBatchesAsync(InMemoryBatchedSink pbs, int batchCount = 1)
-#else
         private static async ValueTask<ConcurrentStack<IList<DirectSubmissionLogEvent>>> WaitForBatchesAsync(InMemoryBatchedSink pbs, int batchCount = 1)
-#endif
         {
             var deadline = DateTime.UtcNow.AddSeconds(30);
             var batches = pbs.Batches;

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -236,7 +236,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             sink.Batches.Should().BeEmpty();
         }
 
-        private static async ValueTask<ConcurrentStack<IList<DirectSubmissionLogEvent>>> WaitForBatchesAsync(InMemoryBatchedSink pbs, int batchCount = 1)
+        private static async Task<ConcurrentStack<IList<DirectSubmissionLogEvent>>> WaitForBatchesAsync(InMemoryBatchedSink pbs, int batchCount = 1)
         {
             var deadline = DateTime.UtcNow.AddSeconds(30);
             var batches = pbs.Batches;

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             sink.EnqueueLog(evt);
 
             // slightly arbitrary time to wait
-            await Task.Delay(1_000).ConfigureAwait(false);
+            await Task.Delay(1_000);
             sink.Batches.Should().BeEmpty();
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             sink.EnqueueLog(evt);
 
             // slightly arbitrary time to wait
-            Thread.Sleep(1_000);
+            await Task.Delay(1_000).ConfigureAwait(false);
             sink.Batches.Should().BeEmpty();
         }
 

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void ReplacingGlobalTracerManagerMidTraceWritesTheTrace()
+        public async Task ReplacingGlobalTracerManagerMidTraceWritesTheTrace()
         {
             var agentPort = TcpPortProvider.GetOpenPort();
 
@@ -102,7 +102,7 @@ namespace Datadog.Trace.Tests
 
                 scope.Dispose();
 
-                var spans = agent.WaitForSpans(count: 1);
+                var spans = await agent.WaitForSpansAsync(count: 1);
                 var received = spans.Should().ContainSingle().Subject;
                 received.Name.Should().Be("Test span");
                 received.Tags.Should().Contain("test-tag", "original-value");

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -474,7 +474,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         var agent = helper.Agent;
 
-        agent.WaitForLatestTelemetry(IsCrashReport).Should().NotBeNull();
+        (await agent.WaitForLatestTelemetryAsync(IsCrashReport)).Should().NotBeNull();
     }
 
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/RunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/RunCommandTests.cs
@@ -64,7 +64,7 @@ public class RunCommandTests : ConsoleTestHelper
         errorOutput.Should().BeEmpty();
         exitCode.Should().Be(0);
 
-        var spans = agent.WaitForSpans(5);
+        var spans = await agent.WaitForSpansAsync(5);
 
         spans.Should().HaveCount(5)
             .And.OnlyContain(s => s.Service == "TestService" && s.Tags[Tags.Version] == "TestVersion" && s.Tags[Tags.Env] == "TestEnv");


### PR DESCRIPTION
## Summary of changes

This PR replaces Thread.Sleep usages in async methods with Task.Delay

## Reason for change

Is bad to use Thread.Sleep in async methods (:shame:)

## Implementation details

Find and replace and transform some sync methods in async methods.

## Test coverage

PR is green? then it worked!

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
