### PR TITLE
fix: Make OTLP metrics snapshot testing more stable

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -202,7 +202,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [Flaky("The received payload is super flaky, sometimes we receive multiple payloads", maxRetries: 3)]
         [MemberData(nameof(PackageVersions.OpenTelemetry), MemberType = typeof(PackageVersions))]
         public async Task SubmitsOtlpMetrics(string packageVersion)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -260,9 +260,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     {
                         var metrics = scopeMetricByResource
                                         .SelectMany(r => r.Metrics)
-                                        .OrderBy(metric => metric.Name)
+                                        .GroupBy(r => r.Name)
+                                        .OrderBy(group => group.Key)
+                                        .Select(group => group.First())
                                         .ToList();
-                        OtlpHelper.DeduplicateOtlpMetrics(metrics);
 
                         scopeMetrics.Add(new
                         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -273,6 +273,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         });
                     }
 
+                    // Filter out the telemetry resource name, if any
+                    foreach (var attribute in resourceMetricByResource.Key.Item1.Attributes)
+                    {
+                        if (attribute.Key.Equals("telemetry.sdk.version"))
+                        {
+                            attribute.Value.StringValue = "sdk-version";
+                        }
+                    }
+
                     resourceMetrics.Add(new
                     {
                         Resource = resourceMetricByResource.Key.Item1,

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -976,19 +976,13 @@ namespace Datadog.Trace.TestHelpers
                 h => h.Value.ToList(),
                 StringComparer.OrdinalIgnoreCase);
 
-            object deserializedData = null;
+            MetricsData metricsData = null;
 
             if (request.PathAndQuery.StartsWith("/v1/metrics") && contentType.Contains("protobuf"))
             {
                 try
                 {
-                    var metricsData = MetricsData.Parser.ParseFrom(body);
-                    var resource = metricsData.ResourceMetrics;
-
-                    if (resource is not null)
-                    {
-                        deserializedData = resource;
-                    }
+                    metricsData = MetricsData.Parser.ParseFrom(body);
                 }
                 catch (Exception ex)
                 {
@@ -996,14 +990,14 @@ namespace Datadog.Trace.TestHelpers
                 }
             }
 
-            if (deserializedData is not null)
+            if (metricsData is not null)
             {
                 OtlpRequests.Enqueue(new MockOtlpRequest(
                                          request.PathAndQuery,
                                          headersDict,
                                          body,
                                          contentType,
-                                         deserializedData));
+                                         metricsData));
             }
         }
 
@@ -1704,13 +1698,13 @@ namespace Datadog.Trace.TestHelpers
 
         public class MockOtlpRequest
         {
-            public MockOtlpRequest(string pathAndQuery, Dictionary<string, List<string>> headers, byte[] body, string contentType, object deserializedData)
+            public MockOtlpRequest(string pathAndQuery, Dictionary<string, List<string>> headers, byte[] body, string contentType, MetricsData metricsData)
             {
                 PathAndQuery = pathAndQuery;
                 Headers = headers;
                 Body = body;
                 ContentType = contentType;
-                DeserializedData = deserializedData;
+                MetricsData = metricsData;
             }
 
             public string PathAndQuery { get; }
@@ -1724,7 +1718,7 @@ namespace Datadog.Trace.TestHelpers
             /// <summary>
             /// Gets the deserialized protobuf data (if available)
             /// </summary>
-            public object DeserializedData { get; }
+            public MetricsData MetricsData { get; }
         }
     }
 }

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics.verified.txt
@@ -84,44 +84,6 @@
             DataCase: Gauge
           },
           {
-            Name: example.upDownCounter,
-            Description: ,
-            Unit: ,
-            Sum: {
-              DataPoints: [
-                {
-                  Attributes: [
-                    {
-                      Key: http.method,
-                      Value: {
-                        StringValue: GET,
-                        HasStringValue: true,
-                        BytesValue: [],
-                        ValueCase: StringValue
-                      }
-                    },
-                    {
-                      Key: rid,
-                      Value: {
-                        StringValue: 1234567890,
-                        HasStringValue: true,
-                        BytesValue: [],
-                        ValueCase: StringValue
-                      }
-                    }
-                  ],
-                  StartTimeUnixNano": <DateTimeOffset.Now>,
-                  TimeUnixNano": <DateTimeOffset.Now>,
-                  AsInt: 55,
-                  HasAsInt: true,
-                  ValueCase: AsInt
-                }
-              ],
-              AggregationTemporality: Cumulative
-            },
-            DataCase: Sum
-          },
-          {
             Name: example.async.upDownCounter,
             Description: ,
             Unit: ,
@@ -138,43 +100,6 @@
               AggregationTemporality: Cumulative
             },
             DataCase: Sum
