### PR TITLE
Remove global state to try to fix flake

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
@@ -50,7 +50,8 @@ public class PutEventsAsyncIntegration
             return CallTargetState.GetDefault();
         }
 
-        var scope = AwsEventBridgeCommon.CreateScope(Tracer.Instance, Operation, SpanKind, out var tags);
+        var tracer = Tracer.Instance;
+        var scope = AwsEventBridgeCommon.CreateScope(tracer, Operation, SpanKind, out var tags);
         if (tags is not null)
         {
             var busName = AwsEventBridgeCommon.GetBusName(request.Entries.Value);
@@ -63,7 +64,7 @@ public class PutEventsAsyncIntegration
         }
 
         var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
-        ContextPropagation.InjectContext(request, context);
+        ContextPropagation.InjectContext(tracer, request, context);
 
         return new CallTargetState(scope);
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
@@ -47,7 +47,8 @@ public class PutEventsIntegration
             return CallTargetState.GetDefault();
         }
 
-        var scope = AwsEventBridgeCommon.CreateScope(Tracer.Instance, Operation, SpanKind, out var tags);
+        var tracer = Tracer.Instance;
+        var scope = AwsEventBridgeCommon.CreateScope(tracer, Operation, SpanKind, out var tags);
         if (tags is not null)
         {
             var busName = AwsEventBridgeCommon.GetBusName(request.Entries.Value);
@@ -60,7 +61,7 @@ public class PutEventsIntegration
         }
 
         var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
-        ContextPropagation.InjectContext(request, context);
+        ContextPropagation.InjectContext(tracer, request, context);
 
         return new CallTargetState(scope);
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
@@ -50,13 +50,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             if (tags is not null)
             {
                 tags.StreamName = request.StreamName;
             }
 
