### PR TITLE
Refactor `TraceSampler` to separate building from evaluation

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Sampling/CISampler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Sampling/CISampler.cs
@@ -16,10 +16,6 @@ namespace Datadog.Trace.Ci.Sampling
             return new SamplingDecision(SamplingPriorityValues.UserKeep, mechanism: null, rate: null, limiterRate: null);
         }
 
-        public void RegisterRule(ISamplingRule rule)
-        {
-        }
-
         public void SetDefaultSampleRates(IReadOnlyDictionary<string, float> sampleRates)
         {
         }

--- a/tracer/src/Datadog.Trace/Sampling/ITraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ITraceSampler.cs
@@ -14,7 +14,5 @@ namespace Datadog.Trace.Sampling
         void SetDefaultSampleRates(IReadOnlyDictionary<string, float> sampleRates);
 
         SamplingDecision MakeSamplingDecision(Span span);
-
-        void RegisterRule(ISamplingRule rule);
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -136,11 +136,10 @@ namespace Datadog.Trace.Sampling
             public void RegisterAgentSamplingRule(AgentSamplingRule rule)
             {
                 // only register the one AgentSamplingRule
+                // keep a reference to this rule so we can call SetDefaultSampleRates() later
+                // to update the agent sampling rates
                 if (Interlocked.Exchange(ref _agentSamplingRule, rule) == null)
                 {
-                    // keep a reference to this rule so we can call SetDefaultSampleRates() later
-                    // to update the agent sampling rates
-
                     RegisterRule(rule);
                 }
                 else

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -140,7 +140,6 @@ namespace Datadog.Trace.Sampling
                 {
                     // keep a reference to this rule so we can call SetDefaultSampleRates() later
                     // to update the agent sampling rates
-                    _agentSamplingRule = rule;
 
                     RegisterRule(rule);
                 }

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -17,13 +17,14 @@ namespace Datadog.Trace.Sampling
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TraceSampler>();
 
         private readonly IRateLimiter _limiter;
-        private readonly List<ISamplingRule> _rules = [];
+        private readonly List<ISamplingRule> _rules;
+        private readonly AgentSamplingRule? _agentSamplingRule;
 
-        private AgentSamplingRule? _agentSamplingRule;
-
-        public TraceSampler(IRateLimiter limiter)
+        public TraceSampler(IRateLimiter limiter, List<ISamplingRule> rules, AgentSamplingRule? agentSamplingRule)
         {
             _limiter = limiter;
+            _rules = [..rules];
+            _agentSamplingRule = agentSamplingRule;
         }
 
         public void SetDefaultSampleRates(IReadOnlyDictionary<string, float> sampleRates)
@@ -46,57 +47,6 @@ namespace Datadog.Trace.Sampling
             // (even before we receive rates from the agent)
             Log.Debug("No sampling rules matched for trace {TraceId}. Using default sampling decision.", span.Context.RawTraceId);
             return SamplingDecision.Default;
-        }
-
-        /// <summary>
-        /// Register a new sampling rule. To register a <see cref="AgentSamplingRule"/>,
-        /// use <see cref="RegisterAgentSamplingRule"/> instead.
-        /// </summary>
-        /// <remarks>
-        /// The order that rules are registered is important, as they are evaluated in order.
-        /// The first rule that matches will be used to determine the sampling rate.
-        /// </remarks>
-        public void RegisterRule(ISamplingRule rule)
-        {
-            _rules.Add(rule);
-        }
-
-        /// <summary>
-        /// Register new sampling rules. To register a <see cref="AgentSamplingRule"/>,
-        /// use <see cref="RegisterAgentSamplingRule"/> instead.
-        /// </summary>
-        /// <remarks>
-        /// The order that rules are registered is important, as they are evaluated in order.
-        /// The first rule that matches will be used to determine the sampling rate.
-        /// </remarks>
-        public void RegisterRules(IEnumerable<ISamplingRule> rules)
-        {
-            _rules.AddRange(rules);
-        }
-
-        /// <summary>
-        /// Register a new agent sampling rule. This rule should be registered last,
-        /// after any calls to <see cref="RegisterRule"/> or <see cref="RegisterRules"/>.
-        /// </summary>
-        /// <remarks>
-        /// The order that rules are registered is important, as they are evaluated in order.
-        /// The first rule that matches will be used to determine the sampling rate.
-        /// </remarks>
-        public void RegisterAgentSamplingRule(AgentSamplingRule rule)
-        {
-            // only register the one AgentSamplingRule
-            if (Interlocked.Exchange(ref _agentSamplingRule, rule) == null)
-            {
-                // keep a reference to this rule so we can call SetDefaultSampleRates() later
-                // to update the agent sampling rates
-                _agentSamplingRule = rule;
-
-                RegisterRule(rule);
-            }
-            else
-            {
-                Log.Warning("AgentSamplingRule already registered. Ignoring additional registration.");
-            }
         }
 
         // used for testing
