### PR TITLE
Refactor `SpanContextInjector` and `SpanContextExtractor` and improve tests

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIncludingDsmIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIncludingDsmIntegration.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Proxies;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Telemetry;
@@ -17,7 +16,7 @@ using Datadog.Trace.Telemetry.Metrics;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Propagators;
 
 /// <summary>
-/// Instrumentation for <see cref="SpanContextExtractor.ExtractIncludingDsm{TCarrier}"/>
+/// Instrumentation for <c>SpanContextExtractor.ExtractIncludingDsm{TCarrier}</c>
 /// </summary>
 [InstrumentMethod(
     AssemblyName = "Datadog.Trace.Manual",
@@ -41,7 +40,8 @@ public class SpanContextExtractorExtractIncludingDsmIntegration
         var extract = (Func<TCarrier, string, IEnumerable<string?>>)(object)getter!;
         var extractor = new SafeExtractor<TCarrier>(extract);
 
-        var extracted = SpanContextExtractor.ExtractInternal(carrier, extractor.SafeExtract, messageType, source);
+        var tracer = Datadog.Trace.Tracer.Instance;
+        var extracted = SpanContextExtractor.ExtractInternal(tracer, carrier, extractor.SafeExtract, messageType, source);
         return new CallTargetState(scope: null, extracted);
     }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIncludingDsmIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIncludingDsmIntegration.cs
@@ -41,7 +41,7 @@ public class SpanContextExtractorExtractIncludingDsmIntegration
         var extractor = new SafeExtractor<TCarrier>(extract);
 
         var tracer = Datadog.Trace.Tracer.Instance;
-        var extracted = SpanContextExtractor.ExtractInternal(tracer, carrier, extractor.SafeExtract, messageType, source);
+        var extracted = SpanContextExtractor.Extract(tracer, carrier, extractor.SafeExtract, messageType, source);
         return new CallTargetState(scope: null, extracted);
     }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIntegration.cs
@@ -40,7 +40,7 @@ public class SpanContextExtractorExtractIntegration
         var extractor = new SafeExtractor<TCarrier>(extract);
 
         var tracer = Datadog.Trace.Tracer.Instance;
-        var extracted = SpanContextExtractor.ExtractInternal(tracer, carrier, extractor.SafeExtract);
+        var extracted = SpanContextExtractor.Extract(tracer, carrier, extractor.SafeExtract);
         return new CallTargetState(scope: null, state: extracted);
     }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextExtractorExtractIntegration.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Proxies;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Telemetry;
@@ -40,7 +39,8 @@ public class SpanContextExtractorExtractIntegration
         var extract = (Func<TCarrier, string, IEnumerable<string?>>)(object)getter!;
         var extractor = new SafeExtractor<TCarrier>(extract);
 
-        var extracted = SpanContextExtractor.ExtractInternal(carrier, extractor.SafeExtract);
+        var tracer = Datadog.Trace.Tracer.Instance;
+        var extracted = SpanContextExtractor.ExtractInternal(tracer, carrier, extractor.SafeExtract);
         return new CallTargetState(scope: null, state: extracted);
     }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIncludingDsmIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIncludingDsmIntegration.cs
@@ -13,7 +13,7 @@ using Datadog.Trace.Telemetry.Metrics;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Propagators;
 
 /// <summary>
-/// Instrumentation for <see cref="Datadog.Trace.SpanContextInjector.InjectIncludingDsm{TCarrier}"/>
+/// Instrumentation for <c>Datadog.Trace.SpanContextInjector.InjectIncludingDsm{TCarrier}</c>
 /// </summary>
 [InstrumentMethod(
     AssemblyName = "Datadog.Trace.Manual",
@@ -40,7 +40,8 @@ public class SpanContextInjectorInjectIncludingDsmIntegration
             // so we wrap the method in a try/catch to ensure we don't throw
             var inject = (Action<TCarrier, string, string>)(object)setter!;
             var injector = new SafeInjector<TCarrier>(inject);
-            SpanContextInjector.InjectInternal(carrier, injector.SafeInject, spanContext, messageType, target);
+            var tracer = Datadog.Trace.Tracer.Instance;
+            SpanContextInjector.InjectInternal(tracer, carrier, injector.SafeInject, spanContext, messageType, target);
         }
 
         return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIncludingDsmIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIncludingDsmIntegration.cs
@@ -41,7 +41,7 @@ public class SpanContextInjectorInjectIncludingDsmIntegration
             var inject = (Action<TCarrier, string, string>)(object)setter!;
             var injector = new SafeInjector<TCarrier>(inject);
             var tracer = Datadog.Trace.Tracer.Instance;
-            SpanContextInjector.InjectInternal(tracer, carrier, injector.SafeInject, spanContext, messageType, target);
+            SpanContextInjector.Inject(tracer, carrier, injector.SafeInject, spanContext, messageType, target);
         }
 
         return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIncludingDsmIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIncludingDsmIntegration.cs
