### PR TITLE
Reference platform/artifacts instead of artifacts on macrobenchs

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -25,7 +25,7 @@ check_azure_pipeline:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
       - build-id.txt
     expire_in: 3 months
   tags: ["arch:amd64"]
@@ -95,7 +95,7 @@ update-bp-infra:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
@@ -279,7 +279,7 @@ profiler_cpu_timer_create:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
@@ -469,7 +469,7 @@ profiler_cpu_timer_create-arm64:
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"


### PR DESCRIPTION
## Summary of changes

Reference `platform/artifacts` instead of `artifacts` on macrobenchmarking jobs.

## Reason for change

Macrobenchmarking jobs were not publishing artifacts on GitLab. See https://dd.slack.com/archives/C045F97HYJD/p1751030383320189?thread_ts=1750944398.786819&cid=C045F97HYJD.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
