### PR TITLE
Try to fix flake in Kafa DSM tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
@@ -23,10 +23,11 @@ async Task RunStandardPipelineScenario()
 {
     // Create Topics
     var topicPrefix = "data-streams";
+    var topicSuffix = Guid.NewGuid();
 
-    var topic1 = $"{topicPrefix}-1";
-    var topic2 = $"{topicPrefix}-2";
-    var topic3 = $"{topicPrefix}-3";
+    var topic1 = $"{topicPrefix}-1-{topicSuffix:N}";
+    var topic2 = $"{topicPrefix}-2-{topicSuffix:N}";
+    var topic3 = $"{topicPrefix}-3-{topicSuffix:N}";
     var allTopics = new[] { topic1, topic2, topic3 };
     var topic3ConsumeCount = 0;
 
@@ -123,9 +124,10 @@ async Task RunBatchProcessingScenario()
 {
     // Create Topics
     var topicPrefix = "data-streams-batch-processing";
+    var topicSuffix = Guid.NewGuid();
 
-    var topic1 = $"{topicPrefix}-1";
-    var topic2 = $"{topicPrefix}-2";
+    var topic1 = $"{topicPrefix}-1-{topicSuffix:N}";
+    var topic2 = $"{topicPrefix}-2-{topicSuffix:N}";
     var allTopics = new[] { topic1, topic2};
     var topic2ConsumeCount = 0;
 


### PR DESCRIPTION
## Summary of changes

Add unique suffix to data streams topics in kafka tests

## Reason for change

[Saw some flake in a test recently](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=181163&view=logs&j=b7fc299e-b4c1-5ec0-1e5a-2167c3cc6270&t=2406fbf1-c048-53d0-bb5f-56f6b7adbd43): `10:19:53 [DBG]  Unhandled exception. Confluent.Kafka.ProduceException`2[System.String,System.String]: Local: Unknown topic`

What's more, the creation logs are kind of strange.

```
10:19:53 [DBG]  Creating topics...
10:19:53 [DBG]  Trying to delete topic data-streams-1...
10:19:53 [DBG]  Trying to create topic data-streams-1...
10:19:53 [DBG]  Topic already exists
10:19:53 [DBG]  Trying to delete topic data-streams-2...
10:19:53 [DBG]  Trying to delete topic data-streams-2...
10:19:53 [DBG]  Topic did not exist, skipping
10:19:53 [DBG]  Trying to create topic data-streams-2...
10:19:53 [DBG]  Topic created
10:19:53 [DBG]  Trying to delete topic data-streams-3...
10:19:53 [DBG]  Trying to create topic data-streams-3...
10:19:53 [DBG]  Topic created
10:19:53 [DBG]  Finished creating topics: 0:00:02.1158037
```

I can't really understand that sequence of logs, but deletes don't happen atomically, so not entirely surprised by weirdness. Rather than have to deal with it explicitly, add a random suffix to the topics so that we don't have to worry about the delete case.

## Implementation details

Add a random suffix to topic names, so that we should always be starting with fresh topics

## Test coverage

This is the test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