-          },
-          {
-            Name: example.gauge,
-            Description: ,
-            Unit: ,
-            Gauge: {
-              DataPoints: [
-                {
-                  Attributes: [
-                    {
-                      Key: http.method,
-                      Value: {
-                        StringValue: GET,
-                        HasStringValue: true,
-                        BytesValue: [],
-                        ValueCase: StringValue
-                      }
-                    },
-                    {
-                      Key: rid,
-                      Value: {
-                        StringValue: 1234567890,
-                        HasStringValue: true,
-                        BytesValue: [],
-                        ValueCase: StringValue
-                      }
-                    }
-                  ],
-                  StartTimeUnixNano": <DateTimeOffset.Now>,
-                  TimeUnixNano": <DateTimeOffset.Now>,
-                  AsDouble: 77.0,
-                  HasAsDouble: true,
-                  ValueCase: AsDouble
-                }
-              ]
-            },
-            DataCase: Gauge
           },
           {
             Name: example.counter,
@@ -214,6 +139,43 @@
               IsMonotonic: true
             },
             DataCase: Sum
+          },
+          {
+            Name: example.gauge,
+            Description: ,
+            Unit: ,
+            Gauge: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsDouble: 77.0,
+                  HasAsDouble: true,
+                  ValueCase: AsDouble
+                }
+              ]
+            },
+            DataCase: Gauge
           },
           {
             Name: example.histogram,
@@ -291,6 +253,44 @@
               AggregationTemporality: Delta
             },
             DataCase: Histogram