-            ContextPropagation.InjectTraceIntoData(request, scope, request.StreamName);
+            ContextPropagation.InjectTraceIntoData(tracer, request, scope, request.StreamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncV3_7Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncV3_7Integration.cs
@@ -50,14 +50,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             var streamName = AwsKinesisCommon.GetStreamName(request);
             if (tags is not null)
             {
                 tags.StreamName = streamName;
             }
 
-            ContextPropagation.InjectTraceIntoData(request, scope, streamName);
+            ContextPropagation.InjectTraceIntoData(tracer, request, scope, streamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
@@ -48,13 +48,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             if (tags is not null)
             {
                 tags.StreamName = request.StreamName;
             }
 
-            ContextPropagation.InjectTraceIntoData(request, scope, request.StreamName);
+            ContextPropagation.InjectTraceIntoData(tracer, request, scope, request.StreamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordV3_7Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordV3_7Integration.cs
@@ -48,14 +48,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             var streamName = AwsKinesisCommon.GetStreamName(request);
             if (tags is not null)
             {
                 tags.StreamName = streamName;
             }
 
-            ContextPropagation.InjectTraceIntoData(request, scope, streamName);
+            ContextPropagation.InjectTraceIntoData(tracer, request, scope, streamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
@@ -50,13 +50,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             if (tags is not null)
             {
                 tags.StreamName = request.StreamName;
             }
 
-            ContextPropagation.InjectTraceIntoRecords(request, scope, request.StreamName);
+            ContextPropagation.InjectTraceIntoRecords(tracer, request, scope, request.StreamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncV3_7Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncV3_7Integration.cs
@@ -50,14 +50,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             var streamName = AwsKinesisCommon.GetStreamName(request);
             if (tags is not null)
             {
                 tags.StreamName = streamName;
             }
 
-            ContextPropagation.InjectTraceIntoRecords(request, scope, streamName);
+            ContextPropagation.InjectTraceIntoRecords(tracer, request, scope, streamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
@@ -48,13 +48,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             if (tags is not null)
             {
                 tags.StreamName = request.StreamName;
             }
 
-            ContextPropagation.InjectTraceIntoRecords(request, scope, request.StreamName);
+            ContextPropagation.InjectTraceIntoRecords(tracer, request, scope, request.StreamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsV3_7Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsV3_7Integration.cs
@@ -48,14 +48,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsKinesisCommon.CreateScope(tracer, Operation, SpanKinds.Producer, null, out var tags);
             var streamName = AwsKinesisCommon.GetStreamName(request);
             if (tags is not null)
             {
                 tags.StreamName = streamName;
             }
 
-            ContextPropagation.InjectTraceIntoRecords(request, scope, streamName);
+            ContextPropagation.InjectTraceIntoRecords(tracer, request, scope, streamName);
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Shared/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Shared/ContextPropagation.cs
@@ -17,12 +17,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Shared
     {
         internal const string InjectionKey = "_datadog";
 
-        private static void Inject(PropagationContext context, IDictionary messageAttributes, DataStreamsManager? dataStreamsManager, IMessageHeadersHelper messageHeadersHelper)
+        private static void Inject(Tracer tracer, PropagationContext context, IDictionary messageAttributes, DataStreamsManager? dataStreamsManager, IMessageHeadersHelper messageHeadersHelper)
         {
             // Consolidate headers into one JSON object with <header_name>:<value>
             var sb = Util.StringBuilderCache.Acquire();
             sb.Append('{');
-            Tracer.Instance.TracerManager.SpanContextPropagator.Inject(context, sb, default(StringBuilderCarrierSetter));
+            tracer.TracerManager.SpanContextPropagator.Inject(context, sb, default(StringBuilderCarrierSetter));
 
             if (context.SpanContext?.PathwayContext is { } pathwayContext)
             {
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Shared
             messageAttributes[InjectionKey] = messageHeadersHelper.CreateMessageAttributeValue(resultString);
         }
 
-        public static void InjectHeadersIntoMessage(IContainsMessageAttributes carrier, SpanContext spanContext, DataStreamsManager? dataStreamsManager, IMessageHeadersHelper messageHeadersHelper)
+        public static void InjectHeadersIntoMessage(Tracer tracer, IContainsMessageAttributes carrier, SpanContext spanContext, DataStreamsManager? dataStreamsManager, IMessageHeadersHelper messageHeadersHelper)
         {
             // add distributed tracing headers to the message
             if (carrier.MessageAttributes == null)
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Shared
             if (carrier.MessageAttributes.Count < 10)
             {
                 var context = new PropagationContext(spanContext, Baggage.Current);
-                Inject(context, carrier.MessageAttributes, dataStreamsManager, messageHeadersHelper);
+                Inject(tracer, context, carrier.MessageAttributes, dataStreamsManager, messageHeadersHelper);
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/ContextPropagation.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
     {
         private const string StepFunctionsKey = "_datadog";
 
-        public static void InjectContextIntoInput<TClientMarker, TExecutionRequest>(TExecutionRequest carrier, PropagationContext context)
+        public static void InjectContextIntoInput<TClientMarker, TExecutionRequest>(Tracer tracer, TExecutionRequest carrier, PropagationContext context)
             where TExecutionRequest : IContainsInput
         {
             // Inject the tracing headers
@@ -24,11 +24,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
                 return;
             }
 
-            Inject<TClientMarker>(context, ref input);
+            Inject<TClientMarker>(tracer, context, ref input);
             carrier.Input = input;
         }
 
-        private static void Inject<TExecutionRequest>(PropagationContext context, ref string input)
+        private static void Inject<TExecutionRequest>(Tracer tracer, PropagationContext context, ref string input)
         {
             var sb = Util.StringBuilderCache.Acquire();
             sb.Append(input);
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
             }
 
             sb.AppendFormat(" \"{0}\": {{", StepFunctionsKey); // Add _datadog:" {
-            Tracer.Instance.TracerManager.SpanContextPropagator.Inject(context, sb, default(StringBuilderCarrierSetter));
+            tracer.TracerManager.SpanContextPropagator.Inject(context, sb, default(StringBuilderCarrierSetter));
             sb.Remove(sb.Length - 1, 1); // remove trailing comma
             sb.Append("}}"); // re-add both closing braces one for original JSON and one for context
             input = Util.StringBuilderCache.GetStringAndRelease(sb);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartExecutionAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartExecutionAsyncIntegration.cs
@@ -53,7 +53,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsStepFunctionsCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsStepFunctionsCommon.CreateScope(tracer, Operation, SpanKinds.Producer, out var tags);
             if (tags is not null && request.StateMachineArn is not null)
             {
                 tags.StateMachineName = AwsStepFunctionsCommon.GetStateMachineName(request.StateMachineArn);
@@ -62,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
             if (request.Input is not null && scope?.Span.Context is { } spanContext)
             {
                 var context = new PropagationContext(spanContext, Baggage.Current);
-                ContextPropagation.InjectContextIntoInput<TTarget, TStartExecutionRequest>(request, context);
+                ContextPropagation.InjectContextIntoInput<TTarget, TStartExecutionRequest>(tracer, request, context);
             }
 
             return new CallTargetState(scope, state: request);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartExecutionIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartExecutionIntegration.cs
@@ -52,7 +52,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsStepFunctionsCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsStepFunctionsCommon.CreateScope(tracer, Operation, SpanKinds.Producer, out var tags);
             if (tags is not null && request.StateMachineArn is not null)
             {
                 tags.StateMachineName = AwsStepFunctionsCommon.GetStateMachineName(request.StateMachineArn);
@@ -61,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
             if (request.Input is not null && scope?.Span.Context is { } spanContext)
             {
                 var context = new PropagationContext(spanContext, Baggage.Current);
-                ContextPropagation.InjectContextIntoInput<TTarget, TStartExecutionRequest>(request, context);
+                ContextPropagation.InjectContextIntoInput<TTarget, TStartExecutionRequest>(tracer, request, context);
             }
 
             return new CallTargetState(scope, state: request);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartSyncExecutionAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartSyncExecutionAsyncIntegration.cs
@@ -53,7 +53,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsStepFunctionsCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsStepFunctionsCommon.CreateScope(tracer, Operation, SpanKinds.Producer, out var tags);
             if (tags is not null && request.StateMachineArn is not null)
             {
                 tags.StateMachineName = AwsStepFunctionsCommon.GetStateMachineName(request.StateMachineArn);
@@ -62,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
             if (request.Input is not null && scope?.Span.Context is { } spanContext)
             {
                 var context = new PropagationContext(spanContext, Baggage.Current);
-                ContextPropagation.InjectContextIntoInput<TTarget, TStartSyncExecutionRequest>(request, context);
+                ContextPropagation.InjectContextIntoInput<TTarget, TStartSyncExecutionRequest>(tracer, request, context);
             }
 
             return new CallTargetState(scope, state: request);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartSyncExecutionIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/StartSyncExecutionIntegration.cs
@@ -52,7 +52,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsStepFunctionsCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, out var tags);
+            var tracer = Tracer.Instance;
+            var scope = AwsStepFunctionsCommon.CreateScope(tracer, Operation, SpanKinds.Producer, out var tags);
             if (tags is not null && request.StateMachineArn is not null)
             {
                 tags.StateMachineName = AwsStepFunctionsCommon.GetStateMachineName(request.StateMachineArn);
@@ -61,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
             if (request.Input is not null && scope?.Span.Context is { } spanContext)
             {
                 var context = new PropagationContext(spanContext, Baggage.Current);
-                ContextPropagation.InjectContextIntoInput<TTarget, TStartSyncExecutionRequest>(request, context);
+                ContextPropagation.InjectContextIntoInput<TTarget, TStartSyncExecutionRequest>(tracer, request, context);
             }
 
             return new CallTargetState(scope, state: request);


### PR DESCRIPTION
## Summary of changes

Remove usages of `Tracer.Instance` to try to stop flake

## Reason for change

I've seen flake in these unit tests: e.g.

```
InjectTraceIntoData_WithJsonString_AddsTraceContext from Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.AWS.Kinesis.ContextPropagationTests (Datadog)
The given key 'dd-pathway-ctx-base64' was not present in the dictionary.
```

My strong suspicion is that that flake is due to the fact that the tested classes are using `Tracer.Instance` state, which is global, and so state is leaking between tests.

Also, the tracers weren't being disposed, so we were likely leaking threads.

## Implementation details

- Inject a `Tracer` instance instead of grabbing the global one
- Use `TracerHelper.Create()` and dispose the returned agent

## Test coverage

Covered by existing tests

## Other details
 
I suspect the actual flake was introduced by
- https://github.com/DataDog/dd-trace-dotnet/pull/7244

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
