### PR TITLE
Prevent and remove double-disposal in `DiscoveryService` and `RemoteConfigurationManager`

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
@@ -92,9 +92,10 @@ internal static class CiUtils
         else
         {
             Log.Debug("RunCiCommand: Agent-based mode has been enabled. Checking agent connection to {AgentUrl}.", agentUrl);
-            (agentConfiguration, discoveryService) = await Utils.CheckAgentConnectionAsync(agentUrl).ConfigureAwait(false);
+            (agentConfiguration, discoveryService) = await Utils.GetDiscoveryServiceAndCheckConnectionAsync(agentUrl).ConfigureAwait(false);
             if (agentConfiguration is null)
             {
+                await discoveryService.DisposeAsync().ConfigureAwait(false);
                 Log.Error("RunCiCommand: Agent configuration cannot be retrieved.");
                 context.ExitCode = 1;
                 return new InitResults(false, lstArguments, profilerEnvironmentVariables, false, false, Task.CompletedTask);
@@ -221,6 +222,11 @@ internal static class CiUtils
                     testOptimization.Log.Warning(ex, "Error getting ITR settings from configuration api");
                 }
             }
+        }
+        else
+        {
+            // Didn't use the discovery service, so we need to dispose it
+            await discoveryService.DisposeAsync().ConfigureAwait(false);
         }
 
         Log.Debug("RunCiCommand: CodeCoverageEnabled = {Value}", codeCoverageEnabled);

--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
@@ -114,7 +114,7 @@ namespace Datadog.Trace.Tools.Runner
                                 return;
                             }
                         }
-                        else if (AsyncUtil.RunSync(() => Utils.CheckAgentConnectionAsync(agentUrl)).Configuration is null)
+                        else if (AsyncUtil.RunSync(() => Utils.CheckAgentConnectionAsync(agentUrl)) is null)
                         {
                             context.ExitCode = 1;
                             return;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -431,7 +431,6 @@ namespace Datadog.Trace.Tools.Runner
                        }))
             {
                 var configuration = await tcs.Task.ConfigureAwait(false);
-                await discoveryService.DisposeAsync().ConfigureAwait(false);
                 return (configuration, discoveryService);
             }
         }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -396,7 +396,14 @@ namespace Datadog.Trace.Tools.Runner
             return defaultValue;
         }
 
-        public static async Task<(AgentConfiguration Configuration, DiscoveryService DiscoveryService)> CheckAgentConnectionAsync(string agentUrl)
+        public static async Task<AgentConfiguration> CheckAgentConnectionAsync(string agentUrl)
+        {
+            var (configuration, discoveryService) = await GetDiscoveryServiceAndCheckConnectionAsync(agentUrl).ConfigureAwait(false);
+            await discoveryService.DisposeAsync().ConfigureAwait(false);
+            return configuration;
+        }
+
+        public static async Task<(AgentConfiguration Configuration, DiscoveryService DiscoveryService)> GetDiscoveryServiceAndCheckConnectionAsync(string agentUrl)
         {
             var env = new NameValueCollection();
             if (!string.IsNullOrWhiteSpace(agentUrl))

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -39,6 +39,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
         private readonly List<Action<AgentConfiguration>> _agentChangeCallbacks = new();
         private readonly object _lock = new();
         private readonly Task _discoveryTask;
+        private int _disposed = 0;
         private AgentConfiguration? _configuration;
 
         /// <summary>
@@ -312,7 +313,17 @@ namespace Datadog.Trace.Agent.DiscoveryService
 
         public Task DisposeAsync()
         {
-            _processExit.SetResult(true);
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                // First dispose, so mark the process exit as completed
+                _processExit.SetResult(true);
+            }
+            else
+            {
+                // Double dispose in prod shouldn't happen, and should be avoided, so logging for follow-up
+                Log.Debug($"{nameof(DiscoveryService)} is already disposed, skipping further disposal.");
+            }
+
             return _discoveryTask;
         }
     }

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -59,7 +59,9 @@ namespace Datadog.Trace.IntegrationTests
             });
 
             var discovery = DiscoveryService.Create(settings.Exporter);
-            await using var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
+            // Note: we are explicitly _not_ using a using here, as we dispose it ourselves manually at a specific point
+            // and this was easiest to retrofit without changing the test structure too much.
+            var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
             Span span;
 
             // Wait until the discovery service has been reached and we've confirmed that we can send stats
@@ -107,7 +109,7 @@ namespace Datadog.Trace.IntegrationTests
             CreateDefaultSpan(httpStatusCode: "99");
             CreateDefaultSpan(httpStatusCode: "600");
 
-            await tracer.TracerManager.ShutdownAsync(); // Flushes and closes both traces and stats
+            await tracer.DisposeAsync(); // Flushes and closes both traces and stats
 
             var statsPayload = await agent.WaitForStatsAsync(1);
             var spans = await agent.WaitForSpansAsync(13);
