### PR TITLE
Update smoke tests for `debian:trixie`

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -16,6 +16,22 @@ if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
     add_compile_options(-DDD_ALPINE)
 endif()
 
+if (ISLINUX)
+    # ------------------------------------------------------
+    # Hardening: make sure no target in this project ever
+    # requests an executable stack.  Without this, glibc ≥2.41
+    # (Debian 13 "trixie", Fedora 40, etc.) rejects the shared
+    # library with:
+    #   "cannot enable executable stack as shared object requires"
+    # ------------------------------------------------------
+    # 1. Tell the assembler to emit a .note.GNU-stack note that
+    #    marks the object as **non‑exec‑stack**.
+    add_compile_options("$<$<COMPILE_LANGUAGE:ASM>:-Wa,--noexecstack>")
+    # 2. Instruct the linker to *clear* any stray exec‑stack flag
+    #    that might still be present when it produces the final ELF.
+    add_link_options(-Wl,-z,noexecstack)
+endif()
+
 # ******************************************************
 # Environment detection
 # ******************************************************

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -50,6 +50,21 @@ elseif (ISARM)
     add_compile_options(-DARM)
 endif()
 
+if (ISLINUX)
+    # ------------------------------------------------------
+    # Hardening: make sure no target in this project ever
+    # requests an executable stack.  Without this, glibc ≥2.41
+    # (Debian 13 "trixie", Fedora 40, etc.) rejects the shared
+    # library with:
+    #   "cannot enable executable stack as shared object requires"
+    # ------------------------------------------------------
+    # 1. Tell the assembler to emit a .note.GNU-stack note that
+    #    marks the object as **non‑exec‑stack**.
+    add_compile_options("$<$<COMPILE_LANGUAGE:ASM>:-Wa,--noexecstack>")
+    # 2. Instruct the linker to *clear* any stray exec‑stack flag
+    #    that might still be present when it produces the final ELF.
+    add_link_options(-Wl,-z,noexecstack)
+endif()
 
 # ******************************************************
 # Environment detection

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -146,6 +146,22 @@ elseif (ISARM)
     add_compile_options(-DARM)
 endif()
 
+if (ISLINUX)
+    # ------------------------------------------------------
+    # Hardening: make sure no target in this project ever
+    # requests an executable stack.  Without this, glibc ≥2.41
+    # (Debian 13 "trixie", Fedora 40, etc.) rejects the shared
+    # library with:
+    #   "cannot enable executable stack as shared object requires"
+    # ------------------------------------------------------
+    # 1. Tell the assembler to emit a .note.GNU-stack note that
+    #    marks the object as **non‑exec‑stack**.
+    add_compile_options("$<$<COMPILE_LANGUAGE:ASM>:-Wa,--noexecstack>")
+    # 2. Instruct the linker to *clear* any stray exec‑stack flag
+    #    that might still be present when it produces the final ELF.
+    add_link_options(-Wl,-z,noexecstack)
+endif()
+
 # ******************************************************
 # Suppress Warning on MacOS
 # ******************************************************

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -581,22 +581,18 @@ partial class Build : NukeBuild
 
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
-                        "debian",
+                        // This is actually a mix of ubuntu and debian, but they're all in the same MS repository
+                        "ubuntu",
                         new SmokeTestImage[]
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
                             new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
-                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
-                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-buster-slim"),
                             new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bionic"),
-                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-bionic"),
                             new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
                         },
                         installer: "datadog-dotnet-apm*_amd64.deb",
@@ -604,6 +600,22 @@ partial class Build : NukeBuild
                         linuxArtifacts: "linux-packages-linux-x64",
                         runtimeId: "linux-x64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
