### PR TITLE
Add workaround for messed up execution_benchmark results

### DIFF
--- a/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
+++ b/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
@@ -70,15 +70,23 @@ public class CompareExecutionTime
                                     return (@pairedScenarios.Key, conclusion: EquivalenceTestConclusion.Same);
                                 }
 
-                                var userThresholdResult = StatisticalTestHelper.CalculateTost(WelchTest.Instance, masterValues, commitValues, SignificantResultThreshold);
-                                var conclusion = userThresholdResult.Conclusion switch
+                                try
                                 {
-                                    EquivalenceTestConclusion.Same => EquivalenceTestConclusion.Same,
-                                    _ when StatisticalTestHelper.CalculateTost(WelchTest.Instance, masterValues, commitValues, NoiseThreshold).Conclusion == EquivalenceTestConclusion.Same => EquivalenceTestConclusion.Same,
-                                    _ => userThresholdResult.Conclusion,
-                                };
+                                    var userThresholdResult = StatisticalTestHelper.CalculateTost(WelchTest.Instance, masterValues, commitValues, SignificantResultThreshold);
+                                    var conclusion = userThresholdResult.Conclusion switch
+                                    {
+                                        EquivalenceTestConclusion.Same => EquivalenceTestConclusion.Same,
+                                        _ when StatisticalTestHelper.CalculateTost(WelchTest.Instance, masterValues, commitValues, NoiseThreshold).Conclusion == EquivalenceTestConclusion.Same => EquivalenceTestConclusion.Same,
+                                        _ => userThresholdResult.Conclusion,
+                                    };
 
-                                return (@pairedScenarios.Key, conclusion);
+                                    return (@pairedScenarios.Key, conclusion);
+                                }
+                                catch (Exception e)
+                                {
+                                    Logger.Warning("Error calculating TOST for {Scenario}: {Message}", @pairedScenarios.Key, e.Message);
+                                    return (@pairedScenarios.Key, conclusion: EquivalenceTestConclusion.Same);
+                                }
                             })
                            .ToDictionary(x => x.Key, x => x.conclusion);
 


### PR DESCRIPTION
## Summary of changes

Fix the execution_benchmarks job

## Reason for change

The job went haywire, and we had broken results, which has broken the comparison stage. This adds a workaround so we can get good results uploading again.

## Implementation details

Add a try-catch to handle the error we were seeing

<details><summary>Details</summary>
<p>
<pre><code> at Perfolizer.Mathematics.SignificanceTesting.WelchTest.IsGreater(Double[] x, Double[] y, Threshold threshold)
   at Perfolizer.Mathematics.SignificanceTesting.StatisticalTestHelper.CalculateTost[T](IOneSidedTest`1 test, Double[] baseline, Double[] candidate, Threshold threshold)
   at CompareExecutionTime.<>c.<GetMermaidSection>b__3_3(IGrouping`2 pairedScenarios) in C:\repos\dd-trace-dotnet\tracer\build\_build\ExecutionTimeComparison\CompareExecutionTime.cs:line 73
   at System.Linq.Enumerable.IteratorSelectIterator`2.MoveNext()
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   at CompareExecutionTime.GetMermaidSection(String scenario, IEnumerable`1 results) in C:\repos\dd-trace-dotnet\tracer\build\_build\ExecutionTimeComparison\CompareExecutionTime.cs:line 60
   at CompareExecutionTime.<>c.<GetMarkdown>b__2_5(IGrouping`2 scenarioResults, Int32 i) in C:\repos\dd-trace-dotnet\tracer\build\_build\ExecutionTimeComparison\CompareExecutionTime.cs:line 33
   at System.Linq.Enumerable.SelectIterator[TSource,TResult](IEnumerable`1 source, Func`3 selector)+MoveNext()
   at System.String.Join(String separator, IEnumerable`1 values)
   at CompareExecutionTime.<>c.<GetMarkdown>b__2_1(IGrouping`2 group) in C:\repos\dd-trace-dotnet\tracer\build\_build\ExecutionTimeComparison\CompareExecutionTime.cs:line 34
   at System.Linq.Enumerable.IteratorSelectIterator`2.MoveNext()
   at System.String.JoinCore[T](ReadOnlySpan`1 separator, IEnumerable`1 values)
   at System.String.Join[T](Char separator, IEnumerable`1 values)
   at CompareExecutionTime.GetCommentMarkdown(List`1 sources, IEnumerable`1 charts) in C:\repos\dd-trace-dotnet\tracer\build\_build\ExecutionTimeComparison\CompareExecutionTime.cs:line 115
   at CompareExecutionTime.GetMarkdown(List`1 sources) in C:\repos\dd-trace-dotnet\tracer\build\_build\ExecutionTimeComparison\CompareExecutionTime.cs:line 46
   at Build.<get_CompareExecutionTimeBenchmarkResults>b__170_4() in C:\repos\dd-trace-dotnet\tracer\build\_build\Build.GitHub.cs:line 919
   at Nuke.Common.Execution.TargetDefinition.<>c__DisplayClass77_0.<Executes>b__0() in /_/source/Nuke.Common/Execution/TargetDefinition.cs:line 71
   at Nuke.Common.Execution.BuildExecutor.<>c.<Execute>b__4_2(Action x) in /_/source/Nuke.Common/Execution/BuildExecutor.cs:line 112
   at Nuke.Common.Utilities.Collections.EnumerableExtensions.ForEach[T](IEnumerable`1 enumerable, Action`1 action) in /_/source/Nuke.Common/Utilities/Collections/Enumerable.ForEach.cs:line 17
   at Nuke.Common.Execution.BuildExecutor.Execute(NukeBuild build, ExecutableTarget target, IReadOnlyCollection`1 previouslyExecutedTargets, Boolean failureMode) in /_/source/Nuke.Common/Execution/BuildE</code></pre>


</p>
</details> 

## Test coverage

This is the test - if it works, we're good

## Other details

Need to merge this to fix the runs in other branches