### PR TITLE
[Test Optimization] Add pr.number tag to Github provider

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
@@ -105,7 +106,7 @@ internal sealed class GithubActionsEnvironmentValues<TValueProvider>(TValueProvi
                 var number = githubEventObject["number"]?.Value<int>();
                 if (number is > 0)
                 {
-                    PrNumber = number.ToString(CultureInfo.InvariantCulture);
+                    PrNumber = number.Value.ToString(CultureInfo.InvariantCulture);
                 }
 
                 var pullRequestObject = githubEventObject["pull_request"];

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
@@ -102,6 +102,12 @@ internal sealed class GithubActionsEnvironmentValues<TValueProvider>(TValueProvi
             {
                 var githubEvent = File.ReadAllText(githubEventPath);
                 var githubEventObject = JObject.Parse(githubEvent);
+                var number = githubEventObject["number"]?.Value<int>();
+                if (number is > 0)
+                {
+                    PrNumber = number.ToString();
+                }
+
                 var pullRequestObject = githubEventObject["pull_request"];
                 if (pullRequestObject is not null)
                 {

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
@@ -105,7 +105,7 @@ internal sealed class GithubActionsEnvironmentValues<TValueProvider>(TValueProvi
                 var number = githubEventObject["number"]?.Value<int>();
                 if (number is > 0)
                 {
-                    PrNumber = number.ToString();
+                    PrNumber = number.ToString(CultureInfo.InvariantCulture);
                 }
 
                 var pullRequestObject = githubEventObject["pull_request"];

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
@@ -163,6 +163,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             githubEnvVars.HeadCommit.Should().Be("df289512a51123083a8e6931dd6f57bb3883d4c4");
             githubEnvVars.PrBaseCommit.Should().Be("52e0974c74d41160a03d59ddc73bb9f5adab054b");
             githubEnvVars.PrBaseBranch.Should().Be("main");
+            githubEnvVars.PrNumber.Should().Be("1");
 
             // Let's test now the `GITHUB_BASE_REF` environment variable.
             githubEnvVars = new GithubActionsEnvironmentValues<DictionaryValuesProvider>(


### PR DESCRIPTION
## Summary of changes

This PR adds `pr.number` test tag for github action jobs.

## Reason for change

We have `pr.number` tag for several providers except github

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
