### PR TITLE
Refactor some telemetry 

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -60,8 +60,8 @@ namespace Datadog.Trace.AppSec
 
             WafTimeoutMicroSeconds = (ulong)config
                                            .WithKeys(ConfigurationKeys.AppSec.WafTimeout)
-                                           .GetAs<int>(
-                                                getDefaultValue: () => 100_000, // Default timeout of 100 ms, only extreme conditions should cause timeout
+                                           .AsInt32(
+                                                defaultValue: 100_000, // Default timeout of 100 ms, only extreme conditions should cause timeout
                                                 converter: ParseWafTimeout,
                                                 validator: wafTimeout => wafTimeout > 0);
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
@@ -12,18 +12,10 @@ using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 
 namespace Datadog.Trace.Configuration.Telemetry;
 
-internal readonly struct ConfigurationBuilder
+internal readonly struct ConfigurationBuilder(IConfigurationSource source, IConfigurationTelemetry telemetry)
 {
-    private readonly IConfigurationSource _source;
-    private readonly IConfigurationTelemetry _telemetry;
-
-    public ConfigurationBuilder(IConfigurationSource source, IConfigurationTelemetry telemetry)
-    {
-        // If the source _isn't_ an IConfigurationSource, it's because it's a custom
-        // IConfigurationSource implementation, so we treat that as a "Code" origin.
-        _source = source;
-        _telemetry = telemetry;
-    }
+    private readonly IConfigurationSource _source = source;
+    private readonly IConfigurationTelemetry _telemetry = telemetry;
 
     public HasKeys WithKeys(string key) => new(_source, _telemetry, key);
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
@@ -307,10 +307,23 @@ internal readonly struct ConfigurationBuilder(IConfigurationSource source, IConf
         public int? AsInt32(int? defaultValue, Func<int, bool>? validator, Func<string, ParsingResult<int>>? converter)
         {
             var result = GetInt32Result(validator, converter);
-            Func<DefaultResult<int>>? getDefaultValue = defaultValue.HasValue ? () => defaultValue.Value : null;
-            return TryHandleResult(Telemetry, Key, result, recordValue: true, getDefaultValue, out var value) ? value : null;
+            if (result is { Result: { } ddResult, IsValid: true })
+            {
+                return ddResult;
+            }
+
+            if (defaultValue is not { } value)
+            {
+                return null;
+            }
+
+            Telemetry.Record(Key, value, ConfigurationOrigins.Default);
+            return value;
         }
 
+        // ****************
+        // Double accessors
+        // ****************
         public double? AsDouble() => AsDouble(defaultValue: null, validator: null);
 
         public double AsDouble(double defaultValue) => AsDouble(defaultValue, validator: null).Value;
@@ -325,8 +338,18 @@ internal readonly struct ConfigurationBuilder(IConfigurationSource source, IConf
         public double? AsDouble(double? defaultValue, Func<double, bool>? validator, Func<string, ParsingResult<double>>? converter)
         {
             var result = GetDoubleResult(validator, converter);
-            Func<DefaultResult<double>>? getDefaultValue = defaultValue.HasValue ? () => defaultValue.Value : null;
-            return TryHandleResult(Telemetry, Key, result, recordValue: true, getDefaultValue, out var value) ? value : null;
+            if (result is { Result: { } ddResult, IsValid: true })
+            {
+                return ddResult;
+            }
+
+            if (defaultValue is not { } value)
+            {
+                return null;
+            }
+
+            Telemetry.Record(Key, value, ConfigurationOrigins.Default);
+            return value;
         }
 
         // ****************

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
@@ -14,32 +14,6 @@ namespace Datadog.Trace.Configuration.Telemetry;
 
 internal readonly struct ConfigurationBuilder
 {
-    // static accessor functions
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<string, bool>?, bool, ConfigurationResult<string>> AsStringSelector
-        = (source, key, telemetry, validator, recordValue) => source.GetString(key, telemetry, validator, recordValue);
-
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<bool, bool>?, bool, ConfigurationResult<bool>> AsBoolSelector
-        = (source, key, telemetry, validator, _) => source.GetBool(key, telemetry, validator);
-
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<int, bool>?, bool, ConfigurationResult<int>> AsInt32Selector
-        = (source, key, telemetry, validator, _) => source.GetInt32(key, telemetry, validator);
-
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<double, bool>?, bool, ConfigurationResult<double>> AsDoubleSelector
-        = (source, key, telemetry, validator, _) => source.GetDouble(key, telemetry, validator);
-
-    // static accessor functions with converters
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<string, bool>?, Func<string, ParsingResult<string>>, bool, ConfigurationResult<string>> AsStringWithConverterSelector
-        = (source, key, telemetry, validator, converter, recordValue) => source.GetAs(key, telemetry, converter, validator, recordValue);
-
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<bool, bool>?, Func<string, ParsingResult<bool>>, bool, ConfigurationResult<bool>> AsBoolWithConverterSelector
-        = (source, key, telemetry, validator, converter, _) => source.GetAs(key, telemetry, converter, validator, recordValue: true);
-
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<int, bool>?, Func<string, ParsingResult<int>>, bool, ConfigurationResult<int>> AsInt32WithConverterSelector
-        = (source, key, telemetry, validator, converter, _) => source.GetAs(key, telemetry, converter, validator, recordValue: true);
-
-    private static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<double, bool>?, Func<string, ParsingResult<double>>, bool, ConfigurationResult<double>> AsDoubleWithConverterSelector
-        = (source, key, telemetry, validator, converter, _) => source.GetAs(key, telemetry, converter, validator, recordValue: true);
-
     private readonly IConfigurationSource _source;
     private readonly IConfigurationTelemetry _telemetry;
 
@@ -374,23 +348,23 @@ internal readonly struct ConfigurationBuilder
 
         private ConfigurationResult<string> GetStringResult(Func<string, bool>? validator, Func<string, ParsingResult<string>>? converter, bool recordValue)
             => converter is null
-                   ? GetResult(AsStringSelector, validator, recordValue)
-                   : GetResult(AsStringWithConverterSelector, validator, converter, recordValue);
+                   ? GetResult(Selectors.AsString, validator, recordValue)
+                   : GetResult(Selectors.AsStringWithConverter, validator, converter, recordValue);
 
         private ConfigurationResult<bool> GetBoolResult(Func<bool, bool>? validator, Func<string, ParsingResult<bool>>? converter)
             => converter is null
-                   ? GetResult(AsBoolSelector, validator, recordValue: true)
-                   : GetResult(AsBoolWithConverterSelector, validator, converter, recordValue: true);
+                   ? GetResult(Selectors.AsBool, validator, recordValue: true)
+                   : GetResult(Selectors.AsBoolWithConverter, validator, converter, recordValue: true);
 
         private ConfigurationResult<int> GetInt32Result(Func<int, bool>? validator, Func<string, ParsingResult<int>>? converter)
             => converter is null
-                   ? GetResult(AsInt32Selector, validator, recordValue: true)
-                   : GetResult(AsInt32WithConverterSelector, validator, converter, recordValue: true);
+                   ? GetResult(Selectors.AsInt32, validator, recordValue: true)
+                   : GetResult(Selectors.AsInt32WithConverter, validator, converter, recordValue: true);
 
         private ConfigurationResult<double> GetDoubleResult(Func<double, bool>? validator, Func<string, ParsingResult<double>>? converter)
             => converter is null
-                   ? GetResult(AsDoubleSelector, validator, recordValue: true)
-                   : GetResult(AsDoubleWithConverterSelector, validator, converter, recordValue: true);
+                   ? GetResult(Selectors.AsDouble, validator, recordValue: true)
+                   : GetResult(Selectors.AsDoubleWithConverter, validator, converter, recordValue: true);
 
         private ConfigurationResult<T> GetAs<T>(Func<T, bool>? validator, Func<string, ParsingResult<T>> converter)
             => GetResult(
@@ -595,5 +569,34 @@ internal readonly struct ConfigurationBuilder
             // need to return default/default value here depending on whether it's a struct
             return null;
         }
+    }
+
+    private static class Selectors
+    {
+        // static accessor functions
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<string, bool>?, bool, ConfigurationResult<string>> AsString
+            = (source, key, telemetry, validator, recordValue) => source.GetString(key, telemetry, validator, recordValue);
+
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<bool, bool>?, bool, ConfigurationResult<bool>> AsBool
+            = (source, key, telemetry, validator, _) => source.GetBool(key, telemetry, validator);
+
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<int, bool>?, bool, ConfigurationResult<int>> AsInt32
+            = (source, key, telemetry, validator, _) => source.GetInt32(key, telemetry, validator);
+
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<double, bool>?, bool, ConfigurationResult<double>> AsDouble
+            = (source, key, telemetry, validator, _) => source.GetDouble(key, telemetry, validator);
+
+        // static accessor functions with converters
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<string, bool>?, Func<string, ParsingResult<string>>, bool, ConfigurationResult<string>> AsStringWithConverter
+            = (source, key, telemetry, validator, converter, recordValue) => source.GetAs(key, telemetry, converter, validator, recordValue);
+
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<bool, bool>?, Func<string, ParsingResult<bool>>, bool, ConfigurationResult<bool>> AsBoolWithConverter
+            = (source, key, telemetry, validator, converter, _) => source.GetAs(key, telemetry, converter, validator, recordValue: true);
+
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<int, bool>?, Func<string, ParsingResult<int>>, bool, ConfigurationResult<int>> AsInt32WithConverter
+            = (source, key, telemetry, validator, converter, _) => source.GetAs(key, telemetry, converter, validator, recordValue: true);
+
+        internal static readonly Func<IConfigurationSource, string, IConfigurationTelemetry, Func<double, bool>?, Func<string, ParsingResult<double>>, bool, ConfigurationResult<double>> AsDoubleWithConverter
+            = (source, key, telemetry, validator, converter, _) => source.GetAs(key, telemetry, converter, validator, recordValue: true);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/DefaultResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/DefaultResult.cs
@@ -4,32 +4,18 @@
 // </copyright>
 
 #nullable enable
-using System.Collections.Generic;
 
 namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 
-internal readonly record struct DefaultResult<T>
+internal readonly struct DefaultResult<T>(T result, string telemetryValue)
 {
-    private readonly string? _telemetryValue;
-
-    public DefaultResult(T result, string? telemetryValue)
-    {
-        Result = result;
-        _telemetryValue = telemetryValue;
-    }
-
     /// <summary>
     /// Gets the value to use as the default result
     /// </summary>
-    public T Result { get; }
+    public T Result { get; } = result;
 
     /// <summary>
     /// Gets a string representation of the result to use in telemetry.
     /// </summary>
-    public string? TelemetryValue => _telemetryValue ?? Result?.ToString();
-
-    public static implicit operator DefaultResult<T>(T result)
-        => result is IDictionary<string, string>
-               ? new(result, telemetryValue: string.Empty) // we don't want to call ToString() on these
-               : new(result, null);
+    public string TelemetryValue { get; } = telemetryValue;
 }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -376,7 +376,7 @@ namespace Datadog.Trace.Configuration
             MetadataSchemaVersion = config
                                    .WithKeys(ConfigurationKeys.MetadataSchemaVersion)
                                    .GetAs(
-                                        () => new DefaultResult<SchemaVersion>(SchemaVersion.V0, "V0"),
+                                        defaultValue: new DefaultResult<SchemaVersion>(SchemaVersion.V0, "V0"),
                                         converter: x => x switch
                                         {
                                             "v1" or "V1" => SchemaVersion.V1,
@@ -446,7 +446,7 @@ namespace Datadog.Trace.Configuration
 
             CustomSamplingRulesFormat = config.WithKeys(ConfigurationKeys.CustomSamplingRulesFormat)
                                               .GetAs(
-                                                   getDefaultValue: () => new DefaultResult<string>(SamplingRulesFormat.Glob, "glob"),
+                                                   defaultValue: new DefaultResult<string>(SamplingRulesFormat.Glob, "glob"),
                                                    converter: value =>
                                                    {
                                                        // We intentionally report invalid values as "valid" in the converter,
@@ -598,7 +598,7 @@ namespace Datadog.Trace.Configuration
             PropagationBehaviorExtract = config
                                          .WithKeys(ConfigurationKeys.PropagationBehaviorExtract)
                                          .GetAs(
-                                             () => new DefaultResult<ExtractBehavior>(ExtractBehavior.Continue, "continue"),
+                                             defaultValue: new(ExtractBehavior.Continue, "continue"),
                                              converter: x => x.ToLowerInvariant() switch
                                              {
                                                  "continue" => ExtractBehavior.Continue,
@@ -700,7 +700,7 @@ namespace Datadog.Trace.Configuration
             DbmPropagationMode = config
                                 .WithKeys(ConfigurationKeys.DbmPropagationMode)
                                 .GetAs(
-                                     () => new DefaultResult<DbmPropagationLevel>(DbmPropagationLevel.Disabled, nameof(DbmPropagationLevel.Disabled)),
+                                     defaultValue: new(DbmPropagationLevel.Disabled, nameof(DbmPropagationLevel.Disabled)),
                                      converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
                                      validator: null);
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -1377,7 +1377,7 @@ namespace Datadog.Trace.Configuration
         {
             var configurationDictionary = config
                    .WithKeys(key)
-                   .AsDictionary(allowOptionalMappings: true, () => new Dictionary<string, string>());
+                   .AsDictionary(allowOptionalMappings: true, () => new Dictionary<string, string>(), string.Empty);
 
             if (configurationDictionary == null)
             {

--- a/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
@@ -80,7 +80,7 @@ internal class IastSettings
         TelemetryVerbosity = config
             .WithKeys(ConfigurationKeys.Iast.TelemetryVerbosity)
             .GetAs(
-                getDefaultValue: () => IastMetricsVerbosityLevel.Information,
+                defaultValue: new(IastMetricsVerbosityLevel.Information, "information"),
                 converter: value => value.ToLowerInvariant() switch
                 {
                     "off" => IastMetricsVerbosityLevel.Off,

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             MinimumLevel = config
                                              .WithKeys(ConfigurationKeys.DirectLogSubmission.MinimumLevel)
                                              .GetAs(
-                                                  () => new DefaultResult<DirectSubmissionLogLevel>(DefaultMinimumLevel, nameof(DirectSubmissionLogLevel.Information)),
+                                                  defaultValue: new(DefaultMinimumLevel, nameof(DirectSubmissionLogLevel.Information)),
                                                   converter: x => DirectSubmissionLogLevelExtensions.Parse(x) ?? ParsingResult<DirectSubmissionLogLevel>.Failure(),
                                                   validator: null);
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -252,7 +252,7 @@ internal static class DatadogLoggingFactory
         var maxLogFileSize = new ConfigurationBuilder(source, telemetry)
                             .WithKeys(ConfigurationKeys.MaxLogFileSize)
                             .GetAs(
-                                 () => DefaultMaxLogFileSize,
+                                 defaultValue: new(DefaultMaxLogFileSize, DefaultMaxLogFileSize.ToString(CultureInfo.InvariantCulture)),
                                  converter: x => long.TryParse(x, out var maxLogSize)
                                                      ? maxLogSize
                                                      : ParsingResult<long>.Failure(),

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
@@ -564,7 +564,7 @@ public class ConfigurationBuilderTests
             var actual = new ConfigurationBuilder(source, _telemetry)
                         .WithKeys("key")
                         .GetAs<Guid>(
-                             getDefaultValue: () => _default,
+                             defaultValue: new(_default, Default),
                              validator: null,
                              converter: _converter);
 
@@ -584,7 +584,7 @@ public class ConfigurationBuilderTests
             var actual = new ConfigurationBuilder(source, _telemetry)
                         .WithKeys("key")
                         .GetAs<Guid?>(
-                             getDefaultValue: () => _default,
+                             defaultValue: new(_default, Default),
                              validator: null,
                              converter: _nullableConverter);
 
@@ -605,7 +605,7 @@ public class ConfigurationBuilderTests
             var actual = new ConfigurationBuilder(source, telemetry)
                         .WithKeys(key)
                         .GetAs<Guid?>(
-                             getDefaultValue: () => _default,
+                             defaultValue: new(_default, Default),
                              validator: null,
                              converter: _nullableConverter);
 
@@ -615,7 +615,7 @@ public class ConfigurationBuilderTests
                                       .OrderByDescending(x => x.SeqId)
                                       .FirstOrDefault()
                                       .Value;
-            finalValue.Should().Be(_default.ToString());
+            finalValue.Should().Be(Default);
         }
 
         [Theory]
@@ -677,7 +677,7 @@ public class ConfigurationBuilderTests
             var actual = new ConfigurationBuilder(source, _telemetry)
                         .WithKeys("key")
                         .GetAs<Guid>(
-                             getDefaultValue: () => _default,
+                             defaultValue: new(_default, Default),
                              validator: x => x.ToString()[0] != '5',
                              converter: _converter);
 


### PR DESCRIPTION
## Summary of changes

Refactor `ConfigurationBuilder`

## Reason for change

As part of some upcoming work, we need to record additional telemetry about default values (so that these can be exposed to customers). As an indirect consequence, it's preferable to provide an explicit default value instead of a `Func<T>`, so this refactoring is _mostly_ using `T` instead of `Func<T>` where it makes sense.

## Implementation details

Mostly standard refactoring stuff. Added some overloads, inlined some methods, moved some other things around. Nothing drastic.

One major difference is that `DefaultResult<T>` now _requires_ that you provide an explicit associated "telemetry value" for recording, whereas it was previously optional. However, we always provided it in practice, so this is a noop.

## Test coverage

Should all be covered by existing tests.

## Other details