### PR TITLE
Clean up header when tracing is disabled

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -46,6 +46,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
                     return new CallTargetState(scope);
                 }
             }
+            else
+            {
+                headers.Remove(HttpHeaderNames.TracingEnabled);
+            }
 
             return CallTargetState.GetDefault();
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -41,7 +41,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
         /// <returns>Returns <c>true</c> if injection was performed, and <c>/false</c> otherwise</returns>
         public static bool TryInjectHeaders<TTarget>(TTarget instance)
         {
-            if (instance is HttpWebRequest request && IsTracingEnabled(request))
+            if (instance is not HttpWebRequest request)
+            {
+                return false;
+            }
+
+            if (IsTracingEnabled(request))
             {
                 var tracer = Tracer.Instance;
 
@@ -73,6 +78,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     }
                 }
             }
+
+            request.Headers.Remove(HttpHeaderNames.TracingEnabled);
 
             return false;
         }


### PR DESCRIPTION
## Summary of changes

When tracing is disabled, also remove the "tracing enabled" header.

## Reason for change

We have a use-case where a partner doesn't allow unknown headers. This header allows the tracing headers to not be added, but it still remains when the request is sent, which breaks their system.

## Implementation details

## Test coverage

None that I found. This is more of a proof of concept to get the maintainers feedback. Happy to dig in more, if this is a good idea.

## Other details


