### PR TITLE
Bump rejit timeout to 200ms

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -695,7 +695,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
                                                                                 promise);
 
             // wait and get the value from the future<ULONG>
-            const auto status = future.wait_for(150ms);
+            const auto status = future.wait_for(200ms);
 
             if (status != std::future_status::timeout)
             {
@@ -1314,7 +1314,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                                                                                 promise);
 
             // wait and get the value from the future<ULONG>
-            const auto status = future.wait_for(150ms);
+            const auto status = future.wait_for(200ms);
 
             if (status != std::future_status::timeout)
             {


### PR DESCRIPTION
## Summary of changes

Bump the ReJIT timeout from 100ms to 200ms

## Reason for change

In #7289 we bumped it from 100ms to 150ms as a bandaid on timeouts we started seeing in CI (which we believe are environment related). We're still seeing timeouts though, so bumping it further

## Implementation details

`150ms`->`200ms`

## Test coverage

This is the test, hopefully no more timeouts

## Other details

This is all a little concerning, but is still preferable to ignoring the timeouts. We have considered auto-retries in CI, but the fact that it can happen to customers potentially too means that we think bumping the timeout is the better option at the moment. 