### PR TITLE
Try to fix flaky tests that use `FileSystemWatcher`

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logDir);
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logDir, Output);
             using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
 
             try
@@ -113,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logDir);
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logDir, Output);
 
             SetEnvironmentVariable("DD_TRACE_SAMPLE_RATE", "0.9");
             using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -43,9 +44,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task UpdateConfiguration()
         {
+            var logDir = Path.Combine(LogDirectory, nameof(UpdateConfiguration));
+            Directory.CreateDirectory(logDir);
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logDir);
             using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
 
             try
@@ -102,9 +107,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task RestoreInitialConfiguration()
         {
+            var logDir = Path.Combine(LogDirectory, nameof(RestoreInitialConfiguration));
+            Directory.CreateDirectory(logDir);
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logDir);
 
             SetEnvironmentVariable("DD_TRACE_SAMPLE_RATE", "0.9");
             using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -41,7 +41,7 @@ public class TracerFlareTests : TestHelper
     {
         using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
+        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory, Output);
         using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
 
         try

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
@@ -16,12 +16,10 @@ public class TracerTests : TestHelper
 {
     private const string LogFileNamePrefix = "dotnet-tracer-managed-";
     private const string DiagnosticLog = "DATADOG TRACER CONFIGURATION";
-    private readonly ITestOutputHelper _output;
 
     public TracerTests(ITestOutputHelper output)
         : base("Console", output)
     {
-        _output = output;
     }
 
     [SkippableFact]
@@ -31,7 +29,7 @@ public class TracerTests : TestHelper
         EnvironmentHelper.CustomEnvironmentVariables["DD_TRACE_ENABLED"] = "0";
         using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory, _output);
+        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory, Output);
         using var processResult = await RunSampleAndWaitForExit(agent, "traces 1");
 
         // Throws if the log entry is not found

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerTests.cs" company="Datadog">
+// <copyright file="TracerTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -16,10 +16,12 @@ public class TracerTests : TestHelper
 {
     private const string LogFileNamePrefix = "dotnet-tracer-managed-";
     private const string DiagnosticLog = "DATADOG TRACER CONFIGURATION";
+    private readonly ITestOutputHelper _output;
 
     public TracerTests(ITestOutputHelper output)
         : base("Console", output)
     {
+        _output = output;
     }
 
     [SkippableFact]
@@ -29,7 +31,7 @@ public class TracerTests : TestHelper
         EnvironmentHelper.CustomEnvironmentVariables["DD_TRACE_ENABLED"] = "0";
         using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
+        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory, _output);
         using var processResult = await RunSampleAndWaitForExit(agent, "traces 1");
 
         // Throws if the log entry is not found

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
@@ -76,7 +76,7 @@ public class LiveDebuggerTests : TestHelper
 
         using var agent = EnvironmentHelper.GetMockAgent();
         string processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Probes";
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logPath);
+        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", logPath, Output);
         using var sample = await StartSample(agent, $"--test-name {testType.TestType}", string.Empty, aspNetCorePort: 5000);
         await logEntryWatcher.WaitForLogEntry(LiveDebuggerDisabledLogEntry);
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -444,7 +444,7 @@ public class ProbesTests : TestHelper
     private LogEntryWatcher CreateLogEntryWatcher()
     {
         string processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Probes";
-        return new LogEntryWatcher($"dotnet-tracer-managed-{processName}*", LogDirectory);
+        return new LogEntryWatcher($"dotnet-tracer-managed-{processName}*", LogDirectory, Output);
     }
 
     private async Task RunMethodProbeTests(ProbeTestDescription testDescription, bool useStatsD)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -441,10 +442,16 @@ public class ProbesTests : TestHelper
 
 #endif
 
