### PR TITLE
Fix the signing of the fleet installer exe

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -882,9 +882,9 @@ partial class Build
         .DependsOn(PublishNativeTracerUnix)
         .DependsOn(PublishNativeTracerOsx);
 
-    Target PublishFleetInstaller => _ => _
+    Target BuildFleetInstaller => _ => _
         .Unlisted()
-        .Description("Builds and publishes the fleet installer binary files as a zip")
+        .Description("Builds and publishes the fleet installer binary files")
         .After(Clean, Restore, CompileManagedSrc)
         .Before(SignDlls)
         .OnlyWhenStatic(() => IsWin)
@@ -905,7 +905,17 @@ partial class Build
                               .SetConfiguration(BuildConfiguration)
                               .SetOutput(publishFolder)
                               .CombineWith(tfms, (p, tfm) => p.SetFramework(tfm)));
+        });
 
+    Target PublishFleetInstaller => _ => _
+        .Unlisted()
+        .Description("Publishes the fleet installer binary files as a zip")
+        .DependsOn(BuildFleetInstaller)
+        .After(SignDlls)
+        .OnlyWhenStatic(() => IsWin)
+        .Executes(() =>
+        {
+            var publishFolder = ArtifactsDirectory / "Datadog.FleetInstaller";
             CompressZip(publishFolder, ArtifactsDirectory / "fleet-installer.zip", fileMode: FileMode.Create);
         });
 


### PR DESCRIPTION
## Summary of changes

Ensure we sign Datadog.FleetInstaller.exe

## Reason for change

We should be signing the exe, it's an oversight, because we're zipping up the directory _before_ signing.

## Implementation details

Split the build and publish in two, so that we can sign the files inbetween

- `BuildFleetInstaller`
- `SignDlls`
- `PublishFleetInstaller`

## Test coverage

- [x] I'll check the GitLab output to make sure it's now signed
