### PR TITLE
Update the Windows test agent to latest

### DIFF
--- a/tracer/build/_build/docker/test-agent.windows.dockerfile
+++ b/tracer/build/_build/docker/test-agent.windows.dockerfile
@@ -3,6 +3,6 @@
 WORKDIR /
 
 # Pin to older test agent versions to try to avoid breakages in the future
-RUN pip install --no-cache-dir "ddapm-test-agent==1.16.0" "ddsketch==3.0.1" "ddsketch[serialization]==3.0.1"
+RUN pip install --no-cache-dir "ddapm-test-agent==1.28.0" "ddsketch==3.0.1" "ddsketch[serialization]==3.0.1"
 
 ENTRYPOINT [ "ddapm-test-agent", "--port=8126" ]


### PR DESCRIPTION
## Summary of changes

Update the test agent to use the latest version

## Reason for change

#7244 requires endpoints that are not in the existing version

## Implementation details

Try just bumping the version

## Test coverage

This is the test
