### PR TITLE
Use non-BOM version of `Encoding.UTF8` in Libdatadog interop code

### DIFF
--- a/tracer/src/Datadog.Trace/LibDatadog/CharSlice.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/CharSlice.cs
@@ -9,6 +9,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.MessagePack;
 
 namespace Datadog.Trace.LibDatadog;
 
@@ -44,7 +45,7 @@ internal readonly struct CharSlice : IDisposable
         }
         else
         {
-            var encoding = Encoding.UTF8;
+            var encoding = StringEncoding.UTF8;
             var maxBytesCount = encoding.GetMaxByteCount(str.Length);
             Ptr = Marshal.AllocHGlobal(maxBytesCount);
             unsafe


### PR DESCRIPTION
## Summary of changes

Use the non-BOM version of `Encoding.UTF8` in libdatadog interop-code

## Reason for change

libdatadog assumes no BOM, so we should too.

## Implementation details

Use the existing non-BOM instance we are using in various places:

https://github.com/DataDog/dd-trace-dotnet/blob/cdf2c3b9d2dfe72c885c1e58e7c99def0769699e/tracer/src/Datadog.Trace/Vendors/MessagePack/StringEncoding.cs#L12

## Test coverage

Meh, covered by existing (kinda 😅)

## Other details