### PR TITLE
Dispose the inferred proxy span last

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -201,8 +201,9 @@ namespace Datadog.Trace.PlatformHelpers
                 }
 
                 CoreHttpContextStore.Instance.Remove();
-                proxyScope?.Dispose();
+
                 rootScope.Dispose();
+                proxyScope?.Dispose();
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsEventBridgeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsEventBridgeTests.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var spans = await agent.WaitForSpansAsync(1, returnAllOperations: true);
 
                 Assert.NotEmpty(spans);
-                Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+                spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
                 await telemetry.AssertIntegrationDisabledAsync(IntegrationId.AwsEventBridge);
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsS3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsS3Tests.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var spans = await agent.WaitForSpansAsync(1, returnAllOperations: true);
 
                 Assert.NotEmpty(spans);
-                Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+                spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
                 await telemetry.AssertIntegrationDisabledAsync(IntegrationId.AwsS3);
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsStepFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsStepFunctionsTests.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var spans = await agent.WaitForSpansAsync(1, returnAllOperations: true);
 
                 Assert.NotEmpty(spans);
-                Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+                spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
                 await telemetry.AssertIntegrationDisabledAsync(IntegrationId.AwsStepFunctions);
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -101,7 +102,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.SqlClient);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -101,7 +102,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Sqlite);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.MySql);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -85,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.MySql);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -110,7 +110,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Npgsql);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.SqlClient);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -135,7 +135,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.SqlClient);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -53,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Sqlite);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -132,16 +132,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(Data))]
-        public async Task SubmitsTraces(string path, HttpStatusCode statusCode)
+        public async Task SubmitsTraces(string path, int statusCode)
         {
             // TransferRequest cannot be called in the classic mode, so we expect a 500 when this happens
             var toLowerPath = path.ToLower();
             if (_testName.Contains(".Classic") && toLowerPath.Contains("badrequest") && toLowerPath.Contains("transferrequest"))
             {
-                statusCode = (HttpStatusCode)500;
+                statusCode = 500;
             }
 
-            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode);
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode);
             ValidateIntegrationSpans(spans, metadataSchemaVersion: "v0", expectedServiceName: "sample", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5QueryStringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5QueryStringTests.cs
@@ -71,14 +71,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(Data))]
-        public async Task SubmitsTraces(string path, HttpStatusCode statusCode)
+        public async Task SubmitsTraces(string path, int statusCode)
         {
             // Append virtual directory to the actual request
-            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode);
+            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
 
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Ensures that we get nice file nesting in Solution Explorer

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -255,13 +255,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(Data))]
-        public async Task SubmitsTraces(string path, HttpStatusCode statusCode)
+        public async Task SubmitsTraces(string path, int statusCode)
         {
             // TransferRequest cannot be called in the classic mode, so we expect a 500 when this happens
             var toLowerPath = path.ToLower();
             if (_testName.Contains(".Classic") && toLowerPath.Contains("badrequest") && toLowerPath.Contains("transferrequest"))
             {
-                statusCode = (HttpStatusCode)500;
+                statusCode = 500;
             }
 
             var expectedSpanCount = _enableInferredProxySpans ? 3 : 2;
@@ -270,7 +270,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 path: _iisFixture.VirtualApplicationPath + path, // Append virtual directory to the actual request
                 agent: _iisFixture.Agent,
                 httpPort: _iisFixture.HttpPort,
-                expectedHttpStatusCode: statusCode,
+                expectedHttpStatusCode: (HttpStatusCode)statusCode,
                 expectedSpanCount: expectedSpanCount,
                 filterServerSpans: !_enableInferredProxySpans);
 
@@ -279,7 +279,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             ValidateIntegrationSpans(serverSpans, metadataSchemaVersion: "v0", expectedServiceName: ExpectedServiceName, isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Ensures that we get nice file nesting in Solution Explorer
@@ -342,16 +342,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(Data))]
-        public async Task SubmitsTraces(string path, HttpStatusCode statusCode)
+        public async Task SubmitsTraces(string path, int statusCode)
         {
             // TransferRequest cannot be called in the classic mode, so we expect a 500 when this happens
             if (_testName.Contains(".Classic") && path.ToLowerInvariant().Contains("transferrequest"))
             {
-                statusCode = (HttpStatusCode)500;
+                statusCode = 500;
             }
 
             // Append virtual directory if there is one
-            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode, expectedSpanCount: 1);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -290,21 +290,21 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(Data))]
-        public async Task SubmitsTraces(string path, HttpStatusCode statusCode, int expectedSpanCount)
+        public async Task SubmitsTraces(string path, int statusCode, int expectedSpanCount)
         {
             // Append virtual directory to the actual request
-            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount);
+            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode, expectedSpanCount);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
 
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Overriding the method name to _
             // Overriding the parameters to remove the expectedSpanCount parameter, which is necessary for operation but unnecessary for the filename
             await Verifier.Verify(spans, settings)
                           .DisableRequireUniquePrefix()
-                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={(int)statusCode}");
+                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={statusCode}");
         }
 
         public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
@@ -127,20 +127,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(Data))]
-        public async Task SubmitsTraces(string path, HttpStatusCode statusCode, int expectedSpanCount)
+        public async Task SubmitsTraces(string path, int statusCode, int expectedSpanCount)
         {
             // Append virtual directory to the actual request
-            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount);
+            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode, expectedSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion: "v0", expectedServiceName: "sample", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Overriding the method name to _
             // Overriding the parameters to remove the expectedSpanCount parameter, which is necessary for operation but unnecessary for the filename
             await Verifier.Verify(spans, settings)
