### PR TITLE
Update to alpine 3.17

### DIFF
--- a/tracer/build/_build/docker/alpine.build.arm64.dockerfile
+++ b/tracer/build/_build/docker/alpine.build.arm64.dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.6
 
+# See alpine.build.dockerfile for more information on how to build this image
 FROM alpine:3.18 as base
 
 RUN apk update \

--- a/tracer/build/_build/docker/alpine.build.dockerfile
+++ b/tracer/build/_build/docker/alpine.build.dockerfile
@@ -1,11 +1,23 @@
 # syntax=docker/dockerfile:1.6
 
-FROM alpine:3.14 as base
+# Build this image as described in https://andrewlock.net/combining-multiple-docker-images-into-a-multi-arch-image
+# Ultimately the process will look something like this, assuming that you need to build for both amd64 and arm64
+# (if you're only changing one of the dockerfiles, you can use the existing manifest already on docker hub)
+#
+# cd tracer/build/_build/docker
+# docker buildx build -t andrewlockdd/alpine-clang -f alpine.build.dockerfile --platform linux/amd64 --provenance false --output push-by-digest=true,type=image,push=true .
+# docker buildx build -t andrewlockdd/alpine-clang -f alpine.build.arm64.dockerfile --platform linux/arm64 --provenance false --output push-by-digest=true,type=image,push=true .
+#
+# Create the manifest using the digests from the previous two commands and push it to Docker Hub, using an appropriate tag
+# docker manifest create andrewlockdd/alpine-clang:dotnet10 --amend andrewlockdd/alpine-clang@sha256:5805da6408d5cbadee2be250b6ade63e1f2a6e4541146c3ec56d53d386eaff27 --amend andrewlockdd/alpine-clang@sha256:680c4e5a622100dd2b79d3f9da0a6434a150bd250714efcc1f109bce1bdd54e6
+# docker manifest push andrewlockdd/alpine-clang:dotnet10
+FROM alpine:3.17 as base
 
 RUN apk update \
         && apk upgrade \
         && apk add --no-cache \
         cmake \
+        bash \
         git \
         make \
         alpine-sdk \
@@ -15,8 +27,7 @@ RUN apk update \
         xz-dev \
         build-base \
         python3 \
-        linux-headers \
-        libexecinfo-dev
+        linux-headers
 
 ## snapshot 
 

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,4 +1,4 @@
-﻿FROM andrewlockdd/alpine-clang:1.0 as base
+﻿FROM andrewlockdd/alpine-clang:dotnet10 as base
 ARG DOTNETSDK_VERSION
 
 ENV \

--- a/tracer/test/snapshots/native-profiler-symbols-alpine-x64.verified.txt
+++ b/tracer/test/snapshots/native-profiler-symbols-alpine-x64.verified.txt
@@ -15,7 +15,6 @@ blaze_read_elf_build_id
 btowc
 calloc
 ceil
-ceill
 clock_gettime
 close
 closedir
@@ -78,7 +77,6 @@ fclose
 fdopen
 fflush
 fileno
-floorl
 fopen
 fprintf
 fputc
@@ -93,6 +91,7 @@ get_nprocs
 getauxval
 getc
 getegid
+getentropy
 getenv
 geteuid
 getgid

--- a/tracer/test/snapshots/native-tracer-symbols-alpine-x64.verified.txt
+++ b/tracer/test/snapshots/native-tracer-symbols-alpine-x64.verified.txt
@@ -20,7 +20,6 @@ fclose
 fdopen
 fflush
 fileno
-floorl
 fopen
 fprintf
 fputc
@@ -33,6 +32,7 @@ ftello
 fwrite
 get_nprocs
 getc
+getentropy
 getenv
 getpid
 gettimeofday
@@ -116,6 +116,7 @@ strerror
 strerror_r
 strftime
 strlen
+strncmp
 strrchr
 strstr
 strtod


### PR DESCRIPTION
## Summary of changes

Updates the `alpine:3.14` base image we use for `linux-musl-x64` to `alpine:3.17`

## Reason for change

.NET 10 [has bumped](https://github.com/dotnet/runtime/issues/109939) the minimum supported version of Alpine from 3.13 ([.NET 9<](https://github.com/dotnet/core/blob/main/release-notes/9.0/supported-os.md#linux-compatibility)) to 3.17 ([.NET 10+](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux-compatibility)). My _previous_ understanding was that musl is essentially unversioned, so they're essentially also forward compatible. Unfortunately, that is apparently not true. Attempting to run .NET 10 on Alpine 3.13 does not work, and it specifically fails with a `symbol not found` error.

This PR bumps the base image to 3.17 and updates our symbol snapshots

## Implementation details

We added snapshots for which symbols we depend on here:
- https://github.com/DataDog/dd-trace-dotnet/pull/7224

That means we can see exactly what the impact of this change should be. 

For the native tracer, the symbol changes moving from `3.14` -> `3.17`
```diff
-floorl
+getentropy
+strncmp
```

For the continuous profiler, the symbol changes moving from `3.14` -> `3.17`
```diff
-ceill
-floorl
+getentropy
```

We're only really worried about the extra symbols, i.e. `strncmp` and `getentropy`.

- `strncmp` [we already depended on this in the native loader](https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/test/snapshots/native-loader-symbols-x64.verified.txt#L108), so overall this symbol is not _new_, so we should be ok. It's also part of the base ISO C standard, and is there from the first release, so we're fine.
- `getentropy` was [added in 2018](https://www.openwall.com/lists/musl/2018/01/06/2?utm_source=chatgpt.com), and was introduced [in musl 1.1.20](https://www.openwall.com/lists/musl/2018/09/04/17). Our previous `3.14` alpine image was built with musl `1.2.2`, so again we're fine 

## Test coverage

For the most part, this is the test. The smoke tests should catch if I've got something wrong here, but 🤞 

## Other details

This is a prerequisite for the .NET 10 work:
- https://github.com/DataDog/dd-trace-dotnet/pull/7170

However, merging it will require that we update the VMs, so I suggest we don't merge it _until_ we're ready to merge the .NET 10 PR shortly afterwards (as that will require another update)

https://datadoghq.atlassian.net/browse/LANGPLAT-632