### PR TITLE
Include `telemetry_forwarder.exe` in the Windows SSI OCI images

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1025,8 +1025,8 @@ stages:
           artifact: dd-dotnet-win-x64
           path: $(monitoringHome)/win-x64
 
-      - script: tracer\build.cmd PackageTracerHome PublishFleetInstaller
-        displayName: Build MSI and Tracer home
+      - script: tracer\build.cmd PackageTracerHome PublishFleetInstaller DownloadWinSsiTelemetryForwarder
+        displayName: Build MSI, Tracer home, FleetInstaller, and TelemetryForwarder
         retryCountOnTaskFailure: 1
 
       - publish: $(artifacts)/windows-tracer-home.zip
@@ -1044,6 +1044,10 @@ stages:
       - publish: $(artifacts)/Datadog.FleetInstaller
         displayName: Publish fleet installer
         artifact: fleet-installer
+
+      - publish: $(artifacts)/telemetry_forwarder.exe
+        displayName: Publish telemetry-forwarder
+        artifact: fleet-installer-telemetry-forwarder
 
 - stage: build_dd_dotnet_windows
   dependsOn: [merge_commit_id]
@@ -6046,6 +6050,11 @@ stages:
         - template: steps/download-artifact.yml
           parameters:
             artifact: fleet-installer
