### PR TITLE
Try to fix flake by using unique keys in StackExchange sample tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -124,27 +124,27 @@ namespace Samples.StackExchangeRedis
 #endif
 
 #if (STACKEXCHANGEREDIS_1_2_0)
-                { "GeoAdd", () => db.GeoAdd($"{prefix}Geo", new GeoEntry(1.5, 2.5, "member")) },
-                { "GeoDistance", () => db.GeoDistance($"{prefix}Geo", "member1", "member2") },
-                { "GeoHash", () => db.GeoHash($"{prefix}Geo", "member") },
-                { "GeoPosition", () => db.GeoPosition($"{prefix}Geo", "member") },
-                { "GeoRadius", () => db.GeoRadius($"{prefix}Geo", "member", 2.3) },
-                { "GeoRemove", () => db.GeoRemove($"{prefix}Geo", "member") },
+                { "GeoAdd", () => db.GeoAdd($"{prefix}GeoAdd", new GeoEntry(1.5, 2.5, "member")) },
+                { "GeoDistance", () => db.GeoDistance($"{prefix}GeoDistance", "member1", "member2") },
+                { "GeoHash", () => db.GeoHash($"{prefix}GeoHash", "member") },
+                { "GeoPosition", () => db.GeoPosition($"{prefix}GeoPosition", "member") },
+                { "GeoRadius", () => db.GeoRadius($"{prefix}GeoRadius", "member", 2.3) },
+                { "GeoRemove", () => db.GeoRemove($"{prefix}GeoRemove", "member") },
 #endif
 
-                { "HashDecrement", () => db.HashDecrement($"{prefix}Hash", "hashfield", 4.5) },
-                { "HashDelete", () => db.HashDelete($"{prefix}Hash", "hashfield") },
-                { "HashExists", () => db.HashExists($"{prefix}Hash", "hashfield") },
-                { "HashGet", () => db.HashGet($"{prefix}Hash", "hashfield") },
-                { "HashGetAll", () => db.HashGetAll($"{prefix}Hash") },
-                { "HashIncrement", () => db.HashIncrement($"{prefix}Hash", "hashfield") },
-                { "HashKeys", () => db.HashKeys($"{prefix}Hash") },
-                { "HashLength", () => db.HashLength($"{prefix}Hash") },
+                { "HashDecrement", () => db.HashDecrement($"{prefix}HashDecrement", "hashfield", 4.5) },
+                { "HashDelete", () => db.HashDelete($"{prefix}HashDelete", "hashfield") },
+                { "HashExists", () => db.HashExists($"{prefix}HashExists", "hashfield") },
+                { "HashGet", () => db.HashGet($"{prefix}HashGet", "hashfield") },
+                { "HashGetAll", () => db.HashGetAll($"{prefix}HashGetAll") },
+                { "HashIncrement", () => db.HashIncrement($"{prefix}HashIncrement", "hashfield") },
+                { "HashKeys", () => db.HashKeys($"{prefix}HashKeys") },
+                { "HashLength", () => db.HashLength($"{prefix}HashLength") },
 #if (STACKEXCHANGEREDIS_1_0_228)
-                { "HashScan", () => db.HashScan($"{prefix}Hash", "*", 5, CommandFlags.None) },
+                { "HashScan", () => db.HashScan($"{prefix}HashScan", "*", 5, CommandFlags.None) },
 #endif
-                { "HashSet", () => { db.HashSet($"{prefix}Hash", ApiSafeCreateHashSetEntryList(new KeyValuePair<RedisValue, RedisValue>[] { new KeyValuePair<RedisValue, RedisValue>("hashfield", "hashvalue") })); return null; } },
-                { "HashValues", () => db.HashValues($"{prefix}Hash") },
+                { "HashSet", () => { db.HashSet($"{prefix}HashSet", ApiSafeCreateHashSetEntryList(new KeyValuePair<RedisValue, RedisValue>[] { new KeyValuePair<RedisValue, RedisValue>("hashfield", "hashvalue") })); return null; } },
+                { "HashValues", () => db.HashValues($"{prefix}HashValues") },
 
 #if (STACKEXCHANGEREDIS_1_0_242)
                 { "HyperLogLogAdd", () => db.HyperLogLogAdd($"{prefix}HyperLogLog", "value") },


### PR DESCRIPTION
## Summary of changes

Try to fix flake by using unique keys in StackExchange sample tests

## Reason for change

Saw some flake in the stackexchange tests, with a diff looking like this:

```diff
   {
     TraceId: Id_107,
     SpanId: Id_108,
     Name: redis.command,
     Resource: HINCRBYFLOAT,
     Service: Samples.StackExchange.Redis,
     Type: redis,
+     Error: 1,
     Tags: {
       component: StackExchangeRedis,
       env: integration_tests,
+       error.msg: ERR hash value is not a float,
+       error.stack:
+ StackExchange.Redis.RedisServerException: ERR hash value is not a float
+ at StackExchange.Redis.ConnectionMultiplexer.ExecuteSyncImpl[T](Message message, ResultProcessor`1 processor, ServerEndPoint server, T defaultValue),
+       error.type: StackExchange.Redis.RedisServerException,
       language: dotnet,
       out.host: stackexchangeredis,
       out.port: 6379,
       peer.service: stackexchangeredis,
       redis.raw_command: HINCRBYFLOAT StackExchange.Redis.Database.Hash,
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
       _dd.peer.service.source: out.host
     },
     Metrics: {
       db.redis.database_index: 1.0,
       process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
     }
   },
```

I _think_ the problem is that we are performing multiple operations against the same hash in the "sync" tests, and some ordering of commands it didn't like

## Implementation details

Use a unique command for each test, like we do in the async version

## Test coverage

Covered by existing

## Other details

Originally failed [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=185286&view=logs&j=a69d05c5-a1c4-5b6f-4792-656fb54d97d4&t=7f0459b0-1f69-5432-c3d8-9b1decfa9496)


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