-                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={(int)statusCode}")
+                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={statusCode}")
                           .DisableRequireUniquePrefix(); // sharing snapshots between web api and owin
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -120,7 +120,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task SubmitsTraces(string path, HttpStatusCode statusCode, int expectedSpanCount)
+        public async Task SubmitsTraces(string path, int statusCode, int expectedSpanCount)
         {
             await _fixture.TryStartApp(this, _output);
 
@@ -128,13 +128,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             ValidateIntegrationSpans(spans, metadataSchemaVersion: "v0", expectedServiceName: "Samples.Owin.WebApi2", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Overriding the method name to _
             // Overriding the parameters to remove the expectedSpanCount parameter, which is necessary for operation but unnecessary for the filename
             await Verifier.Verify(spans, settings)
-                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={(int)statusCode}");
+                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={statusCode}");
         }
 
         public sealed class OwinFixture : IDisposable

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
@@ -69,10 +69,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
-            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode, expectedSpanCount: 1);
             foreach (var span in spans)
             {
                 var result = ValidateIntegrationSpan(span, metadataSchemaVersion: "v0");
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
 
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Ensures that we get nice file nesting in Solution Explorer

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
@@ -53,10 +53,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
-            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode, expectedSpanCount: 1);
             foreach (var span in spans)
             {
                 var result = ValidateIntegrationSpan(span, metadataSchemaVersion: "v0");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
@@ -69,10 +69,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
-            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode, expectedSpanCount: 1);
             foreach (var span in spans)
             {
                 var result = ValidateIntegrationSpan(span, metadataSchemaVersion: "v0");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
@@ -69,10 +69,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
-            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, (HttpStatusCode)statusCode, expectedSpanCount: 1);
             foreach (var span in spans)
             {
                 var result = ValidateIntegrationSpan(span, metadataSchemaVersion: "v0");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIpCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIpCollectionTests.cs
@@ -40,7 +40,7 @@ public abstract class AspNetCoreIpCollectionTests : AspNetCoreMvcTestBase
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
     [MemberData(nameof(IpData), MemberType = typeof(AspNetCoreIpCollectionTests))]
-    public async Task CollectsIpWhenEnabled(string path, HttpStatusCode statusCode)
+    public async Task CollectsIpWhenEnabled(string path, int statusCode)
     {
         await Fixture.TryStartApp(this);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             SetInstrumentationVerification();
 
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             ValidateIntegrationSpans(spans, metadataSchemaVersion: "v0", expectedServiceName: "Samples.AspNetCoreMinimalApis", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Ensures that we get nice file nesting in Solution Explorer

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             await Fixture.TryStartApp(this);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             await Fixture.TryStartApp(this);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31QueryStringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31QueryStringTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             await Fixture.TryStartApp(this);
 
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
 
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Ensures that we get nice file nesting in Solution Explorer

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             await Fixture.TryStartApp(this);
 
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             ValidateIntegrationSpans(spans, metadataSchemaVersion: "v0", expectedServiceName: "Samples.AspNetCoreMvc31", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Ensures that we get nice file nesting in Solution Explorer

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31TraceId128BitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31TraceId128BitTests.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
-        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, int statusCode)
         {
             await Fixture.TryStartApp(this);
 
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
 
-            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
 
             // Overriding the type name here as we have multiple test classes in the file
             // Ensures that we get nice file nesting in Solution Explorer

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
@@ -154,16 +154,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             var requestFactory = new HttpClientRequestFactory(new Uri("http://localhost"), Array.Empty<KeyValuePair<string, string>>(), new TestMessageHandler());
             var apiRequest = requestFactory.Create(new Uri("http://localhost/api"));
             var response = await apiRequest.PostAsync(
-                                          new[] { new MultipartFormItem("TestName", "application/binary", "TestFileName", "TestContent"u8.ToArray()) },
-                                          MultipartCompression.GZip)
-                                     .ConfigureAwait(false);
-            var stream = await response.GetStreamAsync().ConfigureAwait(false);
+                               new[] { new MultipartFormItem("TestName", "application/binary", "TestFileName", "TestContent"u8.ToArray()) },
+                               MultipartCompression.GZip);
+            var stream = await response.GetStreamAsync();
             using var unzippedStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
             var ms = new MemoryStream();
-            await unzippedStream.CopyToAsync(ms).ConfigureAwait(false);
+            await unzippedStream.CopyToAsync(ms);
             ms.Position = 0;
             using var rs = new StreamReader(ms, Encoding.UTF8);
-            var requestContent = await rs.ReadToEndAsync().ConfigureAwait(false);
+            var requestContent = await rs.ReadToEndAsync();
             requestContent.Should().Contain("Content-Type: application/binary");
             requestContent.Should().Contain("Content-Disposition: form-data; name=TestName; filename=TestFileName; filename*=utf-8''TestFileName");
             requestContent.Should().Contain("TestContent");
@@ -261,7 +260,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             }
 
             // We force flush
-            await agentlessWriter.FlushTracesAsync().ConfigureAwait(false);
+            await agentlessWriter.FlushTracesAsync();
 
             lock (lstPayloads)
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -25,7 +25,7 @@
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
 
     <PackageReference Include="Testcontainers" Version="3.6.0" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />  

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.Spans; // no spans expected
 
-            Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
             await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Process);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
 
         public static IEnumerable<object[]> GetEnabledDbmData()
-            => from command in GetDbmCommands()
+            => from command in (IEnumerable<object[]>)GetDbmCommands()
                from dbm in new[] { "service", "full" }
                from storedProcInject in new[] { false, true }
                select new[] { command[0], dbm, storedProcInject };

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Datadog.Trace.Debugger.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Datadog.Trace.Debugger.IntegrationTests.csproj
@@ -16,7 +16,7 @@
 
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
@@ -388,14 +388,14 @@ internal static class DebuggerTestHelper
         var probeTestData = method.GetCustomAttributes<MethodProbeTestDataAttribute>().ElementAt(testIndex);
         if (probeTestData == null)
         {
-            throw new Xunit.Sdk.SkipException($"{typeof(T).Name} has not found for method: {method.DeclaringType?.FullName}.{method.Name}");
+            throw new SkipException($"{typeof(T).Name} has not found for method: {method.DeclaringType?.FullName}.{method.Name}");
         }
 
         typeName = probeTestData.UseFullTypeName ? method.DeclaringType?.FullName : method.DeclaringType?.Name;
 
         if (typeName == null)
         {
-            throw new Xunit.Sdk.SkipException($"{nameof(CreateLogMethodProbe)} failed in getting type name for method: {method.Name}");
+            throw new SkipException($"{nameof(CreateLogMethodProbe)} failed in getting type name for method: {method.Name}");
         }
 
         return probeTestData;

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.IntegrationTests
                 await tracer.FlushAsync();
 
                 var spans = await agent.WaitForSpansAsync(count: 1);
-                Assert.Equal(expected: 1, spans.Count);
+                spans.Count.Should().Be(1);
 
                 var headers = agent.TraceRequestHeaders.Should().ContainSingle().Subject;
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
     {
         [SkippableTheory]
         [MemberData(nameof(AspNetCoreMvcTestData.WithoutFeatureFlag), MemberType = typeof(AspNetCoreMvcTestData))]
-        public async Task DiagnosticObserver_ForMvcEndpoints_SubmitsSpans(string path, HttpStatusCode statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
+        public async Task DiagnosticObserver_ForMvcEndpoints_SubmitsSpans(string path, int statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
         {
             await AssertDiagnosticObserverSubmitsSpans<MvcStartup>(path, statusCode, isError, resourceName, expectedTags);
         }
@@ -47,7 +47,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreMvcTestData.WithFeatureFlag), MemberType = typeof(AspNetCoreMvcTestData))]
         public async Task DiagnosticObserver_ForMvcEndpoints_WithFeatureFlag_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -75,7 +75,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreMvcTestData.WithExpandRouteTemplates), MemberType = typeof(AspNetCoreMvcTestData))]
         public async Task DiagnosticObserver_ForMvcEndpoints_WithExpandedRouteTemplates_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -103,7 +103,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 #if NETCOREAPP3_0_OR_GREATER
         [SkippableTheory]
         [MemberData(nameof(AspNetCoreRazorPagesTestData.WithoutFeatureFlag), MemberType = typeof(AspNetCoreRazorPagesTestData))]