+                    // Microsoft stopped pushing debian tags in .NET 10, so using separate repo
+                    AddToLinuxSmokeTestsMatrix(
+                        matrix,
+                        "debian",
+                        new SmokeTestImage[]
+                        {
+                            new (publishFramework: TargetFramework.NET9_0, "trixie-9.0"),
+                            new (publishFramework: TargetFramework.NET8_0, "trixie-8.0"),
+                        },
+                        installer: "datadog-dotnet-apm*_amd64.deb",
+                        installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb",
+                        linuxArtifacts: "linux-packages-linux-x64",
+                        runtimeId: "linux-x64",
+                        dockerName: "andrewlock/dotnet-debian"
                     );
 
                     AddToLinuxSmokeTestsMatrix(
@@ -641,12 +653,9 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.13"),
                             new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.13"),
                             new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         // currently we direct customers to the musl-specific package in the command line.
@@ -669,12 +678,9 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.13"),
                             new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.13"),
                             new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         installer: "datadog-dotnet-apm*-musl.tar.gz",
@@ -793,9 +799,10 @@ partial class Build : NukeBuild
                 {
                     var matrix = new Dictionary<string, object>();
 
+                    // This is actually a mix of ubuntu and debian, but they're all in the same MS repository
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
-                        "debian",
+                        "ubuntu",
                         new SmokeTestImage[]
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
@@ -803,7 +810,6 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
                             // https://github.com/dotnet/runtime/issues/66707
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
@@ -812,6 +818,22 @@ partial class Build : NukeBuild
                         linuxArtifacts: "linux-packages-linux-arm64",
                         runtimeId: "linux-arm64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
+                    // Microsoft stopped pushing debian tags in .NET 10, so using separate repo
+                    AddToLinuxSmokeTestsMatrix(
+                        matrix,
+                        "debian",
+                        new SmokeTestImage[]
+                        {
+                            new (publishFramework: TargetFramework.NET9_0, "trixie-9.0"),
+                            new (publishFramework: TargetFramework.NET8_0, "trixie-8.0"),
+                        },
+                        installer: "datadog-dotnet-apm_*_arm64.deb",
+                        installCmd: "dpkg -i ./datadog-dotnet-apm_*_arm64.deb",
+                        linuxArtifacts: "linux-packages-linux-arm64",
+                        runtimeId: "linux-arm64",
+                        dockerName: "andrewlock/dotnet-debian"
                     );
 
                     AddToLinuxSmokeTestsMatrix(
@@ -926,7 +948,6 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
-                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
@@ -1029,7 +1050,6 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
@@ -1098,7 +1118,6 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
-                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
@@ -1192,11 +1211,9 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
-                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
@@ -1211,7 +1228,7 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-alpine3.20"),
                             new (publishFramework: TargetFramework.NET9_0, "9.0-alpine3.20-composite"),
-                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.20"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.19"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.19-composite"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.18"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.18"),
@@ -1236,7 +1253,6 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
-                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
@@ -1279,7 +1295,6 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET9_0, "9.0-noble"),
                             new (publishFramework: TargetFramework.NET9_0, "9.0-bookworm-slim"),
-                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                         },
                         installer: "datadog-dotnet-apm*_amd64.deb",
@@ -1628,9 +1643,11 @@ partial class Build : NukeBuild
                         { "macos-14_net6.0", new { vmImage = "macos-14", publishFramework = "net6.0" } },
                         { "macos-14_net8.0", new { vmImage = "macos-14", publishFramework = "net8.0" } },
                         { "macos-14_net9.0", new { vmImage = "macos-14", publishFramework = "net9.0" } },
+                        { "macos-14_net10.0", new { vmImage = "macos-14", publishFramework = "net10.0" } },
                         { "macos-15_net6.0", new { vmImage = "macos-15", publishFramework = "net6.0" } },
                         { "macos-15_net8.0", new { vmImage = "macos-15", publishFramework = "net8.0" } },
                         { "macos-15_net9.0", new { vmImage = "macos-15", publishFramework = "net9.0" } },
+                        { "macos-15_net10.0", new { vmImage = "macos-15", publishFramework = "net10.0" } },
                     };
 
                     Logger.Information($"Installer smoke tests dotnet-tool NuGet matrix MacOs");

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -136,6 +136,22 @@ elseif (ISARM)
     add_compile_options(-DARM)
 endif()
 
+if (ISLINUX)
+    # ------------------------------------------------------
+    # Hardening: make sure no target in this project ever
+    # requests an executable stack.  Without this, glibc ≥2.41
+    # (Debian 13 "trixie", Fedora 40, etc.) rejects the shared
+    # library with:
+    #   "cannot enable executable stack as shared object requires"
+    # ------------------------------------------------------
+    # 1. Tell the assembler to emit a .note.GNU-stack note that
+    #    marks the object as **non‑exec‑stack**.
+    add_compile_options("$<$<COMPILE_LANGUAGE:ASM>:-Wa,--noexecstack>")
+    # 2. Instruct the linker to *clear* any stray exec‑stack flag
+    #    that might still be present when it produces the final ELF.
+    add_link_options(-Wl,-z,noexecstack)
+endif()
+
 # ******************************************************
 # Suppress Warning on MacOS
 # ******************************************************


### PR DESCRIPTION
## Summary of changes

- Adds (and removes) some more smoke tests
- Fixes an issue with recent glibc version (in `debian:trixie`) that causes native tracer to fail to load

## Reason for change

Initial .NET 10 tests show that `debian:trixie` causes the .NET tracer to fail to load with:

```
/opt/datadog/./linux-x64/Datadog.Tracer.Native.so: cannot enable executable stack as shared object requires: Invalid argument
```

This is due to the fact that debian 13 uses glibc 2.41 which stopped automatically enabling executable stacks when loading shared libraries. This PR addresses the root cause, and adds smoke tests to demonstrate that.

## Implementation details

- Added smoke tests for `debian:trixie`
- Removed some smoke tests for older runtime/distro coverage - ensures we still cover all the TFMs and distros, but removes some redundancy
- Fixes the glibc issue (TBC)

## Test coverage

Adds some more smoke tests

## Other details

We discovered this in the .NET 10 upgrade PR, but Microsoft have [since _stopped_ publishing](https://github.com/dotnet/dotnet-docker/pull/6541) `debian` images 😅 So I recreated the images and .NET 8/ .NET 9 versions so we can test it right now.
