### PR TITLE
Add retry to smoke crash tracking tests

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -172,7 +172,7 @@ steps:
     # This job sometimes hangs, and when it does, we lose all the logs, so explicitly end it early instead
     # and retry instead. It should be very unlikely to hang on both trys, and if it does, we should probably
     # investigate the cause of the hang further.
-    timeoutInMinutes: 10
+    timeoutInMinutes: 5
     retryCountOnTaskFailure: 2
     condition: and(succeeded(), eq(variables['runCrashTest'], 'true'))
 

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -170,7 +170,10 @@ steps:
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
     displayName: Check logs for evidence of crash output
     # This job sometimes hangs, and when it does, we lose all the logs, so explicitly end it early instead
-    timeoutInMinutes: 15
+    # and retry instead. It should be very unlikely to hang on both trys, and if it does, we should probably
+    # investigate the cause of the hang further.
+    timeoutInMinutes: 10
+    retryCountOnTaskFailure: 2
     condition: and(succeeded(), eq(variables['runCrashTest'], 'true'))
 
 - ${{ if eq(parameters.isLinux, true) }}:


### PR DESCRIPTION
## Summary of changes

Retry the crash-test smoke tests if the sample fails to exit after crash analysis

## Reason for change

We have an intermittent hang _after_ performing the crash analysis in crash tests. We don't have any good leads in terms of investigating the issue, so to avoid impacting devex, just retry the job.

## Implementation details

We already have a timeout, so just add a retry. This will retry when we explicitly fail too, but that's _probably_ not a big concern. If it is, we will have to [manage the timeout in bash itself](https://stackoverflow.com/questions/687948/how-to-run-a-command-with-a-timeout-so-that-it-is-killed-if-it-exceeds-the-timeo) but I don't think it's worth the hassle

## Test coverage

I'll retry it a few times and see if we catch a failure 😅 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
