### PR TITLE
Fix potential flake in crash-tracking tests for chiseled containers

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -79,7 +79,10 @@ steps:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
 
 - bash: |
-    ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e PROFILER_IS_NOT_REQUIRED=${{ parameters.isNoop }} ${{ parameters.target }}
+    # We explicitly set the DD_PROFILING_ENABLED=1 flag here, because we want to ensure that profiling is enabled for this
+    # test, but _not_ for the crash tracking test. For some scenarios (e.g. chiseled tests) we can't set env vars directly
+    # in the container, so we explicitly set this once here because it needs to change between the two tests.
+    ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e DD_PROFILING_ENABLED=1 -e PROFILER_IS_NOT_REQUIRED=${{ parameters.isNoop }} ${{ parameters.target }}
   env:
     dockerTag: $(dockerTag)
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -74,8 +74,8 @@ ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]
 # Because there _is_ no shell in the chiseled containers
 # Also, we can't use env vars/args in the entrypoint, hence the need for separate targets
 FROM installer-base as dd-dotnet-final-linux-x64
-ENTRYPOINT ["/opt/datadog/linux-x64/dd-dotnet", "run", "--set-env", "DD_PROFILING_ENABLED=1","--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--", "dotnet", "/app/AspNetCoreSmokeTest.dll"]
+ENTRYPOINT ["/opt/datadog/linux-x64/dd-dotnet", "run", "--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--", "dotnet", "/app/AspNetCoreSmokeTest.dll"]
 
 ###########################################################
 FROM installer-base as dd-dotnet-final-linux-arm64
-ENTRYPOINT ["/opt/datadog/linux-arm64/dd-dotnet", "run", "--set-env", "DD_PROFILING_ENABLED=1","--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--", "dotnet", "/app/AspNetCoreSmokeTest.dll"]
+ENTRYPOINT ["/opt/datadog/linux-arm64/dd-dotnet", "run", "--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--", "dotnet", "/app/AspNetCoreSmokeTest.dll"]


### PR DESCRIPTION
## Summary of changes

Ensure we don't run crash-tests with the profiler enabled for chiseled containers

## Reason for change

We have a known flake interaction between the CP and crash tracking. We merged a fix for most cases in https://github.com/DataDog/dd-trace-dotnet/pull/7184, this handles the chiseled container scenario

## Implementation details

We can't use `ENV` in chiseled containers, so we can't move the `DD_PROFILING_ENABLED` call to the ambient container (and override it for the crash tracking tests). So instead, we remove it entirely, and then explicitly enable/disable for _both_ the crash-tracking and normal tests intead.

## Test coverage

This is the test, as long as everything passes, we're ok.
