### PR TITLE
Bump timeitsharp to 0.4.1

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net48.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net48.json
@@ -70,5 +70,5 @@
     "benchmark.job.runtime.name": ".NET Framework 4.8",
     "benchmark.job.runtime.moniker": "net48"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net48.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net48.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -68,5 +69,6 @@
     "runtime.version": "4.8",
     "benchmark.job.runtime.name": ".NET Framework 4.8",
     "benchmark.job.runtime.moniker": "net48"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -70,5 +70,5 @@
     "benchmark.job.runtime.name": ".NET 6.0",
     "benchmark.job.runtime.moniker": "net6.0"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -68,5 +69,6 @@
     "runtime.version": "6.0",
     "benchmark.job.runtime.name": ".NET 6.0",
     "benchmark.job.runtime.moniker": "net6.0"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -68,5 +69,6 @@
     "runtime.version": "8.0",
     "benchmark.job.runtime.name": ".NET 8.0",
     "benchmark.job.runtime.moniker": "net8.0"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -70,5 +70,5 @@
     "benchmark.job.runtime.name": ".NET 8.0",
     "benchmark.job.runtime.moniker": "net8.0"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -70,5 +70,5 @@
     "benchmark.job.runtime.name": ".NET Core 3.1",
     "benchmark.job.runtime.moniker": "netcoreapp3.1"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -68,5 +69,6 @@
     "runtime.version": "3.1",
     "benchmark.job.runtime.name": ".NET Core 3.1",
     "benchmark.job.runtime.moniker": "netcoreapp3.1"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -7,7 +7,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net80.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.4.0
+dotnet tool update -g timeitsharp --version 0.4.1
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -7,7 +7,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net80.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.3.2
+dotnet tool update -g timeitsharp --version 0.4.0
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net48.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net48.json
@@ -69,5 +69,5 @@
     "benchmark.job.runtime.name": ".NET Framework 4.8",
     "benchmark.job.runtime.moniker": "net48"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net48.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net48.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -67,5 +68,6 @@
     "runtime.version": "4.8",
     "benchmark.job.runtime.name": ".NET Framework 4.8",
     "benchmark.job.runtime.moniker": "net48"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -69,5 +69,5 @@
     "benchmark.job.runtime.name": ".NET 6.0",
     "benchmark.job.runtime.moniker": "net6.0"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -67,5 +68,6 @@
     "runtime.version": "6.0",
     "benchmark.job.runtime.name": ".NET 6.0",
     "benchmark.job.runtime.moniker": "net6.0"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -67,5 +68,6 @@
     "runtime.version": "8.0",
     "benchmark.job.runtime.name": ".NET 8.0",
     "benchmark.job.runtime.moniker": "net8.0"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -69,5 +69,5 @@
     "benchmark.job.runtime.name": ".NET 8.0",
     "benchmark.job.runtime.moniker": "net8.0"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -25,6 +25,7 @@
   "scenarios": [
     {
       "name": "Baseline",
+      "isBaseline": true,
       "environmentVariables": {
         "CORECLR_ENABLE_PROFILING": "0",
         "COR_ENABLE_PROFILING": "0"
@@ -67,5 +68,6 @@
     "runtime.version": "3.1",
     "benchmark.job.runtime.name": ".NET Core 3.1",
     "benchmark.job.runtime.moniker": "netcoreapp3.1"
-  }
+  },
+  "overheadThreshold": 5
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -69,5 +69,5 @@
     "benchmark.job.runtime.name": ".NET Core 3.1",
     "benchmark.job.runtime.moniker": "netcoreapp3.1"
   },
-  "overheadThreshold": 5
+  "overheadThreshold": 10
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -7,7 +7,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net80.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.4.0
+dotnet tool update -g timeitsharp --version 0.4.1
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -7,7 +7,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net80.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.3.2
+dotnet tool update -g timeitsharp --version 0.4.0
 
 echo *********************
 echo .NET Framework 4.6.1


### PR DESCRIPTION
## Summary of changes

This PR bumps timeit up to v0.4.1

## Reason for change

This version fixes the Process.Refresh() issue on getting runtime metrics and also adds overhead calculation.

## Implementation details

Just bumping the version and modifyin the configuration json files

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
