### PR TITLE
Don't write native loader logs when bailing out in Windows SSI

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
@@ -24,6 +24,10 @@ private:
         inline static const shared::WSTRING folder_path = WStr(R"(Datadog .NET Tracer\logs)");
 #endif
         inline static const std::string pattern = "[%Y-%m-%d %H:%M:%S.%e | %l | PId: %P | TId: %t] %v";
+        static bool enable_buffering() {
+            // We don't buffer logs, as we know we are definitely instrumenting
+            return false;
+        }
         struct logging_environment
         {
             inline static const shared::WSTRING log_path = EnvironmentVariables::LogPath;

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
@@ -10,6 +10,7 @@ class EnvironmentVariables final
 public:
     inline static const shared::WSTRING LogPath = WStr("DD_TRACE_LOG_PATH");
     inline static const shared::WSTRING LogDirectory = WStr("DD_TRACE_LOG_DIRECTORY");
+    inline static const shared::WSTRING LogBufferingEnabled = WStr("DD_TRACE_LOG_BUFFERING_ENABLED");
     inline static const shared::WSTRING DebugLogEnabled = WStr("DD_TRACE_DEBUG");
     inline static const shared::WSTRING IncludeProcessNames = WStr("DD_PROFILER_PROCESSES");
     inline static const shared::WSTRING ExcludeProcessNames = WStr("DD_PROFILER_EXCLUDE_PROCESSES");

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -254,6 +254,9 @@ namespace datadog::shared::nativeloader
             return E_FAIL;
         }
 
+        // Guard rails have all passed, so we enable (and flush) logs if necessary
+        Log::EnableAutoFlush();
+
         if (m_dispatcher == nullptr)
         {
             Log::Error("Dispatcher is not set.");

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/log.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/log.h
@@ -23,6 +23,34 @@ public:
         inline static const shared::WSTRING folder_path = WStr(R"(Datadog .NET Tracer\logs)");
 #endif
         inline static const std::string pattern = "[%Y-%m-%d %H:%M:%S.%e | %l | PId: %P | TId: %t] %v";
+
+        static bool enable_buffering() {
+#ifdef _WIN32
+            // For Windows SSI, we are injected into all .NET Core processes, so we can't enable flushing of logs
+            // until we know that the process is going to be instrumented, otherwise we will create way
+            // too many log files. Note that we don't currently distinguish between .NET FX and .NET Core, because
+            // we need to make the decision _before_ we have that information.
+            const auto isSingleStepVariable = shared::GetEnvironmentValue(EnvironmentVariables::SingleStepInstrumentationEnabled);
+            if (isSingleStepVariable.empty())
+            {
+                // not in Windows SSI, so we don't need buffering
+                return false;
+            }
+
+            const auto bufferEnvVar = shared::GetEnvironmentValue(EnvironmentVariables::LogBufferingEnabled);
+
+            // enable buffering _unless_ the variable is present and set to false
+            // if the variable is not set, or it's set to false
+            bool enable_buffering;
+            return bufferEnvVar.empty()
+                || !shared::TryParseBooleanEnvironmentValue(bufferEnvVar, enable_buffering)
+                || enable_buffering == true;
+#else
+            // On linux/mac, we are only injected where we know we are needed, so we don't buffer
+            return false;
+#endif
+        }
+
         struct logging_environment
         {
             inline static const shared::WSTRING log_path = EnvironmentVariables::LogPath;
@@ -31,6 +59,11 @@ public:
     };
 
     inline static ds::Logger* const Instance = ds::LogManager::Get<Log::NativeLoaderLoggerPolicy>();
+
+    static void EnableAutoFlush()
+    {
+        Instance->FlushAndDisableBuffering();
+    }
 
     static bool IsDebugEnabled()
     {

--- a/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems
+++ b/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems
@@ -21,6 +21,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)environment_variables.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)il_rewriter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)il_rewriter_wrapper.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)lazy_rotating_file_sink.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)lazy_rotating_file_sink-inl.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)loader.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)logger.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)logmanager.h" />

--- a/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems.filters
+++ b/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems.filters
@@ -32,6 +32,12 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)lazy_rotating_file_sink.h">
+      <Filter>ManagedLibraryLoader-Dependencies</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)lazy_rotating_file_sink-inl.h">
+      <Filter>ManagedLibraryLoader-Dependencies</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)loader.h">
       <Filter>ManagedLibraryLoader</Filter>
     </ClInclude>

