### PR TITLE
Refactor the debug symbols folder setup

### DIFF
--- a/.github/actions/publish-debug-symbols/action.yml
+++ b/.github/actions/publish-debug-symbols/action.yml
@@ -2,15 +2,15 @@ name: "Publish native debug symbols"
 description: 'Publish native debug symbols'
 
 inputs:
-  symbols_folder:
-    description: "Folder containing the debug symbols"
+  artifacts_path:
+    description: "Path to the build artifacts"
     required: true
   preprod_key:
     description: "Preprod API key"
     default: ""
     required: false
-  prod_key:
-    description: "Prod API key"
+  public_symbols_key:
+    description: "Public symbols API key"
     default: ""
     required: false
 
@@ -34,19 +34,67 @@ runs:
       shell: bash
       run: npm install -g @datadog/datadog-ci@3.15.0
 
+    - name: Create debug symbols directory
+      shell: bash
+      run: |
+        linux_artifact=${{inputs.artifacts_path}}/linux-native-symbols.tar.gz
+        if [ ! -f $linux_artifact ]; then
+          echo "Linux native symbols not found at $linux_artifact"
+          exit 1
+        fi
+
+        windows_native_symbols=${{inputs.artifacts_path}}/windows-native-symbols.zip
+        if [ ! -f $windows_native_symbols ]; then
+          echo "Windows native symbols not found at $windows_native_symbols"
+          exit 1
+        fi
+
+        windows_tracer_home=${{inputs.artifacts_path}}/windows-tracer-home.zip
+        if [ ! -f $windows_tracer_home ]; then
+          echo "Windows tracer home not found at $windows_tracer_home"
+          exit 1
+        fi
+
+        export DEBUG_SYMBOLS_DIR="$GITHUB_WORKSPACE/debug_symbols"
+        mkdir -p "$DEBUG_SYMBOLS_DIR"
+        echo "DEBUG_SYMBOLS_DIR=$DEBUG_SYMBOLS_DIR" >> $GITHUB_ENV
+
+        ## By splitting windows and linux symbols, we prevent trashing the logs
+        ## Ex: when running datadog-ci for linux, it will report all PE files as non-ELF files.
+        ##     when running datadog-ci for windows, it will report all ELF files as non-PE files.
+
+        linux_subfolder="$DEBUG_SYMBOLS_DIR/linux"
+        mkdir "$linux_subfolder"
+        # Extract Linux symbols
+        tar -zxvf $linux_artifact -C "$linux_subfolder"
+
+        windows_subfolder="$DEBUG_SYMBOLS_DIR/windows"
+        mkdir "$windows_subfolder"
+        # Extract Windows symbols
+        unzip -d "$windows_subfolder" $windows_native_symbols
+        # Extract Windows tracer home
+        unzip -d "$windows_subfolder" $windows_tracer_home
+
+        # Remove all directories except the ones containing native symbols
+        find "$windows_subfolder" -mindepth 1 -maxdepth 1 -type d \
+          ! -name dd-dotnet-win-x64 \
+          ! -name win-x64 \
+          ! -name win-x86 \
+          -exec rm -rf {} +
+
     - name: Push debug symbols
       shell: bash
       run: |
-        if [ -n "${{ inputs.prod_key }}" ]; then
+        if [ -n "${{ inputs.public_symbols_key }}" ]; then
           echo "Push symbols to prod env"
-          DATADOG_API_KEY="${{ inputs.prod_key }}" DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload ${{inputs.symbols_folder}}
-          DATADOG_API_KEY="${{ inputs.prod_key }}" DD_BETA_COMMANDS_ENABLED=1 datadog-ci pe-symbols upload ${{inputs.symbols_folder}}
+          DATADOG_API_KEY="${{ inputs.public_symbols_key }}" DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload "$DEBUG_SYMBOLS_DIR/linux"
+          DATADOG_API_KEY="${{ inputs.public_symbols_key }}" DD_BETA_COMMANDS_ENABLED=1 datadog-ci pe-symbols upload "$DEBUG_SYMBOLS_DIR/windows"
         fi
 
         if [ -n "${{ inputs.preprod_key }}" ]; then
           echo "Push symbols to staging env"
