### PR TITLE
Fix typo in `create_draft_release`

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -138,7 +138,7 @@ jobs:
           dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
       - name: "Copy gitlab artifacts to artifacts_path"
-        run: cp "${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip" "${{steps.assets.outputs.artifacts_path}}/""
+        run: cp "${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip" "${{steps.assets.outputs.artifacts_path}}/"
 
       - name: 'Push debug symbols to datadog'
         uses: ./.github/actions/publish-debug-symbols


### PR DESCRIPTION
## Summary of changes

Fixes a typo that caused release to fail

## Reason for change

The release failed because there was a typo

## Implementation details

Fix the typo

## Test coverage

No
