### PR TITLE
Mark some debugger tests flaky

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -386,6 +386,7 @@ public class ProbesTests : TestHelper
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
     [MemberData(nameof(ProbeTests))]
+    [Flaky("This test fails for various different reasons and needs investigating")]
     public async Task MethodProbeTest(ProbeTestDescription testDescription)
     {
         SkipOverTestIfNeeded(testDescription);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
@@ -9,6 +9,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Snapshots;
+using Datadog.Trace.TestHelpers;
 using Newtonsoft.Json.Linq;
 using VerifyXunit;
 using Xunit;
@@ -28,6 +29,7 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        [Flaky("This test sporadically fails due to invalid json e.g. Unexpected end of content while loading JObject. Path 'debugger', line 1, position 12313")]
         public async Task SnapshotBiggerThanMaxSize_OneLevel_LevelSliced()
         {
             var snapshot = SnapshotHelper.GenerateSnapshot(new ComplexClass(), false);
@@ -39,6 +41,7 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        [Flaky("This test sporadically fails due to invalid json e.g. Unexpected end of content while loading JObject. Path 'debugger', line 1, position 12313")]
         public async Task SnapshotBiggerThanMaxSize_TwoLevel_OneSliced()
         {
             var snapshot = SnapshotHelper.GenerateSnapshot(new VeryComplexClass() { ComplexClass = new ComplexClass() { SimpleClass = new SimpleClass() } }, false);
@@ -50,6 +53,7 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        [Flaky("This test sporadically fails due to invalid json e.g. Unexpected end of content while loading JObject. Path 'debugger', line 1, position 20557")]
         public async Task SnapshotBiggerThanMaxSize_ThreeLevel_AllSliced()
         {
             var snapshot = SnapshotHelper.GenerateSnapshot(new VeryComplexClass() { Class = new VeryComplexClass() { ComplexClass = new ComplexClass() { SimpleClass = new SimpleClass() } } }, false);


### PR DESCRIPTION
## Summary of changes

Marks a bunch of flaky debugger tests

## Reason for change

These have been flaky for a while and are impacting CI

## Implementation details

Mark the tests flaky
- `MethodProbeTests` has [failed 5 times in the last week](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.full_name%3ADatadog.Trace.Debugger.IntegrationTests.Datadog.Trace.Debugger.IntegrationTests.ProbesTests.MethodProbeTest%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1752592512674&end=1753197312674&paused=false)
- `SnapshotSlicerTests` has [failed 4 times](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40git.branch%3Amaster%20%40test.status%3Afail%20%40test.suite%3ADatadog.Trace.Tests.Debugger.SnapshotSlicerTests&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1750605315672&end=1753197315672&paused=false)

## Test coverage

The failures are for a variety of reasons, and should be investigated as they could be hiding real issues
