### PR TITLE
Fix SSI injection telemetry

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
@@ -10,16 +10,16 @@ class SingleStepGuardRails
 private:
     bool m_isRunningInSingleStep;
     bool m_isForcedExecution = false;
-    std::string m_injectResult;
-    std::string m_injectResultReason;
-    std::string m_injectResultClass;
+    std::string m_forcedRuntimeDescription;
 
     bool ShouldForceInstrumentationOverride(const std::string& eolDescription, bool isEol);
     HRESULT HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion, const bool isEol);
     HRESULT HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion, const bool isEol);
 
-    void SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const bool isEol) const;
-    void SendTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& telemetryPoints) const;
+    void SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const bool isEol, const std::string& unsupportedDescription) const;
+    void SendTelemetry(const std::string& runtimeName, const std::string& runtimeVersion,
+                       const std::string& telemetryPoints, const std::string& injectResult,
+                       const std::string& injectResultReason, const std::string& injectResultClass) const;
 public:
     inline static const std::string NetFrameworkRuntime = ".NET Framework";
     inline static const std::string NetCoreRuntime = ".NET Core";
@@ -28,9 +28,7 @@ public:
     ~SingleStepGuardRails();
     HRESULT CheckRuntime(const RuntimeInformation& runtimeInformation, IUnknown* pICorProfilerInfoUnk);
     void RecordBootstrapError(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& errorType) const;
-    void RecordBootstrapError(const RuntimeInformation& runtimeInformation, const std::string& errorType);
+    void RecordBootstrapError(const RuntimeInformation& runtimeInformation, const std::string& errorType) const;
     void RecordBootstrapSuccess(const RuntimeInformation& runtimeInformation) const;
-    void SetInjectResult(const std::string& result, const std::string& resultReason, const std::string& resultClass);
-
 };
 } // namespace datadog::shared::nativeloader

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -425,7 +425,7 @@ namespace Foo
                                "name": "library_entrypoint.abort.runtime"
                              }]
                              """;
-            AssertHasExpectedTelemetry(logFileName, processResult, pointsJson,  "abort", ".NET Framework 4.6.0 or lower", "incompatible_library");
+            AssertHasExpectedTelemetry(logFileName, processResult, pointsJson,  "abort", ".NET Core 3.0 or lower", "incompatible_runtime");
         }
 
         [SkippableFact]
@@ -456,7 +456,7 @@ namespace Foo
                                "tags": ["injection_forced:true"]
                              }]
                              """;
-            AssertHasExpectedTelemetry(logFileName, processResult, pointsJson, "success", "Force instrumentation enabled, incompatible runtime", "success_forced");
+            AssertHasExpectedTelemetry(logFileName, processResult, pointsJson, "success", "Force instrumentation enabled, incompatible runtime, .NET Core 3.0 or lower", "success_forced");
         }
 
 #endif


### PR DESCRIPTION
## Summary of changes

Update the SSI telemetry implementation and tests

## Reason for change

The .NET Core 3.0 tests are broken on `master`. Also, there were some inconsistencies in the implementation.

## Implementation details

- Move towards a more functional style to reduce clobbering
- Fix incorrect values
- Include more information when force-injecting

## Test coverage

Covered by existing tests. I've also started an "[all frameworks run](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=184613&view=results)"

## Other details