--- a/shared/src/native-src/lazy_rotating_file_sink-inl.h
+++ b/shared/src/native-src/lazy_rotating_file_sink-inl.h
@@ -1,0 +1,158 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#ifndef SPDLOG_HEADER_ONLY
+#    include <spdlog/sinks/lazy_rotating_file_sink.h>
+#endif
+
+#include <spdlog/common.h>
+
+#include <spdlog/details/file_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <cerrno>
+#include <chrono>
+#include <ctime>
+#include <mutex>
+#include <string>
+#include <tuple>
+
+namespace spdlog {
+namespace sinks {
+
+template<typename Mutex>
+SPDLOG_INLINE lazy_rotating_file_sink<Mutex>::lazy_rotating_file_sink(
+    filename_t base_filename, std::size_t max_size, std::size_t max_files, const file_event_handlers &event_handlers)
+    : base_filename_(std::move(base_filename))
+    , max_size_(max_size)
+    , max_files_(max_files)
+    , file_helper_{event_handlers}
+    , file_opened_(false)
+    , current_size_(0)
+{
+    if (max_size == 0)
+    {
+        throw_spdlog_ex("rotating sink constructor: max_size arg cannot be zero");
+    }
+
+    if (max_files > 200000)
+    {
+        throw_spdlog_ex("rotating sink constructor: max_files arg cannot exceed 200000");
+    }
+}
+
+// calc filename according to index and file extension if exists.
+// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
+template<typename Mutex>
+SPDLOG_INLINE filename_t lazy_rotating_file_sink<Mutex>::calc_filename(const filename_t &filename, std::size_t index)
+{
+    if (index == 0u)
+    {
+        return filename;
+    }
+
+    filename_t basename, ext;
+    std::tie(basename, ext) = details::file_helper::split_by_extension(filename);
+    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
+}
+
+template<typename Mutex>
+SPDLOG_INLINE filename_t lazy_rotating_file_sink<Mutex>::filename()
+{
+    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
+    return file_helper_.filename();
+}
+
+template<typename Mutex>
+SPDLOG_INLINE void lazy_rotating_file_sink<Mutex>::sink_it_(const details::log_msg &msg)
+{
+     if (!file_opened_)
+    {
+        // I _think_ this is called under a mutex, so we don't need to lock here.
+        file_opened_ = true;
+        file_helper_.open(calc_filename(base_filename_, 0));
+        current_size_ = file_helper_.size(); // expensive. called only once
+    }
+
+    memory_buf_t formatted;
+    base_sink<Mutex>::formatter_->format(msg, formatted);
+    auto new_size = current_size_ + formatted.size();
+
+    // rotate if the new estimated file size exceeds max size.
+    // rotate only if the real size > 0 to better deal with full disk (see issue #2261).
+    // we only check the real size when new_size > max_size_ because it is relatively expensive.
+    if (new_size > max_size_)
+    {
+        file_helper_.flush();
+        if (file_helper_.size() > 0)
+        {
+            rotate_();
+            new_size = formatted.size();
+        }
+    }
+    file_helper_.write(formatted);
+    current_size_ = new_size;
+}
+
+template<typename Mutex>
+SPDLOG_INLINE void lazy_rotating_file_sink<Mutex>::flush_()
+{
+    if (file_opened_)
+    {
+        file_helper_.flush();
+    }
+}
+
+// Rotate files:
+// log.txt -> log.1.txt
+// log.1.txt -> log.2.txt
+// log.2.txt -> log.3.txt
+// log.3.txt -> delete
+template<typename Mutex>
+SPDLOG_INLINE void lazy_rotating_file_sink<Mutex>::rotate_()
+{
+    using details::os::filename_to_str;
+    using details::os::path_exists;
+
+    file_helper_.close();
+    for (auto i = max_files_; i > 0; --i)
+    {
+        filename_t src = calc_filename(base_filename_, i - 1);
+        if (!path_exists(src))
+        {
+            continue;
+        }
+        filename_t target = calc_filename(base_filename_, i);
+
+        if (!rename_file_(src, target))
+        {
+            // if failed try again after a small delay.
+            // this is a workaround to a windows issue, where very high rotation
+            // rates can cause the rename to fail with permission denied (because of antivirus?).
+            details::os::sleep_for_millis(100);
+            if (!rename_file_(src, target))
+            {
+                file_helper_.reopen(true); // truncate the log file anyway to prevent it to grow beyond its limit!
+                current_size_ = 0;
+                throw_spdlog_ex("lazy_rotating_file_sink: failed renaming " + filename_to_str(src) + " to " + filename_to_str(target), errno);
+            }
+        }
+    }
+    file_helper_.reopen(true);
+}
+
+// delete the target if exists, and rename the src file  to target
+// return true on success, false otherwise.
+template<typename Mutex>
+SPDLOG_INLINE bool lazy_rotating_file_sink<Mutex>::rename_file_(const filename_t &src_filename, const filename_t &target_filename)
+{
+    // try to delete the target file in case it already exists.
+    (void)details::os::remove(target_filename);
+    return details::os::rename(src_filename, target_filename) == 0;
+}
+
+} // namespace sinks
+} // namespace spdlog

