### PR TITLE
Fix release process by removing check for SSI artifacts

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -999,32 +999,6 @@ partial class Build
 
                 var stages = string.Join(", ", ssiStatuses.Select(x => x.Key));
                 Logger.Information("All gitlab build stages ({Stages}) completed successfully", stages);
-                
-                // assert that the docker image for the commit is present
-                var image = $"ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:{CommitSha}";
-                VerifyDockerImageExists(image);
-                
-                if(new Version(Version).Major < 3)
-                {
-                    image = $"{image}-musl";
-                    VerifyDockerImageExists(image);
-                }
-
-                static void VerifyDockerImageExists(string image)
-                {
-                    try
-                    {
-                        Logger.Information("Checking for presence of SSI image '{Image}'", image);
-                        DockerTasks.DockerManifest(
-                            s => s.SetCommand($"inspect")
-                                .SetProcessArgumentConfigurator(c => c.Add(image)));
-                        Logger.Information("SSI image '{Image}' exists", image);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception($"Error verifying SSI artifacts: '{image}' could not be found. Ensure GitLab has successfully built and pushed the image", ex);
-                    }
-                }
             });
 
     async Task ReplaceCommentInPullRequest(int prNumber, string title, string markdown)


### PR DESCRIPTION
## Summary of changes

Removes the SSI artifact presence check

## Reason for change

We no longer push SSI images to ghcr so can't check that as part of release readiness check. The images are only pushed to an internal repo now

## Implementation details

Just delete the check

## Test coverage

Meh

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
