### PR TITLE
Work around flake in the Couchbase 3 integration tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Couchbase3/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase3/Program.cs
@@ -12,7 +12,7 @@ namespace Samples.Couchbase3
     {
         private static bool ContainsAuthenticationException(Exception ex) => ex switch
         {
-            AuthenticationException => true,
+            AuthenticationException or AuthenticationFailureException => true,
             AggregateException aggEx => aggEx.InnerExceptions.Any(ContainsAuthenticationException),
             { InnerException: { } inner } => ContainsAuthenticationException(inner),
             _ => false,


### PR DESCRIPTION
## Summary of changes

Work around flake in the Couchbase 3 integration tests

## Reason for change

In #7029 we added code to workaround infra flake in the couchbase tests by looking for `AuthenticationException`. However, in Couchbase 3, `AuthenticationFailureException` is thrown instead, so we should look for that too. 

Additionally, I noticed that if I just run the sample locally, with no couchbase running, a totally different issue arises. Working abound that by trying to explicitly connect, and timing out if that fails

## Implementation details

Add `AuthenticationFailureException` and `UnambiguousTimeoutException` to the ignored list. Re-throwing (instead of swallowing) when an error occurs during auth (as we can't continue)

## Test coverage

Tested locally, and confirmed we return the skip code.
