### PR TITLE
Add `[Flaky]` attribute to `EnumerateAssemblyReferencesTest`

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
+        [Flaky("This test often crashes with a shutdown bug which we haven't been able to track down yet")]
         public async Task NoExceptions()
         {
             await CheckForSmoke(shouldDeserializeTraces: false);


### PR DESCRIPTION
## Summary of changes

Adds `[Flaky]` attribute to `EnumerateAssemblyReferencesTest`

## Reason for change

The test often fails with a crash on shutdown, but it fails so late that we can't even capture a core dump, because the process has already gone:

```
16:02:43 [DBG]   Standard Output Messages:
16:02:43 [DBG]  Application path: /project/artifacts/bin/EnumerateAssemblyReferences/release_net9.0/EnumerateAssemblyReferences.dll
16:02:43 [DBG]  Executable path: dotnet
16:02:43 [DBG]  Assigning port 39045 for the aspNetCorePort.
16:02:43 [DBG]  Agent listener info: Traces at port 46637
16:02:43 [DBG]  StandardOutput:
16:02:43 [DBG]  System.Runtime, Version=9.0.0.0, Culture=neutral, PublicKey***=b03f5f7f11d50a3a
16:02:43 [DBG]  System.Collections.Concurrent, Version=9.0.0.0, Culture=neutral, PublicKey***=b03f5f7f11d50a3a
16:02:43 [DBG]  System.Net.HttpListener, Version=9.0.0.0, Culture=neutral, PublicKey***=cc7b13ffcd2ddd51
16:02:43 [DBG]  System.Net.Sockets, Version=9.0.0.0, Culture=neutral, PublicKey***=b03f5f7f11d50a3a
16:02:43 [DBG]  System.Collections, Version=9.0.0.0, Culture=neutral, PublicKey***=b03f5f7f11d50a3a
16:02:43 [DBG]  System.Console, Version=9.0.0.0, Culture=neutral, PublicKey***=b03f5f7f11d50a3a
16:02:43 [DBG]  System.Linq, Version=9.0.0.0, Culture=neutral, PublicKey***=b03f5f7f11d50a3a
16:02:43 [DBG]  System.Net.Primitives, Version=9.0.0.0, Culture=neutral, PublicKey***=b03f5f7f11d50a3a
16:02:43 [DBG]  System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKey***=7cec85d7bea7798e
16:02:43 [DBG]  
16:02:43 [DBG]  App completed successfully
16:02:43 [DBG]  
16:02:43 [DBG]  StandardError:
16:02:43 [DBG]  [createdump] Invalid process id: open(/proc/23756/mem) FAILED No such file or directory (2)
16:02:43 [DBG]  [createdump] Target process terminated
16:02:43 [DBG]  [createdump] Failure took 0ms
```

## Implementation details

Given we don't have any leads on this, and can't easily address it, just mark the test as flaky for now.

## Test coverage

N/A

## Other details

_Maybe_ related to https://github.com/dotnet/runtime/issues/112565?