### PR TITLE
Bump timeitsharp to 0.4.2

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -7,7 +7,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net80.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.4.1
+dotnet tool update -g timeitsharp --version 0.4.2
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -7,7 +7,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net80.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.4.1
+dotnet tool update -g timeitsharp --version 0.4.2
 
 echo *********************
 echo .NET Framework 4.6.1


### PR DESCRIPTION
## Summary of changes

Bump timeitsharp to 0.4.2

## Reason for change

There's a new version of timeitsharp that reduces the performance impact on writing the runtime metrics (from json to raw binary)

https://github.com/tonyredondo/timeitsharp/pull/68/files

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
