### PR TITLE
Increase rejit timeout from 100ms to 150ms

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -695,7 +695,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
                                                                                 promise);
 
             // wait and get the value from the future<ULONG>
-            const auto status = future.wait_for(100ms);
+            const auto status = future.wait_for(120ms);
 
             if (status != std::future_status::timeout)
             {
@@ -1314,7 +1314,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                                                                                 promise);
 
             // wait and get the value from the future<ULONG>
-            const auto status = future.wait_for(100ms);
+            const auto status = future.wait_for(120ms);
 
             if (status != std::future_status::timeout)
             {

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -695,7 +695,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
                                                                                 promise);
 
             // wait and get the value from the future<ULONG>
-            const auto status = future.wait_for(120ms);
+            const auto status = future.wait_for(150ms);
 
             if (status != std::future_status::timeout)
             {
@@ -1314,7 +1314,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                                                                                 promise);
 
             // wait and get the value from the future<ULONG>
-            const auto status = future.wait_for(120ms);
+            const auto status = future.wait_for(150ms);
 
             if (status != std::future_status::timeout)
             {


### PR DESCRIPTION
## Summary of changes

Increases the rejit timeout from 100ms to ~~120ms~~ 150ms

## Reason for change

We have seen some timeouts of this in smoke tests, particularly on .NET Core 2.1. We have traced this down to an environmental issue at the core (we updated the smoke-test VMs) but nevertheless this is something which could also happen in customer environments, and which could give undefined behaviour.

## Implementation details

Bump the timeout to try to remediate.

## Test coverage

This is the test, I'll run the installer tests several times to confirm it resolves the issue.

## Other details

We need to find a way to be more efficient here, as increasing the timeout is a crude control.