### PR TITLE
Fix potential deadlocks in `IisFixture` process code

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -76,6 +76,9 @@ namespace Datadog.Trace.TestHelpers
                     // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
                 }
 
+                // The ProcessHelper doesn't dispose the process automatically, so we need to do it manually
+                IisExpress.Process.Process.Dispose();
+
                 try
                 {
                     File.Delete(IisExpress.ConfigFile);

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.TestHelpers
     [CollectionDefinition("IisTests", DisableParallelization = false)]
     public sealed class IisFixture : GacFixture, IDisposable
     {
-        public (Process Process, string ConfigFile) IisExpress { get; private set; }
+        public (ProcessHelper Process, string ConfigFile) IisExpress { get; private set; }
 
         public MockTracerAgent Agent { get; private set; }
 
@@ -65,22 +65,16 @@ namespace Datadog.Trace.TestHelpers
             {
                 try
                 {
-                    if (!IisExpress.Process.HasExited)
-                    {
-                        // sending "Q" to standard input does not work because
-                        // iisexpress is scanning console key press, so just kill it.
-                        // maybe try this in the future:
-                        // https://github.com/roryprimrose/Headless/blob/master/Headless.IntegrationTests/IisExpress.cs
-                        IisExpress.Process.Kill();
-                        IisExpress.Process.WaitForExit(8000);
-                    }
+                    // sending "Q" to standard input does not work because
+                    // iisexpress is scanning console key press, so just kill it.
+                    // maybe try this in the future:
+                    // https://github.com/roryprimrose/Headless/blob/master/Headless.IntegrationTests/IisExpress.cs
+                    IisExpress.Process.Dispose(8000);
                 }
                 catch
                 {
                     // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
                 }
-
-                IisExpress.Process.Dispose();
 
                 try
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.TestHelpers
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
-        public async Task<(Process Process, string ConfigFile)> StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath)
+        public async Task<(ProcessHelper Process, string ConfigFile)> StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath)
         {
             var iisExpress = EnvironmentHelper.GetIisExpressPath();
 
@@ -285,30 +285,18 @@ namespace Datadog.Trace.TestHelpers
 
             var semaphore = new SemaphoreSlim(0, 1);
 
-            _ = Task.Factory.StartNew(
-                () =>
+            var processHelper = new ProcessHelper(
+                process,
+                line =>
                 {
-                    while (process.StandardOutput.ReadLine() is { } line)
-                    {
-                        Output.WriteLine($"[webserver][stdout] {line}");
+                    Output.WriteLine($"[webserver][stdout] {line}");
 
-                        if (line.Contains("IIS Express is running"))
-                        {
-                            semaphore.Release();
-                        }
+                    if (line.Contains("IIS Express is running"))
+                    {
+                        semaphore.Release();
                     }
                 },
-                TaskCreationOptions.LongRunning);
-
-            _ = Task.Factory.StartNew(
-                () =>
-                {
-                    while (process.StandardError.ReadLine() is { } line)
-                    {
-                        Output.WriteLine($"[webserver][stderr] {line}");
-                    }
-                },
-                TaskCreationOptions.LongRunning);
+                line => Output.WriteLine($"[webserver][stderr] {line}"));
 
             await semaphore.WaitAsync(TimeSpan.FromSeconds(10));
 
@@ -335,7 +323,7 @@ namespace Datadog.Trace.TestHelpers
                 await Task.Delay(1500);
             }
 
-            return (process, newConfig);
+            return (processHelper, newConfig);
         }
 
         public void EnableIast(bool enable = true)

--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
@@ -130,8 +130,6 @@ namespace Datadog.Trace.TestHelpers
                     // Ignore exceptions when killing the process, as it may have already exited
                 }
             }
-
-            Process.Dispose();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
@@ -111,19 +111,27 @@ namespace Datadog.Trace.TestHelpers
                 && _errorTask.Task.Wait(timeout);
         }
 
