### PR TITLE
Show correct `agent_uri` path in startup log

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/StreamFactories/NamedPipeClientStreamFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/StreamFactories/NamedPipeClientStreamFactory.cs
@@ -14,34 +14,27 @@ namespace Datadog.Trace.Agent.StreamFactories
 {
     internal class NamedPipeClientStreamFactory : IStreamFactory
     {
+        private const string ServerName = ".";
+        private const PipeOptions PipeOptions = System.IO.Pipes.PipeOptions.Asynchronous;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(NamedPipeClientStreamFactory));
 
         private readonly string _pipeName;
-        private readonly string _serverName;
-        private readonly PipeOptions _pipeOptions;
         private readonly int _timeoutMs;
 
         public NamedPipeClientStreamFactory(string pipeName, int timeoutMs)
-            : this(pipeName, ".", PipeOptions.Asynchronous, timeoutMs)
-        {
-        }
-
-        public NamedPipeClientStreamFactory(string pipeName, string serverName, PipeOptions pipeOptions, int timeoutMs)
         {
             _pipeName = pipeName;
-            _serverName = serverName;
-            _pipeOptions = pipeOptions;
             _timeoutMs = timeoutMs;
         }
 
         public string Info()
         {
-            return $@"\\{_serverName}\pipe\{_pipeName}";
+            return $@"\\{ServerName}\pipe\{_pipeName}";
         }
 
         public Stream GetBidirectionalStream()
         {
-            var pipeStream = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut, _pipeOptions);
+            var pipeStream = new NamedPipeClientStream(ServerName, _pipeName, PipeDirection.InOut, PipeOptions);
             pipeStream.Connect(_timeoutMs);
             return pipeStream;
         }
@@ -52,7 +45,7 @@ namespace Datadog.Trace.Agent.StreamFactories
             NamedPipeClientStream pipeStream = null;
             try
             {
-                pipeStream = new NamedPipeClientStream(_serverName, _pipeName, PipeDirection.InOut, _pipeOptions);
+                pipeStream = new NamedPipeClientStream(ServerName, _pipeName, PipeDirection.InOut, PipeOptions);
                 await pipeStream.ConnectAsync(_timeoutMs, token).ConfigureAwait(false);
                 return pipeStream;
             }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -399,7 +399,7 @@ namespace Datadog.Trace
                     writer.WriteValue(instance.DefaultServiceName);
 
                     writer.WritePropertyName("agent_url");
-                    writer.WriteValue(instanceSettings.Exporter.AgentUri);
+                    writer.WriteValue(instanceSettings.Exporter.TraceAgentUriBase);
 
                     writer.WritePropertyName("agent_transport");
                     writer.WriteValue(instanceSettings.Exporter.TracesTransport.ToString());

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Linq;
+using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using FluentAssertions;
@@ -284,6 +285,54 @@ namespace Datadog.Trace.Tests.Configuration
         {
             var settingsFromSource = Setup(DefaultSocketFilesExist(), "DD_TRACE_AGENT_URL:unix:///var/datadog/myscocket.soc", "DD_AGENT_HOST:someotherhost");
             AssertMetricsUdpIsConfigured(settingsFromSource, hostname: "someotherhost");
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("http://someUrl", null, null)]
+        [InlineData("http://someUrl:1234", null, null)]
+        [InlineData(null, "somehost", null)]
+        [InlineData(null, "somehost", "1234")]
+        [InlineData(null, null, "1234")]
+        public void TraceAgentUriBase_WhenTcp_MatchesAgentUri(string agentUrl, string host, string port)
+        {
+            var settings = Setup(
+                BuildSource(
+                    $"DD_TRACE_AGENT_URL:{agentUrl}",
+                    $"DD_AGENT_HOST:{host}",
+                    $"DD_TRACE_AGENT_PORT:{port}"),
+                NoFile());
+
+            settings.TracesTransport.Should().Be(TracesTransportType.Default);
+            settings.TraceAgentUriBase.Should().Be(settings.AgentUri.ToString());
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [Theory]
+        [InlineData("unix://some/socket.soc", null)]
+        [InlineData(null, "some/socket.soc")]
+        [InlineData(null, "./socket.soc")]
+        public void TraceAgentUriBase_WhenUnix_MatchesAgentUri(string agentUrl, string apmReceiverSocket)
+        {
+            var settings = Setup(
+                BuildSource(
+                    $"DD_TRACE_AGENT_URL:{agentUrl}",
+                    $"DD_APM_RECEIVER_SOCKET:{apmReceiverSocket}"),
+                NoFile());
+
+            settings.TracesTransport.Should().Be(TracesTransportType.UnixDomainSocket);
+            settings.TraceAgentUriBase.Should().Be(settings.AgentUri.ToString());
+        }
+#endif
+
+        [Fact]
+        public void TraceAgentUriBase_WhenNamedPipes_ShowsPipeName()
+        {
+            var pipeName = "something";
+            var settings = Setup("DD_TRACE_PIPE_NAME", pipeName);
+
+            settings.TracesTransport.Should().Be(TracesTransportType.WindowsNamedPipe);
+            settings.TraceAgentUriBase.Should().Be(@"\\.\pipe\" + pipeName);
         }
 
         private static ExporterSettings Setup(IConfigurationSource source, Func<string, bool> fileExists)


### PR DESCRIPTION
## Summary of changes

Shows the correct `agent_uri` path in the startup logs

## Reason for change

Currently, `agent_uri` _always_ shows the output of `TracerSettings.AgentUri`. However, this is set to a default/dummy value for windows named pipes. This PR ensures we report the correct value in the `DATADOG TRACER CONFIGURATION` log when using named pipes

## Implementation details

Exposed another property to write the "real" `TraceAgentUriBase` value. We can't easily change `AgentUri` to return the correct value because 

1. The named pipe name isn't a valid Uri
2. AgentUri is exposed publicly, so we can't change it without introducing potentially breaking behaviour

If, in the future, we consider introducing a `npipe://` prefix for _setting_ the named pipe, then we may be able to reconsider this, but for now, this is the least risky change while still exposing the correct info.

## Test coverage

Added some unit tests

## Other details

Did some minor cleanup in `NamedPipeClientStreamFactory`