-    private LogEntryWatcher CreateLogEntryWatcher()
+    private LogEntryWatcher CreateLogEntryWatcher(string suffix = "", [CallerMemberName] string testName = null)
     {
+        // Create a subdirectory for the logs based on the test name and suffix
+        // And write logs there instead
+        var logDir = Path.Combine(LogDirectory, $"{testName}{suffix}");
+        Directory.CreateDirectory(logDir);
+        SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+
         string processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Probes";
-        return new LogEntryWatcher($"dotnet-tracer-managed-{processName}*", LogDirectory, Output);
+        return new LogEntryWatcher($"dotnet-tracer-managed-{processName}*", logDir, Output);
     }
 
     private async Task RunMethodProbeTests(ProbeTestDescription testDescription, bool useStatsD)
@@ -453,7 +460,7 @@ public class ProbesTests : TestHelper
 
         using var agent = EnvironmentHelper.GetMockAgent(useStatsD: useStatsD);
         SetDebuggerEnvironment(agent);
-        using var logEntryWatcher = CreateLogEntryWatcher();
+        using var logEntryWatcher = CreateLogEntryWatcher($"optimized_{testDescription.IsOptimized}_type_{testDescription.TestType.Name}");
         using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -49,6 +49,13 @@ public class LogEntryWatcher : IDisposable
         }
 
         _fileWatcher.Created += NewLogFileCreated;