@@ -136,6 +86,69 @@ namespace Datadog.Trace.Sampling
             }
 
             return new SamplingDecision(priority, mechanism, rate, limiterRate);
+        }
+
+        public class Builder(IRateLimiter limiter)
+        {
+            private readonly IRateLimiter _limiter = limiter;
+            private readonly List<ISamplingRule> _rules = [];
+            private AgentSamplingRule? _agentSamplingRule;
+
+            public TraceSampler Build()
+            {
+                return new TraceSampler(_limiter, _rules, _agentSamplingRule);
+            }
+
+            /// <summary>
+            /// Register a new sampling rule. To register a <see cref="AgentSamplingRule"/>,
+            /// use <see cref="RegisterAgentSamplingRule"/> instead.
+            /// </summary>
+            /// <remarks>
+            /// The order that rules are registered is important, as they are evaluated in order.
+            /// The first rule that matches will be used to determine the sampling rate.
+            /// </remarks>
+            public void RegisterRule(ISamplingRule rule)
+            {
+                _rules.Add(rule);
+            }
+
+            /// <summary>
+            /// Register new sampling rules. To register a <see cref="AgentSamplingRule"/>,
+            /// use <see cref="RegisterAgentSamplingRule"/> instead.
+            /// </summary>
+            /// <remarks>
+            /// The order that rules are registered is important, as they are evaluated in order.
+            /// The first rule that matches will be used to determine the sampling rate.
+            /// </remarks>
+            public void RegisterRules(IEnumerable<ISamplingRule> rules)
+            {
+                _rules.AddRange(rules);
+            }
+
+            /// <summary>
+            /// Register a new agent sampling rule. This rule should be registered last,
+            /// after any calls to <see cref="RegisterRule"/> or <see cref="RegisterRules"/>.
+            /// </summary>
+            /// <remarks>
+            /// The order that rules are registered is important, as they are evaluated in order.
+            /// The first rule that matches will be used to determine the sampling rate.
+            /// </remarks>
+            public void RegisterAgentSamplingRule(AgentSamplingRule rule)
+            {
+                // only register the one AgentSamplingRule
+                if (Interlocked.Exchange(ref _agentSamplingRule, rule) == null)
+                {
+                    // keep a reference to this rule so we can call SetDefaultSampleRates() later
+                    // to update the agent sampling rates
+                    _agentSamplingRule = rule;
+
+                    RegisterRule(rule);
+                }
+                else
+                {
+                    Log.Warning("AgentSamplingRule already registered. Ignoring additional registration.");
+                }
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -275,12 +275,12 @@ namespace Datadog.Trace
                 (Security.Instance.Settings.AppsecEnabled || Iast.Iast.Instance.Settings.Enabled))
             {
                 // Custom sampler for ASM and IAST standalone billing mode
-                var samplerStandalone = new TraceSampler(new TracerRateLimiter(maxTracesPerInterval: 1, intervalMilliseconds: 60_000));
+                var samplerStandalone = new TraceSampler.Builder(new TracerRateLimiter(maxTracesPerInterval: 1, intervalMilliseconds: 60_000));
                 samplerStandalone.RegisterRule(new GlobalSamplingRateRule(1.0f));
-                return samplerStandalone;
+                return samplerStandalone.Build();
             }
 
-            var sampler = new TraceSampler(new TracerRateLimiter(maxTracesPerInterval: settings.MaxTracesSubmittedPerSecond, intervalMilliseconds: null));
+            var sampler = new TraceSampler.Builder(new TracerRateLimiter(maxTracesPerInterval: settings.MaxTracesSubmittedPerSecond, intervalMilliseconds: null));
 
             // sampling rules (remote value overrides local value)
             var samplingRulesJson = settings.CustomSamplingRules;
@@ -336,7 +336,7 @@ namespace Datadog.Trace
             // This rule is always present, even if the agent has not yet provided any sampling rates.
             sampler.RegisterAgentSamplingRule(new AgentSamplingRule());
 
-            return sampler;
+            return sampler.Build();
         }
 
         protected virtual ISpanSampler GetSpanSampler(TracerSettings settings)

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -30,9 +30,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public async Task RateLimiter_Never_Applied_For_DefaultRule()
         {
-            var sampler = new TraceSampler(new DenyAll());
+            var builder = new TraceSampler.Builder(new DenyAll());
             await RunSamplerTest(
-                sampler,
+                builder.Build(),
                 iterations: 500,
                 expectedAutoKeepRate: 1,
                 expectedUserKeepRate: 0,
@@ -42,9 +42,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public async Task RateLimiter_Denies_All_Traces()
         {
-            var sampler = new TraceSampler(new DenyAll());
+            var builder = new TraceSampler.Builder(new DenyAll());
 
-            sampler.RegisterRule(
+            builder.RegisterRule(
                 new LocalCustomSamplingRule(
                     rate: 1,
                     patternFormat: SamplingRulesFormat.Regex,
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Tests.Sampling
                     timeout: Timeout));
 
             await RunSamplerTest(
-                sampler,
+                builder.Build(),
                 iterations: 500,
                 expectedAutoKeepRate: 0,
                 expectedUserKeepRate: 0,
@@ -65,9 +65,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public async Task Keep_Everything_Rule()
         {
-            var sampler = new TraceSampler(new NoLimits());
+            var builder = new TraceSampler.Builder(new NoLimits());
 
-            sampler.RegisterRule(
+            builder.RegisterRule(
                 new LocalCustomSamplingRule(
                     rate: 1,
                     patternFormat: SamplingRulesFormat.Regex,
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Tests.Sampling
                     timeout: Timeout));
 
             await RunSamplerTest(
-                sampler,
+                builder.Build(),
                 iterations: 500,
                 expectedAutoKeepRate: 0,
                 expectedUserKeepRate: 1,
@@ -88,9 +88,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public async Task Keep_Nothing_Rule()
         {
-            var sampler = new TraceSampler(new NoLimits());
+            var builder = new TraceSampler.Builder(new NoLimits());
 
-            sampler.RegisterRule(
+            builder.RegisterRule(
                 new LocalCustomSamplingRule(
                     rate: 0,
                     patternFormat: SamplingRulesFormat.Regex,
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Tests.Sampling
                     timeout: Timeout));
 
             await RunSamplerTest(
-                sampler,
+                builder.Build(),
                 iterations: 500,
                 expectedAutoKeepRate: 0,
                 expectedUserKeepRate: 0,
@@ -111,9 +111,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public async Task Keep_Half_Rule()
         {
-            var sampler = new TraceSampler(new NoLimits());
+            var builder = new TraceSampler.Builder(new NoLimits());
 
-            sampler.RegisterRule(
+            builder.RegisterRule(
                 new LocalCustomSamplingRule(
                     rate: 0.5f,
                     patternFormat: SamplingRulesFormat.Regex,
@@ -124,7 +124,7 @@ namespace Datadog.Trace.Tests.Sampling
                     timeout: Timeout));
 
             await RunSamplerTest(
-                sampler,
+                builder.Build(),
                 iterations: 50_000, // Higher number for lower variance
                 expectedAutoKeepRate: 0,
                 expectedUserKeepRate: 0.5f,
@@ -134,8 +134,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public async Task No_Registered_Rules_Uses_Legacy_Rates()
         {
-            var sampler = new TraceSampler(new NoLimits());
-            sampler.RegisterAgentSamplingRule(new AgentSamplingRule());
+            var builder = new TraceSampler.Builder(new NoLimits());
+            builder.RegisterAgentSamplingRule(new AgentSamplingRule());
+            var sampler = builder.Build();
             sampler.SetDefaultSampleRates(MockAgentRates);
 
             await RunSamplerTest(
@@ -156,8 +157,9 @@ namespace Datadog.Trace.Tests.Sampling
             scope.Span.Context.TraceContext.Environment = Env;
 
             var span = scope.Span;
-            var sampler = new TraceSampler(new NoLimits());
-            sampler.RegisterAgentSamplingRule(new AgentSamplingRule());
+            var builder = new TraceSampler.Builder(new NoLimits());
+            builder.RegisterAgentSamplingRule(new AgentSamplingRule());
+            var sampler = builder.Build();
 
             // if there are no other rules, and before we have agent rates, mechanism is "Default"
             var (_, mechanism1, _, _) = sampler.MakeSamplingDecision(span);


### PR DESCRIPTION
## Summary of changes

Refactors the `TraceSampler` and `ITraceSampler` abstractions to separate the building of the rules from the evaluation

## Reason for change

It's neater, and it makes some subsequent changes much simpler, easier and more performant

## Implementation details

Create a nested `Builder` type in `TraceSampler` and move all the `RegisterRule()` methods on it. Call `Build` to get a final list of rules to be applied.

## Test coverage

Covered by existing tests

## Other details

Part of a stack of branches related to sampling improvements

- https://github.com/DataDog/dd-trace-dotnet/pull/7311 👈
- https://github.com/DataDog/dd-trace-dotnet/pull/7312 