-        public async Task DiagnosticObserver_ForRazorPages_SubmitsSpans(string path, HttpStatusCode statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
+        public async Task DiagnosticObserver_ForRazorPages_SubmitsSpans(string path, int statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
         {
             await AssertDiagnosticObserverSubmitsSpans<RazorPagesStartup>(path, statusCode, isError, resourceName, expectedTags);
         }
@@ -112,7 +112,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreRazorPagesTestData.WithFeatureFlag), MemberType = typeof(AspNetCoreRazorPagesTestData))]
         public async Task DiagnosticObserver_ForRazorPages_WithFeatureFlag_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -140,7 +140,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreRazorPagesTestData.WithExpandRouteTemplates), MemberType = typeof(AspNetCoreRazorPagesTestData))]
         public async Task DiagnosticObserver_ForRazorPages_WithExpandedRouteTemplates_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -167,7 +167,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
         [SkippableTheory]
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithoutFeatureFlag), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
-        public async Task DiagnosticObserver_ForEndpointRouting_SubmitsSpans(string path, HttpStatusCode statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
+        public async Task DiagnosticObserver_ForEndpointRouting_SubmitsSpans(string path, int statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
         {
             await AssertDiagnosticObserverSubmitsSpans<EndpointRoutingStartup>(path, statusCode, isError, resourceName, expectedTags);
         }
@@ -176,7 +176,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithFeatureFlag), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
         public async Task DiagnosticObserver_ForEndpointRouting_WithFeatureFlag_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -204,7 +204,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithExpandRouteTemplates), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
         public async Task DiagnosticObserver_ForEndpointRouting_WithExpandedRouteTemplates_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -233,14 +233,14 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 #if NET6_0_OR_GREATER
         [SkippableTheory]
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithoutFeatureFlag), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
-        public async Task DiagnosticObserver_ForWebApplicationBuilder_SubmitsSpans(string path, HttpStatusCode statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
+        public async Task DiagnosticObserver_ForWebApplicationBuilder_SubmitsSpans(string path, int statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
         {
             await AssertDiagnosticObserverForWebApplicationBuilder(useImplicitRouting: false, path, statusCode, isError, resourceName, expectedTags, featureFlagEnabled: false);
         }
 
         [SkippableTheory]
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithoutFeatureFlag), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
-        public async Task DiagnosticObserver_ForWebApplicationBuilder_WithImplicitRouting_SubmitsSpans(string path, HttpStatusCode statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
+        public async Task DiagnosticObserver_ForWebApplicationBuilder_WithImplicitRouting_SubmitsSpans(string path, int statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
         {
             await AssertDiagnosticObserverForWebApplicationBuilder(useImplicitRouting: true, path, statusCode, isError, resourceName, expectedTags, featureFlagEnabled: false);
         }
@@ -249,7 +249,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithFeatureFlag), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
         public async Task DiagnosticObserver_ForWebApplicationBuilder_WithFeatureFlag_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -266,7 +266,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithFeatureFlag), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
         public async Task DiagnosticObserver_ForWebApplicationBuilder_WithFeatureFlag_WithImplicitRouting_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -283,7 +283,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithExpandRouteTemplates), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
         public async Task DiagnosticObserver_ForWebApplicationBuilder_WithExpandedRouteTemplates_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -300,7 +300,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreEndpointRoutingTestData.WithExpandRouteTemplates), MemberType = typeof(AspNetCoreEndpointRoutingTestData))]
         public async Task DiagnosticObserver_ForWebApplicationBuilder_WithExpandedRouteTemplates_WithImplicitRouting_SubmitsSpans(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -316,7 +316,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         private static async Task AssertDiagnosticObserverForWebApplicationBuilder(
             bool useImplicitRouting,
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedTags,
@@ -373,7 +373,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
         private static async Task AssertDiagnosticObserverSubmitsSpans<T>(
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedParentSpanTags,
@@ -411,7 +411,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         private static async Task AssertDiagnosticObserverSubmitsSpans(
             HttpClient client,
             string path,
-            HttpStatusCode statusCode,
+            int statusCode,
             bool isError,
             string resourceName,
             SerializableDictionary expectedParentSpanTags,
@@ -442,7 +442,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
                 try
                 {
                     var response = await client.GetAsync(path);
-                    Assert.Equal(statusCode, response.StatusCode);
+                    response.StatusCode.Should().Be((HttpStatusCode)statusCode);
                 }
                 catch (Exception ex)
                 {
@@ -476,7 +476,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             parentSpan.Type.Should().Be(SpanTypes.Web);
             parentSpan.ResourceName.Should().Be(resourceName);
             AssertTagHasValue(parentSpan, Tags.SpanKind, SpanKinds.Server);
-            AssertTagHasValue(parentSpan, Tags.HttpStatusCode, ((int)statusCode).ToString());
+            AssertTagHasValue(parentSpan, Tags.HttpStatusCode, statusCode.ToString());
             parentSpan.Error.Should().Be(isError);
 
             if (expectedParentSpanTags is not null)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
@@ -73,6 +73,6 @@ public class WeakCipherTests : TestHelper
         using var process = await RunSampleAndWaitForExit(agent);
         var spans = agent.Spans; // we expect no spans
 
-        Assert.Empty(spans.Where(s => s.Name.Equals(ExpectedOperationName)));
+        spans.Where(s => s.Name.Equals(ExpectedOperationName)).Should().BeEmpty();
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmAttackerBlocking.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmAttackerBlocking.cs
@@ -75,8 +75,8 @@ public class AspNetCore5AsmAttackerBlocking : RcmBase
         IncludeAllHttpSpans = true;
         await TryStartApp();
         var agent = Fixture.Agent;
-        var result = SubmitRequest(url, null, null, headers: headersAttackerScanner);
-        result.Result.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var result = await SubmitRequest(url, null, null, headers: headersAttackerScanner);
+        result.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
         var configurationInitial = new[]
         {
@@ -98,7 +98,7 @@ public class AspNetCore5AsmAttackerBlocking : RcmBase
         };
 
         await agent.SetupRcmAndWait(Output, configurationInitial);
-        result = SubmitRequest(url, null, null, headers: headersAttackerScanner);
+        result = await SubmitRequest(url, null, null, headers: headersAttackerScanner);
 
         var exclusions = "[{\"id\": \"exc-000-001\",\"on_match\": \"block_custom\",\"conditions\": [{\"operator\": \"ip_match\",\"parameters\": {\"data\": \"suspicious_ips_data_id\", \"inputs\": [{\"address\": \"http.client_ip\"}]}}]}]";
         var configuration = new[]
@@ -125,14 +125,14 @@ public class AspNetCore5AsmAttackerBlocking : RcmBase
         };
 
         await agent.SetupRcmAndWait(Output, configuration);
-        result = SubmitRequest(url + "?a=3", null, null, headers: headersAttackerScanner);
-        result.Result.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
-        result = SubmitRequest(url + "?a=4", null, null, headers: headersRegularScanner);
-        result.Result.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-        result = SubmitRequest(url + "?a=5", null, null, headers: headersAttackerArachni);
-        result.Result.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
-        result = SubmitRequest(url + "?a=6", null, null, headers: headersRegularArachni);
-        result.Result.StatusCode.Should().Be(HttpStatusCode.OK);
+        result = await SubmitRequest(url + "?a=3", null, null, headers: headersAttackerScanner);
+        result.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        result = await SubmitRequest(url + "?a=4", null, null, headers: headersRegularScanner);
+        result.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        result = await SubmitRequest(url + "?a=5", null, null, headers: headersAttackerArachni);
+        result.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        result = await SubmitRequest(url + "?a=6", null, null, headers: headersRegularArachni);
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -76,6 +76,9 @@ namespace Datadog.Trace.TestHelpers
                     // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
                 }
 
+                // The ProcessHelper doesn't dispose the process automatically, so we need to do it manually
+                IisExpress.Process.Process.Dispose();
+
                 try
                 {
                     File.Delete(IisExpress.ConfigFile);

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.TestHelpers
     [CollectionDefinition("IisTests", DisableParallelization = false)]
     public sealed class IisFixture : GacFixture, IDisposable
     {
-        public (Process Process, string ConfigFile) IisExpress { get; private set; }
+        public (ProcessHelper Process, string ConfigFile) IisExpress { get; private set; }
 
         public MockTracerAgent Agent { get; private set; }
 
@@ -65,22 +65,16 @@ namespace Datadog.Trace.TestHelpers
             {
                 try
                 {
-                    if (!IisExpress.Process.HasExited)
-                    {
-                        // sending "Q" to standard input does not work because
-                        // iisexpress is scanning console key press, so just kill it.
-                        // maybe try this in the future:
-                        // https://github.com/roryprimrose/Headless/blob/master/Headless.IntegrationTests/IisExpress.cs
-                        IisExpress.Process.Kill();
-                        IisExpress.Process.WaitForExit(8000);
-                    }
+                    // sending "Q" to standard input does not work because
+                    // iisexpress is scanning console key press, so just kill it.
+                    // maybe try this in the future:
+                    // https://github.com/roryprimrose/Headless/blob/master/Headless.IntegrationTests/IisExpress.cs
+                    IisExpress.Process.Dispose(8000);
                 }
                 catch
                 {
                     // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
                 }
-
-                IisExpress.Process.Dispose();
 
                 try
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -405,7 +405,7 @@ namespace Datadog.Trace.TestHelpers
 
             foreach (var e in missing)
             {
-                Assert.True(false, $"no span found for `{e}`, remaining spans: `{string.Join(", ", spanLookup.Select(kvp => $"{kvp.Key}").ToArray())}`");
+                Assert.Fail($"no span found for `{e}`, remaining spans: `{string.Join(", ", spanLookup.Select(kvp => $"{kvp.Key}").ToArray())}`");
             }
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.TestHelpers
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
-        public async Task<(Process Process, string ConfigFile)> StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath)
+        public async Task<(ProcessHelper Process, string ConfigFile)> StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath)
         {
             var iisExpress = EnvironmentHelper.GetIisExpressPath();
 
@@ -285,30 +285,18 @@ namespace Datadog.Trace.TestHelpers
 
             var semaphore = new SemaphoreSlim(0, 1);
 
-            _ = Task.Factory.StartNew(
-                () =>
+            var processHelper = new ProcessHelper(
+                process,
+                line =>
                 {
-                    while (process.StandardOutput.ReadLine() is { } line)
-                    {
-                        Output.WriteLine($"[webserver][stdout] {line}");
+                    Output.WriteLine($"[webserver][stdout] {line}");
 
-                        if (line.Contains("IIS Express is running"))
-                        {
-                            semaphore.Release();
-                        }
+                    if (line.Contains("IIS Express is running"))
+                    {
+                        semaphore.Release();
                     }
                 },
-                TaskCreationOptions.LongRunning);
-
-            _ = Task.Factory.StartNew(
-                () =>
-                {
-                    while (process.StandardError.ReadLine() is { } line)
-                    {
-                        Output.WriteLine($"[webserver][stderr] {line}");
-                    }
-                },
-                TaskCreationOptions.LongRunning);
+                line => Output.WriteLine($"[webserver][stderr] {line}"));
 
             await semaphore.WaitAsync(TimeSpan.FromSeconds(10));
 
@@ -335,7 +323,7 @@ namespace Datadog.Trace.TestHelpers
                 await Task.Delay(1500);
             }
 
-            return (process, newConfig);
+            return (processHelper, newConfig);
         }
 
         public void EnableIast(bool enable = true)

--- a/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+++ b/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="HttpMultipartParser" Version="5.1.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />

--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
@@ -130,8 +130,6 @@ namespace Datadog.Trace.TestHelpers
                     // Ignore exceptions when killing the process, as it may have already exited
                 }
             }
-
-            Process.Dispose();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
@@ -111,19 +111,27 @@ namespace Datadog.Trace.TestHelpers
                 && _errorTask.Task.Wait(timeout);
         }
 
-        public virtual void Dispose()
+        public virtual void Dispose() => Dispose(0);
+
+        public virtual void Dispose(int waitForExitTimeout)
         {
             if (!Process.HasExited)
             {
                 try
                 {
                     Process.Kill();
+                    if (waitForExitTimeout > 0)
+                    {
+                        Process.WaitForExit(waitForExitTimeout);
+                    }
                 }
                 catch
                 {
                     // Ignore exceptions when killing the process, as it may have already exited
                 }
             }
+
+            Process.Dispose();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
@@ -24,8 +24,8 @@ namespace Datadog.Trace.TestHelpers
             DisallowEmpty
         }
 
-        public static TheoryData<string, bool?> BooleanTestCases(bool? defaultValue)
-            => new TheoryData<string, bool?>
+        public static TheoryData<string, bool> BooleanTestCases(bool defaultValue)
+            => new()
             {
                 { "true", true },
                 { "1", true },
@@ -36,8 +36,8 @@ namespace Datadog.Trace.TestHelpers
                 { string.Empty, defaultValue },
             };
 
-        public static TheoryData<string, int?> Int32TestCases(int defaultValue)
-            => new TheoryData<string, int?>
+        public static TheoryData<string, int> Int32TestCases(int defaultValue)
+            => new()
             {
                 { "1", 1 },
                 { "0", 0 },
@@ -47,8 +47,8 @@ namespace Datadog.Trace.TestHelpers
                 { string.Empty, defaultValue }
             };
 
-        public static TheoryData<string, double?> DoubleTestCases(double? defaultValue)
-            => new TheoryData<string, double?>
+        public static TheoryData<string, double?> DoubleTestCases(double defaultValue)
+            => new()
             {
                 { "1.5", 1.5d },
                 { "1", 1.0d },

--- a/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
@@ -36,6 +36,18 @@ namespace Datadog.Trace.TestHelpers
                 { string.Empty, defaultValue },
             };
 
+        public static TheoryData<string, bool?> NullableBooleanTestCases(bool? defaultValue)
+            => new()
+            {
+                { "true", true },
+                { "1", true },
+                { "false", false },
+                { "0", false },
+                { "A", defaultValue },
+                { null, defaultValue },
+                { string.Empty, defaultValue },
+            };
+
         public static TheoryData<string, int> Int32TestCases(int defaultValue)
             => new()
             {

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
@@ -111,7 +111,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // After setting the continuation, we resolve the task completion source.
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore xUnit1031
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context
@@ -217,7 +219,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // After setting the continuation, we resolve the task completion source.
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore xUnit1031
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/TaskContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/TaskContinuationGeneratorTests.cs
@@ -110,7 +110,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // After setting the continuation, we resolve the task completion source.
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore xUnit1031
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context
@@ -216,7 +218,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // After setting the continuation, we resolve the task completion source.
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore xUnit1031
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
@@ -113,7 +113,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // After setting the continuation, we resolve the task completion source.
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore xUnit1031
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context
@@ -221,7 +223,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // After setting the continuation, we resolve the task completion source.
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore xUnit1031
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Tests.CallTarget
         }
 
         [Fact]
-        public async ValueTask SuccessTest()
+        public async Task SuccessTest()
         {
             var tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask>();
             var state = CallTargetState.GetDefault();

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskContinuationGeneratorTests.cs
@@ -111,7 +111,9 @@ namespace Datadog.Trace.Tests.CallTarget
             var cTask = tcg.SetContinuation(this, GetPreviousTask(tcs.Task), null, in state).AsTask();
 
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore xUnit1031
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context
@@ -219,7 +221,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // After setting the continuation, we resolve the task completion source.
             tcs.TrySetResult(true);
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             Task.WaitAny(cTask, synchronizationContext.Task);
+#pragma warning restore
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
             // If not, the cTask should complete without using the synchronization context

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskContinuationGeneratorTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tests.CallTarget
         }
 
         [Fact]
-        public async ValueTask SuccessTest()
+        public async Task SuccessTest()
         {
             var tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask>();
             var state = CallTargetState.GetDefault();

--- a/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
@@ -71,7 +71,7 @@ public class IpcTests
 
         var delayTask = Task.Delay(30_000);
         var ipcTasks = Task.WhenAll(serverTaskCompletion.Task, clientTaskCompletion.Task);
-        if (await Task.WhenAny(ipcTasks, delayTask).ConfigureAwait(false) == delayTask)
+        if (await Task.WhenAny(ipcTasks, delayTask) == delayTask)
         {
             throw new TimeoutException($"Timeout waiting for messages. Values went up to [{finalValue?.ServerValue}, {finalValue?.ClientValue}]");
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TestOptimizationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TestOptimizationSettingsTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests.Configuration
         private static readonly string ExpectedExcludedSession = "/session/FakeSessionIdForPollingPurposes".ToUpperInvariant();
 
         [Theory]
-        [MemberData(nameof(BooleanTestCases), null)]
+        [MemberData(nameof(NullableBooleanTestCases), null)]
         public void Enabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Enabled, value));
@@ -120,7 +120,7 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(BooleanTestCases), parameters: new object[] { null })]
+        [MemberData(nameof(NullableBooleanTestCases), null)]
         public void TestsSkippingEnabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.TestsSkippingEnabled, value));
