### PR TITLE
Update default value of DD_LOGS_INJECTION to true

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -170,8 +170,8 @@ namespace Datadog.Trace.Logging.DirectSubmission
             ValidationErrors = validationErrors;
             IsEnabled = isEnabled;
 
-            // Logs injection is enabled by default if direct log submission is enabled, otherwise disabled by default
-            LogsInjectionEnabled = config.WithKeys(ConfigurationKeys.LogsInjectionEnabled).AsBool(defaultValue: isEnabled);
+            // Logs injection is enabled by default
+            LogsInjectionEnabled = config.WithKeys(ConfigurationKeys.LogsInjectionEnabled).AsBool(defaultValue: true);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes
- updates the default value of DD_LOGS_INJECTION to be true
- this change will enable log injection for structured logging frameworks by default 

## Reason for change
- Phase 1 of Trace Log Correlation [RFC](https://docs.google.com/document/d/1Okl7hQcJgA9NdQ8msSVu5P2cPQOx139K9s9f3C_bTho/edit?tab=t.0) 

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
