### PR TITLE
Add xunit.runner.json to Datadog.Trace.IntegrationTests

### DIFF
--- a/tracer/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
@@ -16,6 +16,11 @@
     <ProjectReference Include="..\..\src\Datadog.FleetInstaller\Datadog.FleetInstaller.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Remove="xunit.runner.json" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
@@ -60,4 +65,5 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
   </ItemGroup>
+
 </Project>

--- a/tracer/test/Datadog.Trace.IntegrationTests/xunit.runner.json
+++ b/tracer/test/Datadog.Trace.IntegrationTests/xunit.runner.json
@@ -1,0 +1,5 @@
+﻿{
+  "shadowCopy": false,
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": true
+}


### PR DESCRIPTION
## Summary of changes

Add missing xunit.runner.json

## Reason for change

It was missing from the Datadog.Trace.IntegrationTests project, and it shows which tests are running when there are failures etc. Also useful for cross referencing errors in the managed logs with currently running tests.

## Implementation details

Copy the file across, as we have for other projects

## Test coverage

Tested locally, it works like it should

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