@@ -130,7 +130,7 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(BooleanTestCases), parameters: new object[] { null })]
+        [MemberData(nameof(NullableBooleanTestCases), null)]
         public void CodeCoverageEnabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverage, value));
@@ -170,7 +170,7 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(BooleanTestCases), parameters: new object[] { null })]
+        [MemberData(nameof(NullableBooleanTestCases), null)]
         public void GitUploadEnabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.GitUploadEnabled, value));

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsContextPropagatorTests.cs
@@ -143,7 +143,7 @@ namespace Datadog.Trace.Tests.DataStreamsMonitoring
                 var binaryAsBase64 = Encoding.UTF8.GetString(binaryHeaderValueBytes);
                 Convert.FromBase64String(binaryAsBase64);
                 // If no exception then the binary header was incorrectly Base64-encoded
-                Assert.False(true, "Binary header should not be Base64-encoded.");
+                Assert.Fail("Binary header should not be Base64-encoded.");
             }
             catch (FormatException)
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/CacheTests/ConcurrentAdaptiveCacheTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/CacheTests/ConcurrentAdaptiveCacheTests.cs
@@ -207,7 +207,7 @@ namespace Datadog.Trace.Tests.Debugger.CacheTests
         }
 
         [Fact]
-        public void Cache_Should_Be_Thread_Safe()
+        public async Task Cache_Should_Be_Thread_Safe()
         {
             using var cache = new ConcurrentAdaptiveCache<int, string>(capacity: 1000);
 
@@ -231,7 +231,7 @@ namespace Datadog.Trace.Tests.Debugger.CacheTests
                     }
                 });
 
