### PR TITLE
Fix fleet smoke tests... again

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -52,7 +52,7 @@ services:
       # api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
       # The iis agent also ignores the _dd.appsec.waf.version because whether it appears in the 
       # aspnet_core.request span is flaky
-    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers,_dd.appsec.waf.version
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers,meta._dd.appsec.waf.version
 
   # The IIS images are based on Windows images, so they can only be run on Docker for Windows,
   # and only after switching to run Windows containers

--- a/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
@@ -19,7 +19,6 @@
         "http.status_code": "404",
         "network.client.ip": "::1",
         "http.client_ip": "::1",
-        "_dd.appsec.waf.version": "1.26.0",
         "_dd.p.dm": "-5",
         "_dd.p.tid": "67a4e73b00000000",
         "runtime-id": "05dff020-c9cc-4b50-9395-e1fe88603312",


### PR DESCRIPTION
## Summary of changes

Tries to fix the `fleet_installer_iis_smoke_tests` again

## Reason for change

I tried to fix this in #7177 by ignoring the `_dd.appsec.waf.version` tag, but this recently flaked with the exact same issue

## Implementation details

EDIT ~~The problem is the tag was still in the "expected" snapshots. Removing it should fix the flake~~. Turns out I was missing the `meta.` prefix 🤦‍♂️ Should be fixed now

## Test coverage

This is the test
