### PR TITLE
Try to fix flaky IIS fleet-installer tests

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -20,6 +20,10 @@ parameters:
   - name: 'dockerComposePath'
     type: string
     default: 'docker-compose'
+  
+  - name: 'testAgentTarget'
+    type: string
+    default: ''
 
 steps:
 - template: ./clean-docker-containers.yml
@@ -42,9 +46,11 @@ steps:
 
 - ${{ if eq(parameters.isLinux, true) }}:
   - bash: |
+      testAgentTarget="${{ parameters.testAgentTarget }}"
+      testAgentTarget="${testAgentTarget:-test-agent}"
       echo "##vso[task.setvariable variable=CURL_COMMAND]/usr/bin/curl"
-      echo "##vso[task.setvariable variable=TEST_AGENT_TARGET]test-agent"
-      echo "##vso[task.setvariable variable=START_TEST_AGENT_TARGET]start-test-agent"
+      echo "##vso[task.setvariable variable=TEST_AGENT_TARGET]${testAgentTarget}"
+      echo "##vso[task.setvariable variable=START_TEST_AGENT_TARGET]start-${testAgentTarget}"
       echo "##vso[task.setvariable variable=COMPOSE_PATH]docker-compose.yml"
     displayName: Set env-specific variables
 
@@ -57,9 +63,11 @@ steps:
     displayName: create test data directories
 - ${{ else }}:
   - bash: |
+      testAgentTarget="${{ parameters.testAgentTarget }}"
+      testAgentTarget="${testAgentTarget:-test-agent.windows}"
       echo "##vso[task.setvariable variable=CURL_COMMAND]curl"
-      echo "##vso[task.setvariable variable=TEST_AGENT_TARGET]test-agent.windows"
-      echo "##vso[task.setvariable variable=START_TEST_AGENT_TARGET]start-test-agent.windows"
+      echo "##vso[task.setvariable variable=TEST_AGENT_TARGET]${testAgentTarget}"
+      echo "##vso[task.setvariable variable=START_TEST_AGENT_TARGET]start-${testAgentTarget}"
       echo "##vso[task.setvariable variable=COMPOSE_PATH]docker-compose.windows.yml"
     displayName: Set env-specific  variables
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5993,6 +5993,7 @@ stages:
         - template: steps/run-snapshot-test.yml
           parameters:
             target: 'fleet-installer-smoke-tests-iis.windows'
+            testAgentTarget: 'test-agent.iis.windows'
             snapshotPrefix: "smoke_test_iis"
             isLinux: false
             dockerComposePath: $(dockerComposePath)

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -11,6 +11,17 @@ services:
     - TIMEOUT_LENGTH=120
     command: test-agent.windows:8126
 
+  start-test-agent.iis.windows:
+    build:
+      context: ./tracer/build/_build/docker/
+      dockerfile: wait-for-dependencies-windows.dockerfile
+    image: andrewlock/wait-for-dependencies-windows
+    depends_on:
+    - test-agent.iis.windows
+    environment:
+    - TIMEOUT_LENGTH=120
+    command: test-agent.iis.windows:8126
+
   test-agent.windows:
     build:
       context: ./tracer/build/_build/docker/
@@ -23,7 +34,25 @@ services:
     - "8126"
     environment:
     - SNAPSHOT_CI=1
-    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers #api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
+      # api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers
+
+  test-agent.iis.windows:
+    build:
+      context: ./tracer/build/_build/docker/
+      dockerfile: test-agent.windows.dockerfile
+    image: dd-trace-dotnet/ddapm-test-agent-windows
+    volumes:
+    - ./tracer/build/smoke_test_snapshots:c:/snapshots
+    - ./artifacts/build_data/snapshots:c:/debug_snapshots
+    ports:
+    - "8126"
+    environment:
+    - SNAPSHOT_CI=1
+      # api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
+      # The iis agent also ignores the _dd.appsec.waf.version because whether it appears in the 
+      # aspnet_core.request span is flaky
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers,_dd.appsec.waf.version
 
   # The IIS images are based on Windows images, so they can only be run on Docker for Windows,
   # and only after switching to run Windows containers


### PR DESCRIPTION
## Summary of changes

Add workaround for flaky ASM tags on fleet installer IIS tests 

## Reason for change

The IIS fleet-installer tests are kind of gnarly and slow, and we have been seeing some flay related to the presence (or lack of) the `_dd.appsec.waf.version` tag on spans where we expect them. We tried to solve the flakiness at the source in https://github.com/DataDog/dd-trace-dotnet/pull/7121, but we're still seeing flakiness, so for now just ignoring the tag in the snapshot comparison.

## Implementation details

Unfortunately, this is a bit more tricky than we'd like because we _only_ want to ignore it for IIS atm.  That means we have to create a separate docker target, and add the ability to specify the target to run.

## Test coverage

Covered by existing tests - if they pass, that's good enough for now

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
