### PR TITLE
[Docs] Fix Readme BuildAndRunOsxIntegrationTests sample

### DIFF
--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -161,7 +161,7 @@ docker-compose up StartDependencies.OSXARM64
 ./build.sh BuildAndRunOsxIntegrationTests
 
 # Build and run integration tests filtering on one framework, one set of tests and a sample app.
-./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "rabbit" --SampleName "Samples.Rabbit"
+./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "FullyQualifiedName=Datadog.Trace.ClrProfiler.IntegrationTests.RabbitMQTests" --SampleName "Samples.Rabbit"
 
 # Stop IntegrationTests dependencies.
 docker-compose down

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -161,7 +161,7 @@ docker-compose up StartDependencies.OSXARM64
 ./build.sh BuildAndRunOsxIntegrationTests
 
 # Build and run integration tests filtering on one framework, one set of tests and a sample app.
-./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "FullyQualifiedName=Datadog.Trace.ClrProfiler.IntegrationTests.RabbitMQTests" --SampleName "Samples.Rabbit"
+./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "Datadog.Trace.ClrProfiler.IntegrationTests.RabbitMQTests" --SampleName "Samples.Rabbit"
 
 # Stop IntegrationTests dependencies.
 docker-compose down


### PR DESCRIPTION
## Summary of changes
The sample integration test command also matches `DataStreamsMonitoringRabbitMQTests`, which depends on `Samples.DataStreams.RabbitMQ` which causes the example command to fail. Updating the readme to match the exact test name instead.

## Reason for change
New users following this guide will likely be confused why this example test fails.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