--- a/shared/src/native-src/lazy_rotating_file_sink.h
+++ b/shared/src/native-src/lazy_rotating_file_sink.h
@@ -1,0 +1,83 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/file_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
+
+#include <chrono>
+#include <mutex>
+#include <string>
+
+namespace spdlog {
+namespace sinks {
+
+//
+// Rotating file sink based on size that does not create the file until a log is first written
+// Basd on the sink in spdlog/sinks/rotating_file_sink.h
+//
+template<typename Mutex>
+class lazy_rotating_file_sink final : public base_sink<Mutex>
+{
+public:
+    lazy_rotating_file_sink(filename_t base_filename, std::size_t max_size, std::size_t max_files,
+        const file_event_handlers &event_handlers = {});
+    static filename_t calc_filename(const filename_t &filename, std::size_t index);
+    filename_t filename();
+
+protected:
+    void sink_it_(const details::log_msg &msg) override;
+    void flush_() override;
+
+private:
+    // Rotate files:
+    // log.txt -> log.1.txt
+    // log.1.txt -> log.2.txt
+    // log.2.txt -> log.3.txt
+    // log.3.txt -> delete
+    void rotate_();
+
+    // delete the target if exists, and rename the src file  to target
+    // return true on success, false otherwise.
+    bool rename_file_(const filename_t &src_filename, const filename_t &target_filename);
+
+    filename_t base_filename_;
+    std::size_t max_size_;
+    std::size_t max_files_;
+    std::size_t current_size_;
+    details::file_helper file_helper_;
+    bool file_opened_;
+};
+
+using lazy_rotating_file_sink_mt = lazy_rotating_file_sink<std::mutex>;
+using lazy_rotating_file_sink_st = lazy_rotating_file_sink<details::null_mutex>;
+
+} // namespace sinks
+
+//
+// factory functions
+//
+
+template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> lazy_rotating_logger_mt(const std::string &logger_name, const filename_t &filename, size_t max_file_size,
+    size_t max_files, bool rotate_on_open = false, const file_event_handlers &event_handlers = {})
+{
+    return Factory::template create<sinks::lazy_rotating_file_sink_mt>(
+        logger_name, filename, max_file_size, max_files, event_handlers);
+}
+
+template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> lazy_rotating_logger_st(const std::string &logger_name, const filename_t &filename, size_t max_file_size,
+    size_t max_files, bool rotate_on_open = false, const file_event_handlers &event_handlers = {})
+{
+    return Factory::template create<sinks::lazy_rotating_file_sink_st>(
+        logger_name, filename, max_file_size, max_files, event_handlers);
+}
+} // namespace spdlog
+
+#ifdef SPDLOG_HEADER_ONLY
+#    include "lazy_rotating_file_sink-inl.h"
+#endif

--- a/shared/src/native-src/logger.h
+++ b/shared/src/native-src/logger.h
@@ -10,6 +10,7 @@
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
+#include "lazy_rotating_file_sink.h"
 
 #include "dd_filesystem.hpp"
 #include "pal.h"
