### PR TITLE
Update the configuration key for controlling managed activation

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ConfigurationKeys.cs
@@ -11,6 +11,6 @@ namespace Datadog.Trace.ContinuousProfiler
         public const string CodeHotspotsEnabled = "DD_PROFILING_CODEHOTSPOTS_ENABLED";
         public const string EndpointProfilingEnabled = "DD_PROFILING_ENDPOINT_COLLECTION_ENABLED";
         public const string SsiDeployed = "DD_INJECTION_ENABLED";
-        public const string ProfilerManagedActivationEnabled = "DD_PROFILER_MANAGED_ACTIVATION_ENABLED";
+        public const string ProfilerManagedActivationEnabled = "DD_PROFILING_MANAGED_ACTIVATION_ENABLED";
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -679,6 +679,6 @@
   "DD_TRACE_BAGGAGE_TAG_KEYS": "trace_baggage_tag_keys",
   "DD_METRICS_OTEL_ENABLED": "metrics_otel_enabled",
   "DD_METRICS_OTEL_METER_NAMES": "metrics_otel_meter_names",
-  "DD_PROFILER_MANAGED_ACTIVATION_ENABLED": "trace_profiler_managed_activation_enabled",
+  "DD_PROFILING_MANAGED_ACTIVATION_ENABLED": "trace_profiler_managed_activation_enabled",
   "DD_CALLSITE_MANAGED_ACTIVATION_ENABLED": "trace_callsite_managed_activation_enabled"
 }


### PR DESCRIPTION
## Summary of changes

Update the configuration key for controlling managed activation that was added in #7303

## Reason for change

Other keys are `DD_PROFILING_` so should be consistent

## Implementation details

`DD_PROFILER_` => ``DD_PROFILING_`

## Test coverage


N/A