@@ -32,7 +32,7 @@ public class SpanContextInjectorInjectIncludingDsmIntegration
     {
         // The Injector.Inject method currently _only_ works with SpanContext objects
         // Therefore, there's no point calling inject unless we can remap it to a SpanContext
-        TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_Inject);
+        TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_InjectIncludingDsm);
 
         if (SpanContextHelper.GetContext(context) is { } spanContext)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIntegration.cs
@@ -40,7 +40,8 @@ public class SpanContextInjectorInjectIntegration
             // so we wrap the method in a try/catch to ensure we don't throw
             var inject = (Action<TCarrier, string, string>)(object)setter!;
             var injector = new SafeInjector<TCarrier>(inject);
-            SpanContextInjector.InjectInternal(carrier, injector.SafeInject, spanContext);
+            var tracer = Datadog.Trace.Tracer.Instance;
+            SpanContextInjector.InjectInternal(tracer, carrier, injector.SafeInject, spanContext);
         }
 
         return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Propagators/SpanContextInjectorInjectIntegration.cs
@@ -41,7 +41,7 @@ public class SpanContextInjectorInjectIntegration
             var inject = (Action<TCarrier, string, string>)(object)setter!;
             var injector = new SafeInjector<TCarrier>(inject);
             var tracer = Datadog.Trace.Tracer.Instance;
-            SpanContextInjector.InjectInternal(tracer, carrier, injector.SafeInject, spanContext);
+            SpanContextInjector.Inject(tracer, carrier, injector.SafeInject, spanContext);
         }
 
         return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -9,10 +9,6 @@ using System.Linq;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Propagators;
-using Datadog.Trace.SourceGenerators;
-using Datadog.Trace.Telemetry;
-using Datadog.Trace.Telemetry.Metrics;
 
 #nullable enable
 