+        _fileWatcher.Error += (sender, args) =>
+        {
+            _outputHelper?.WriteLine(
+                args.GetException() is InternalBufferOverflowException
+                    ? "ERROR: FileSystemWatcher buffer overflowed. Events were lost."
+                    : $"ERROR: FileSystemWatcher error: {args.GetException()}");
+        };
     }
 
     public void Dispose()

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Castle.Core.Internal;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Xunit.Abstractions;
@@ -126,7 +125,7 @@ public class LogEntryWatcher : IDisposable
 
         if (i != logEntries.Length)
         {
-            if (logsReadLogLineRead.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(logsReadLogLineRead))
             {
                 throw new InvalidOperationException($"No logs could be read from {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}");
             }

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -31,7 +31,14 @@ public class LogEntryWatcher : IDisposable
     public LogEntryWatcher(string logFilePattern, string logDirectory = null, ITestOutputHelper outputHelper = null)
     {
         var logPath = logDirectory ?? DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance);
-        _fileWatcher = new FileSystemWatcher { Path = logPath, Filter = logFilePattern, EnableRaisingEvents = true };
+        _fileWatcher = new FileSystemWatcher
+        {
+            Path = logPath,
+            Filter = logFilePattern,
+            EnableRaisingEvents = true,
+            InternalBufferSize = 64 * 1024 // 64KB buffer size - default is 8KB, which may not be enough for high-frequency log writes
+        };
+
         _readers = new();
         _outputHelper = outputHelper;
         var dir = new DirectoryInfo(logPath);

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -5,13 +5,16 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Castle.Core.Internal;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
+using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers;
 
@@ -23,13 +26,15 @@ public class LogEntryWatcher : IDisposable
     // We must finish reading from the old one before switching to the new one, hence the queue
     private readonly ConcurrentQueue<StreamReader> _readers;
 
+    private readonly ITestOutputHelper _outputHelper;
     private StreamReader _activeReader;
 
-    public LogEntryWatcher(string logFilePattern, string logDirectory = null)
+    public LogEntryWatcher(string logFilePattern, string logDirectory = null, ITestOutputHelper outputHelper = null)
     {
         var logPath = logDirectory ?? DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance);
         _fileWatcher = new FileSystemWatcher { Path = logPath, Filter = logFilePattern, EnableRaisingEvents = true };
         _readers = new();
+        _outputHelper = outputHelper;
         var dir = new DirectoryInfo(logPath);
         var lastFile = dir
                       .GetFiles(logFilePattern)
@@ -38,6 +43,7 @@ public class LogEntryWatcher : IDisposable
 
         if (lastFile != null && lastFile.LastWriteTime.Date == DateTime.Today)
         {
+            _outputHelper?.WriteLine($"Last log file detected {lastFile.FullName}");
             var reader = OpenStream(lastFile.FullName);
             reader.ReadToEnd();
             _readers.Enqueue(reader);
@@ -66,14 +72,24 @@ public class LogEntryWatcher : IDisposable
 
     public async Task<string[]> WaitForLogEntries(string[] logEntries, TimeSpan? timeout = null)
     {
-        using var cancellationSource = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(20));
+        using var cancellationSource = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(40));
 
         var i = 0;
 
         var foundLogs = new string[logEntries.Length];
+        var logsReadLogLineRead = string.Empty;
+        var timeoutReached = false;
 
-        while (logEntries.Length > i && !cancellationSource.IsCancellationRequested)
+        while (logEntries.Length > i)
         {
+            timeoutReached = cancellationSource.IsCancellationRequested;
+
+            if (timeoutReached)
+            {
+                _outputHelper?.WriteLine($"Timeout reached.");
+                break;
+            }
+
             if (_activeReader == null)
             {
                 if (!_readers.TryDequeue(out _activeReader))
@@ -87,8 +103,10 @@ public class LogEntryWatcher : IDisposable
 
             if (line != null)
             {
+                logsReadLogLineRead = line;
                 if (line.Contains(logEntries[i]))
                 {
+                    _outputHelper?.WriteLine($"Entry found {logEntries[i]}.");
                     foundLogs[i] = line;
                     i++;
                 }
@@ -108,7 +126,14 @@ public class LogEntryWatcher : IDisposable
 
         if (i != logEntries.Length)
         {
-            throw new InvalidOperationException(_readers.IsEmpty ? $"Log file was not found for path: {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}. Logs read so far: {string.Join("\r\n", foundLogs)}" : $"Log entry was not found {logEntries[i]} in {_fileWatcher.Path} with filter {_fileWatcher.Filter}. Cancellation token reached: {cancellationSource.IsCancellationRequested}");
+            if (logsReadLogLineRead.IsNullOrEmpty())
+            {
+                throw new InvalidOperationException($"No logs could be read from {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}");
+            }
+            else
+            {
+                throw new InvalidOperationException($"Timeout is {timeoutReached}. Log entry {logEntries[i]} was not found in {_fileWatcher.Path} with filter {_fileWatcher.Filter}. Last Log line read: {logsReadLogLineRead}");
+            }
         }
 
         return foundLogs;
@@ -127,6 +152,7 @@ public class LogEntryWatcher : IDisposable
 
     private void NewLogFileCreated(object sender, FileSystemEventArgs e)
     {
+        _outputHelper?.WriteLine($"New Log file created {e.FullPath}");
         _readers.Enqueue(OpenStream(e.FullPath));
     }
 }


### PR DESCRIPTION
## Summary of changes

- Re-implements #7163 to get visibility on `LogEntryWatcher` behaviour
- Ensure tests that use `LogEntryWatcher` write logs to separate locations
- Increase notification buffer size of `FileSystemWatcher`
- Add logging if/when buffer overflows

## Reason for change

#7163 was attempting to improve our visibility of the behaviour of the `LogEntryWatcher` (which uses a  `FileSystemWatcher`) to try to understand flake we were seeing. However, that PR _massively_ increased the flake in the Debugger tests on Windows (to the extent that we had no successful runs any more). So we reverted that PR in #7191.

This PR reinstates the original PR, but adds additional mitigations, to attempt to avoid the issue repeating.

## Implementation details

The first commit is a simple revert of the "revert PR" #7191 (no need to review it closely).

The mitigations to prevent repeat issues are:
- Don't write all logs to the same folder. Theoretically I thought that this _shouldn't_ make a difference, as we already split log folders by class, and these aren't run concurrently, but on its own, this resolved the issue, so it clearly does have an impact 🤷‍♂️ 
- Increase the size of the notification buffer. A notification buffer overflow is the most likely cause of the issue, especially as the error happened the most on debug runs, when the most file-change notifications will be sent. 
- Add a notification if the buffer overflows, so we know _why_ we're failing.

## Test coverage

Ran tests locally - previously I saw flake, afterwards I didn't, and the same goes for CI.

## Other details

I updated everywhere I found that was using the `LogEntryWatcher`, even those that haven't seen flake so far, just in case.