@@ -119,8 +120,10 @@ std::tuple<std::shared_ptr<spdlog::logger>, bool> Logger::CreateInternalLogger()
 
     try
     {
-        logger =
-            spdlog::rotating_logger_mt(LoggerPolicy::file_name, Logger::GetLogPath<LoggerPolicy>(file_name_suffix), 1048576 * 5, 10);
+        // If we are buffering logs, we use a LazyRotatingFileSink to avoid creating the file until the first log is written.
+        logger = buffering_enabled
+            ? spdlog::lazy_rotating_logger_mt(LoggerPolicy::file_name, Logger::GetLogPath<LoggerPolicy>(file_name_suffix), 1048576 * 5, 10)
+            : spdlog::rotating_logger_mt(LoggerPolicy::file_name, Logger::GetLogPath<LoggerPolicy>(file_name_suffix), 1048576 * 5, 10);
     }
     catch (...)
     {

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net48.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net48.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.FakeDbCommand.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net48.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net48.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -33,7 +33,8 @@
     {
       "name": "Bailout",
       "environmentVariables": {
-        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "Samples.HttpMessageHandler.exe",
+        "DD_INJECTION_ENABLED": "tracing"
       }
     },
     {

--- a/tracer/src/Datadog.Tracer.Native/logger.h
+++ b/tracer/src/Datadog.Tracer.Native/logger.h
@@ -20,6 +20,10 @@ struct TracerLoggerPolicy
     inline static const shared::WSTRING folder_path = WStr(R"(Datadog .NET Tracer\logs)");
 #endif
     inline static const std::string pattern = "%D %I:%M:%S.%e %p [%P|%t] [%l] %v";
+    static bool enable_buffering() {
+        // We don't buffer logs, as we know we are definitely instrumenting
+        return false;
+    }
     struct logging_environment
     {
         // cannot reuse environment::log_path variable. On alpine, test fails

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -464,8 +464,15 @@ namespace Foo
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
             AssertInstrumented(agent, logDir);
-            AssertNativeLoaderLogContainsString(logDir, "Buffering of logs enabled");
-            AssertNativeLoaderLogContainsString(logDir, "Buffered logs flushed and buffering disabled");
+            if (EnvironmentTools.IsWindows())
+            {
+                AssertNativeLoaderLogContainsString(logDir, "Buffering of logs enabled");
+                AssertNativeLoaderLogContainsString(logDir, "Buffered logs flushed and buffering disabled");
+            }
+            else
+            {
+                AssertNativeLoaderLogContainsString(logDir, "Buffering of logs disabled");
+            }
         }
 #endif
 


### PR DESCRIPTION
## Summary of changes

- When we're running in Windows SSI, buffer logs for native loader until we know whether we're bailing out. If we bail out, drop the logs, otherwise, write them and enable-auto flushing
- Refactor `InstrumentationTests`

## Reason for change

In Windows SSI, we inject into every process by default, and then bail out. Today, this results in creating a native loader file for every injection, which causes a lot of noise in the log files. With the updated implementation, we buffer those logs until we know we're continuing with instrumentation instead, so we don't create loads of log files.

## Implementation details

- Use spdlog's "backtrace" support, that allows buffering logs without writing them.
- Introduce an `enable_buffering()` method to the `TLoggerPolicy` abstraction, to know whether logs should be buffered initially, or just auto-flushed
  - This returns `false` for Tracer and Profiler, because by the time they're running, we know we want to instrument.
  - For the native loader, we look for the SSI variable. If it's set, we check if buffering is explicitly enabled/disabled (default is enabled). This ensures that if we have a crash (for example) that we have a way of forcing logs to be written.
- If buffering is **not enabled**, the existing behavior (pre this PR) is used.
- If buffering is **enabled**:
  - We disable automatic flushing
  - Set the log level to be "don't write any logs"
  - Enable back trace
  - Use a `lazy_rolling_file_sink`. This is necessary because the built-in `rolling_file_sink` creates and opens the target file as soon as it's created. The updated version delays this until we write to the sink
  - Later, if we determine that we _do_ want to instrument the app, we call `FlushAndDisableBuffering` to restore the original behaviour

## Test coverage

I refactored the existing instrumentation tests 
- Don't not rely on `dotnet run`, because is a bit messy because we instrument it _and_ the target app (we should look into this seperately)
- Reduce duplication
- Add expanded assertions that we don't have native tracer or profiler in "normal" bailout scenarios
- Add additional tests and assertions for the new behavaiour in this PR
- Updated execution benchmarks scenario to emulate bailout in SSI (i.e. no logs scenario)