@@ -28,59 +24,11 @@ namespace Datadog.Trace
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SpanContextExtractor>();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SpanContextExtractor"/> class
-        /// </summary>
-        [PublicApi]
-        public SpanContextExtractor()
-        {
-            TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextExtractor_Ctor);
-        }
-
-        internal SpanContextExtractor(bool unusedParamNotToUsePublicApi)
-        {
-            // unused parameter is to give us a non-public API we can use
-        }
-
-        /// <summary>
-        /// Given a SpanContext carrier and a function to access the values, this method will extract the <see cref="ISpanContext"/> if any.
-        /// </summary>
-        /// <param name="carrier">The carrier of the SpanContext. Often a header (http, kafka message header...)</param>
-        /// <param name="getter">Given a key name, returns values from the carrier. Should return an empty collection if the requested key is not present.</param>
-        /// <typeparam name="TCarrier">Type of the carrier</typeparam>
-        /// <returns>A potentially null Datadog <see cref="ISpanContext"/></returns>
-        [PublicApi]
-        public ISpanContext? Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
-        {
-            TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextExtractor_Extract);
-            return ExtractInternal(carrier, getter);
-        }
-
-        /// <summary>
-        /// Given a SpanContext carrier and a function to access the values, this method will extract the SpanContext
-        /// and the PathwayContext, and will set a DataStreams Monitoring checkpoint if enabled.
-        /// You should only call <see cref="ExtractIncludingDsm{TCarrier}"/> once on the message <paramref name="carrier"/>. Calling
-        /// multiple times may lead to incorrect stats when using Data Streams Monitoring.
-        /// </summary>
-        /// <param name="carrier">The carrier of the SpanContext. Often a header (http, kafka message header...)</param>
-        /// <param name="getter">Given a key name, returns values from the carrier. Should return an empty collection if the requested key is not present.</param>
-        /// <param name="messageType">For Data Streams Monitoring: The type of messaging system where the message is coming from.</param>
-        /// <param name="source">For Data Streams Monitoring: The queue or topic where the message is coming from.</param>
-        /// <typeparam name="TCarrier">Type of the carrier</typeparam>
-        /// <returns>A potentially null Datadog SpanContext</returns>
-        [PublicApi]
-        public ISpanContext? ExtractIncludingDsm<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string messageType, string source)
-        {
-            TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextExtractor_ExtractIncludingDsm);
-            return ExtractInternal(carrier, getter, messageType, source);
-        }
-
-        internal static SpanContext? ExtractInternal<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string? messageType = null, string? source = null)
+        internal static SpanContext? ExtractInternal<TCarrier>(Tracer tracer, TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string? messageType = null, string? source = null)
         {
             if (messageType != null && source == null) { ThrowHelper.ThrowArgumentNullException(nameof(source)); }
             else if (messageType == null && source != null) { ThrowHelper.ThrowArgumentNullException(nameof(messageType)); }
 
-            var tracer = Tracer.Instance;
             var context = tracer.TracerManager.SpanContextPropagator.Extract(carrier, getter);
 
             // DSM

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SpanContextExtractor>();
 
-        internal static SpanContext? ExtractInternal<TCarrier>(Tracer tracer, TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string? messageType = null, string? source = null)
+        internal static SpanContext? Extract<TCarrier>(Tracer tracer, TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string? messageType = null, string? source = null)
         {
             if (messageType != null && source == null) { ThrowHelper.ThrowArgumentNullException(nameof(source)); }
             else if (messageType == null && source != null) { ThrowHelper.ThrowArgumentNullException(nameof(messageType)); }

--- a/tracer/src/Datadog.Trace/SpanContextInjector.cs
+++ b/tracer/src/Datadog.Trace/SpanContextInjector.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace
     /// </summary>
     public class SpanContextInjector
     {
-        internal static void InjectInternal<TCarrier>(Tracer tracer, TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext? context, string? messageType = null, string? target = null)
+        internal static void Inject<TCarrier>(Tracer tracer, TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext? context, string? messageType = null, string? target = null)
         {
             if (messageType != null && target == null) { ThrowHelper.ThrowArgumentNullException(nameof(target)); }
             else if (messageType == null && target != null) { ThrowHelper.ThrowArgumentNullException(nameof(messageType)); }

--- a/tracer/src/Datadog.Trace/SpanContextInjector.cs
+++ b/tracer/src/Datadog.Trace/SpanContextInjector.cs
@@ -7,9 +7,6 @@ using System;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
-using Datadog.Trace.SourceGenerators;
-using Datadog.Trace.Telemetry;
-using Datadog.Trace.Telemetry.Metrics;
 
 #nullable enable
 
@@ -21,51 +18,7 @@ namespace Datadog.Trace
     /// </summary>
     public class SpanContextInjector
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SpanContextInjector"/> class
-        /// </summary>
-        [PublicApi]
-        public SpanContextInjector()
-        {
-            TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_Ctor);
-        }
-
-        /// <summary>
-        /// Given a SpanContext carrier and a function to set a value, this method will inject a SpanContext.
-        /// You should only call <see cref="Inject{TCarrier}"/> once on the message <paramref name="carrier"/>. Calling
-        /// multiple times may lead to incorrect behaviors.
-        /// </summary>
-        /// <param name="carrier">The carrier of the SpanContext. Often a header (http, kafka message header...)</param>
-        /// <param name="setter">Given a key name and value, sets the value in the carrier</param>
-        /// <param name="context">The context you want to inject</param>
-        /// <typeparam name="TCarrier">Type of the carrier</typeparam>
-        [PublicApi]
-        public void Inject<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext context)
-        {
-            TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_Inject);
-            InjectInternal(carrier, setter, context);
-        }
-
-        /// <summary>
-        /// Given a SpanContext carrier and a function to set a value, this method will inject a SpanContext.
-        /// You should only call <see cref="Inject{TCarrier}"/> once on the message <paramref name="carrier"/>. Calling
-        /// multiple times may lead to incorrect behaviors.
-        /// This method also sets a data streams monitoring checkpoint (if enabled).
-        /// </summary>
-        /// <param name="carrier">The carrier of the SpanContext. Often a header (http, kafka message header...)</param>
-        /// <param name="setter">Given a key name and value, sets the value in the carrier</param>
-        /// <param name="context">The context you want to inject</param>
-        /// <param name="messageType">For Data Streams Monitoring: The type of messaging system where the data being injected will be sent.</param>
-        /// <param name="target">For Data Streams Monitoring: The queue or topic where the data being injected will be sent.</param>
-        /// <typeparam name="TCarrier">Type of the carrier</typeparam>
-        [PublicApi]
-        public void InjectIncludingDsm<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext context, string messageType, string target)
-        {
-            TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_InjectIncludingDsm);
-            InjectInternal(carrier, setter, context, messageType, target);
-        }
-
-        internal static void InjectInternal<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext? context, string? messageType = null, string? target = null)
+        internal static void InjectInternal<TCarrier>(Tracer tracer, TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext? context, string? messageType = null, string? target = null)
         {
             if (messageType != null && target == null) { ThrowHelper.ThrowArgumentNullException(nameof(target)); }
             else if (messageType == null && target != null) { ThrowHelper.ThrowArgumentNullException(nameof(messageType)); }
@@ -75,7 +28,6 @@ namespace Datadog.Trace
                 return;
             }
 
-            var tracer = Tracer.Instance;
             tracer.TracerManager.SpanContextPropagator.Inject(
                 new PropagationContext(spanContext, baggage: null),
                 carrier,


### PR DESCRIPTION
## Summary of changes

- Fix incorrect telemetry in manual instrumetation
- Remove unused instance methods from `SpanContextInjector` and `SpanContextExtractor`
- Pass in a `Tracer` instance instead of using global `Tracer.Instance`
- Ensure proper tracer instance cleanup in tests

## Reason for change

#7244 touched some of these tests and we noticed that the tracer instances weren't necessarily being cleaned up properly. That prompted me to look at this code, and realise it needed a bunch of cleanup.

## Implementation details

- Remove now-unused code (none of the public instance methods are actually invoked)
- Remove the unnecessary `Internal` suffix on methods
- Passing the `Tracer` instances into the static methods is better for testing purposes
- Use the `ScopedTracer` in the tests

## Test coverage

Covered by existing tests
