### PR TITLE
Fix github token usage

### DIFF
--- a/.azure-pipelines/steps/update-github-status-jobs.yml
+++ b/.azure-pipelines/steps/update-github-status-jobs.yml
@@ -11,7 +11,7 @@ jobs:
   - job: set_pending
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-linux-task-scale-set
+      name: azure-managed-linux-tasks
     steps:
     - checkout: none
     - template: update-github-status.yml
@@ -23,7 +23,7 @@ jobs:
   - job: set_succeeded
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-linux-task-scale-set
+      name: azure-managed-linux-tasks
     dependsOn:
     - set_pending
     - ${{ each job in parameters.jobs }}:
@@ -47,7 +47,7 @@ jobs:
   - job: set_failed
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-linux-task-scale-set
+      name: azure-managed-linux-tasks
     dependsOn:
       - set_pending
       - ${{ each job in parameters.jobs }}:

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -24,7 +24,7 @@ steps:
       TARGET_URL="https://dev.azure.com/datadoghq/$(AZURE_PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
       curl_fail_with_body -X POST --silent --show-error \
         -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: Bearer $(GITHUB_TOKEN)" \
+        -H "Authorization: token $(GITHUB_TOKEN)" \
         https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
         -d '{"state":"${{ parameters.status }}","context":"'"$stageToSkip"'","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'    
     done

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -24,7 +24,8 @@ steps:
       TARGET_URL="https://dev.azure.com/datadoghq/$(AZURE_PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
       curl_fail_with_body -X POST --silent --show-error \
         -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: token $(GITHUB_TOKEN)" \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
         https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
         -d '{"state":"${{ parameters.status }}","context":"'"$stageToSkip"'","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'    
     done

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -10,6 +10,7 @@
 
 steps:
   # Use semicolon delimited list of checks, and update each of them
+- template: create-github-app-token.yml
 - script: |
     # curl is too old so doesn't support --fail-with-body
     curl_fail_with_body() {
@@ -33,5 +34,5 @@ steps:
   continueOnError: true
   env:
     AZURE_PROJECT_NAME: $(AZURE_PROJECT_NAME)
-    GITHUB_TOKEN: $(GITHUB_TOKEN)
+    GITHUB_TOKEN: $(retrieve_github_token.GITHUB_APP_TOKEN)
     GITHUB_REPOSITORY_NAME: $(GITHUB_REPOSITORY_NAME)


### PR DESCRIPTION
## Summary of changes

Fix the github status updates from Azure DevOps

## Reason for change

In #7091 we switched to how we were obtaining the token. We missed one place it's needed.

## Implementation details

Obtain a token instead of trying to use an ambient token

## Test coverage

This is the test

## Other details

Oops 🤦‍♂️ 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