-            Task.WaitAll(addTask, readTask);
+            await Task.WhenAll(addTask, readTask);
             Assert.Equal(1000, cache.Count);
         }
 
@@ -418,7 +418,7 @@ namespace Datadog.Trace.Tests.Debugger.CacheTests
         }
 
         [Fact]
-        public void Adaptive_Cleanup_Should_Adjust_Interval_Based_On_Expired_Items()
+        public async Task Adaptive_Cleanup_Should_Adjust_Interval_Based_On_Expired_Items()
         {
             var mockTimeProvider = new Mock<ITimeProvider>();
             var currentTime = DateTime.UtcNow;
@@ -443,7 +443,7 @@ namespace Datadog.Trace.Tests.Debugger.CacheTests
             // Advance time beyond expiration
             currentTime = currentTime.Add(expiration.Add(TimeSpan.FromMilliseconds(1500)));
 
-            timeUpdated.Task.Wait(TimeSpan.FromMilliseconds(250));
+            await timeUpdated.Task.WaitAsync(TimeSpan.FromMilliseconds(250));
 
             cache.PerformCleanup();
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/MethodMatcherTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/MethodMatcherTests.cs
@@ -354,7 +354,9 @@ public class MethodMatcherTests
         // Arrange
         try
         {
+#pragma warning disable xUnit1031 // Test methods should not use Blocking operations
             AsyncMethodWithGenerics<int, string>(42, "test").GetAwaiter().GetResult();
+#pragma warning restore xUnit1031
         }
         catch (Exception ex)
         {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
@@ -78,7 +78,7 @@ public class SymbolUploaderTest
             Assert.NotNull(root1);
             var assembly = root1.Scopes?[0];
             Assert.NotNull(assembly);
-            var classesScope = assembly.Value.Scopes;
+            var classesScope = assembly!.Value.Scopes;
             Assert.NotNull(root1.Scopes);
             Assert.NotNull(root.Scopes);
             Assert.NotNull(classesScope);

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
     public class AspNetCoreDiagnosticObserverTests
     {
         [Fact]
-        public async Task<string> CompleteDiagnosticObserverTest()
+        public async Task CompleteDiagnosticObserverTest()
         {
             TracerRestorerAttribute.SetTracer(GetTracer());
 
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
                 DiagnosticManager.Instance = null;
             }
 
-            return retValue;
+            _ = retValue;
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Util/Delegates/FuncInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Delegates/FuncInstrumentationTests.cs
@@ -603,7 +603,7 @@ public class FuncInstrumentationTests
             return 42;
         };
         func = func.Instrument(callbacks);
-        var result = await func("Arg01").ConfigureAwait(false);
+        var result = await func("Arg01");
         result.Should().Be(43);
         callbacks.Count.Value.Should().Be(4);
 
@@ -634,7 +634,7 @@ public class FuncInstrumentationTests
                                                      await Task.Delay(100).ConfigureAwait(false);
                                                      return ((int)returnValue) + 1;
                                                  }));
