### PR TITLE
Mark the OTLP metrics test as `[Flaky]`

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -202,6 +202,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Flaky("The received payload is super flaky, sometimes we receive multiple payloads", maxRetries: 3)]
         [MemberData(nameof(PackageVersions.OpenTelemetry), MemberType = typeof(PackageVersions))]
         public async Task SubmitsOtlpMetrics(string packageVersion)
         {
@@ -234,6 +235,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 metricRequests.Should().NotBeEmpty("Expected OTLP metric requests were not received.");
 
+                // TODO: We only expect one metric request in the snapshot, but we could actually have multiple payloads, some of which
+                // could contain no metrics, some of which could contain _duplicate_ metrics. Flake central.
+                // To fix it we need to deserialize the data into a "real" payload, and aggregate the metrics as appropriate,
+                // to make sure that we're actually sending the "correct" results. For example, gauge values should not change,
+                // count values should be 0 in subsequent payloads etc.
                 var snapshotPayload = metricRequests
                     .Select(r => r.DeserializedData)
                     .ToList();


### PR DESCRIPTION
## Summary of changes

Mark the OTLP metrics test as `[Flaky]`

## Reason for change

#7138 added integration tests for OTLP metrics, but unfortunately it's super flaky. The problem is that we can't guarantee one payload, so we theoretically need to aggregate the metrics across all the payloads. Some failing payloads shown below for prosperity

## Implementation details

Marked the test as flaky, as deserializing and merging all the metrics looked like a pain. It's what we _should_ do though I think, to make sure everything's working properly and as expected

## Test coverage

N/A