+          },
+          {
+            Name: example.upDownCounter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 55,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Sum
           }
         ],
         SchemaUrl: 

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics.verified.txt
@@ -23,7 +23,7 @@
         {
           Key: telemetry.sdk.version,
           Value: {
-            StringValue: 1.12.0,
+            StringValue: sdk-version,
             HasStringValue: true,
             BytesValue: [],
             ValueCase: StringValue

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics.verified.txt
@@ -1,303 +1,301 @@
 ﻿[
-  [
-    {
-      Resource: {
-        Attributes: [
-          {
-            Key: telemetry.sdk.name,
-            Value: {
-              StringValue: opentelemetry,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          },
-          {
-            Key: telemetry.sdk.language,
-            Value: {
-              StringValue: dotnet,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          },
-          {
-            Key: telemetry.sdk.version,
-            Value: {
-              StringValue: 1.12.0,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          },
-          {
-            Key: service.name,
-            Value: {
-              StringValue: unknown_service:dotnet,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          }
-        ]
-      },
-      ScopeMetrics: [
+  {
+    Resource: {
+      Attributes: [
         {
-          Scope: {
-            Name: OpenTelemetryMetricsMeter,
-            Version: 
-          },
-          Metrics: [
-            {
-              Name: example.async.counter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 22,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Delta,
-                IsMonotonic: true
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.async.gauge,
-              Description: ,
-              Unit: ,
-              Gauge: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsDouble: 88.0,
-                    HasAsDouble: true,
-                    ValueCase: AsDouble
-                  }
-                ]
-              },
-              DataCase: Gauge
-            },
-            {
-              Name: example.upDownCounter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 55,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.async.upDownCounter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 66,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.gauge,
-              Description: ,
-              Unit: ,
-              Gauge: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsDouble: 77.0,
-                    HasAsDouble: true,
-                    ValueCase: AsDouble
-                  }
-                ]
-              },
-              DataCase: Gauge
-            },
-            {
-              Name: example.counter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 11,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Delta,
-                IsMonotonic: true
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.histogram,
-              Description: ,
-              Unit: ,
-              Histogram: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    Count: 1,
-                    Sum: 33.0,
-                    HasSum: true,
-                    BucketCounts: [
-                      0,
-                      0,
-                      0,
-                      0,
-                      1,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0
-                    ],
-                    ExplicitBounds: [
-                      0.0,
-                      5.0,
-                      10.0,
-                      25.0,
-                      50.0,
-                      75.0,
-                      100.0,
-                      250.0,
-                      500.0,
-                      750.0,
-                      1000.0,
-                      2500.0,
-                      5000.0,
-                      7500.0,
-                      10000.0
-                    ],
-                    Min: 33.0,
-                    HasMin: true,
-                    Max: 33.0,
-                    HasMax: true
-                  }
-                ],
-                AggregationTemporality: Delta
-              },
-              DataCase: Histogram
-            }
-          ],
-          SchemaUrl: 
+          Key: telemetry.sdk.name,
+          Value: {
+            StringValue: opentelemetry,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
+        },
+        {
+          Key: telemetry.sdk.language,
+          Value: {
+            StringValue: dotnet,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
+        },
+        {
+          Key: telemetry.sdk.version,
+          Value: {
+            StringValue: 1.12.0,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
+        },
+        {
+          Key: service.name,
+          Value: {
+            StringValue: unknown_service:dotnet,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
         }
-      ],
-      SchemaUrl: 
-    }
-  ]
+      ]
+    },
+    ScopeMetrics: [
+      {
+        Scope: {
+          Name: OpenTelemetryMetricsMeter,
+          Version: 
+        },
+        Metrics: [
+          {
+            Name: example.async.counter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 22,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Delta,
+              IsMonotonic: true
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.async.gauge,
+            Description: ,
+            Unit: ,
+            Gauge: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsDouble: 88.0,
+                  HasAsDouble: true,
+                  ValueCase: AsDouble
+                }
+              ]
+            },
+            DataCase: Gauge
+          },
+          {
+            Name: example.upDownCounter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 55,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.async.upDownCounter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 66,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.gauge,
+            Description: ,
+            Unit: ,
+            Gauge: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsDouble: 77.0,
+                  HasAsDouble: true,
+                  ValueCase: AsDouble
+                }
+              ]
+            },
+            DataCase: Gauge
+          },
+          {
+            Name: example.counter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 11,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Delta,
+              IsMonotonic: true
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.histogram,
+            Description: ,
+            Unit: ,
+            Histogram: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  Count: 1,
+                  Sum: 33.0,
+                  HasSum: true,
+                  BucketCounts: [
+                    0,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ],
+                  ExplicitBounds: [
+                    0.0,
+                    5.0,
+                    10.0,
+                    25.0,
+                    50.0,
+                    75.0,
+                    100.0,
+                    250.0,
+                    500.0,
+                    750.0,
+                    1000.0,
+                    2500.0,
+                    5000.0,
+                    7500.0,
+                    10000.0
+                  ],
+                  Min: 33.0,
+                  HasMin: true,
+                  Max: 33.0,
+                  HasMax: true
+                }
+              ],
+              AggregationTemporality: Delta
+            },
+            DataCase: Histogram
+          }
+        ],
+        SchemaUrl: 
+      }
+    ],
+    SchemaUrl: 
+  }
 ]

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_5_0.NET_6.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_5_0.NET_6.verified.txt
@@ -1,169 +1,167 @@
 ﻿[
-  [
-    {
-      Resource: {
-        Attributes: [
-          {
-            Key: service.name,
-            Value: {
-              StringValue: unknown_service:dotnet,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          }
-        ]
-      },
-      ScopeMetrics: [
+  {
+    Resource: {
+      Attributes: [
         {
-          Scope: {
-            Name: OpenTelemetryMetricsMeter,
-            Version: 
-          },
-          Metrics: [
-            {
-              Name: example.async.counter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 22,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative,
-                IsMonotonic: true
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.async.gauge,
-              Description: ,
-              Unit: ,
-              Gauge: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsDouble: 88.0,
-                    HasAsDouble: true,
-                    ValueCase: AsDouble
-                  }
-                ]
-              },
-              DataCase: Gauge
-            },
-            {
-              Name: example.counter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 11,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative,
-                IsMonotonic: true
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.histogram,
-              Description: ,
-              Unit: ,
-              Histogram: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    Count: 1,
-                    Sum: 33.0,
-                    HasSum: true,
-                    BucketCounts: [
-                      0,
-                      0,
-                      0,
-                      0,
-                      1,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0
-                    ],
-                    ExplicitBounds: [
-                      0.0,
-                      5.0,
-                      10.0,
-                      25.0,
-                      50.0,
-                      75.0,
-                      100.0,
-                      250.0,
-                      500.0,
-                      1000.0
-                    ]
-                  }
-                ],
-                AggregationTemporality: Cumulative
-              },
-              DataCase: Histogram
-            }
-          ],
-          SchemaUrl: 
+          Key: service.name,
+          Value: {
+            StringValue: unknown_service:dotnet,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
         }
-      ],
-      SchemaUrl: 
-    }
-  ]
+      ]
+    },
+    ScopeMetrics: [
+      {
+        Scope: {
+          Name: OpenTelemetryMetricsMeter,
+          Version: 
+        },
+        Metrics: [
+          {
+            Name: example.async.counter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 22,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative,
+              IsMonotonic: true
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.async.gauge,
+            Description: ,
+            Unit: ,
+            Gauge: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsDouble: 88.0,
+                  HasAsDouble: true,
+                  ValueCase: AsDouble
+                }
+              ]
+            },
+            DataCase: Gauge
+          },
+          {
+            Name: example.counter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 11,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative,
+              IsMonotonic: true
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.histogram,
+            Description: ,
+            Unit: ,
+            Histogram: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  Count: 1,
+                  Sum: 33.0,
+                  HasSum: true,
+                  BucketCounts: [
+                    0,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ],
+                  ExplicitBounds: [
+                    0.0,
+                    5.0,
+                    10.0,
+                    25.0,
+                    50.0,
+                    75.0,
+                    100.0,
+                    250.0,
+                    500.0,
+                    1000.0
+                  ]
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Histogram
+          }
+        ],
+        SchemaUrl: 
+      }
+    ],
+    SchemaUrl: 
+  }
 ]

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_7_0.NET_7_8.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_7_0.NET_7_8.verified.txt
@@ -1,266 +1,264 @@
 ﻿[
-  [
-    {
-      Resource: {
-        Attributes: [
-          {
-            Key: telemetry.sdk.name,
-            Value: {
-              StringValue: opentelemetry,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          },
-          {
-            Key: telemetry.sdk.language,
-            Value: {
-              StringValue: dotnet,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          },
-          {
-            Key: telemetry.sdk.version,
-            Value: {
-              StringValue: 1.5.1,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          },
-          {
-            Key: service.name,
-            Value: {
-              StringValue: unknown_service:dotnet,
-              HasStringValue: true,
-              BytesValue: [],
-              ValueCase: StringValue
-            }
-          }
-        ]
-      },
-      ScopeMetrics: [
+  {
+    Resource: {
+      Attributes: [
         {
-          Scope: {
-            Name: OpenTelemetryMetricsMeter,
-            Version: 
-          },
-          Metrics: [
-            {
-              Name: example.async.counter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 22,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative,
-                IsMonotonic: true
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.async.gauge,
-              Description: ,
-              Unit: ,
-              Gauge: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsDouble: 88.0,
-                    HasAsDouble: true,
-                    ValueCase: AsDouble
-                  }
-                ]
-              },
-              DataCase: Gauge
-            },
-            {
-              Name: example.upDownCounter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 55,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.async.upDownCounter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 66,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.counter,
-              Description: ,
-              Unit: ,
-              Sum: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    AsInt: 11,
-                    HasAsInt: true,
-                    ValueCase: AsInt
-                  }
-                ],
-                AggregationTemporality: Cumulative,
-                IsMonotonic: true
-              },
-              DataCase: Sum
-            },
-            {
-              Name: example.histogram,
-              Description: ,
-              Unit: ,
-              Histogram: {
-                DataPoints: [
-                  {
-                    Attributes: [
-                      {
-                        Key: http.method,
-                        Value: {
-                          StringValue: GET,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      },
-                      {
-                        Key: rid,
-                        Value: {
-                          StringValue: 1234567890,
-                          HasStringValue: true,
-                          BytesValue: [],
-                          ValueCase: StringValue
-                        }
-                      }
-                    ],
-                    StartTimeUnixNano": <DateTimeOffset.Now>,
-                    TimeUnixNano": <DateTimeOffset.Now>,
-                    Count: 1,
-                    Sum: 33.0,
-                    HasSum: true,
-                    BucketCounts: [
-                      0,
-                      0,
-                      0,
-                      0,
-                      1,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0
-                    ],
-                    ExplicitBounds: [
-                      0.0,
-                      5.0,
-                      10.0,
-                      25.0,
-                      50.0,
-                      75.0,
-                      100.0,
-                      250.0,
-                      500.0,
-                      750.0,
-                      1000.0,
-                      2500.0,
-                      5000.0,
-                      7500.0,
-                      10000.0
-                    ],
-                    Min: 33.0,
-                    HasMin: true,
-                    Max: 33.0,
-                    HasMax: true
-                  }
-                ],
-                AggregationTemporality: Cumulative
-              },
-              DataCase: Histogram
-            }
-          ],
-          SchemaUrl: 
+          Key: telemetry.sdk.name,
+          Value: {
+            StringValue: opentelemetry,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
+        },
+        {
+          Key: telemetry.sdk.language,
+          Value: {
+            StringValue: dotnet,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
+        },
+        {
+          Key: telemetry.sdk.version,
+          Value: {
+            StringValue: 1.5.1,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
+        },
+        {
+          Key: service.name,
+          Value: {
+            StringValue: unknown_service:dotnet,
+            HasStringValue: true,
+            BytesValue: [],
+            ValueCase: StringValue
+          }
         }
-      ],
-      SchemaUrl: 
-    }
-  ]
+      ]
+    },
+    ScopeMetrics: [
+      {
+        Scope: {
+          Name: OpenTelemetryMetricsMeter,
+          Version: 
+        },
+        Metrics: [
+          {
+            Name: example.async.counter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 22,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative,
+              IsMonotonic: true
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.async.gauge,
+            Description: ,
+            Unit: ,
+            Gauge: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsDouble: 88.0,
+                  HasAsDouble: true,
+                  ValueCase: AsDouble
+                }
+              ]
+            },
+            DataCase: Gauge
+          },
+          {
+            Name: example.upDownCounter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 55,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.async.upDownCounter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 66,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.counter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 11,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative,
+              IsMonotonic: true
+            },
+            DataCase: Sum
+          },
+          {
+            Name: example.histogram,
+            Description: ,
+            Unit: ,
+            Histogram: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  Count: 1,
+                  Sum: 33.0,
+                  HasSum: true,
+                  BucketCounts: [
+                    0,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ],
+                  ExplicitBounds: [
+                    0.0,
+                    5.0,
+                    10.0,
+                    25.0,
+                    50.0,
+                    75.0,
+                    100.0,
+                    250.0,
+                    500.0,
+                    750.0,
+                    1000.0,
+                    2500.0,
+                    5000.0,
+                    7500.0,
+                    10000.0
+                  ],
+                  Min: 33.0,
+                  HasMin: true,
+                  Max: 33.0,
+                  HasMax: true
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Histogram
+          }
+        ],
+        SchemaUrl: 
+      }
+    ],
+    SchemaUrl: 
+  }
 ]

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_7_0.NET_7_8.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_7_0.NET_7_8.verified.txt
@@ -84,44 +84,6 @@
             DataCase: Gauge
           },
           {
-            Name: example.upDownCounter,
-            Description: ,
-            Unit: ,
-            Sum: {
-              DataPoints: [
-                {
-                  Attributes: [
-                    {
-                      Key: http.method,
-                      Value: {
-                        StringValue: GET,
-                        HasStringValue: true,
-                        BytesValue: [],
-                        ValueCase: StringValue
-                      }
-                    },
-                    {
-                      Key: rid,
-                      Value: {
-                        StringValue: 1234567890,
-                        HasStringValue: true,
-                        BytesValue: [],
-                        ValueCase: StringValue
-                      }
-                    }
-                  ],
-                  StartTimeUnixNano": <DateTimeOffset.Now>,
-                  TimeUnixNano": <DateTimeOffset.Now>,
-                  AsInt: 55,
-                  HasAsInt: true,
-                  ValueCase: AsInt
-                }
-              ],
-              AggregationTemporality: Cumulative
-            },
-            DataCase: Sum
-          },
-          {
             Name: example.async.upDownCounter,
             Description: ,
             Unit: ,
@@ -254,6 +216,44 @@
               AggregationTemporality: Cumulative
             },
             DataCase: Histogram
