### PR TITLE
Silently ignore empty user ids.

### DIFF
--- a/tracer/src/Datadog.Trace.Manual/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace.Manual/SpanExtensions.cs
@@ -32,11 +32,6 @@ public static class SpanExtensions
     /// <param name="userDetails">The details of the current logged on user</param>
     public static void SetUser(this ISpan span, UserDetails userDetails)
     {
-        if (string.IsNullOrEmpty(userDetails.Id))
-        {
-            ThrowHelper.ThrowArgumentException(nameof(userDetails.Id) + " must be set to a value other than null or the empty string", nameof(userDetails.Id));
-        }
-
         SetUser(span, userDetails.Email, userDetails.Name, userDetails.Id, userDetails.PropagateId, userDetails.SessionId, userDetails.Role, userDetails.Scope);
     }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Extensions/SpanExtensionsSetUserIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Extensions/SpanExtensionsSetUserIntegration.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanExtensionsSetUserIntegration.cs" company="Datadog">
+// <copyright file="SpanExtensionsSetUserIntegration.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -30,37 +30,40 @@ public class SpanExtensionsSetUserIntegration
 {
     internal static CallTargetState OnMethodBegin<TTarget, TSpan>(ref TSpan span, string? email, string? name, string id, bool propagateId, string? sessionId, string? role, string? scope)
     {
-        // Annoyingly, this takes an ISpan, so we have to do some duckTyping to make it work
-        ISpan? realSpan = null;
+        if (!string.IsNullOrEmpty(id))
+        {
+            // Annoyingly, this takes an ISpan, so we have to do some duckTyping to make it work
+            ISpan? realSpan = null;
 
-        // it's most likely to be a duck-typed Span, so try that first
-        if (span is IDuckType { Instance: Span s })
-        {
-            realSpan = s;
-        }
-        else if (span is Span autoSpan)
-        {
-            // Not likely, but technically possible for this to happen
-            realSpan = autoSpan;
-        }
-        else
-        {
-            // This is a worst case, should basically never be necessary
-            // Only required if customers create a custom ISpan
-            // Should we handle it? I chose to just ignore it here because it's a pain
-            // but we could throw, or log?
-        }
-
-        realSpan?.SetUserInternal(
-            new UserDetails(id)
+            // it's most likely to be a duck-typed Span, so try that first
+            if (span is IDuckType { Instance: Span s })
             {
-                Email = email,
-                Name = name,
-                PropagateId = propagateId,
-                SessionId = sessionId,
-                Role = role,
-                Scope = scope
-            });
+                realSpan = s;
+            }
+            else if (span is Span autoSpan)
+            {
+                // Not likely, but technically possible for this to happen
+                realSpan = autoSpan;
+            }
+            else
+            {
+                // This is a worst case, should basically never be necessary
+                // Only required if customers create a custom ISpan
+                // Should we handle it? I chose to just ignore it here because it's a pain
+                // but we could throw, or log?
+            }
+
+            realSpan?.SetUserInternal(
+                new UserDetails(id)
+                {
+                    Email = email,
+                    Name = name,
+                    PropagateId = propagateId,
+                    SessionId = sessionId,
+                    Role = role,
+                    Scope = scope
+                });
+        }
 
         return CallTargetState.GetDefault();
     }


### PR DESCRIPTION
## Summary of changes

In order to avoid customers getting new Exceptions when empty user ids are sent in the SetUser method, we will silently ignore empty ids (no exceptions and no error logs).

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
