### PR TITLE
Fix debug symbol upload in release

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -137,6 +137,9 @@ jobs:
         run: |
           dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
+      - name: "Copy gitlab artifacts to artifacts_path"
+        run: cp "${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip" "${{steps.assets.outputs.artifacts_path}}/""
+
       - name: 'Push debug symbols to datadog'
         uses: ./.github/actions/publish-debug-symbols
         with:


### PR DESCRIPTION
## Summary of changes

Fix "missing artifacts" in the debug symbol upload stage

## Reason for change
[
The release](https://github.com/DataDog/dd-trace-dotnet/actions/runs/16597402928/job/46954252957) (partially) failed due to the gitlab artifacts (Windows) being in a different folder

## Implementation details

Just copy the gitlab artifacts into the other folder

## Test coverage

We'll test this in the next release 😅 

## Other details

We could also path in the paths separately to the action as two separate variables, I'm happy with either 🤷‍♂️ 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
