### PR TITLE
Try removing exceptions from the shutdown path

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
@@ -23,7 +23,7 @@ internal class HardcodedSecretsAnalyzer : IDisposable
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<HardcodedSecretsAnalyzer>();
     private static HardcodedSecretsAnalyzer? _instance = null;
 
-    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly TaskCompletionSource<bool> _processExit = new();
     private readonly TimeSpan _regexTimeout;
     private List<SecretRegex>? _secretRules = null;
 
@@ -32,17 +32,17 @@ internal class HardcodedSecretsAnalyzer : IDisposable
     {
         Log.Debug("HardcodedSecretsAnalyzer -> Init");
         _regexTimeout = regexTimeout;
-        Task.Run(() => PollingThread(_cancellationTokenSource.Token))
+        Task.Run(() => PollingThread())
             .ContinueWith(t => Log.Error(t.Exception, "Error in Hardcoded secret analyzer"), TaskContinuationOptions.OnlyOnFaulted);
     }
 
-    private async Task PollingThread(CancellationToken cancellationToken)
+    private async Task PollingThread()
     {
         try
         {
             Log.Debug("HardcodedSecretsAnalyzer polling thread -> Started");
             var userStrings = new UserStringInterop[UserStringsArraySize];
-            while (!cancellationToken.IsCancellationRequested)
+            while (!_processExit.Task.IsCompleted)
             {
                 if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId.HardcodedSecret))
                 {
@@ -92,7 +92,7 @@ internal class HardcodedSecretsAnalyzer : IDisposable
                     }
                 }
 
-                await Task.Delay(2_000, cancellationToken).ConfigureAwait(false);
+                await Task.WhenAny(_processExit.Task, Task.Delay(2_000)).ConfigureAwait(false);
             }
         }
         catch (Exception err) when (!(err is OperationCanceledException))
@@ -219,7 +219,7 @@ internal class HardcodedSecretsAnalyzer : IDisposable
 
     public void Dispose()
     {
-        _cancellationTokenSource.Cancel();
+        _processExit.SetResult(true);
         Log.Debug("HardcodedSecretsAnalyzer -> Disposed");
     }
 


### PR DESCRIPTION
## Summary of changes

Replace `CancellationTokenSource` with `TaskCompletionSource`

## Reason for change

There's a bug in the runtime, [which we have seen primarily on .NET 9 on arm64](https://github.com/dotnet/runtime/issues/112565), but which we have occasionally seen both on x64 and also .NET FX. The bug appears to be triggered by some combination of:

- The app shutting down
- Rejit ongoing
- An exception is thrown

It's very likely a race condition in the runtime somewhere, but we have started seeing this more commonly in CI since making changes to how we delay loading the native tracer/profiler. It's particularly noticable for short programs.

The crashing cases we have seen recently were all triggered by the `DiscoveryService` cancelling its `FetchConfigurationLoopAsync` by setting `CancellationTokenSource.Cancel()`. This triggers a `TaskCancelledException` to be thrown (as is normal for task cancellation), which is then caught, and the loop exits gracefully.

However, the bug means that _the act of throwing the exception_ triggers a crash 😅 So this PR is about trying to avoid throwing an exception in non-exceptional circumstances (i.e. graceful cancellation). 

## Implementation details

tl;dr; 

- `CancellationTokenSource` => `TaskCompletionSource<bool>`
- `_processExit.IsCancellationRequested` => `_processExit.Task.IsCompleted`
- `Task.Delay(duration, _processExit.Token)` => `Task.WhenAny(_processExit.Task, Task.Delay(duration))`

The semantics are _almost_ the same, and as we're always "cancelling" a _delay_ it's pretty safe; the delay will technically continue in the background but that's not a problem really.

I did a sweep for all the places using a `CancellationTokenSource` in _Datadog.Trace_ (we don't care about the `dd-trace` runner etc, because the profiler isn't attached).

- `DiscoveryService` ✅ Fixed
- `XunitTestMethodRunnerContextCtorV3Integration` ✅ Required for instrumentation, unused
- `Debugger*` ⚠️ _dozens of places_... we may need to look into this in more detail
- `TaskExtensions.SafeWait` ⚠️ Only used in `TestOptimization.Flush`, I'll let @tonyredondo evaluate
- `HardcodedSecretsAnalyzer` ✅ Fixed
- `RemoteConfigurationManager` ✅ Fixed
- `AsyncManualResetEvent.WaitAsync` ⚠️ Only used in `CIVisibilityProtocolWriter`, I'll let @tonyredondo evaluate
- `AsyncUtil.WaitAsync` ⚠️ Used in `AsyncUtil.RunSync()` which we use in the shutdown path, but _shoudln't_ be a massive problem, as we only hit it in a timeout scenario. We probably _could_ change it to be the same though
- `TraceClock` ✅ Fixed

## Test coverage

In general, we're covered by the existing tests. But I hooked up a quick app to check on the first chance exceptions

```csharp
using System;
using System.Threading;

int _firstChanceExceptionCount = 0;

AppDomain.CurrentDomain.FirstChanceException += (sender, e) =>
{
    Interlocked.Increment(ref _firstChanceExceptionCount);
};

AppDomain.CurrentDomain.ProcessExit += (sender, e) =>
{
    Console.WriteLine($"First chance exceptions: {_firstChanceExceptionCount}");
};
```

The app just starts, does nothing, and exits.

Without instrumentation:
```
First chance exceptions: 0
```

With instrumentation (with 3.20.1 release)
```
First chance exceptions: 2
```

With instrumentation (this PR)
```
First chance exceptions: 0
```

## Other details

This almost certainly won't completely solve the problem. For example the [original issue](https://github.com/dotnet/runtime/issues/112565) happened with an `ObjectDisposedException` being thrown from a socket. That could still happen, and isn't resolved by this PR.


There's also a whole separate avenue we could explore related to a Rejit happening at the same time. It's very plausible that's part of the issue. We could look into using `PrepareMethod` to side step that [RuntimeHelpers.PrepareMethod](https://github.com/dotnet/runtime/issues/1711), but that would be a next step. Hopefully this PR will reduce the impact anyway