### PR TITLE
Ensure file_opened_ is getting updated when rotating

### DIFF
--- a/shared/src/native-src/lazy_rotating_file_sink-inl.h
+++ b/shared/src/native-src/lazy_rotating_file_sink-inl.h
@@ -138,6 +138,7 @@ SPDLOG_INLINE void lazy_rotating_file_sink<Mutex>::rotate_()
             {
                 file_helper_.reopen(true); // truncate the log file anyway to prevent it to grow beyond its limit!
                 current_size_ = 0;
+                file_opened_ = true;
                 throw_spdlog_ex("lazy_rotating_file_sink: failed renaming " + filename_to_str(src) + " to " + filename_to_str(target), errno);
             }
         }

--- a/shared/src/native-src/lazy_rotating_file_sink-inl.h
+++ b/shared/src/native-src/lazy_rotating_file_sink-inl.h
@@ -93,8 +93,12 @@ SPDLOG_INLINE void lazy_rotating_file_sink<Mutex>::sink_it_(const details::log_m
             new_size = formatted.size();
         }
     }
-    file_helper_.write(formatted);
-    current_size_ = new_size;
+
+    if (file_opened_)
+    {
+        file_helper_.write(formatted);
+        current_size_ = new_size;
+    }
 }
 
 template<typename Mutex>

--- a/shared/src/native-src/lazy_rotating_file_sink.h
+++ b/shared/src/native-src/lazy_rotating_file_sink.h
@@ -8,7 +8,6 @@
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/details/synchronous_factory.h>
 
-#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <string>

--- a/shared/src/native-src/lazy_rotating_file_sink.h
+++ b/shared/src/native-src/lazy_rotating_file_sink.h
@@ -41,7 +41,7 @@ private:
     // log.3.txt -> delete
     void rotate_();
 
-    void ensure_file_open_();
+    void open_if_needed_();
 
     // delete the target if exists, and rename the src file  to target
     // return true on success, false otherwise.
@@ -52,8 +52,7 @@ private:
     std::size_t max_files_;
     std::size_t current_size_;
     details::file_helper file_helper_;
-    std::atomic<bool> file_opened_;
-    Mutex lazy_mutex_;
+    bool file_opened_;
 };
 
 using lazy_rotating_file_sink_mt = lazy_rotating_file_sink<std::mutex>;

--- a/shared/src/native-src/lazy_rotating_file_sink.h
+++ b/shared/src/native-src/lazy_rotating_file_sink.h
@@ -8,6 +8,7 @@
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/details/synchronous_factory.h>
 
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <string>
@@ -40,6 +41,8 @@ private:
     // log.3.txt -> delete
     void rotate_();
 
+    void ensure_file_open_();
+
     // delete the target if exists, and rename the src file  to target
     // return true on success, false otherwise.
     bool rename_file_(const filename_t &src_filename, const filename_t &target_filename);
@@ -49,7 +52,8 @@ private:
     std::size_t max_files_;
     std::size_t current_size_;
     details::file_helper file_helper_;
-    bool file_opened_;
+    std::atomic<bool> file_opened_;
+    Mutex lazy_mutex_;
 };
 
 using lazy_rotating_file_sink_mt = lazy_rotating_file_sink<std::mutex>;


### PR DESCRIPTION
## Summary of changes

This PR just make sure that the `file_opened_` flag gets updated properly.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