-        result = await func2("Arg01").ConfigureAwait(false);
+        result = await func2("Arg01");
         using var scope = new AssertionScope();
         result.Should().Be(43);
         value.Should().Be(4);
@@ -668,7 +668,7 @@ public class FuncInstrumentationTests
                                                      Interlocked.Increment(ref value);
                                                      throw new InvalidOperationException("Expected");
                                                  }));
-        var result = await func("Arg01").ConfigureAwait(false);
+        var result = await func("Arg01");
         using var scope = new AssertionScope();
         value.Should().Be(4);
         result.Should().Be(42);
@@ -693,7 +693,7 @@ public class FuncInstrumentationTests
             async () =>
             {
                 result = new StrongBox<int>(await func("Arg01").ConfigureAwait(false));
-            }).ConfigureAwait(false);
+            });
 
         callbacks.Count.Value.Should().Be(4);
 
@@ -730,7 +730,7 @@ public class FuncInstrumentationTests
             async () =>
             {
                 result = new StrongBox<int>(await func2("Arg01").ConfigureAwait(false));
-            }).ConfigureAwait(false);
+            });
 
         value.Should().Be(4);
     }
@@ -753,7 +753,7 @@ public class FuncInstrumentationTests
             async () =>
             {
                 result = new StrongBox<int>(await func("Arg01").ConfigureAwait(false));
-            }).ConfigureAwait(false);
+            });
 
         callbacks.Count.Value.Should().Be(4);
 
