### PR TITLE
Revert "[Serverless] Remove "preview" version suffix from `Datadog.AzureFunctions` (#7229)"

### DIFF
--- a/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
+++ b/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
@@ -8,6 +8,11 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoDefaultExcludes>true</NoDefaultExcludes>
 
+    <!-- nuget version: move $Version to $VersionPrefix so we can add a prerelease suffix. -->
+    <VersionPrefix>$(Version)</VersionPrefix>
+    <VersionSuffix>preview</VersionSuffix>
+    <Version></Version>
+
     <!-- nuget package metadata -->
     <PackageId>Datadog.AzureFunctions</PackageId>
     <Description>Datadog instrumentation library for Azure Functions</Description>

--- a/tracer/src/Datadog.AzureFunctions/README.md
+++ b/tracer/src/Datadog.AzureFunctions/README.md
@@ -1,5 +1,7 @@
-# Datadog Instrumentation Library for .NET Azure Functions
+# Datadog Instrumentation Library for .NET Azure Functions [Preview]
 ## `Datadog.AzureFunctions`
+
+**Note: This is an unsupported pre-release version of this package.**
 
 Add this package to your Azure Functions project to enable Datadog APM tracing.
 Further configuration is required for your Azure Functions to send instrumentation data to Datadog.


### PR DESCRIPTION
## Summary of changes

This reverts commit 37f308a9380ededda8d60bf7078e69bc6452ccc8.

## Reason for change

CI is broken, and it should not have been merged

## Implementation details

Revert

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
