### PR TITLE
Use `TrySetResult` instead of `SetResult`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -39,7 +39,6 @@ namespace Datadog.Trace.Agent.DiscoveryService
         private readonly List<Action<AgentConfiguration>> _agentChangeCallbacks = new();
         private readonly object _lock = new();
         private readonly Task _discoveryTask;
-        private int _disposed = 0;
         private AgentConfiguration? _configuration;
 
         /// <summary>
@@ -313,12 +312,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
 
         public Task DisposeAsync()
         {
-            if (Interlocked.Exchange(ref _disposed, 1) == 0)
-            {
-                // First dispose, so mark the process exit as completed
-                _processExit.SetResult(true);
-            }
-            else
+            if (!_processExit.TrySetResult(true))
             {
                 // Double dispose in prod shouldn't happen, and should be avoided, so logging for follow-up
                 Log.Debug($"{nameof(DiscoveryService)} is already disposed, skipping further disposal.");

--- a/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
@@ -219,7 +219,7 @@ internal class HardcodedSecretsAnalyzer : IDisposable
 
     public void Dispose()
     {
-        _processExit.SetResult(true);
+        _processExit.TrySetResult(true);
         Log.Debug("HardcodedSecretsAnalyzer -> Disposed");
     }
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -33,7 +33,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         private readonly TaskCompletionSource<bool> _processExit = new();
 
-        private int _disposed = 0;
         private int _isPollingStarted;
         private bool _isRcmEnabled;
         private bool _gitMetadataAddedToRequestTags;
@@ -115,10 +114,9 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public void Dispose()
         {
-            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            if (_processExit.TrySetResult(true))
             {
                 _discoveryService.RemoveSubscription(SetRcmEnabled);
-                _processExit.SetResult(true);
             }
             else
             {

--- a/tracer/src/Datadog.Trace/TraceClock.cs
+++ b/tracer/src/Datadog.Trace/TraceClock.cs
@@ -23,7 +23,7 @@ internal sealed class TraceClock
 
     static TraceClock()
     {
-        LifetimeManager.Instance.AddShutdownTask(_ => ProcessExit.SetResult(true));
+        LifetimeManager.Instance.AddShutdownTask(_ => ProcessExit.TrySetResult(true));
         _instance = new TraceClock();
         _ = UpdateClockAsync();
     }


### PR DESCRIPTION
## Summary of changes

Use `TaskCompletionSource.TrySetResult` instead of `SetResult` (which throws)

## Reason for change

In #7200 we replaced `CancellationTokenSource` with `TaskCompletionSource`, but this caused some exceptions on shutdown due to double-disposal. In #7240 we fixed that, but did it in a way that doesn't make sense. We don't need to use `Interlocked.Exchange` we can just use `TrySetResult`.

## Implementation details

- Use `TrySetResult` instead of `SetResult` as the latter just calls the former and throws
- Did a sweep to update some other usages of `SetResult` which are unnecessarily risky

## Test coverage

Covered by existing test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