-        public virtual void Dispose()
+        public virtual void Dispose() => Dispose(0);
+
+        public virtual void Dispose(int waitForExitTimeout)
         {
             if (!Process.HasExited)
             {
                 try
                 {
                     Process.Kill();
+                    if (waitForExitTimeout > 0)
+                    {
+                        Process.WaitForExit(waitForExitTimeout);
+                    }
                 }
                 catch
                 {
                     // Ignore exceptions when killing the process, as it may have already exited
                 }
             }
+
+            Process.Dispose();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
@@ -187,7 +187,7 @@ public class IisCheckTests : ToolTestHelper
 
     private static string IisExpressOptions(IisFixture iisFixture)
     {
-        return $"--workerProcess {iisFixture.IisExpress.Process.Id} --iisConfigPath {iisFixture.IisExpress.ConfigFile}";
+        return $"--workerProcess {iisFixture.IisExpress.Process.Process.Id} --iisConfigPath {iisFixture.IisExpress.ConfigFile}";
     }
 
     private static void EnsureWindowsAndX64()

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
@@ -53,7 +53,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                 siteName,
                 iisFixture.IisExpress.ConfigFile,
-                iisFixture.IisExpress.Process.Id,
+                iisFixture.IisExpress.Process.Process.Id,
                 MockRegistryService());
 
             result.Should().Be(0);
@@ -93,7 +93,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                              siteName,
                              iisFixture.IisExpress.ConfigFile,
-                             iisFixture.IisExpress.Process.Id,
+                             iisFixture.IisExpress.Process.Process.Id,
                              MockRegistryService());
 
             result.Should().Be(0);
@@ -126,7 +126,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                 "sample",
                 iisFixture.IisExpress.ConfigFile,
-                iisFixture.IisExpress.Process.Id,
+                iisFixture.IisExpress.Process.Process.Id,
                 MockRegistryService());
 
             result.Should().Be(0);
@@ -162,7 +162,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                              "sample",
                              iisFixture.IisExpress.ConfigFile,
-                             iisFixture.IisExpress.Process.Id,
+                             iisFixture.IisExpress.Process.Process.Id,
                              MockRegistryService());
 
             result.Should().Be(1);
@@ -188,7 +188,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
             "sample",
             iisFixture.IisExpress.ConfigFile,
-            iisFixture.IisExpress.Process.Id,
+            iisFixture.IisExpress.Process.Process.Id,
             MockRegistryService());
 
         result.Should().Be(1);
@@ -209,7 +209,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
             "dummySite",
             iisFixture.IisExpress.ConfigFile,
-            iisFixture.IisExpress.Process.Id,
+            iisFixture.IisExpress.Process.Process.Id,
             MockRegistryService());
 
         result.Should().Be(1);
@@ -230,7 +230,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
             "sample/dummy",
             iisFixture.IisExpress.ConfigFile,
-            iisFixture.IisExpress.Process.Id,
+            iisFixture.IisExpress.Process.Process.Id,
             MockRegistryService());
 
         result.Should().Be(1);
@@ -251,7 +251,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
                          "sample",
                          iisFixture.IisExpress.ConfigFile,
-                         iisFixture.IisExpress.Process.Id,
+                         iisFixture.IisExpress.Process.Process.Id,
                          MockRegistryService());
 
         result.Should().Be(1);


### PR DESCRIPTION
## Summary of changes

Fixes potential deadlocks in the IIS fixture code 

## Reason for change

While working on the .NET branch, we had to update xunit. We subsequently started seeing deadlocks in the Iis tests. I noticed potential issues with the code that reads the process output (because I fixed something similar in #7116 recently) and voila, no deadlocks 🎉 

## Implementation details

Use the event-based handling already available in `ProcessHelper` instead of spawning separate dedicated threads for handling reading the output. Also some minor additional things:

- Allowed specifying a time to wait after calling `Process.Kill()` in `ProcessHelper` before returning (we need this for the IIS Fixture)
- ~Make sure we dispose the `Process` object held by `ProcessHelper`~ This _is_ already disposed, because it gets "owned" by the `ProcessResult` object instead

## Test coverage

Covered by existing tests - if it passes, we're good

## Other details

Following are dependent on this PR:
- #7170 
- #7280

https://datadoghq.atlassian.net/browse/LANGPLAT-632