### PR TITLE
Fix debug symbol upload in release job

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -138,7 +138,7 @@ jobs:
           dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
       - name: "Copy gitlab artifacts to artifacts_path"
-        run: cp "${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip" "${{steps.assets.outputs.artifacts_path}}/"
+        run: cp "${{steps.assets.outputs.gitlab_artifacts_path}}/"*.zip "${{steps.assets.outputs.artifacts_path}}/"
 
       - name: 'Push debug symbols to datadog'
         uses: ./.github/actions/publish-debug-symbols


### PR DESCRIPTION
## Summary of changes

Fixes the debug symbol upload in release job

## Reason for change

It broke with:

```
cp: cannot stat '/home/runner/work/dd-trace-dotnet/dd-trace-dotnet/tracer/bin/543c80fd22857677ec9a86bc52131eb2907d5899/*.zip': No such file or directory
```

## Implementation details

It turns out, bash globbing doesn't work like I thought it did 😅 I _thought_ that shell expansion worked inside strings as long as they were wrapped in `"` (and not `'`). But while that's true for _variable_ expansion, it's not true for expanding file paths etc.

i.e. 

- ✅ `/some/path/*.zip` - expands globs
- ✅ `"/some/path/"*.zip` - expands globs
- ❌ `"/some/path/*.zip"` - does not expand globs

## Test coverage

Tested it locally to confirm
