### PR TITLE
Swap disposal ordering of inferred span

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -201,8 +201,9 @@ namespace Datadog.Trace.PlatformHelpers
                 }
 
                 CoreHttpContextStore.Instance.Remove();
-                proxyScope?.Dispose();
+
                 rootScope.Dispose();
+                proxyScope?.Dispose();
             }
         }
 

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=__statusCode=200_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=__statusCode=200_spanCount=3.verified.txt
@@ -20,33 +20,6 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      http.method: GET,
-      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 200,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /home/index,
@@ -75,6 +48,36 @@
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      http.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 200,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_bad-request_statusCode=500_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_bad-request_statusCode=500_spanCount=3.verified.txt
@@ -20,38 +20,6 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Error: 1,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      error.msg: This was a bad request.,
-      error.stack:
-System.Exception: This was a bad request.
-at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
-      error.type: System.Exception,
-      http.method: GET,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 500,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /bad-request,
@@ -85,6 +53,41 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack:
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 500,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_handled-exception_statusCode=500_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_handled-exception_statusCode=500_spanCount=3.verified.txt
@@ -26,35 +26,6 @@ System.Exception: Exception of type 'System.Exception' was thrown.
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Error: 1,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
-      http.method: GET,
-      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 500,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /handled-exception,
@@ -85,6 +56,38 @@ System.Exception: Exception of type 'System.Exception' was thrown.
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 500,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_not-found_statusCode=404_spanCount=2.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_not-found_statusCode=404_spanCount=2.verified.txt
@@ -2,6 +2,34 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      http.useragent: testhelper,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
     Name: aws.apigateway,
     Resource: GET /api/test/?,
     Service: test.api.com,
@@ -26,34 +54,6 @@
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_3,
-    Name: aspnet_core.request,
-    Resource: GET /not-found,
-    Service: Samples.AspNetCoreMvc31,
-    Type: web,
-    ParentId: Id_2,
-    Tags: {
-      component: aspnet_core,
-      datadog-header-tag: asp-net-core,
-      env: integration_tests,
-      http.method: GET,
-      http.request.headers.host: localhost:00000,
-      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.status_code: 404,
-      http.url: http://localhost:00000/not-found,
-      http.useragent: testhelper,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
-      version: 1.0.0
-    },
-    Metrics: {
-      _dd.top_level: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_status-code_203_statusCode=203_spanCount=3.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31InferredProxySpansTests.Enabled.__path=_status-code_203_statusCode=203_spanCount=3.verified.txt
@@ -20,33 +20,6 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
-    Name: aws.apigateway,
-    Resource: GET /api/test/?,
-    Service: test.api.com,
-    Type: web,
-    ParentId: Id_5,
-    Tags: {
-      component: aws-apigateway,
-      env: integration_tests,
-      http.method: GET,
-      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
-      http.response.headers.server: Kestrel,
-      http.route: /api/test/?,
-      http.status_code: 203,
-      http.url: test.api.com/api/test/1,
-      language: dotnet,
-      span.kind: internal,
-      stage: prod,
-      _dd.base_service: Samples.AspNetCoreMvc31
-    },
-    Metrics: {
-      _dd.inferred_span: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_3,
     Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
@@ -75,6 +48,36 @@
     },
     Metrics: {
       _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aws.apigateway,
+    Resource: GET /api/test/?,
+    Service: test.api.com,
+    Type: web,
+    Tags: {
+      component: aws-apigateway,
+      env: integration_tests,
+      http.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.route: /api/test/?,
+      http.status_code: 203,
+      http.url: test.api.com/api/test/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      stage: prod,
+      _dd.base_service: Samples.AspNetCoreMvc31
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.inferred_span: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   }
 ]


### PR DESCRIPTION
## Summary of changes

Swaps the ordering when disposing the API Gateway inferred span to be after the "root" span.
Realistically the API Gateway span will be the parent of the root span for the ASP NET Core instrumentation.

## Reason for change

If the proxy scope is the parent of the `ASPNET Core` scope AND that `ASPNET Core` scope is active this was hitting the following [piece of code](https://github.com/DataDog/dd-trace-dotnet/blob/1752abdc32c02c702b7c8374bfd1bae8b381d7db/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs#L44-L48) in `Async

```csharp
            if (current == null || current != scope)
            {
                // This is not the current scope for this context, bail out
                return;
            }
```

This would cause the scope for the proxy to remain open 😢 

## Implementation details

Swapped the ordering of them.

## Test coverage

- Identified and covered by existing tests and was caught in [this](https://github.com/DataDog/dd-trace-dotnet/pull/7280) PR when updating xUnit

## Other details
<!-- Fixes #{issue} -->

Cherry picked out and making it's own PR instead of bundling into the [xUnit update one ](https://github.com/DataDog/dd-trace-dotnet/pull/7284) because it passes and works without that.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
