### PR TITLE
[Dynamic Instrumentaiton] Marking instrumentation as failure if IsReEntryField is absent

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1630,7 +1630,7 @@ HRESULT DebuggerMethodRewriter::ApplyAsyncMethodProbe(
     if (hr != S_OK)
     {
         Logger::Info("Failed to apply Method Probe on Async Method due to failure in the lookup of the isReEntry field in the state machine. module id:", module_id, " method: ", caller->type.name, ".", caller->name);
-        return S_OK; // We do not fail the whole instrumentation as there could be Line Probes that we want to emit. They do not suffer from the absence of the IsReEntry field.
+        return E_NOTIMPL; // We do not fail the whole instrumentation as there could be Line Probes that we want to emit. They do not suffer from the absence of the IsReEntry field.
     }
 
     LogDebugCallerInfo(caller, instrumentedMethodIndex);


### PR DESCRIPTION
## Summary of changes
In DI rewriting, we inject a field in all state machines to track the state between re-entrances of async flow. If we fail to inject that field on module load, we mark the method as not eligible for instrumentation of method probes.
Line Probes, on the other hand, we don't need to track re-entrances thus they stay intact if we fail to inject that failed. In the current state of the instrumentation, we returned S_OK from the method probe instrumentation even though we failed to apply to to let line probes proceed. It lead to the situation where we fixed Exception Handler Clauses even though we didn't have to, leading to `InvalidProgramException` as a result.