### PR TITLE
Fix Windows SSI release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ publish:
       do {
           try {
               # The grants option at the end is used to allow public access on the files we upload as the acls only aren't enough.
-              aws s3 cp artifacts-out/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+              aws s3 cp artifacts-out/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --include "telemetry_forwarder.exe" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
               If ($LASTEXITCODE -eq 0) { 
                 return
               }

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -31,6 +31,12 @@ if [ -n "$CI_COMMIT_TAG" ] || [ -n "$DOTNET_PACKAGE_VERSION" ]; then
     curl --location --fail \
         --output $win_target_dir/fleet-installer.zip \
         "https://dd-windowsfilter.s3.amazonaws.com/builds/tracer/${CI_COMMIT_SHA}/fleet-installer.zip"
+
+    echo "Downloading Telemetry Forwarder from S3"
+
+    curl --location --fail \
+        --output $win_target_dir/telemetry_forwarder.exe \
+        "https://dd-windowsfilter.s3.amazonaws.com/builds/tracer/${CI_COMMIT_SHA}/telemetry_forwarder.exe"
   fi
 
   echo -n $VERSION > $target_dir/version.txt


### PR DESCRIPTION
## Summary of changes

Fixes the Windows SSI release

## Reason for change

In the last release, 3.24.0, the SSI images failed because the Windows OCI image could not be built. This is due to inherent differences between how the artifacts are handled for the release versus normal builds (and means we can't actually _test_ the "release" path until we, you know, release). 

## Implementation details

Make sure we publish the `telemetry_forwarder.exe` as part of the publish stage, and then pull this when creating the release.

## Test coverage

It worked in the 3.24.1 release, so we're good now

## Other details

It really feels like this whole process is kind of broken. The OCI images should be created _once_ and then just promoted as part of the release, not completely re-built, but that's on the libdatadog-build team...