@@ -789,7 +789,7 @@ public class FuncInstrumentationTests
             async () =>
             {
                 result = new StrongBox<int>(await func2("Arg01").ConfigureAwait(false));
-            }).ConfigureAwait(false);
+            });
 
         value.Should().Be(4);
     }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -8,9 +8,10 @@ using Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.AspectAnalyzers.BeforeAfterAspectAnalyzer,
-    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.BeforeAfterAspectCodeFixProvider>;
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.BeforeAfterAspectCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.AspectAnalyzers;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/ReplaceAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/ReplaceAspectAnalyzerTests.cs
@@ -8,9 +8,10 @@ using Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.AspectAnalyzers.ReplaceAspectAnalyzer,
-    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.ReplaceAspectCodeFixProvider>;
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.ReplaceAspectCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.AspectAnalyzers;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
@@ -7,12 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/DoNotCapturePrimaryConstructorParametersAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/DoNotCapturePrimaryConstructorParametersAnalyzerTests.cs
@@ -8,8 +8,9 @@ using Datadog.Trace.Tools.Analyzers.PrimaryConstructorAnalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Datadog.Trace.Tools.Analyzers.PrimaryConstructorAnalyzer.DoNotCapturePrimaryConstructorParametersAnalyzer>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Datadog.Trace.Tools.Analyzers.PrimaryConstructorAnalyzer.DoNotCapturePrimaryConstructorParametersAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/ConstantMessageTemplateDiagnosticTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/ConstantMessageTemplateDiagnosticTests.cs
@@ -9,13 +9,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
     Datadog.Trace.Tools.Analyzers.LogAnalyzer.ConstantMessageTemplateCodeFixProvider,
-    Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.ConstantMessageTemplateCodeFixProvider>;
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/CorrectContextDiagnosticTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/CorrectContextDiagnosticTests.cs
@@ -7,9 +7,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.CorrectContextCodeFixProvider>;
+    Datadog.Trace.Tools.Analyzers.LogAnalyzer.CorrectContextCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/CorrectLoggingAbstractionDiagnostic.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/CorrectLoggingAbstractionDiagnostic.cs
@@ -7,8 +7,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/DestructureAnonymousObjectsDiagnosticTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/DestructureAnonymousObjectsDiagnosticTests.cs
@@ -7,9 +7,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.DestructuringHintCodeFixProvider>;
+    Datadog.Trace.Tools.Analyzers.LogAnalyzer.DestructuringHintCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/Helpers.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/Helpers.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Xunit;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
@@ -127,7 +126,7 @@ public static class Helpers
         where TAnalyzer : DiagnosticAnalyzer, new()
         where TCodeFix : CodeFixProvider, new()
     {
-        var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+        var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
         {
             TestCode = src,
             FixedCode = fix,

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/InvalidTemplateDiagnosticTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/InvalidTemplateDiagnosticTests.cs
@@ -9,8 +9,9 @@ using Datadog.Trace.Tools.Analyzers.LogAnalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/PascalPropertyNameDiagnosticTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/PascalPropertyNameDiagnosticTests.cs
@@ -8,9 +8,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.PascalCaseCodeFixProvider>;
+    Datadog.Trace.Tools.Analyzers.LogAnalyzer.PascalCaseCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/PropertyDiagnosticTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/PropertyDiagnosticTests.cs
@@ -9,9 +9,10 @@ using Datadog.Trace.Tools.Analyzers.LogAnalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.LogAnalyzer.LogAnalyzer,
-    Datadog.Trace.Tools.Analyzers.LogAnalyzer.ExceptionPositionCodeFixProvider>;
+    Datadog.Trace.Tools.Analyzers.LogAnalyzer.ExceptionPositionCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests.LogAnalyzer;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/PublicApiAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/PublicApiAnalyzerTests.cs
@@ -10,10 +10,10 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    Datadog.Trace.Tools.Analyzers.PublicApiAnalyzer.PublicApiAnalyzer>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Datadog.Trace.Tools.Analyzers.PublicApiAnalyzer.PublicApiAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests
 {
@@ -130,7 +130,7 @@ namespace Datadog.Trace.Tools.Analyzers.Tests
             };
 
             // Expect it to throw because there's no warning when there should be.
-            await ideallyShouldThrow.Should().ThrowAsync<EqualWithMessageException>();
+            await ideallyShouldThrow.Should().ThrowAsync<InvalidOperationException>();
         }
 
         private static string GetSampleCode(string publicAttribute, bool includeNamespace, string testFragment, bool attributeIsConditional)

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThreadAbortAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThreadAbortAnalyzerTests.cs
@@ -7,9 +7,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
     Datadog.Trace.Tools.Analyzers.ThreadAbortAnalyzer.ThreadAbortAnalyzer,
-    Datadog.Trace.Tools.Analyzers.ThreadAbortAnalyzer.ThreadAbortCodeFixProvider>;
+    Datadog.Trace.Tools.Analyzers.ThreadAbortAnalyzer.ThreadAbortCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Datadog.Trace.Tools.Analyzers.Tests
 {

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
@@ -53,7 +53,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                 siteName,
                 iisFixture.IisExpress.ConfigFile,
-                iisFixture.IisExpress.Process.Id,
+                iisFixture.IisExpress.Process.Process.Id,
                 MockRegistryService());
 
             result.Should().Be(0);
@@ -93,7 +93,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                              siteName,
                              iisFixture.IisExpress.ConfigFile,
-                             iisFixture.IisExpress.Process.Id,
+                             iisFixture.IisExpress.Process.Process.Id,
                              MockRegistryService());
 
             result.Should().Be(0);
