### PR TITLE
[Serverless] Remove "preview" version suffix from `Datadog.AzureFunctions`

### DIFF
--- a/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
+++ b/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
@@ -8,11 +8,6 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoDefaultExcludes>true</NoDefaultExcludes>
 
-    <!-- nuget version: move $Version to $VersionPrefix so we can add a prerelease suffix. -->
-    <VersionPrefix>$(Version)</VersionPrefix>
-    <VersionSuffix>preview</VersionSuffix>
-    <Version></Version>
-
     <!-- nuget package metadata -->
     <PackageId>Datadog.AzureFunctions</PackageId>
     <Description>Datadog instrumentation library for Azure Functions</Description>

--- a/tracer/src/Datadog.AzureFunctions/README.md
+++ b/tracer/src/Datadog.AzureFunctions/README.md
@@ -1,7 +1,5 @@
-# Datadog Instrumentation Library for .NET Azure Functions [Preview]
+# Datadog Instrumentation Library for .NET Azure Functions
 ## `Datadog.AzureFunctions`
-
-**Note: This is an unsupported pre-release version of this package.**
 
 Add this package to your Azure Functions project to enable Datadog APM tracing.
 Further configuration is required for your Azure Functions to send instrumentation data to Datadog.


### PR DESCRIPTION
## Summary of changes

Remove "preview" from version tag and README text.

## Reason for change

GA is coming.

## Implementation details

Remove "preview" from version tag and README text.

## Test coverage

None needed.

## Other details

~Don't merge yet. Just trying to get early pre-approvals so it's ready to go when needed.~ 😅

Fixes APMSVLS-95

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
