### PR TITLE
enable runtime metrics by default

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -420,10 +420,11 @@ namespace Datadog.Trace.Configuration
                                                value => string.Equals(value, "none", StringComparison.OrdinalIgnoreCase)
                                                             ? ParsingResult<bool>.Success(result: false)
                                                             : ParsingResult<bool>.Failure());
+
             _runtimeMetricsEnabled = config
                                    .WithKeys(ConfigurationKeys.RuntimeMetricsEnabled)
                                    .AsBoolResult()
-                                   .OverrideWith(in otelRuntimeMetricsEnabled, ErrorLog, defaultValue: false);
+                                   .OverrideWith(in otelRuntimeMetricsEnabled, ErrorLog, defaultValue: EnvironmentHelpers.ShouldActivateRuntimeMetrics(isRunningInCiVisibility));
 
             DataPipelineEnabled = config
                                   .WithKeys(ConfigurationKeys.TraceDataPipelineEnabled)

--- a/tracer/src/Datadog.Trace/FrameworkDescription.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.cs
@@ -68,6 +68,11 @@ namespace Datadog.Trace
             return Environment.Version.Major >= 5;
         }
 
+        public static bool IsLowerThanNet9()
+        {
+            return Environment.Version.Major < 9;
+        }
+
         public bool IsWindows()
         {
             return string.Equals(OSPlatform, OSPlatformName.Windows, StringComparison.OrdinalIgnoreCase);

--- a/tracer/src/Datadog.Trace/Util/EnvironmentHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/EnvironmentHelpers.cs
@@ -155,6 +155,24 @@ namespace Datadog.Trace.Util
         }
 
         /// <summary>
+        /// Activate runtime metrics only on >= net9 or NetFx
+        /// </summary>
+        /// <param name="isRunningInCiVisibility">isRunningInCiVisibility</param>
+        /// <returns>whether to activate it or not</returns>
+        public static bool ShouldActivateRuntimeMetrics(bool isRunningInCiVisibility)
+        {
+            // only activate runtime metrics by default from net9 or netframework
+            var shouldActivateRuntimeMetrics = !isRunningInCiVisibility;
+#if !NETFRAMEWORK
+            if (shouldActivateRuntimeMetrics && FrameworkDescription.IsLowerThanNet9())
+            {
+                shouldActivateRuntimeMetrics = false;
+            }
+#endif
+            return shouldActivateRuntimeMetrics;
+        }
+
+        /// <summary>
         /// Checks if the specified environment variable exists in the current environment.
         /// </summary>
         private static bool EnvironmentVariableExists(string key) => !string.IsNullOrEmpty(GetEnvironmentVariable(key));


### PR DESCRIPTION
## Summary of changes

Perf tests two rounds:

<img width="3666" height="2486" alt="image" src="https://github.com/user-attachments/assets/0bb11640-3a82-40bf-95ac-d75d0d127536" />
<img width="3666" height="2486" alt="image" src="https://github.com/user-attachments/assets/7bb33bfb-cfe3-4d43-af3f-3deb57918077" />


## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
