### PR TITLE
Fix the do-not-merge action

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fail if 'status:do-not-merge' label is present
-        env:
-          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
         run: |
-          echo $LABELS_JSON | jq -e '.[] | select(.name == "status:do-not-merge")' > /dev/null
+          cat > labels.json <<EOF
+          ${{ toJson(github.event.pull_request.labels) }}
+          EOF
+
+          jq -e '.[] | select(.name == "status:do-not-merge")' labels.json > /dev/null
           if [ $? -eq 0 ]; then
             echo "Label 'status:do-not-merge' is present. Failing the job."
             exit 1

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -10,16 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fail if 'status:do-not-merge' label is present
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
         run: |
-          cat > raw_labels.json <<EOF
-          ${{ toJson(github.event.pull_request.labels) }}
-          EOF
-          
-          # Remove leading spaces from each line that seems to make jq choke
-          sed 's/^[[:space:]]*//' raw_labels.json > labels.json
-
-
-          jq -e '.[] | select(.name == "status:do-not-merge")' labels.json > /dev/null
+          echo $LABELS_JSON | jq -e '.[] | select(.name == "status:do-not-merge")' > /dev/null
           if [ $? -eq 0 ]; then
             echo "Label 'status:do-not-merge' is present. Failing the job."
             exit 1

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -16,8 +16,9 @@ jobs:
           set -x
 
           # The multiline string needs to be reformed into 'real' JSON again
-          jq -Rs 'fromjson | .[] | select(.name == "status:do-not-merge")'<<<"$LABELS_JSON"
-          if [ $? -eq 0 ]; then
+          MATCH=$(jq -Rs 'fromjson | map(select(.name == "status:do-not-merge")) | length' <<<"$LABELS_JSON")
+
+          if [ "$MATCH" -gt 0 ]; then
             echo "Label 'status:do-not-merge' is present. Failing the job."
             exit 1
           else

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   do-not-merge:
-    name: Check status
+    name: Blocked by label
     runs-on: ubuntu-latest
     steps:
       - name: Fail if 'status:do-not-merge' label is present

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -13,7 +13,9 @@ jobs:
         env:
           LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
         run: |
-          echo $LABELS_JSON | jq -e '.[] | select(.name == "status:do-not-merge")' > /dev/null
+          set -x
+
+          echo $LABELS_JSON | jq -e '.[] | select(.name == "status:do-not-merge")'
           if [ $? -eq 0 ]; then
             echo "Label 'status:do-not-merge' is present. Failing the job."
             exit 1

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -16,7 +16,7 @@ jobs:
           set -x
 
           # The multiline string needs to be reformed into 'real' JSON again
-          echo $LABELS_JSON | jq -Rs 'fromjson | .[] | select(.name == "status:do-not-merge")' > /dev/null
+          jq -Rs 'fromjson | .[] | select(.name == "status:do-not-merge")'<<<"$LABELS_JSON"
           if [ $? -eq 0 ]; then
             echo "Label 'status:do-not-merge' is present. Failing the job."
             exit 1

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -10,8 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fail if 'status:do-not-merge' label is present
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
         run: |
-          if echo "${{ toJson(github.event.pull_request.labels) }}" | grep -q '"name":"status:do-not-merge"'; then
+          echo $LABELS_JSON | jq -e '.[] | select(.name == "status:do-not-merge")' > /dev/null
+          if [ $? -eq 0 ]; then
             echo "Label 'status:do-not-merge' is present. Failing the job."
             exit 1
           else

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -11,9 +11,13 @@ jobs:
     steps:
       - name: Fail if 'status:do-not-merge' label is present
         run: |
-          cat > labels.json <<EOF
+          cat > raw_labels.json <<EOF
           ${{ toJson(github.event.pull_request.labels) }}
           EOF
+          
+          # Remove leading spaces from each line that seems to make jq choke
+          sed 's/^[[:space:]]*//' raw_labels.json > labels.json
+
 
           jq -e '.[] | select(.name == "status:do-not-merge")' labels.json > /dev/null
           if [ $? -eq 0 ]; then

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -15,7 +15,8 @@ jobs:
         run: |
           set -x
 
-          echo $LABELS_JSON | jq -e '.[] | select(.name == "status:do-not-merge")'
+          # The multiline string needs to be reformed into 'real' JSON again
+          echo $LABELS_JSON | jq -Rs 'fromjson | .[] | select(.name == "status:do-not-merge")' > /dev/null
           if [ $? -eq 0 ]; then
             echo "Label 'status:do-not-merge' is present. Failing the job."
             exit 1


### PR DESCRIPTION
## Summary of changes

Fix the `status:do-not-merge` action added in #7266

## Reason for change

It didn't work 😅 escaping issues I think

## Implementation details

Write the value to an env var, and use the built-in env var escaping in bash to make sure it works out. Also use `jq` instead of `grep`

## Test coverage

I _can_ test it this time 😄 
