### PR TITLE
Write `DD_LOGGER_` logs to a separate un-checked location

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -75,6 +75,7 @@ steps:
         --env enable_crash_dumps=$(enable_crash_dumps) \
         --env DD_COLLECTOR_CPU_USAGE="1" \
         --env DD_LOGGER_DD_API_KEY="$(DD_LOGGER_DD_API_KEY)" \
+        --env DD_LOGGER_DD_TRACE_LOG_DIRECTORY="/project/artifacts/build_data/infra_logs" \
         --env DD_LOGGER_DD_SERVICE \
         --env DD_LOGGER_DD_ENV \
         --env DD_LOGGER_ENABLED \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -96,6 +96,7 @@ variables:
   DD_LOGGER_DD_API_KEY: $(DD_API_KEY_PROD)
   DD_LOGGER_DD_SERVICE: dd-trace-dotnet
   DD_LOGGER_DD_ENV: CI
+  DD_LOGGER_DD_TRACE_LOG_DIRECTORY: $(System.DefaultWorkingDirectory)/artifacts/build_data/infra_logs
   DD_LOGGER_TF_BUILD: True
   DD_LOGGER_BUILD_BUILDID: $(Build.BuildId)
   DD_LOGGER_BUILD_DEFINITIONNAME: $(Build.DefinitionName)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -348,6 +348,7 @@ services:
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - DD_LOGGER_DD_API_KEY
+      - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
       - DD_LOGGER_ENABLED
@@ -426,6 +427,7 @@ services:
       - COUCHBASE_PORT=8091
       - CONTAINER_HOSTNAME=http://integrationtests
       - DD_LOGGER_DD_API_KEY
+      - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
       - DD_LOGGER_ENABLED
@@ -496,6 +498,7 @@ services:
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
       - DD_LOGGER_DD_API_KEY
+      - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
       - DD_LOGGER_ENABLED
@@ -552,6 +555,7 @@ services:
       - CONTAINER_HOSTNAME=http://integrationtests
       - IncludeAllTestFrameworks
       - DD_LOGGER_DD_API_KEY
+      - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
       - DD_LOGGER_ENABLED
@@ -602,6 +606,7 @@ services:
       - IncludeAllTestFrameworks
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - DD_LOGGER_DD_API_KEY
+      - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
       - DD_LOGGER_ENABLED
@@ -693,6 +698,7 @@ services:
       - RABBITMQ_HOST=rabbitmq_arm64
       - AWS_SDK_HOST=localstack_arm64:4566
       - DD_LOGGER_DD_API_KEY
+      - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
       - DD_LOGGER_ENABLED
@@ -771,6 +777,7 @@ services:
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
       - DD_LOGGER_DD_API_KEY
+      - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
       - DD_LOGGER_ENABLED


### PR DESCRIPTION
## Summary of changes

Writes the logs written by the test-logger to a different directory

## Reason for change

We recently saw a CI test failure caused by our "check logs for errors" stage, but the error didn't come from our tests per se, instead it came from the _logger_ that we use to send our logs to CI visibility. We don't care about errors in this component, so we write the logs to somewhere else that is not checked  for errors (but where we can still access them if required) 

## Implementation details

Use `DD_LOGGER_DD_TRACE_LOG_DIRECTORY` to set the log directory for the logger

## Test coverage

This is the test, if there are logs in the `infra_logs`, then we should be good 

EDIT: Looks good:

<img width="402" height="328" alt="image" src="https://github.com/user-attachments/assets/c952678f-e638-4dc9-8109-c37b22e1b1db" />
