### PR TITLE
Integrations: Disable AWS Kinesis injection when the integration is disabled

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/ContextPropagation.cs
@@ -41,8 +41,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
         public static void InjectTraceIntoData<TRecordRequest>(TRecordRequest record, Scope? scope, string? streamName)
             where TRecordRequest : IContainsData
         {
+            if (scope is null)
+            {
+                return;
+            }
+
             Dictionary<string, object> propagatedContext = new Dictionary<string, object>();
-            if (scope?.Span.Context != null && !string.IsNullOrEmpty(streamName))
+            if (scope.Span.Context != null && !string.IsNullOrEmpty(streamName))
             {
                 var dataStreamsManager = Tracer.Instance.TracerManager.DataStreamsManager;
                 if (dataStreamsManager != null && dataStreamsManager.IsEnabled)


### PR DESCRIPTION
## Summary of changes
Updates the AWS Kinesis injection logic to leave the outgoing message unmodified when the integration is disabled, aka `scope == null`

## Reason for change
We've observed that even when the AWS Kinesis integration is disabled, attaching the .NET tracer modifies the message by adding `_datadog: {}` (when enabled the dictionary contains key-value pairs for trace context information and other properties). Instead, I think we should omit injecting this entirely when the integration is disabled.

## Implementation details
Adds a branch to `Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis.ContextPropagation.InjectTraceIntoData` to return immediately if the scope is `null`

## Test coverage
Adds two unit tests that assert that the Kinesis message is not modified when the AWS Kinesis integration is disabled via `DD_TRACE_AwsSdk_ENABLED=false` and `DD_TRACE_AwsKinesis_ENABLED=false`
## Other details
