### PR TITLE
chore: clean up baggage span tags implementation

### DIFF
--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -125,21 +125,6 @@ namespace Datadog.Trace.AspNet
             }
         }
 
-        private static void AddBaggageTagsToSpan(ISpan span, Baggage baggage, Tracer tracer)
-        {
-            if (baggage != null)
-            {
-                try
-                {
-                    tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(span, baggage, tracer.Settings.BaggageTagKeys);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error adding baggage tags to span.");
-                }
-            }
-        }
-
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
             Scope scope = null;
@@ -213,7 +198,7 @@ namespace Datadog.Trace.AspNet
                 scope.Span.DecorateWebServerSpan(resourceName: resourceName, httpMethod, host, url, userAgent, tags);
                 tracer.TracerManager.SpanContextPropagator.AddHeadersToSpanAsTags(scope.Span, headers, tracer.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpRequestHeadersTagPrefix);
 
-                AddBaggageTagsToSpan(scope.Span, extractedContext.Baggage, tracer);
+                tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(scope.Span, extractedContext.Baggage, tracer.Settings.BaggageTagKeys);
 
                 if (tracer.Settings.IpHeaderEnabled || Security.Instance.AppsecEnabled)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -40,21 +40,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         private const IntegrationId IntegrationId = Configuration.IntegrationId.AspNetMvc;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AspNetMvcIntegration));
 
-        private static void AddBaggageTagsToSpan(ISpan span, Baggage baggage, Tracer tracer)
-        {
-            if (baggage != null)
-            {
-                try
-                {
-                    tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(span, baggage, tracer.Settings.BaggageTagKeys);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error adding baggage tags to span.");
-                }
-            }
-        }
-
         /// <summary>
         /// Creates a scope used to instrument an MVC action and populates some common details.
         /// </summary>
@@ -198,7 +183,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         tracer.TracerManager.SpanContextPropagator.AddHeadersToSpanAsTags(span, headers.Value, tracer.Settings.HeaderTags, SpanContextPropagator.HttpRequestHeadersTagPrefix);
                     }
 
-                    AddBaggageTagsToSpan(span, extractedContext.Baggage, tracer);
+                    tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(span, extractedContext.Baggage, tracer.Settings.BaggageTagKeys);
 
                     if (tracer.Settings.IpHeaderEnabled || Security.Instance.AppsecEnabled)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -33,21 +33,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         private const IntegrationId IntegrationId = Configuration.IntegrationId.AspNetWebApi2;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AspNetWebApi2Integration));
 
-        private static void AddBaggageTagsToSpan(ISpan span, Baggage baggage, Tracer tracer)
-        {
-            if (baggage != null)
-            {
-                try
-                {
-                    tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(span, baggage, tracer.Settings.BaggageTagKeys);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error adding baggage tags to span.");
-                }
-            }
-        }
-
         internal static Scope CreateScope(IHttpControllerContext controllerContext, out AspNetTags tags)
         {
             Scope scope = null;
@@ -119,7 +104,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     tracer.TracerManager.SpanContextPropagator.AddHeadersToSpanAsTags(scope.Span, headersCollection.Value, tracer.Settings.HeaderTags, SpanContextPropagator.HttpRequestHeadersTagPrefix, request.Headers.UserAgent.ToString());
                 }
 
-                AddBaggageTagsToSpan(scope.Span, extractedContext.Baggage, tracer);
+                tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(scope.Span, extractedContext.Baggage, tracer.Settings.BaggageTagKeys);
 
                 tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);
                 tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -637,10 +637,11 @@ namespace Datadog.Trace.Configuration
                                  .WithKeys(ConfigurationKeys.BaggageMaximumBytes)
                                  .AsInt32(defaultValue: W3CBaggagePropagator.DefaultMaximumBaggageBytes);
 
-            BaggageTagKeys = config
+            BaggageTagKeys = new HashSet<string>(
+                            config
                             .WithKeys(ConfigurationKeys.BaggageTagKeys)
                             .AsString(defaultValue: "user.id,session.id,account.id")
-                            ?.Split([','], StringSplitOptions.RemoveEmptyEntries) ?? [];
+                            ?.Split([','], StringSplitOptions.RemoveEmptyEntries) ?? []);
 
             LogSubmissionSettings = new DirectLogSubmissionSettings(source, _telemetry);
 
