### PR TITLE
Add a `do-not-merge action` to block merging

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -1,0 +1,17 @@
+﻿name: Do Not Merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'do-not-merge') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'do not merge'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -6,12 +6,15 @@ on:
 
 jobs:
   do-not-merge:
-    if: ${{ contains(github.event.*.labels.*.name, 'do-not-merge') }}
-    name: Prevent Merging
+    name: Check status
     runs-on: ubuntu-latest
     steps:
-      - name: Check for label
+      - name: Fail if 'status:do-not-merge' label is present
         run: |
-          echo "Pull request is labeled as 'do not merge'"
-          echo "This workflow fails so that the pull request cannot be merged"
-          exit 1
+          if echo "${{ toJson(github.event.pull_request.labels) }}" | grep -q '"name":"status:do-not-merge"'; then
+            echo "Label 'status:do-not-merge' is present. Failing the job."
+            exit 1
+          else
+            echo "Label 'status:do-not-merge' is NOT present. Passing."
+            exit 0
+          fi


### PR DESCRIPTION
## Summary of changes

Adds a GitHub workflow that fails when the `status:do-not-run` label is added

## Reason for change

We use that label, but it's easy to miss, and this enforces it

## Implementation details

Check if the github event contains the label

## Test coverage

Can't actually test this until it's merged 🙄 
