### PR TITLE
Elaborate on Run failed description

### DIFF
--- a/.azure-pipelines/steps/update-github-status-jobs.yml
+++ b/.azure-pipelines/steps/update-github-status-jobs.yml
@@ -66,4 +66,4 @@ jobs:
       parameters:
         checkName: $(System.StageName)
         status: 'failure'
-        description: 'Run failed'
+        description: 'Run failed, please investigate and/or retry this (if flake) via Azure DevOps'


### PR DESCRIPTION
## Summary of changes

Adds some words after `Run failed` when it shows up in the status

`Run failed, please investigate and/or retry this (if flake) via Azure DevOps`

## Reason for change

Push toward looking at Azure DevOps for the failure and re-running / re-trying from there as it likely isn't obvious that we use a different CI/CD tool than other tracing libraries. And hopefully it'll help raise awareness for flake / issues 🤷 

## Implementation details

Added words

## Test coverage

No test

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