@@ -1156,7 +1157,7 @@ namespace Datadog.Trace.Configuration
         /// Default value is "user.id,session.id,account.id".
         /// </summary>
         /// <seealso cref="ConfigurationKeys.BaggageTagKeys"/>
-        internal string[] BaggageTagKeys { get; }
+        internal HashSet<string> BaggageTagKeys { get; }
 
         /// <summary>
         /// Gets a value indicating whether runtime metrics

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -98,21 +98,6 @@ namespace Datadog.Trace.PlatformHelpers
             }
         }
 
-        private void AddBaggageTagsToSpan(ISpan span, Baggage baggage, Tracer tracer)
-        {
-            if (baggage != null)
-            {
-                try
-                {
-                    tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(span, baggage, tracer.Settings.BaggageTagKeys);
-                }
-                catch (Exception ex)
-                {
-                    _log.Error(ex, "Error adding baggage tags to span.");
-                }
-            }
-        }
-
         public Scope StartAspNetCorePipelineScope(Tracer tracer, Security security, HttpContext httpContext, string resourceName)
         {
             var request = httpContext.Request;
@@ -140,7 +125,7 @@ namespace Datadog.Trace.PlatformHelpers
             var scope = tracer.StartActiveInternal(_requestInOperationName, extractedContext.SpanContext, tags: tags, links: extractedContext.Links);
             scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, userAgent, tags);
             AddHeaderTagsToSpan(scope.Span, request, tracer);
-            AddBaggageTagsToSpan(scope.Span, extractedContext.Baggage, tracer);
+            tracer.TracerManager.SpanContextPropagator.AddBaggageToSpanAsTags(scope.Span, extractedContext.Baggage, tracer.Settings.BaggageTagKeys);
 
             var originalPath = request.PathBase.HasValue ? request.PathBase.Add(request.Path) : request.Path;
             var requestTrackingFeature = new RequestTrackingFeature(originalPath, scope);

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -329,13 +329,13 @@ namespace Datadog.Trace.Propagators
             try
             {
                 var addAllItems = baggageTagKeys.Length == 1 && baggageTagKeys[0] == "*";
-                var keysToProcess = addAllItems ? baggage.Select(item => item.Key) : baggageTagKeys;
+                var allowedKeys = addAllItems ? null : new HashSet<string>(baggageTagKeys);
 
-                foreach (var key in keysToProcess)
+                foreach (var item in baggage)
                 {
-                    if (baggage.TryGetValue(key, out var value))
+                    if (addAllItems || allowedKeys!.Contains(item.Key))
                     {
-                        span.SetTag("baggage." + key, value);
+                        span.SetTag("baggage." + item.Key, item.Value);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -313,14 +313,14 @@ namespace Datadog.Trace.Propagators
             }
         }
 
-        internal void AddBaggageToSpanAsTags(ISpan span, Baggage? baggage, string[] baggageTagKeys)
+        internal void AddBaggageToSpanAsTags(ISpan span, Baggage? baggage, HashSet<string> baggageTagKeys)
         {
             if (baggage is null or { Count: 0 })
             {
                 return;
             }
 
-            if (baggageTagKeys.Length == 0)
+            if (baggageTagKeys.Count == 0)
             {
                 // feature disabled
                 return;
@@ -328,12 +328,11 @@ namespace Datadog.Trace.Propagators
 
             try
             {
-                var addAllItems = baggageTagKeys.Length == 1 && baggageTagKeys[0] == "*";
-                var allowedKeys = addAllItems ? null : new HashSet<string>(baggageTagKeys);
+                var addAllItems = baggageTagKeys.Count == 1 && baggageTagKeys.Contains("*");
 
                 foreach (var item in baggage)
                 {
-                    if (addAllItems || allowedKeys!.Contains(item.Key))
+                    if (addAllItems || baggageTagKeys.Contains(item.Key))
                     {
                         span.SetTag("baggage." + item.Key, item.Value);
                     }


### PR DESCRIPTION
## Summary of changes
- Removed identical AddBaggageTagsToSpan methods
- Added to SpanContextPropagator method AddBaggageToSpanAsTags with centralized exception handling and logging
- Replaced all method calls with direct calls to the propagator
- Optimized loop consolidation for better performance
- Original PR: #7020
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
