### PR TITLE
Pre pull aerospike image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1181,4 +1181,3 @@ services:
   # keep syncronized image version with tracer\test\Datadog.Trace.TestHelpers.AutoInstrumentation\Containers\AerospikeFixture.cs
   aerospike:
     image: aerospike/aerospike-server:6.2.0.6
-    entrypoint: ["/bin/sh", "-c", "sleep infinity"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1177,3 +1177,8 @@ services:
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Strong!Passw0rd
+
+  # keep syncronized image version with tracer\test\Datadog.Trace.TestHelpers.AutoInstrumentation\Containers\AerospikeFixture.cs
+  aerospike:
+    image: aerospike/aerospike-server:6.2.0.6
+    entrypoint: ["/bin/sh", "-c", "sleep infinity"]

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/AerospikeFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/AerospikeFixture.cs
@@ -28,6 +28,7 @@ public class AerospikeFixture : ContainerFixture
     {
         // pinning to a known good version because the latest version
         // (6.3.0.5 at time of issue) causes 'Server memory error' and flake
+        // Keep syncronized image version with docker-compose.yml
         var container = new ContainerBuilder()
                        .WithImage("aerospike/aerospike-server:6.2.0.6")
                        .WithPortBinding(AerospikePort, true)


### PR DESCRIPTION
## Summary of changes

When running aerospike tests, we pull the docker image during the test execution. This can lead to some failures due to rate limits. This PR pulls the image directly from the CI along with all the needed ones.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