@@ -126,7 +126,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                 "sample",
                 iisFixture.IisExpress.ConfigFile,
-                iisFixture.IisExpress.Process.Id,
+                iisFixture.IisExpress.Process.Process.Id,
                 MockRegistryService());
 
             result.Should().Be(0);
@@ -162,7 +162,7 @@ public class IisCheckTests : TestHelper
             var result = await CheckIisCommand.ExecuteAsync(
                              "sample",
                              iisFixture.IisExpress.ConfigFile,
-                             iisFixture.IisExpress.Process.Id,
+                             iisFixture.IisExpress.Process.Process.Id,
                              MockRegistryService());
 
             result.Should().Be(1);
@@ -188,7 +188,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
             "sample",
             iisFixture.IisExpress.ConfigFile,
-            iisFixture.IisExpress.Process.Id,
+            iisFixture.IisExpress.Process.Process.Id,
             MockRegistryService());
 
         result.Should().Be(1);
@@ -209,7 +209,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
             "dummySite",
             iisFixture.IisExpress.ConfigFile,
-            iisFixture.IisExpress.Process.Id,
+            iisFixture.IisExpress.Process.Process.Id,
             MockRegistryService());
 
         result.Should().Be(1);
@@ -230,7 +230,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
             "sample/dummy",
             iisFixture.IisExpress.ConfigFile,
-            iisFixture.IisExpress.Process.Id,
+            iisFixture.IisExpress.Process.Process.Id,
             MockRegistryService());
 
         result.Should().Be(1);
@@ -251,7 +251,7 @@ public class IisCheckTests : TestHelper
         var result = await CheckIisCommand.ExecuteAsync(
                          "sample",
                          iisFixture.IisExpress.ConfigFile,
-                         iisFixture.IisExpress.Process.Id,
+                         iisFixture.IisExpress.Process.Process.Id,
                          MockRegistryService());
 
         result.Should().Be(1);

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -348,7 +348,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     [InlineData("1", true)]
     [InlineData("0", true)]
     [InlineData(null, true)]
-    public async Task DetectContinuousProfilerState(string enabled, bool? ssiInjectionEnabled)
+    public async Task DetectContinuousProfilerState(string? enabled, bool? ssiInjectionEnabled)
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
         var ssiInjection = ssiInjectionEnabled is null

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
   </ItemGroup>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
   </ItemGroup>

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=__statusCode=200_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=__statusCode=200_spanCount=3.verified.txt
@@ -20,33 +20,6 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      http.method: GET,
-      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 200,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /home/index,
@@ -75,6 +48,36 @@
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      http.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 200,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_bad-request_statusCode=500_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_bad-request_statusCode=500_spanCount=3.verified.txt
@@ -20,38 +20,6 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Error: 1,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      error.msg: This was a bad request.,
-      error.stack:
-System.Exception: This was a bad request.
-at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
-      error.type: System.Exception,
-      http.method: GET,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 500,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /bad-request,
@@ -85,6 +53,41 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack:
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 500,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_handled-exception_statusCode=500_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_handled-exception_statusCode=500_spanCount=3.verified.txt
@@ -26,35 +26,6 @@ System.Exception: Exception of type 'System.Exception' was thrown.
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Error: 1,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
-      http.method: GET,
-      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 500,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /handled-exception,
@@ -85,6 +56,38 @@ System.Exception: Exception of type 'System.Exception' was thrown.
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 500,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_not-found_statusCode=404_spanCount=2.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_not-found_statusCode=404_spanCount=2.verified.txt
@@ -2,6 +2,34 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      http.useragent: testhelper,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
     Name: aws.apigateway,
     Resource: GET /api/test/?,
     Service: test.api.com,
@@ -26,34 +54,6 @@
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_3,
-    Name: aspnet_core.request,
-    Resource: GET /not-found,
-    Service: Samples.AspNetCoreMvc31,
-    Type: web,
-    ParentId: Id_2,
-    Tags: {
-      component: aspnet_core,
-      datadog-header-tag: asp-net-core,
-      env: integration_tests,
-      http.method: GET,
-      http.request.headers.host: localhost:00000,
-      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.status_code: 404,
-      http.url: http://localhost:00000/not-found,
-      http.useragent: testhelper,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
-      version: 1.0.0
-    },
-    Metrics: {
-      _dd.top_level: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_status-code_203_statusCode=203_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_status-code_203_statusCode=203_spanCount=3.verified.txt
@@ -20,33 +20,6 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      http.method: GET,
-      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 203,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
@@ -75,6 +48,36 @@
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      http.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 203,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]


### PR DESCRIPTION
## Summary of changes

Swaps the ordering when disposing the API Gateway inferred span to be after the "root" span.
Realistically the API Gateway span will be the parent of the root span for the ASP NET Core instrumentation.

## Reason for change

Strangely only came up with xUnit 2.9.3 upgrade and goes away when downgrading 😕 

But I think this is technically more correct.

## Implementation details

Reversed the ordering.

## Test coverage

Updated snapshots.

## Other details
<!-- Fixes #{issue} -->

I still don't fully understand _why_ the xUnit upgrade detected / caused this?

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
