### PR TITLE
Don't load the profiler on arm64

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,6 +187,9 @@ missing-nullability-files.csv             @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Telemetry/Metrics/IntegrationIdExtensions.cs @DataDog/apm-dotnet
 
+# Native loader 
+/shared/src/Datadog.Trace.ClrProfiler.Native/                       @DataDog/profiling-dotnet @DataDog/apm-dotnet
+
 # Version Bump Related Files - overriding to have wider coverage
 
 /profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt @DataDog/profiling-dotnet @DataDog/apm-dotnet

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,7 @@ generate-lib-init-pinned-tag-values:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_profiling,lib-injection"
+    SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_profiling,simple_onboarding_appsec,lib-injection"
 
 deploy_to_reliability_env:
   rules:

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/loader.conf
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/loader.conf
@@ -3,8 +3,8 @@ PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x64;.\Datadog.Profiler.Nativ
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x86;.\Datadog.Profiler.Native.dll
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-x64;./Datadog.Profiler.Native.so
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-musl-x64;./Datadog.Profiler.Native.so
-PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-arm64;./Datadog.Profiler.Native.so
-PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-musl-arm64;./Datadog.Profiler.Native.so
+# PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-arm64;./Datadog.Profiler.Native.so
+# PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-musl-arm64;./Datadog.Profiler.Native.so
 
 #Tracer
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-arm64;.\Datadog.Tracer.Native.dll


### PR DESCRIPTION
## Summary of changes

- Don't try to load the profiler on Linux arm64 at all
- Cherry pick #7153 to see if it resolves the issues

## Reason for change

#7153 ran into what we think is glibc `dlclose` issue (i.e. #7125). Given the profiler always bails out on arm64 as it's not yet supported, this is the easiest way to ensure that we don't load (and therefore, more importantly, we don't _unload_ the profiler on arm64).

## Implementation details

Comment out the profiler from the loader.conf for arm64. That ensures we don't _try_ to load it on arm64, while making it easy to reenable for testing etc.

## Test coverage

Cherry picked the #7153 smoke tests, to confirm it resolves the issues

## Other details

Supersedes #7153 given that it enables the tests to verify the fix
