### PR TITLE
Explicitly disable debug mode as required

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -75,7 +75,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetInstrumentationVerification();
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
-            SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
             SetEnvironmentVariable("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", enable128BitInjection ? "true" : "false");
             using var logsIntake = new MockLogsIntake();
             if (enableLogShipping)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -29,7 +29,6 @@ public class ManualInstrumentationTests : TestHelper
     public ManualInstrumentationTests(ITestOutputHelper output)
         : base("ManualInstrumentation", output)
     {
-        SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
     }
 
     [SkippableFact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
@@ -14,7 +14,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         public EnumerateAssemblyReferencesTest(ITestOutputHelper output)
             : base(output, "EnumerateAssemblyReferences")
         {
-            SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
         }
 
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -244,7 +244,7 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables["COR_PROFILER_PATH"] = nativeLoaderPath;
             }
 
-            environmentVariables["DD_TRACE_DEBUG"] = DebugModeEnabled ? "1" "0";
+            environmentVariables["DD_TRACE_DEBUG"] = (DebugModeEnabled ? "1" "0");
 
             if (!string.IsNullOrEmpty(processToProfile) && !ignoreProfilerProcessesVar)
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -244,10 +244,7 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables["COR_PROFILER_PATH"] = nativeLoaderPath;
             }
 
-            if (DebugModeEnabled)
-            {
-                environmentVariables["DD_TRACE_DEBUG"] = "1";
-            }
+            environmentVariables["DD_TRACE_DEBUG"] = DebugModeEnabled ? "1" "0";
 
             if (!string.IsNullOrEmpty(processToProfile) && !ignoreProfilerProcessesVar)
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -244,7 +244,7 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables["COR_PROFILER_PATH"] = nativeLoaderPath;
             }
 
-            environmentVariables["DD_TRACE_DEBUG"] = (DebugModeEnabled ? "1" "0");
+            environmentVariables["DD_TRACE_DEBUG"] = DebugModeEnabled ? "1" : "0";
 
             if (!string.IsNullOrEmpty(processToProfile) && !ignoreProfilerProcessesVar)
             {


### PR DESCRIPTION
## Summary of changes

Explicitly sets `DD_TRACE_DEBUG=0` if `DebugModeEnabled==false`

## Reason for change

Some tests have different behaviour between debug and non-debug mode.

## Implementation details

Explicitly set `DD_TRACE_DEBUG=0`, instead of just leaving the ambient value

## Test coverage

This is the test, but will also do a "forced debug" run to confirm

## Other details

Removed some explicit setting of `DD_TRACE_DEBUG` from tests, as we generally shouldn't do this (it changes test behaviour, and we have the debug run explicitly to verify both paths). 