### PR TITLE
Retry building unit tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1304,8 +1304,14 @@ stages:
           targetBranch: $(targetBranch)
       - template: steps/restore-working-directory.yml
 
-      - script: tracer\build.cmd BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
-        displayName: Build and Test
+      - script: tracer\build.cmd BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+        displayName: Build unit tests
+        retryCountOnTaskFailure: 3
+        env:
+          DD_LOGGER_DD_API_KEY: $(ddApiKey)
+
+      - script: tracer\build.cmd RunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+        displayName: Test
         env:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -1354,8 +1360,14 @@ stages:
           artifact: build-macos-native_tracer
           path: $(monitoringHome)
 
-      - script: ./tracer/build.sh BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
-        displayName: Build and Test
+      - script: ./tracer/build.sh BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+        displayName: Build unit tests
+        retryCountOnTaskFailure: 3
+        env:
+          DD_LOGGER_DD_API_KEY: $(ddApiKey)
+
+      - script: ./tracer/build.sh RunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+        displayName: Run unit tests
         retryCountOnTaskFailure: 1
         env:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1404,7 +1416,15 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
+        command: "BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
+        apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 3
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        baseImage: $(baseImage)
+        command: "RunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - template: steps/make-artifacts-uploadable.yml

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -266,12 +266,17 @@ partial class Build : NukeBuild
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);
 
-    Target BuildAndRunManagedUnitTests => _ => _
-        .Description("Builds the managed unit tests and runs them")
+    Target BuildManagedUnitTests => _ => _
+        .Description("Builds the managed unit tests")
         .After(Clean, BuildTracerHome, BuildProfilerHome)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(BuildRunnerTool)
-        .DependsOn(CompileManagedUnitTests)
+        .DependsOn(CompileManagedUnitTests);
+
+    Target BuildAndRunManagedUnitTests => _ => _
+        .Description("Builds the managed unit tests and runs them")
+        .After(Clean, BuildTracerHome, BuildProfilerHome)
+        .DependsOn(BuildManagedUnitTests)
         .DependsOn(RunManagedUnitTests);
 
     Target RunNativeUnitTests => _ => _


### PR DESCRIPTION
## Summary of changes

Adds retry to the "build" stage of unit tests in CI

## Reason for change

We have seen flake during the _build_ stage of unit tests. This should reduce occurrences.

## Implementation details

Split `BuildAndRunManagedUnitTests` into `BuildManagedUnitTests` and `RunManagedUnitTests`. Add a retry to the "build" step

## Test coverage

This is the test, if it builds, we're good.

## Other details

[The error in CI](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=181153&view=logs&j=00d39ea5-139c-5bc9-c508-0b06645946f1&t=ed752223-770b-5b1d-a42e-772154279a67) is dotnet build returning non-zero exit code 🤷‍♂️

```
╬════════════════════════════
║ CompileManagedUnitTests
╬═══════════════════
​
20:01:38 [INF] > /usr/bin/dotnet build /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj --configuration Release --no-restore --no-dependencies --packages /project/packages /property:Platform=AnyCPU /nowarn:NU1701
20:01:46 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/netcoreapp3.1/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:49 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/netcoreapp3.0/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:49 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/net8.0/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:49 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/net5.0/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:50 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/net6.0/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:50 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/netcoreapp2.1/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:50 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/net9.0/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:52 [DBG]   Datadog.Trace.ClrProfiler.Managed.Tests -> /project/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/bin/Release/net7.0/Datadog.Trace.ClrProfiler.Managed.Tests.dll
20:01:52 [DBG] 
20:01:52 [DBG] Build succeeded.
20:01:52 [DBG]     0 Warning(s)
20:01:52 [DBG]     0 Error(s)
20:01:52 [DBG] 
20:01:52 [DBG] Time Elapsed 00:00:13.70
20:01:52 [INF] > /usr/bin/dotnet build /project/tracer/test/Datadog.Trace.BenchmarkDotNet.Tests/Datadog.Trace.BenchmarkDotNet.Tests.csproj --configuration Release --no-restore --no-dependencies --packages /project/packages /property:Platform=AnyCPU /nowarn:NU1701
20:01:52 [ERR] Target CompileManagedUnitTests has thrown an exception
System.AggregateException: One or more errors occurred. (Process 'dotnet' exited with code 139.

```