### PR TITLE
Stop building the native loader twice on macos

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -939,7 +939,7 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/install-latest-dotnet-sdk.yml
 
-    - script: ./tracer/build.sh CreateRequiredDirectories CompileManagedLoader BuildNativeTracerHome BuildNativeLoader
+    - script: ./tracer/build.sh CreateRequiredDirectories CompileManagedLoader BuildNativeTracerHome
       displayName: Build native-tracer
       retryCountOnTaskFailure: 1
 
@@ -959,7 +959,7 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/install-latest-dotnet-sdk.yml
 
-    # The CreateTrimmingFile tasks expects the native loader but we build that in the other stage
+    # The CreateTrimmingFile tasks expects the managed loader but we build that in the other stage
     - script: ./tracer/build.sh BuildManagedTracerHome BuildNativeLoader --skip CreateTrimmingFile
       displayName: Build managed tracer + native loader
       retryCountOnTaskFailure: 1


### PR DESCRIPTION
## Summary of changes

Stop building the native loader twice on macos

## Reason for change

Noticed that we were calling `BuildNativeLoader` twice, in parallel jobs.

## Implementation details

Delete the one that looks like it shouldn't be there

## Test coverage

This is the test, if everything passes, I think we're ok
