### PR TITLE
[AAP] Add resource name to the collected endpoints

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/AppEndpointData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/AppEndpointData.cs
@@ -35,6 +35,7 @@ internal class AppEndpointData
         Method = method;
         Path = path;
         OperationName = "http.request";
+        ResourceName = $"{method} {path}";
     }
 
     /// <summary>
@@ -58,4 +59,9 @@ internal class AppEndpointData
     /// Gets or sets the operation name for the endpoint.
     /// </summary>
     public string OperationName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resource name for the endpoint.
+    /// </summary>
+    public string ResourceName { get; set; }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/AppEndpointData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/AppEndpointData.cs
@@ -35,7 +35,7 @@ internal class AppEndpointData
         Method = method;
         Path = path;
         OperationName = "http.request";
-        ResourceName = $"{method} {path}";
+        ResourceName = method == "*" ? path : $"{method} {path}";
     }
 
     /// <summary>

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5Endpoints.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5Endpoints.cs
@@ -22,8 +22,8 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity
             await base.TestEndpointsCollection();
 
             // Tests for specific endpoints that should be collected
-            Endpoints.Should().Contain(e => e.Path == "/iast/executecommand" && e.Method == "GET");
-            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level");
+            Endpoints.Should().Contain(e => e.Path == "/iast/executecommand" && e.Method == "GET" && e.ResourceName == "GET /iast/executecommand");
+            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level" && e.Method == "*" && e.ResourceName == "* /map_endpoint/sub_level");
         }
     }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5Endpoints.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5Endpoints.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity
 
             // Tests for specific endpoints that should be collected
             Endpoints.Should().Contain(e => e.Path == "/iast/executecommand" && e.Method == "GET" && e.ResourceName == "GET /iast/executecommand");
+            Endpoints.Should().Contain(e => e.Path == "/health/params/{id}" && e.Method == "GET" && e.ResourceName == "GET /health/params/{id}");
             Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level" && e.Method == "*" && e.ResourceName == "/map_endpoint/sub_level");
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5Endpoints.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCore5Endpoints.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity
 
             // Tests for specific endpoints that should be collected
             Endpoints.Should().Contain(e => e.Path == "/iast/executecommand" && e.Method == "GET" && e.ResourceName == "GET /iast/executecommand");
-            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level" && e.Method == "*" && e.ResourceName == "* /map_endpoint/sub_level");
+            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level" && e.Method == "*" && e.ResourceName == "/map_endpoint/sub_level");
         }
     }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreBareEndpoints.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreBareEndpoints.cs
@@ -22,8 +22,8 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity
             await base.TestEndpointsCollection();
 
             // Tests for specific endpoints that should be collected
-            Endpoints.Should().Contain(e => e.Path == "/good" && e.Method == "GET");
-            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level");
+            Endpoints.Should().Contain(e => e.Path == "/good" && e.Method == "GET" && e.ResourceName == "GET /good");
+            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level" && e.Method == "*" && e.ResourceName == "* /map_endpoint/sub_level");
         }
     }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreBareEndpoints.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreBareEndpoints.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity
 
             // Tests for specific endpoints that should be collected
             Endpoints.Should().Contain(e => e.Path == "/good" && e.Method == "GET" && e.ResourceName == "GET /good");
-            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level" && e.Method == "*" && e.ResourceName == "* /map_endpoint/sub_level");
+            Endpoints.Should().Contain(e => e.Path == "/map_endpoint/sub_level" && e.Method == "*" && e.ResourceName == "/map_endpoint/sub_level");
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -309,8 +309,8 @@ public class TelemetryControllerTests
 
         var endpoints = payload.Endpoints;
 
-        endpoints.Should().Contain(x => x.Method == "GET" && x.Path == "/api/test" && x.Type == "REST" && x.OperationName == "http.request");
-        endpoints.Should().Contain(x => x.Method == "POST" && x.Path == "/api/test" && x.Type == "REST" && x.OperationName == "http.request");
+        endpoints.Should().Contain(x => x.Method == "GET" && x.Path == "/api/test" && x.Type == "REST" && x.OperationName == "http.request" && x.ResourceName == "GET /api/test");
+        endpoints.Should().Contain(x => x.Method == "POST" && x.Path == "/api/test" && x.Type == "REST" && x.OperationName == "http.request" && x.ResourceName == "POST /api/test");
 
         await controller.DisposeAsync();
     }


### PR DESCRIPTION
## Summary of changes

Added the ResourceName to the endpoints collected based on the last update of the [RFC](https://docs.google.com/document/d/1txwuurIiSUWjYX7Xa0let7e49XKW2uhm1djgqjl_gL0).
## Reason for change

## Implementation details

- The resource name is defined as `method + path` except in the case of an endpoint detected as a wildcard, the resource name is set to the path.

## Test coverage

Updated the tests.

## Other details

#6733 

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
