### PR TITLE
Set default timeout for Trace Exporter to 15s.

### DIFF
--- a/tracer/src/Datadog.Trace/LibDatadog/NativeInterop.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/NativeInterop.cs
@@ -88,6 +88,9 @@ internal class NativeInterop
 
         [DllImport(DllName, EntryPoint = "ddog_trace_exporter_config_set_client_computed_stats")]
         internal static extern TraceExporterErrorHandle SetClientComputedStats(SafeHandle config, bool clientComputedStats);
+
+        [DllImport(DllName, EntryPoint = "ddog_trace_exporter_config_set_connection_timeout")]
+        internal static extern TraceExporterErrorHandle SetConnectionTimeout(SafeHandle config, ulong timeout_ms);
     }
 
     internal static class Logger

--- a/tracer/src/Datadog.Trace/LibDatadog/TraceExporterConfiguration.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/TraceExporterConfiguration.cs
@@ -151,6 +151,15 @@ internal class TraceExporterConfiguration : SafeHandle
         }
     }
 
+    public ulong ConnectionTimeoutMs
+    {
+        init
+        {
+            using var error = NativeInterop.Config.SetConnectionTimeout(this, value);
+            error.ThrowIfError();
+        }
+    }
+
     protected override bool ReleaseHandle()
     {
         if (_telemetryConfigPtr != IntPtr.Zero)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -40,6 +40,7 @@ namespace Datadog.Trace
     internal class TracerManagerFactory
     {
         private const string UnknownServiceName = "UnknownService";
+        private const ulong DefaultTimeoutMs = 100_000;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerManagerFactory>();
 
         public static readonly TracerManagerFactory Instance = new();
@@ -415,7 +416,8 @@ namespace Datadog.Trace
                         LanguageInterpreter = frameworkDescription.Name,
                         ComputeStats = settings.StatsComputationEnabled,
                         TelemetryClientConfiguration = telemetryClientConfiguration,
-                        ClientComputedStats = clientComputedStats
+                        ClientComputedStats = clientComputedStats,
+                        ConnectionTimeoutMs = DefaultTimeoutMs
                     };
 
                     return new TraceExporter(configuration, updateSampleRates);

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -40,7 +40,6 @@ namespace Datadog.Trace
     internal class TracerManagerFactory
     {
         private const string UnknownServiceName = "UnknownService";
-        private const ulong DefaultTimeoutMs = 100_000;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerManagerFactory>();
 
         public static readonly TracerManagerFactory Instance = new();
@@ -417,7 +416,7 @@ namespace Datadog.Trace
                         ComputeStats = settings.StatsComputationEnabled,
                         TelemetryClientConfiguration = telemetryClientConfiguration,
                         ClientComputedStats = clientComputedStats,
-                        ConnectionTimeoutMs = DefaultTimeoutMs
+                        ConnectionTimeoutMs = 15_000
                     };
 
                     return new TraceExporter(configuration, updateSampleRates);


### PR DESCRIPTION
## Summary of changes
Add new binding to set the trace exporter connection timeout.
## Reason for change
Trace exporter was setting a 3s connection timeout which probably was insufficient for some test cases. This version use the new bindings to increase the time up to 15 seconds.