+          },
+          {
+            Name: example.upDownCounter,
+            Description: ,
+            Unit: ,
+            Sum: {
+              DataPoints: [
+                {
+                  Attributes: [
+                    {
+                      Key: http.method,
+                      Value: {
+                        StringValue: GET,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    },
+                    {
+                      Key: rid,
+                      Value: {
+                        StringValue: 1234567890,
+                        HasStringValue: true,
+                        BytesValue: [],
+                        ValueCase: StringValue
+                      }
+                    }
+                  ],
+                  StartTimeUnixNano": <DateTimeOffset.Now>,
+                  TimeUnixNano": <DateTimeOffset.Now>,
+                  AsInt: 55,
+                  HasAsInt: true,
+                  ValueCase: AsInt
+                }
+              ],
+              AggregationTemporality: Cumulative
+            },
+            DataCase: Sum
           }
         ],
         SchemaUrl: 

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_7_0.NET_7_8.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpMetrics_up_to_1_7_0.NET_7_8.verified.txt
@@ -23,7 +23,7 @@
         {
           Key: telemetry.sdk.version,
           Value: {
-            StringValue: 1.5.1,
+            StringValue: sdk-version,
             HasStringValue: true,
             BytesValue: [],
             ValueCase: StringValue


### PR DESCRIPTION
## Summary of changes
Makes the OTLP metrics snapshots more stable by adding ordering, doing some deduplication (that wasn't reproduced locally), and consolidating data series by their identifying Resources/Scopes

## Reason for change
We had to mark this test as Flaky, but we really want to make sure it's stable so we can correctly do regression tests against it.

## Implementation details
Processes the OTLP metrics data after receiving it from the mock tracer agent. This includes:
- Grouping multiple series of ScopeMetrics into one series if their Resources match (this is expected and asserted to be true)
- Keeping only one metric data point from a Metric with the same Resource & InstrumentationScope (should fix the issue with multiple exports of the same asynchronous counter)
- Scrubs the `telemetry.sdk.version` attribute with a dummy value so we can successfully test against multiple package versions

## Test coverage
This is the test coverage.

## Other details
