### PR TITLE
Only download samples for the framework that we're testing

### DIFF
--- a/.azure-pipelines/steps/download-samples.yml
+++ b/.azure-pipelines/steps/download-samples.yml
@@ -1,15 +1,22 @@
 parameters:
   - name: 'framework'
     type: 'string'
-    default: ''
+  - name: 'includeMultiVersions'
+    type: 'boolean'
+    default: true
 
 steps:
 - template: download-artifact.yml
   parameters:
     artifact: samples-standalone
     path: $(outputDir)/bin
+    # Filter down to just the framework samples that we need, to reduce the size of the download
+    # Assumes we always build in release mode (we should)
+    patterns: |
+      */release_${{ parameters.framework }}/**
+      */release/**
 
-- ${{ if ne(parameters.framework, '') }}:
+- ${{ if eq(parameters.includeMultiVersions, true) }}:
   - template: download-artifact.yml
     parameters:
       artifact: samples-multi-version-${{ parameters.framework }}

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1634,6 +1634,9 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/restore-working-directory.yml
     - template: steps/download-samples.yml
+      parameters:
+        framework: $(framework)
+        includeMultiVersions: false
 
 # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
 #    - powershell: |


### PR DESCRIPTION
## Summary of changes

For integration tests, only download the standalone samples for the framework that we're testing

## Reason for change

Currently we
- Build the "standalone" samples for all TFMs (which is the easiest way to do it)
- Build the "multi-version" samples separately for each TFM

In integration tests, we currently pull down _all_ the standalone samples. For platforms that need it, we also pull down the multi-version samples for the TFM we're testing.

The net result is that we pull down a bunch of extra built samples that we don't need. This is causing problems as we're actually running out of drive space in the .NET 10 upgrade branch 😅 

## Implementation details

Continue to build the samples in a "single shot" as this is optimal in terms of VM usage, and upload as a single blob. This is unchanged, and it looks like this today:

<img width="220" height="469" alt="image" src="https://github.com/user-attachments/assets/eb39a343-1b21-4b26-a39b-c422919bf87b" />

On the download side, only download the artifacts for the TFM we're currently testing. We always split by TFM, and the pattern of artifacts is well known, so this works fine.

## Test coverage

This is the test, as long as the build passes we're good. Appears to reduce the downloaded size from ~8GB to ~300-600MB.

## Other details

Blocker for https://github.com/DataDog/dd-trace-dotnet/pull/7170.

Other options considered:
- Split the `build_samples.standalone` job by TFM. This is doable, but ends up using more VM time overall due to the individual VM overhead. Currently we're very well matched.
- Combine the single TFM build into the multi-sample build. Would use one less VM, but would increase the length of the stage overall. Also would use more drive space for cases where we _don't_ need the multi-sample build (ie. `integration_tests_windows`, which is where we have the biggest space issues), but it's possible.
