### PR TITLE
Reinstate `[Flaky]` attribute

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -397,6 +397,7 @@ namespace Foo
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
+        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnEolFrameworkInSsi_WhenForwarderPathExists_CallsForwarderWithExpectedTelemetry()
         {
             var logDir = SetLogDirectory();
@@ -429,6 +430,7 @@ namespace Foo
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
+        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnEolFrameworkInSsi_WhenOverriden_CallsForwarderWithExpectedTelemetry()
         {
             var logDir = SetLogDirectory();
@@ -463,6 +465,7 @@ namespace Foo
         [Trait("RunOnWindows", "True")]
         [InlineData("1")]
         [InlineData("0")]
+        [Flaky("The creation of the app is flaky due to the .NET SDK: https://github.com/NuGet/Home/issues/14343")]
         public async Task OnSupportedFrameworkInSsi_CallsForwarderWithExpectedTelemetry(string isOverriden)
         {
             var logDir = SetLogDirectory();


### PR DESCRIPTION
## Summary of changes

Adds the `[Flaky]` attribute back to the `InstrumentationTests` as the creation of the app is still liable to hang.

## Reason for change

We had historically seen `dotnet` hanging when trying to run a `dotnet publish` (_without_ the tracer attached). We raised an issue [about it here](https://github.com/NuGet/Home/issues/14343), who suggested 

In #7116 we tried applying suggestions they had provided and reverted the flake. Unfortunately, we are [still seeing flake](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=181140&view=logs&j=d6559b2c-0c83-5174-b60e-8b6211d801de&t=8c1b90bb-5795-5bcd-59da-323cf3b6a982) so re-enabling the retries. 

## Implementation details

Re-enable the retries that we removed previously

## Test coverage

N/A

## Other details

The hang was in a different MSBuild task, so I suspect it's _not_ directly related to that