### PR TITLE
Revert "Fix test InitializesTracerWhenTracingIsDisabled Flakiness (#7163)

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="TracerTests.cs" company="Datadog">
+﻿// <copyright file="TracerTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -16,12 +16,10 @@ public class TracerTests : TestHelper
 {
     private const string LogFileNamePrefix = "dotnet-tracer-managed-";
     private const string DiagnosticLog = "DATADOG TRACER CONFIGURATION";
-    private readonly ITestOutputHelper _output;
 
     public TracerTests(ITestOutputHelper output)
         : base("Console", output)
     {
-        _output = output;
     }
 
     [SkippableFact]
@@ -31,7 +29,7 @@ public class TracerTests : TestHelper
         EnvironmentHelper.CustomEnvironmentVariables["DD_TRACE_ENABLED"] = "0";
         using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory, _output);
+        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
         using var processResult = await RunSampleAndWaitForExit(agent, "traces 1");
 
         // Throws if the log entry is not found


### PR DESCRIPTION
## Summary of changes

This reverts commit 814c3b9385fa0405fb630d54adb403fc776118d4.

## Reason for change

It caused massive flakiness in the Debugger tests on Windows. I think it exacerbates an existing flakiness present in the `LogEntryWatcher`. It appears the `NewLogFileCreated` even is often not triggered. Will re-implement and investigate in a separate PR, this is just to unblock things.

## Implementation details

Revert the previous PR

## Test coverage

I'll do a dedicated run of debugger tests to confirm this resolves the issue

## Other details

The debugger tests and the tracer test _were_ flaky, so it seems likely that this was exacerbating existing flake rather than introducing it