### PR TITLE
Remove CMake warning: jobserver unavailable: using -j1. Add `+' to parent make rule.

### DIFF
--- a/build/cmake/FindRe2.cmake
+++ b/build/cmake/FindRe2.cmake
@@ -8,11 +8,11 @@ if (ISMACOS)
     SET (OSXRE2BUILDCOMMAND
             echo "Building Re2 Arm64" &&
             rm -f -r ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj &&
-            ${CMAKE_COMMAND} -E env LDFLAGS=-arch\ arm64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ arm64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j &&
+            ${CMAKE_COMMAND} -E env LDFLAGS=-arch\ arm64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ arm64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) &&
             mv ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.arm64.a &&
             echo "Building Re2 X86_64" &&
             rm -f -r ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj &&
-            ${CMAKE_COMMAND} -E env LDFLAGS=-arch\ x86_64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ x86_64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j &&
+            ${CMAKE_COMMAND} -E env LDFLAGS=-arch\ x86_64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ x86_64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) &&
             mv ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.x86_64.a &&
             echo "Creating Re2 universal binary" &&
             lipo ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.arm64.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.x86_64.a -create -output ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
@@ -35,7 +35,7 @@ elseif(ISLINUX)
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_IN_SOURCE TRUE
-        BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE)
         BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
     )
 endif()


### PR DESCRIPTION
## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
