### PR TITLE
[CI]: Add custom timeout to CI workflows to detect stuck runs earlier

### DIFF
--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   verify_app_trimming_descriptor_generator:
     runs-on: windows-latest
+    timeout-minutes: 34 # max + 3*std over the last 3700 runs
     permissions:
       contents: read
 

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   bump_package_versions:
     runs-on: windows-latest
+    timeout-minutes: 96 # max + 3*std over the last 3700 runs
     permissions:
       contents: read
 

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   verify_source_generators:
     runs-on: windows-latest
+    timeout-minutes: 34 # max + 3*std over the last 3700 runs
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary of changes
Added custom timeout for `verify_source_generators` job of the `Verify source generator changes have been persisted` workflow (plus two other workflows) based on historical data that could lead to resource savings and faster CI for the project.

## Reason for change
Over the last 3763 successful runs, the `verify_source_generators` job has a maximum runtime of 31 minutes (mean=17, std=1).

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12136662579/job/33838238185) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, the first one on 26-Nov-2024 and the last one one on 03-Dec-2024 (see below for full list of urls), while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of **70 CPU hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

The same happens for the `Verify app trimming xml file changes have been persisted` and `Verify integrations map correctly added`, thus we changed all three workflow files, each of which could have saved around 70 CPU hours over the last months.

<details>
  <summary>Click here to see all the recently timed-out runs.</summary>

  03-Dec-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12136662579/job/33838238185)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12054116201/job/33611398114)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12051189230/job/33601673438)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12050906840/job/33600767415)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033958051/job/33549346428)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033250558/job/33546965533)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033204727/job/33546803917)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032721639/job/33545195627)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032693167/job/33545102577)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032584175/job/33544752408)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032280865/job/33543744475)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12031857018/job/33542326651)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12031597461/job/33541488209)
  03-Dec-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12136662539/job/33838237318)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12054116195/job/33611398101)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12051189242/job/33601673757)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12050906833/job/33600767374)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033958047/job/33549346074)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033250561/job/33546965640)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033204706/job/33546803506)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032721643/job/33545195980)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032693178/job/33545102652)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032584210/job/33544752911)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032280853/job/33543744798)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12031857013/job/33542326023)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12031597480/job/33541488259)
  03-Dec-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12136662548/job/33838237686)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12054116188/job/33611397506)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12051189240/job/33601673724)
27-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12050906856/job/33600767990)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033958050/job/33549346210)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033250575/job/33546966107)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12033204722/job/33546803898)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032721669/job/33545196623)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032693170/job/33545102737)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032584222/job/33544752929)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12032280922/job/33543745690)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12031857002/job/33542325978)
26-Nov-2024 => [timed-out run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/12031597489/job/33541488547)

</details>

## Implementation details

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail after GitHub's timeout of 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 34 minutes` where `max` and `std` (standard deviation) are derived from the history of 3763 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.


## Test coverage
No testing was performed.

## Additional Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this and for your contribution to open-source software in general.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch
