### PR TITLE
[Service Disc] Change type layout to make it x86 safe

### DIFF
--- a/tracer/src/Datadog.Trace/LibDatadog/ServiceDiscovery/ServiceDiscoveryHelper.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/ServiceDiscovery/ServiceDiscoveryHelper.cs
@@ -42,8 +42,8 @@ internal class ServiceDiscoveryHelper
 
                 if (result.Tag == ResultTag.Error)
                 {
-                    Log.Error("Failed to store tracer metadata with message: {Error}", result.Error.Message.ToUtf8String());
-                    NativeInterop.Common.DropError(ref result.Error);
+                    Log.Error("Failed to store tracer metadata with message: {Error}", result.Result.Error.Message.ToUtf8String());
+                    NativeInterop.Common.DropError(ref result.Result.Error);
                     return StoreMetadataResult.Error;
                 }
 

--- a/tracer/src/Datadog.Trace/LibDatadog/ServiceDiscovery/TracerMemfdHandleResult.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/ServiceDiscovery/TracerMemfdHandleResult.cs
@@ -10,21 +10,24 @@ using System.Runtime.InteropServices;
 namespace Datadog.Trace.LibDatadog.ServiceDiscovery;
 
 /// <summary>
-/// **DO NOT USE THIS TYPE in x86** to map with Libdatadog. OK and Err fields needs a 4 offset instead.
 /// Do not change the values of this enum unless you really need to update the interop mapping.
 /// Libdatadog interop mapping of the generic type: https://github.com/DataDog/libdatadog/blob/60583218a8de6768f67d04fcd5bc6443f67f516b/ddcommon-ffi/src/result.rs#L44
 /// Cf also ddog_Result_TracerMemfdHandle in common.h headers.
 /// </summary>
-[StructLayout(LayoutKind.Explicit)]
+[StructLayout(LayoutKind.Sequential)]
 internal struct TracerMemfdHandleResult
 {
-    [FieldOffset(0)]
     public ResultTag Tag;
 
-    // beware that offset 8 is only valid on x64 and would cause a crash if read on x86.
-    [FieldOffset(8)]
-    public int TracerMemfdHandle;
+    public ResultUnion Result;
 
-    [FieldOffset(8)]
-    public Error Error;
+    [StructLayout(LayoutKind.Explicit)]
+    public struct ResultUnion
+    {
+        [FieldOffset(0)]
+        public int TracerMemfdHandle;
+
+        [FieldOffset(0)]
+        public Error Error;
+    }
 }


### PR DESCRIPTION
## Summary of changes

Change service discovery result type to work in x86 systems.

## Reason for change

tested locally removing x64 guards it works on  both

## Implementation details

use a  mix of sequential and explicit layouts

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
