### PR TITLE
Disable legacy Gitlab exec in order to fix jobs failing with green status

### DIFF
--- a/.gitlab/benchmarks/dsm-throughput.yml
+++ b/.gitlab/benchmarks/dsm-throughput.yml
@@ -44,8 +44,5 @@ dsm_throughput:
     paths:
       - artifacts/
     expire_in: 3 months
-  variables:
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-dotnet
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
   rules:
     - when: on_success

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -60,7 +60,6 @@ update-bp-infra:
   rules:
     - when: manual
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     AWS_REGION: "us-east-1"
     CLEANUP: "false"
     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
@@ -98,8 +97,6 @@ update-bp-infra:
       - artifacts/
     expire_in: 3 months
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-
     K6_OPTIONS_WARMUP_RATE: 14000
     K6_OPTIONS_WARMUP_DURATION: 3m
     K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
@@ -282,8 +279,6 @@ profiler_cpu_timer_create:
       - artifacts/
     expire_in: 3 months
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-
     K6_OPTIONS_WARMUP_RATE: 14000
     K6_OPTIONS_WARMUP_DURATION: 3m
     K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
@@ -472,8 +467,6 @@ profiler_cpu_timer_create-arm64:
       - artifacts/
     expire_in: 3 months
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-
     # Whether to cleanup ephemeral instances after benchmarks are run
     CLEANUP: "true"
 

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -38,7 +38,6 @@ update-bp-infra:
   rules:
     - when: manual
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     AWS_REGION: "us-east-1"
     CLEANUP: "false"
     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
@@ -69,7 +68,6 @@ run-benchmarks:
   rules:
     - when: on_success
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     AWS_REGION: "us-east-1"
     CLEANUP: "false"
     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"
@@ -101,7 +99,6 @@ upload-to-bp-ui:
   rules:
     - when: manual
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     AWS_REGION: "us-east-1"
     CLEANUP: "false"
     AWS_EPHEMERAL_INFRA_PROFILE_SSM_PARAMETER: "ci.dd-trace-dotnet.ephemeral-infra-ci.dd-trace-dotnet-profile"


### PR DESCRIPTION
## Summary of changes

Disables `FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY` that we used before to ensure build containers have QoS guaranteed. As of now, it doesn't seem to be necessary anymore, but leads to problems like https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4119.

## Reason for change

Apparently it there were issues with Gitlab CI jobs silently randomly failing with a green status.

## Implementation details

Delete usages of `FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY` and `KUBERNETES_SERVICE_ACCOUNT_OVERWRITE`

## Test coverage

This is the test

## Other details

I based this email on similar PRs raised by @ddyurchenko e.g.
- https://github.com/DataDog/dd-trace-cpp/pull/225
- https://github.com/DataDog/dd-trace-js/pull/6097