### PR TITLE
Reduce log level for `ConcurrentAdaptiveCache` capacity

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Caching/ConcurrentAdaptiveCache.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Caching/ConcurrentAdaptiveCache.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Debugger.Caching
             _environmentChecker = environmentChecker ?? DefaultEnvironmentChecker.Instance;
             _memoryChecker = memoryChecker ?? DefaultMemoryChecker.Instance;
             _capacity = capacity ?? DetermineCapacity();
-            Logger.Information("Cache capacity is: {Capacity}", (object)_capacity);
+            Logger.Debug("ConcurrentAdaptiveCache capacity is: {Capacity}", (object)_capacity);
             _timeProvider = timeProvider ?? new DefaultTimeProvider();
             _cache = new Dictionary<TKey, CacheItem<TValue>>(_capacity, comparer);
             _lock = new ReaderWriterLockSlim();


### PR DESCRIPTION
## Summary of changes

For the log message: `Cache capacity is: {Capacity}`
- Reduce log level from `Information` to `Debug`.
- Add some context: which cache are we talking about?

## Reason for change

"It's too verbose, yet not verbose enough."


Real reason: I was looking through some logs and saw
```
Cache capacity is: <number>
```
and had no idea what it meant. I searched through the code and found it.


## Implementation details

In short:
```diff
- Logger.Information("Cache capacity is: {Capacity}", ...
+ Logger.Debug("ConcurrentAdaptiveCache capacity is: {Capacity}", ...
```

## Test coverage

No

## Other details

Nope

(Sorry. Friday 7pm PR descriptions are fun.)

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