+            path: $(smokeTestAppDir)/artifacts/installer
+
+        - template: steps/download-artifact.yml
+          parameters:
+            artifact: fleet-installer-telemetry-forwarder
             path: $(smokeTestAppDir)/artifacts/installer
 
         - powershell: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ build:
         -e SIGN_WINDOWS=true `
         -e NUGET_CERT_REVOCATION_MODE=offline `
         registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest `
-        Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi
+        Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi DownloadWinSsiTelemetryForwarder
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out
     - remove-item -recurse -force build-out\${CI_JOB_ID}

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -56,6 +56,9 @@ elif [ "$OS" == "windows" ]; then
   mkdir -p sources/installer
   unzip ../artifacts/windows/fleet-installer.zip -d sources/installer/
 
+  # Copy the telemetry forwarder in too
+  cp ../artifacts/windows/telemetry_forwarder.exe sources/installer/
+
 fi
 
 echo -n $VERSION > sources/version

--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -31,7 +31,7 @@ partial class Build
         {
             // Download the forwarder from Azure for now.
             // We will likely change this in the future, but it'll do for now.
-            const string url = "https://apmdotnetci.blob.core.windows.net/apm-datadog-win-ssi-telemetry-forwarder/telemetry_forwarder.exe";
+            const string url = "https://apmdotnetci.blob.core.windows.net/apm-datadog-win-ssi-telemetry-forwarder/c83ee9ad2f93c7314779051662e2e00086a213e0/telemetry_forwarder.exe";
             const string expectedHash = "0B192C1901C670FC9A55464AFDF39774AB7CD0D667ECFB37BC22C27184B49C37D4658383E021F792A2F0C7024E1091F35C3CAD046EC68871FAEEE3C98A40163A";
 
             var tempFile = await DownloadFile(url);

--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -34,7 +34,7 @@ partial class Build
             const string url = "https://apmdotnetci.blob.core.windows.net/apm-datadog-win-ssi-telemetry-forwarder/telemetry_forwarder.exe";
             const string expectedHash = "3A207302683E2BE8CB3D3A6AFF4F40721B7C85763A5A9B8F441D6BFD1B419F02D3EA8155634CEB3A09473F4745CE49679A55095F0EAD91F0582C6CB08C725782";
 
-            var tempFile = await TryDownloadForwarder();
+            var tempFile = await DownloadFile(url);
             var actualHash = GetSha512Hash(tempFile);
             if (!string.Equals(expectedHash, actualHash, StringComparison.Ordinal))
             {
@@ -46,71 +46,6 @@ partial class Build
             // Move to expected location
             var output = ArtifactsDirectory / "telemetry_forwarder.exe";
             FileSystemTasks.CopyFile(tempFile, output, FileExistsPolicy.Overwrite);
-
-            static async Task<string> TryDownloadForwarder()
-            {
-                using var client = new HttpClient();
-                var attemptsRemaining = 3;
-                var defaultdelay = TimeSpan.FromSeconds(2);
-
-                while (attemptsRemaining > 0)
-                {
-                    var retryDelay = defaultdelay;
-                    try
-                    {
-                        Logger.Information("Downloading from {Url}", url);
-                        using var response = await client.GetAsync(url);
-                        var outputPath = Path.GetTempFileName();
-
-                        if (response.IsSuccessStatusCode)
-                        {
-                            Logger.Information("Saving file to {Path}", outputPath);
-                            await using var fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
-                            await response.Content.CopyToAsync(fs);
-                            return outputPath;
-                        }
-
-                        Logger.Warning("Failed to download telemetry forwarder, {StatusCode}: {Body}", response.StatusCode, await response.Content.ReadAsStringAsync());
-
-                        if (response.StatusCode == HttpStatusCode.TooManyRequests
-                            && response.Headers.TryGetValues("Retry-After", out var values)
-                            && values.FirstOrDefault() is {} retryAfter)
-                            {
-                                if (int.TryParse(retryAfter, out var seconds))
-                                {
-                                    retryDelay = TimeSpan.FromSeconds(seconds);
-                                }
-                                else if (DateTimeOffset.TryParse(retryAfter, out var retryDate))
-                                {
-                                    var delta = retryDate - DateTimeOffset.UtcNow;
-                                    retryDelay = delta > TimeSpan.Zero ? delta : retryDelay;
-                                }
-                            }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Warning(ex, "Error downloading telemetry forwarder {Url}", url);
-                    }
-
-                    attemptsRemaining--;
-                    if (attemptsRemaining > 0)
-                    {
-                        Logger.Debug("Waiting {RetryDelayTotalSeconds} seconds before retry...", retryDelay.TotalSeconds);
-                        await Task.Delay(retryDelay);
-                    }
-                }
-
-                throw new Exception("Failed to download telemetry forwarder");
-            }
-
-            static string GetSha512Hash(string filePath)
-            {
-                using var sha512 = SHA512.Create();
-                using var stream = File.OpenRead(filePath);
-
-                var hashBytes = sha512.ComputeHash(stream);
-                return Convert.ToHexString(hashBytes);
-            }
         });
 
     Target SignDlls => _ => _

--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Amazon.SimpleSystemsManagement;
@@ -19,6 +22,97 @@ using Logger = Serilog.Log;
 
 partial class Build
 {
+    Target DownloadWinSsiTelemetryForwarder => _ => _
+       .Description("Downloads the telemetry forwarder executable used by SSI ")
+       .Unlisted()
+       .Requires(() => IsWin)
+       .Before(SignDlls)
+       .Executes(async () =>
+        {
+            // Download the forwarder from Azure for now.
+            // We will likely change this in the future, but it'll do for now.
+            const string url = "https://apmdotnetci.blob.core.windows.net/apm-datadog-win-ssi-telemetry-forwarder/telemetry_forwarder.exe";
+            const string expectedHash = "3A207302683E2BE8CB3D3A6AFF4F40721B7C85763A5A9B8F441D6BFD1B419F02D3EA8155634CEB3A09473F4745CE49679A55095F0EAD91F0582C6CB08C725782";
+
+            var tempFile = await TryDownloadForwarder();
+            var actualHash = GetSha512Hash(tempFile);
+            if (!string.Equals(expectedHash, actualHash, StringComparison.Ordinal))
+            {
+                throw new Exception($"Downloaded file did not have expected hash. Expected hash {expectedHash}, actual hash {actualHash}");
+            }
+
+            Logger.Information("Hash verified: '{Hash}'", expectedHash);
+
+            // Move to expected location
+            var output = ArtifactsDirectory / "telemetry_forwarder.exe";
+            FileSystemTasks.CopyFile(tempFile, output, FileExistsPolicy.Overwrite);
+
+            static async Task<string> TryDownloadForwarder()
+            {
+                using var client = new HttpClient();
+                var attemptsRemaining = 3;
+                var defaultdelay = TimeSpan.FromSeconds(2);
+
+                while (attemptsRemaining > 0)
+                {
+                    var retryDelay = defaultdelay;
+                    try
+                    {
+                        Logger.Information("Downloading from {Url}", url);
+                        using var response = await client.GetAsync(url);
+                        var outputPath = Path.GetTempFileName();
+
+                        if (response.IsSuccessStatusCode)
+                        {
+                            Logger.Information("Saving file to {Path}", outputPath);
+                            await using var fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
+                            await response.Content.CopyToAsync(fs);
+                            return outputPath;
+                        }
+
+                        Logger.Warning("Failed to download telemetry forwarder, {StatusCode}: {Body}", response.StatusCode, await response.Content.ReadAsStringAsync());
+
+                        if (response.StatusCode == HttpStatusCode.TooManyRequests
+                            && response.Headers.TryGetValues("Retry-After", out var values)
+                            && values.FirstOrDefault() is {} retryAfter)
+                            {
+                                if (int.TryParse(retryAfter, out var seconds))
+                                {
+                                    retryDelay = TimeSpan.FromSeconds(seconds);
+                                }
+                                else if (DateTimeOffset.TryParse(retryAfter, out var retryDate))
+                                {
+                                    var delta = retryDate - DateTimeOffset.UtcNow;
+                                    retryDelay = delta > TimeSpan.Zero ? delta : retryDelay;
+                                }
+                            }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning(ex, "Error downloading telemetry forwarder {Url}", url);
+                    }
+
+                    attemptsRemaining--;
+                    if (attemptsRemaining > 0)
+                    {
+                        Logger.Debug("Waiting {RetryDelayTotalSeconds} seconds before retry...", retryDelay.TotalSeconds);
+                        await Task.Delay(retryDelay);
+                    }
+                }
+
+                throw new Exception("Failed to download telemetry forwarder");
+            }
+
+            static string GetSha512Hash(string filePath)
+            {
+                using var sha512 = SHA512.Create();
+                using var stream = File.OpenRead(filePath);
+
+                var hashBytes = sha512.ComputeHash(stream);
+                return Convert.ToHexString(hashBytes);
+            }
+        });
+
     Target SignDlls => _ => _
        .Description("Sign the dlls produced by building the Tracer, Profiler, and Monitoring home directory, as well as the dd-dotnet exes")
        .Unlisted()

--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -32,7 +32,7 @@ partial class Build
             // Download the forwarder from Azure for now.
             // We will likely change this in the future, but it'll do for now.
             const string url = "https://apmdotnetci.blob.core.windows.net/apm-datadog-win-ssi-telemetry-forwarder/telemetry_forwarder.exe";
-            const string expectedHash = "3A207302683E2BE8CB3D3A6AFF4F40721B7C85763A5A9B8F441D6BFD1B419F02D3EA8155634CEB3A09473F4745CE49679A55095F0EAD91F0582C6CB08C725782";
+            const string expectedHash = "0B192C1901C670FC9A55464AFDF39774AB7CD0D667ECFB37BC22C27184B49C37D4658383E021F792A2F0C7024E1091F35C3CAD046EC68871FAEEE3C98A40163A";
 
             var tempFile = await DownloadFile(url);
             var actualHash = GetSha512Hash(tempFile);

--- a/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.fleet-installer.dockerfile
@@ -29,10 +29,12 @@ COPY --from=builder /src/artifacts /install
 
 RUN mkdir /logs; \
     mkdir /monitoring-home; \
+    mkdir /installer; \
     cd /install; \
     Expand-Archive 'c:\install\windows-tracer-home.zip' -DestinationPath 'c:\monitoring-home\';  \
-    c:\install\installer\Datadog.FleetInstaller.exe install-version --home-path c:\monitoring-home; \
-    c:\install\installer\Datadog.FleetInstaller.exe enable-global-instrumentation --home-path c:\monitoring-home; \
+    Copy-Item c:\install\installer\*.* -Destination 'c:\installer\'; \
+    c:\installer\Datadog.FleetInstaller.exe install-version --home-path c:\monitoring-home; \
+    c:\installer\Datadog.FleetInstaller.exe enable-global-instrumentation --home-path c:\monitoring-home; \
     cd /app;
 
 # Set the additional env vars

--- a/tracer/src/Datadog.FleetInstaller/PathHelper.cs
+++ b/tracer/src/Datadog.FleetInstaller/PathHelper.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System.IO;
-using System.Reflection;
 
 namespace Datadog.FleetInstaller;
 
@@ -12,24 +11,18 @@ internal static class PathHelper
 {
     private const string ForwarderFileName = "telemetry_forwarder.exe";
 
-    public static string GetTelemetryForwarderPath()
+    public static string GetTelemetryForwarderPath(string homePath)
     {
-        // Get path of FleetInstaller.exe
-        var fleetInstallerPath = Assembly.GetExecutingAssembly().Location;
-        if (string.IsNullOrEmpty(fleetInstallerPath))
-        {
-            // Shouldn't ever be needed, but let's play it safe
-            fleetInstallerPath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
-        }
-
-        if (string.IsNullOrEmpty(fleetInstallerPath)
-            || Path.GetDirectoryName(fleetInstallerPath) is not { } directory)
+        if (string.IsNullOrEmpty(homePath)
+            || !Path.IsPathRooted(homePath) // can't use relative paths
+            || Path.GetDirectoryName(homePath) is not { } directory)
         {
             // I guess we failed for some reason, so we can't calculate the path to the telemetry forwarder
             return string.Empty;
         }
 
         // Ok, now we have the path
-        return Path.Combine(directory, ForwarderFileName);
+        // Should we care about long paths?
+        return Path.Combine(Path.GetFullPath(directory), "installer", ForwarderFileName);
     }
 }

--- a/tracer/src/Datadog.FleetInstaller/PathHelper.cs
+++ b/tracer/src/Datadog.FleetInstaller/PathHelper.cs
@@ -1,0 +1,35 @@
+// <copyright file="PathHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+using System.Reflection;
+
+namespace Datadog.FleetInstaller;
+
+internal static class PathHelper
+{
+    private const string ForwarderFileName = "telemetry_forwarder.exe";
+
+    public static string GetTelemetryForwarderPath()
+    {
+        // Get path of FleetInstaller.exe
+        var fleetInstallerPath = Assembly.GetExecutingAssembly().Location;
+        if (string.IsNullOrEmpty(fleetInstallerPath))
+        {
+            // Shouldn't ever be needed, but let's play it safe
+            fleetInstallerPath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
+        }
+
+        if (string.IsNullOrEmpty(fleetInstallerPath)
+            || Path.GetDirectoryName(fleetInstallerPath) is not { } directory)
+        {
+            // I guess we failed for some reason, so we can't calculate the path to the telemetry forwarder
+            return string.Empty;
+        }
+
+        // Ok, now we have the path
+        return Path.Combine(directory, ForwarderFileName);
+    }
+}

--- a/tracer/src/Datadog.FleetInstaller/TracerValues.cs
+++ b/tracer/src/Datadog.FleetInstaller/TracerValues.cs
@@ -12,6 +12,11 @@ namespace Datadog.FleetInstaller;
 internal class TracerValues
 {
     public TracerValues(string tracerHomeDirectory)
+        : this(tracerHomeDirectory, PathHelper.GetTelemetryForwarderPath())
+    {
+    }
+
+    public TracerValues(string tracerHomeDirectory, string telemetryForwarderPath)
     {
         TracerHomeDirectory = tracerHomeDirectory;
         NativeLoaderX86Path = Path.Combine(tracerHomeDirectory, "win-x86", "Datadog.Trace.ClrProfiler.Native.dll");
@@ -28,6 +33,7 @@ internal class TracerValues
             { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
             { "DD_INJECTION_ENABLED", "tracer" },
+            { "DD_TELEMETRY_FORWARDER_PATH", telemetryForwarderPath },
             { Defaults.InstrumentationInstallTypeKey, Defaults.InstrumentationInstallTypeValue },
         });
 
@@ -47,6 +53,7 @@ internal class TracerValues
             // { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
             { "DD_TRACING_ENABLED", "tracing" },
+            { "DD_TELEMETRY_FORWARDER_PATH", telemetryForwarderPath },
             { Defaults.InstrumentationInstallTypeKey, Defaults.InstrumentationInstallTypeValue },
         });
 

--- a/tracer/src/Datadog.FleetInstaller/TracerValues.cs
+++ b/tracer/src/Datadog.FleetInstaller/TracerValues.cs
@@ -12,15 +12,11 @@ namespace Datadog.FleetInstaller;
 internal class TracerValues
 {
     public TracerValues(string tracerHomeDirectory)
-        : this(tracerHomeDirectory, PathHelper.GetTelemetryForwarderPath())
-    {
-    }
-
-    public TracerValues(string tracerHomeDirectory, string telemetryForwarderPath)
     {
         TracerHomeDirectory = tracerHomeDirectory;
         NativeLoaderX86Path = Path.Combine(tracerHomeDirectory, "win-x86", "Datadog.Trace.ClrProfiler.Native.dll");
         NativeLoaderX64Path = Path.Combine(tracerHomeDirectory, "win-x64", "Datadog.Trace.ClrProfiler.Native.dll");
+        TelemetryForwarderPath = PathHelper.GetTelemetryForwarderPath(tracerHomeDirectory);
         IisRequiredEnvVariables = new(new Dictionary<string, string>
         {
             { "COR_PROFILER", "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" },
@@ -33,7 +29,7 @@ internal class TracerValues
             { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
             { "DD_INJECTION_ENABLED", "tracer" },
-            { "DD_TELEMETRY_FORWARDER_PATH", telemetryForwarderPath },
+            { "DD_TELEMETRY_FORWARDER_PATH", TelemetryForwarderPath },
             { Defaults.InstrumentationInstallTypeKey, Defaults.InstrumentationInstallTypeValue },
         });
 
@@ -53,7 +49,7 @@ internal class TracerValues
             // { "COR_ENABLE_PROFILING", "1" },
             { "CORECLR_ENABLE_PROFILING", "1" },
             { "DD_TRACING_ENABLED", "tracing" },
-            { "DD_TELEMETRY_FORWARDER_PATH", telemetryForwarderPath },
+            { "DD_TELEMETRY_FORWARDER_PATH", TelemetryForwarderPath },
             { Defaults.InstrumentationInstallTypeKey, Defaults.InstrumentationInstallTypeValue },
         });
 
@@ -69,6 +65,8 @@ internal class TracerValues
     public string NativeLoaderX86Path { get; }
 
     public string NativeLoaderX64Path { get; }
+
+    public string TelemetryForwarderPath { get; }
 
     public ReadOnlyDictionary<string, string> IisRequiredEnvVariables { get; }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/PathHelperTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/FleetInstaller/PathHelperTests.cs
@@ -1,0 +1,41 @@
+// <copyright file="PathHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using Datadog.FleetInstaller;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.IntegrationTests.FleetInstaller;
+
+public class PathHelperTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("./installer")] // relative
+    [InlineData("somewhere/../installer")] // relative
+    [InlineData(@"c:\")] // root (no parent)
+    public void ForInvalidPaths_ReturnsEmptyString(string homePath)
+    {
+        var actual = PathHelper.GetTelemetryForwarderPath(homePath);
+        actual.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(@"c:\some\path\to\aplace", @"c:\some\path\to\installer\telemetry_forwarder.exe")]
+    [InlineData(@"c:\some\path\..\to\aplace", @"c:\some\to\installer\telemetry_forwarder.exe")]
+    [InlineData(@"D:\some\path\to\aplace.exe", @"D:\some\path\to\installer\telemetry_forwarder.exe")] // a bit questionable, but meh
+    [InlineData(@"c:\library", @"c:\installer\telemetry_forwarder.exe")]
+    [InlineData(@"f:\other-library", @"f:\installer\telemetry_forwarder.exe")]
+    public void ForValidPaths_ReturnsExpectedPath(string homePath, string expected)
+    {
+        var actual = PathHelper.GetTelemetryForwarderPath(homePath);
+        actual.Should().Be(expected);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes

Downloads and verifies the telemetry_forwarder.exe binary and includes it in the OCI image

## Reason for change

We want to ship the binary side-by-side with the fleet installer. At some point we'll configure a proper release process for the `telemetry_forwarder.exe` dll, but in the mean time we're simply pulling from a public location for simplicity.

## Implementation details

- Download the telemetry forwarder from our Azure blob storage
- Sign the binary as part of our normal GitLab build
- Include the forwarder in our GitLab build output
- Set the `DD_TELEMETRY_FORWARDER_PATH` when installing the tracer

## Test coverage

Less than I'd like, but ultimately this is a non-critical component, that is tested independently. It would be nice to have some testing that the telemetry is forwarded correctly, but ultimately I think this should be added in the system-tests/onboarding tests repo. I included the telemetry forwarder in our smoke tests so we should at least get warnings/errors there if there's anything egregious. 

## Other details

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/7341