### PR TITLE
Update PR template to add note about MergeQueue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,10 @@
 ## Other details
 <!-- Fixes #{issue} -->
 
-<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
+
+<!--  ⚠️ Note:
+
+Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.
+
+MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
+-->


### PR DESCRIPTION
## Summary of changes

Update PR template to add note about MergeQueue

## Reason for change

Developers not familiar with `dd-trace-dotnet` will sometimes try `/merge`, which doesn't work 😅 
I saw the https://github.com/DataDog/documentation repo includes a note in their template and I thought it was a good idea.

https://github.com/DataDog/documentation/blob/269b35de2967d9548881965acc2d984b3e74c3c7/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L22

## Implementation details

Update PR template to add note about MergeQueue, really.

## Test coverage

N/A

## Other details

N/A