-          DATADOG_API_KEY="${{ inputs.preprod_key }}" DATADOG_SITE="datad0g.com" DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload ${{inputs.symbols_folder}}
-          DATADOG_API_KEY="${{ inputs.preprod_key }}" DATADOG_SITE="datad0g.com" DD_BETA_COMMANDS_ENABLED=1 datadog-ci pe-symbols upload ${{inputs.symbols_folder}}
+          DATADOG_API_KEY="${{ inputs.preprod_key }}" DATADOG_SITE="datad0g.com" DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload "$DEBUG_SYMBOLS_DIR/linux"
+          DATADOG_API_KEY="${{ inputs.preprod_key }}" DATADOG_SITE="datad0g.com" DD_BETA_COMMANDS_ENABLED=1 datadog-ci pe-symbols upload "$DEBUG_SYMBOLS_DIR/windows"
         fi
 
     

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -137,15 +137,9 @@ jobs:
         run: |
           dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
-      - name: Prepare debug symbols for publishing
-        shell: bash
-        run: |
-          mkdir debug_symbols
-          tar -zxvf ${{steps.assets.outputs.artifacts_path}}/linux-native-symbols.tar.gz -C debug_symbols
-
       - name: 'Push debug symbols to datadog'
         uses: ./.github/actions/publish-debug-symbols
         with:
-          symbols_folder: "debug_symbols"
+          artifacts_path: ${{steps.assets.outputs.artifacts_path}}
           preprod_key: "${{ secrets.DD_PREPROD_API_KEY }}"
-          prod_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"
+          public_symbols_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"

--- a/.github/workflows/publish_debug_symbols.yml
+++ b/.github/workflows/publish_debug_symbols.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish_native_debug_symbols:
     runs-on: ubuntu-latest
+    env:
+      ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
 
     steps:
       - name: Checkout
@@ -19,27 +21,17 @@ jobs:
       - name: Download Linux native symbols v${{ github.event.inputs.version }}
         shell: bash
         run: |
-          mkdir debug_symbols
-          curl -s -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${{ github.event.inputs.version }}/linux-native-symbols.tar.gz | tar zxvf - -C debug_symbols
+          curl --create-dirs -s -OL --output-dir "$ARTIFACTS_PATH" https://github.com/DataDog/dd-trace-dotnet/releases/download/v${{ github.event.inputs.version }}/linux-native-symbols.tar.gz
       - name: Download Windows native symbols v${{ github.event.inputs.version }}
         shell: bash
         run: |
-          curl -s -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${{ github.event.inputs.version }}/windows-native-symbols.zip | busybox unzip -d debug_symbols -
+          curl --create-dirs -s -OL --output-dir "$ARTIFACTS_PATH" https://github.com/DataDog/dd-trace-dotnet/releases/download/v${{ github.event.inputs.version }}/windows-native-symbols.zip
           # datadog-ci needs the dll to check if we can send the PDB files
-          curl -s -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${{ github.event.inputs.version }}/windows-tracer-home.zip | busybox unzip -d debug_symbols -
-          # Remove all directories except the ones containing native symbols
-          # Linux symbols are extracted in the `symbols` directory
-          find debug_symbols -maxdepth 1 -type d \
-            ! -name debug_symbols \
-            ! -name dd-dotnet-win-x64 \
-            ! -name win-x64 \
-            ! -name win-x86 \
-            ! -name 'symbols' \
-            -exec rm -rf {} +
+          curl --create-dirs -s -OL --output-dir "$ARTIFACTS_PATH" https://github.com/DataDog/dd-trace-dotnet/releases/download/v${{ github.event.inputs.version }}/windows-tracer-home.zip
 
       - name: 'Push debug symbols to datadog'
         uses: ./.github/actions/publish-debug-symbols
         with:
-          symbols_folder: "debug_symbols"
+          artifacts_path: ${{ env.ARTIFACTS_PATH }}
           preprod_key: "${{ secrets.DD_PREPROD_API_KEY }}"
-          prod_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"
+          public_symbols_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"


### PR DESCRIPTION
## Summary of changes

Fix debug symbols publishing and refactor it.

## Reason for change
In a previous [PR](https://github.com/DataDog/dd-trace-dotnet/pull/7246), we added support for publishing PDB files. But it was added only for the manual workflow.

This PR does it for when releasing a new version too.

## Implementation details

- Move debug symbols preparation in the action
- Clean up there and there

## Test coverage

https://github.com/DataDog/dd-trace-dotnet/actions/runs/16466188593/job/46544059599

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
