### PR TITLE
Fix more flake in the Fleet-installer IIS snapshot smoke tests

### DIFF
--- a/tracer/build/_build/docker/smoke.windows.iis.fleet-installer.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.iis.fleet-installer.dockerfile
@@ -74,7 +74,7 @@ RUN ('$completedFile=\"C:\logs\completed.txt\"; if (Test-Path $completedFile) { 
     ('Write-Host \"Enabling instrumentation\"') >> C:\app\entrypoint.ps1; \
     ('c:\install\installer\Datadog.FleetInstaller.exe ' + $env:INSTALL_COMMAND + ' --home-path c:\monitoring-home') >> C:\app\entrypoint.ps1; \
     ('Write-Host \"Starting AspNetCorePool app pool\"; Start-WebAppPool -Name \"AspNetCorePool\" -PassThru;') >> C:\app\entrypoint.ps1; \
-    ('Write-Host \"Making 404 request\"; curl http://localhost:5000;') >> C:\app\entrypoint.ps1; \
+    ('Write-Host \"Making 404 request\"; Invoke-WebRequest -Uri http://localhost:5000 -Headers @{ \"User-Agent\" = \"FleetInstallerTester/1.0\" }') >> C:\app\entrypoint.ps1; \
     ('while (-not (Test-Path "C:\logs\completed.txt")) { Write-Host \"Waiting for app shutdown\"; Start-Sleep -Seconds 1; }; ') >> C:\app\entrypoint.ps1; \
     ('Write-Host \"Stopping pool\";Stop-WebAppPool \"AspNetCorePool\" -PassThru;') >> C:\app\entrypoint.ps1;  \
     ('Write-Host \"Shutting down\"') >> C:\app\entrypoint.ps1;

--- a/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
@@ -12,7 +12,7 @@
       "meta": {
         "component": "aspnet_core",
         "span.kind": "server",
-        "http.useragent": "Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.20348.2849",
+        "http.useragent": "FleetInstallerTester/1.0",
         "http.method": "GET",
         "http.request.headers.host": "localhost:5000",
         "http.url": "http://localhost:5000/",


### PR DESCRIPTION
## Summary of changes

Fix flake in the `http.useragent` in the IIS fleet installer snapshots

## Reason for change

Saw some recent flake due to an update in the powershell version being used to send the request [in this run](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=181041&view=logs&j=3edc6e7f-f0ab-5e0e-bfbe-5da3aa2bbf26&t=ea4ac017-ebc5-5c2c-8117-71c9627f97da)

```diff
- 'http.useragent': 'Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.20348.2849'
+ 'http.useragent': 'Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.20348.3932',
```

To avoid issues with implicit updates to powershell, we should provide a fixed known value instead.

## Implementation details

Use a custom user agent for fleet-installer 404 invocation. Also switched away from using `curl` which can _sometimes_ be an alias for Invoke-WebRequest and sometimes the "real" `curl.exe`.

## Test coverage

This is the test, if the smoke tests pass we're good

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
