### PR TITLE
Fix null ref type warning in Nuke

### DIFF
--- a/tracer/build/_build/MetricHelper.cs
+++ b/tracer/build/_build/MetricHelper.cs
@@ -91,7 +91,7 @@ public static class MetricHelper
         static bool TryNormalizeTagName(
             string value,
             bool normalizeSpaces,
-            [NotNullWhen(returnValue: true)] out string? normalizedTagName)
+            [NotNullWhen(returnValue: true)] out string normalizedTagName)
         {
             normalizedTagName = null;
 
@@ -123,7 +123,7 @@ public static class MetricHelper
 
         static bool IsValidTagName(
             string value,
-            [NotNullWhen(returnValue: true)] out string? trimmedValue)
+            [NotNullWhen(returnValue: true)] out string trimmedValue)
         {
             trimmedValue = null;
 


### PR DESCRIPTION
## Summary of changes

Fix a warning when running Nuke

## Reason for change

I introduced a null reference type. And the compiler is upset about it.

## Implementation details

Remove the offending `?`

## Test coverage

Tested it locally