@@ -204,7 +206,9 @@ namespace Datadog.Trace.IntegrationTests
             });
 
             var discovery = DiscoveryService.Create(settings.Exporter);
-            await using var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
+            // Note: we are explicitly _not_ using a using here, as we dispose it ourselves manually at a specific point
+            // and this was easiest to retrofit without changing the test structure too much.
+            var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
 
             // Wait until the discovery service has been reached and we've confirmed that we can send stats
             var spinSucceeded = SpinWait.SpinUntil(() => tracer.TracerManager.AgentWriter is AgentWriter { CanComputeStats: true }, 5_000);
@@ -219,7 +223,7 @@ namespace Datadog.Trace.IntegrationTests
             CreateDefaultSpan(type: "redis", resource: "SET le_key le_value");
             CreateDefaultSpan(type: "redis", resource: "SET another_key another_value");
 
-            await tracer.TracerManager.ShutdownAsync(); // Flushes and closes both traces and stats
+            await tracer.DisposeAsync(); // Flushes and closes both traces and stats
 
             var statsPayload = await agent.WaitForStatsAsync(1);
             var spans = await agent.WaitForSpansAsync(6);
@@ -363,7 +367,9 @@ namespace Datadog.Trace.IntegrationTests
                     }));
 
             var discovery = DiscoveryService.Create(settings.Exporter);
-            await using var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
+            // Note: we are explicitly _not_ using a using here, as we dispose it ourselves manually at a specific point
+            // and this was easiest to retrofit without changing the test structure too much.
+            var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
 
             // Wait until the discovery service has been reached and we've confirmed that we can send stats
             if (expectStats)
@@ -465,7 +471,7 @@ namespace Datadog.Trace.IntegrationTests
             await tracer.FlushAsync();
 
             // Flush and close both traces and stats
-            await tracer.TracerManager.ShutdownAsync();
+            await tracer.DisposeAsync();
             WaitForStats(statsWaitEvent, expectStats);
             WaitForTraces(tracesWaitEvent, finishSpansOnClose); // The last span was an error, so we expect to receive it as long as it closed
 


### PR DESCRIPTION
## Summary of changes

- Removes instances of double-disposal
- Prevents double-disposal causing issues

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/7235, we re-enabled the automatic checking of integration test logs for errors which had accidentally been broken during a refactor. When enabled, we discovered multiple errors in the logs, e.g.

```log
Error cleaning up old tracer manager System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
   at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
   at Datadog.Trace.Agent.DiscoveryService.DiscoveryService.DisposeAsync() in /_/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs:line 315
   at Datadog.Trace.TracerManager.CleanUpOldTracerManager(TracerManager oldManager, TracerManager newManager) in /_/tracer/src/Datadog.Trace/TracerManager.cs:line 272
```

Tracing it through, there were 3 main sources of these logs

- https://github.com/DataDog/dd-trace-dotnet/pull/7200
  - This removed exceptions from being thrown in the shutdown path by replacing `CancellationTokenSource` with `TaskCompletionSource`. However, a side-effect is that setting the result for a  `TaskCompletionSource` more than once throws an exception, while calling `Cancel()` on a `CancellationTokenSource` is fine...
- https://github.com/DataDog/dd-trace-dotnet/pull/7220
  - This made sure we _actually_ dispose tracer instances we create in our integration tests properly, to avoid long-running background threads from building up. However, in some cases we accidentally were disposing the tracer _twice_.
- https://github.com/DataDog/dd-trace-dotnet/pull/3736
  - This PR to `dd-trace` resulted in us disposing a `DiscoveryService`, but then returning it for "normal" use, meaning it would be subsequently disposed when the `Tracer` instance was disposed "normally".

## Implementation details

Fixed the three issues I found
- `StatsTests` and `TraceExporterTests` - don't have `using` _and_ `ShutdownAsync()`. 
- Don't call `DiscoveryService.DisposeAsync` on the instance in `dd-trace` when it's reused later
- Prevent double-disposal of `DiscoveryService` and `RemoteConfigurationManager` from _actually_ causing issues

## Test coverage

I rebased https://github.com/DataDog/dd-trace-dotnet/pull/7235 on top of this PR, but _Without_ the double-disposal protections, to ensure that we have removed all existing cases, [and it's looking good](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=182685&view=results). 

Subsequently rebased on this full PR to confirm we're still looking good

## Other details

Ideally we would _always_ use `await using` but refactoring the `StatsTests` was a pain, so I just kept the same structure (which is effectively the same, as long as the stats tests don't throw). These tests are very slow (20s+ each), so I may dig in and refactor them subsequently.

The dd-trace `CiUtil` class is kind of a mess and very hard to follow the logic, but I'll leave that up to @tonyredondo to look into in a separate PR.

The other cases where we moved from CTS to TCS aren't problematic, as we don't dispose them with the TracerManager, they're real singletons which hook into the process exit directly. However, arguably, we should consider making them double-disposal safe too.
