### PR TITLE
Add retry for build of unit tests on arm64

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1473,7 +1473,15 @@ stages:
           parameters:
             build: true
             baseImage: $(baseImage)
-            command: "BuildAndRunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
+            command: "BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
+            apiKey: $(DD_LOGGER_DD_API_KEY)
+            retryCountForRunCommand: 3
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            build: true
+            baseImage: $(baseImage)
+            command: "RunManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
         - template: steps/make-artifacts-uploadable.yml


### PR DESCRIPTION
## Summary of changes

Retry _building_ the unit tests if it fails due to flake

## Reason for change

In #7207 we started retrying the _build_ stage of unit tests, because the .NET SDK would sometimes randomly fail with a 139 exit code. Unfortunately, I missed the `unit_tests_arm64` stage.

## Implementation details

Add a retry to the build stage only (not run)

## Test coverage

If this passes, we're ok
