### PR TITLE
[Serverless] GA nuget package `Datadog.AzureFunctions`

### DIFF
--- a/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
+++ b/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
@@ -8,11 +8,6 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoDefaultExcludes>true</NoDefaultExcludes>
 
-    <!-- nuget version: move $Version to $VersionPrefix so we can add a prerelease suffix. -->
-    <VersionPrefix>$(Version)</VersionPrefix>
-    <VersionSuffix>preview</VersionSuffix>
-    <Version></Version>
-
     <!-- nuget package metadata -->
     <PackageId>Datadog.AzureFunctions</PackageId>
     <Description>Datadog instrumentation library for Azure Functions</Description>

--- a/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
+++ b/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
@@ -31,7 +31,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Datadog.Trace.Annotations\Datadog.Trace.Annotations.csproj" />
 
     <!-- Use PrivateAssets="none" to stop excluding content files by default -->
-    <PackageReference Include="Datadog.Serverless.Compat" Version="0.6.0-preview" PrivateAssets="none" />
+    <PackageReference Include="Datadog.Serverless.Compat" Version="1.0.0" PrivateAssets="none" />
 
     <!-- managed assemblies -->
     <None Include="$(SourcePath)/net6.0/Datadog.Trace.dll" Pack="true" Visible="false" PackagePath="contentFiles/any/any/datadog/net6.0/">

--- a/tracer/src/Datadog.AzureFunctions/README.md
+++ b/tracer/src/Datadog.AzureFunctions/README.md
@@ -1,7 +1,5 @@
-# Datadog Instrumentation Library for .NET Azure Functions [Preview]
+# Datadog Instrumentation Library for .NET Azure Functions
 ## `Datadog.AzureFunctions`
-
-**Note: This is an unsupported pre-release version of this package.**
 
 Add this package to your Azure Functions project to enable Datadog APM tracing.
 Further configuration is required for your Azure Functions to send instrumentation data to Datadog.


### PR DESCRIPTION
Original #7229
Reverted in #7278
This third PR reverts the revert.

Also, update `Datadog.Serverless.Compat` nuget reference to `1.0.0` (no prerelease tag).

## Summary of changes

Remove "preview" from version tags and update README text.

## Reason for change

GA is coming.

## Implementation details

Remove "preview" from version tags and update README text.

## Test coverage

~None needed.~

Actually, the previous attempt failed to build. So there you go. Make sure this one builds.

## Other details

Fixes APMSVLS-95

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
