### PR TITLE
Filter our exit span from Azure Functions tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -280,7 +280,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
-                const int expectedSpanCount = 21;
+                const int expectedSpanCount = 22;
                 var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
                 using var s = new AssertionScope();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -149,11 +149,12 @@ public abstract class AzureFunctionsTests : TestHelper
             {
                 const int expectedSpanCount = 21;
                 var spans = await agent.WaitForSpansAsync(expectedSpanCount);
+                var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
 
                 using var s = new AssertionScope();
-                spans.Count.Should().Be(expectedSpanCount);
+                filteredSpans.Count.Should().Be(expectedSpanCount);
 
-                await AssertInProcessSpans(spans);
+                await AssertInProcessSpans(filteredSpans);
             }
         }
     }
@@ -216,10 +217,10 @@ public abstract class AzureFunctionsTests : TestHelper
             {
                 const int expectedSpanCount = 21;
                 var spans = await agent.WaitForSpansAsync(expectedSpanCount);
-
+                var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
                 using var s = new AssertionScope();
 
-                await AssertIsolatedSpans(spans, $"{nameof(AzureFunctionsTests)}.Isolated.V4.Sdk1");
+                await AssertIsolatedSpans(filteredSpans, $"{nameof(AzureFunctionsTests)}.Isolated.V4.Sdk1");
             }
         }
     }
@@ -280,14 +281,15 @@ public abstract class AzureFunctionsTests : TestHelper
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
-                const int expectedSpanCount = 22;
+                const int expectedSpanCount = 21;
                 var spans = await agent.WaitForSpansAsync(expectedSpanCount);
+                var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
 
                 using var s = new AssertionScope();
 
-                await AssertIsolatedSpans(spans);
+                await AssertIsolatedSpans(filteredSpans);
 
-                spans.Count.Should().Be(expectedSpanCount);
+                filteredSpans.Count.Should().Be(expectedSpanCount);
             }
         }
     }

--- a/tracer/test/snapshots/AzureFunctionsTests.Isolated.verified.txt
+++ b/tracer/test/snapshots/AzureFunctionsTests.Isolated.verified.txt
@@ -3,38 +3,6 @@
     TraceId: Id_1,
     SpanId: Id_2,
     Name: azure_functions.invoke,
-    Resource: Timer ExitApp,
-    Service: AzureFunctionsAllTriggers,
-    Type: serverless,
-    Tags: {
-      aas.environment.extension_version: unknown,
-      aas.environment.instance_id: unknown,
-      aas.environment.instance_name: IntegrationTestHost,
-      aas.environment.os: unknown,
-      aas.environment.runtime: .NET,
-      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.ExitApp,
-      aas.function.name: ExitApp,
-      aas.function.trigger: Timer,
-      aas.site.kind: functionapp,
-      aas.site.name: AzureFunctionsAllTriggers,
-      aas.site.type: function,
-      component: AzureFunctions,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_4,
-    Name: azure_functions.invoke,
     Resource: Timer TriggerAllTimer,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
@@ -64,13 +32,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_5,
+    TraceId: Id_1,
+    SpanId: Id_3,
     Name: http.request,
     Resource: GET localhost:00000/api/trigger,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_4,
+    ParentId: Id_2,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -91,13 +59,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_6,
+    TraceId: Id_1,
+    SpanId: Id_4,
     Name: azure_functions.invoke,
     Resource: GET /api/trigger,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_5,
+    ParentId: Id_3,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -128,13 +96,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_7,
+    TraceId: Id_1,
+    SpanId: Id_5,
     Name: azure_functions.invoke,
     Resource: Http TriggerCaller,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_6,
+    ParentId: Id_4,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -161,12 +129,12 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_8,
+    TraceId: Id_1,
+    SpanId: Id_6,
     Name: Manual inside Trigger,
     Resource: Manual inside Trigger,
     Service: AzureFunctionsAllTriggers,
-    ParentId: Id_7,
+    ParentId: Id_5,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -175,13 +143,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_9,
+    TraceId: Id_1,
+    SpanId: Id_7,
     Name: http.request,
     Resource: GET localhost:00000/api/simple,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_8,
+    ParentId: Id_6,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -202,13 +170,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_10,
+    TraceId: Id_1,
+    SpanId: Id_8,
     Name: http.request,
     Resource: GET localhost:00000/api/exception,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_8,
+    ParentId: Id_6,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -229,13 +197,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_11,
+    TraceId: Id_1,
+    SpanId: Id_9,
     Name: http.request,
     Resource: GET localhost:00000/api/error,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_8,
+    ParentId: Id_6,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -256,13 +224,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_12,
+    TraceId: Id_1,
+    SpanId: Id_10,
     Name: http.request,
     Resource: GET localhost:00000/api/badrequest,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_8,
+    ParentId: Id_6,
     Error: 1,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
@@ -285,13 +253,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_13,
+    TraceId: Id_1,
+    SpanId: Id_11,
     Name: azure_functions.invoke,
     Resource: GET /api/simple,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_9,
+    ParentId: Id_7,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -322,13 +290,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_14,
+    TraceId: Id_1,
+    SpanId: Id_12,
     Name: azure_functions.invoke,
     Resource: GET /api/exception,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_10,
+    ParentId: Id_8,
     Error: 1,
     Tags: {
       aas.environment.extension_version: unknown,
@@ -368,13 +336,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_15,
+    TraceId: Id_1,
+    SpanId: Id_13,
     Name: azure_functions.invoke,
     Resource: GET /api/error,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_11,
+    ParentId: Id_9,
     Error: 1,
     Tags: {
       aas.environment.extension_version: unknown,
@@ -407,13 +375,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_16,
+    TraceId: Id_1,
+    SpanId: Id_14,
     Name: azure_functions.invoke,
     Resource: GET /api/badrequest,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_12,
+    ParentId: Id_10,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -444,13 +412,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_17,
+    TraceId: Id_1,
+    SpanId: Id_15,
     Name: azure_functions.invoke,
     Resource: Http SimpleHttpTrigger,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_13,
+    ParentId: Id_11,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -477,13 +445,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_18,
+    TraceId: Id_1,
+    SpanId: Id_16,
     Name: azure_functions.invoke,
     Resource: Http Exception,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_14,
+    ParentId: Id_12,
     Error: 1,
     Tags: {
       aas.environment.extension_version: unknown,
@@ -516,13 +484,13 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_19,
+    TraceId: Id_1,
+    SpanId: Id_17,
     Name: azure_functions.invoke,
     Resource: Http ServerError,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_15,
+    ParentId: Id_13,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -549,13 +517,13 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_20,
+    TraceId: Id_1,
+    SpanId: Id_18,
     Name: azure_functions.invoke,
     Resource: Http BadRequest,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_16,
+    ParentId: Id_14,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -582,10 +550,38 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_21,
+    TraceId: Id_1,
+    SpanId: Id_19,
     Name: Manual inside Simple,
     Resource: Manual inside Simple,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_15,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: Manual inside Exception,
+    Resource: Manual inside Exception,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_16,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_21,
+    Name: Manual inside ServerError,
+    Resource: Manual inside ServerError,
     Service: AzureFunctionsAllTriggers,
     ParentId: Id_17,
     Tags: {
@@ -596,40 +592,12 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_3,
+    TraceId: Id_1,
     SpanId: Id_22,
-    Name: Manual inside Exception,
-    Resource: Manual inside Exception,
-    Service: AzureFunctionsAllTriggers,
-    ParentId: Id_18,
-    Tags: {
-      aas.site.name: AzureFunctionsAllTriggers,
-      aas.site.type: function,
-      env: integration_tests,
-      language: dotnet
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_23,
-    Name: Manual inside ServerError,
-    Resource: Manual inside ServerError,
-    Service: AzureFunctionsAllTriggers,
-    ParentId: Id_19,
-    Tags: {
-      aas.site.name: AzureFunctionsAllTriggers,
-      aas.site.type: function,
-      env: integration_tests,
-      language: dotnet
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_24,
     Name: Manual inside BadRequest,
     Resource: Manual inside BadRequest,
     Service: AzureFunctionsAllTriggers,
-    ParentId: Id_20,
+    ParentId: Id_18,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,

--- a/tracer/test/snapshots/AzureFunctionsTests.Isolated.verified.txt
+++ b/tracer/test/snapshots/AzureFunctionsTests.Isolated.verified.txt
@@ -3,6 +3,38 @@
     TraceId: Id_1,
     SpanId: Id_2,
     Name: azure_functions.invoke,
+    Resource: Timer ExitApp,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.ExitApp,
+      aas.function.name: ExitApp,
+      aas.function.trigger: Timer,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: azure_functions.invoke,
     Resource: Timer TriggerAllTimer,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
@@ -32,13 +64,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_3,
+    TraceId: Id_3,
+    SpanId: Id_5,
     Name: http.request,
     Resource: GET localhost:00000/api/trigger,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_2,
+    ParentId: Id_4,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -59,13 +91,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_4,
+    TraceId: Id_3,
+    SpanId: Id_6,
     Name: azure_functions.invoke,
     Resource: GET /api/trigger,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_3,
+    ParentId: Id_5,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -96,13 +128,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_5,
+    TraceId: Id_3,
+    SpanId: Id_7,
     Name: azure_functions.invoke,
     Resource: Http TriggerCaller,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_4,
+    ParentId: Id_6,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -129,12 +161,12 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_6,
+    TraceId: Id_3,
+    SpanId: Id_8,
     Name: Manual inside Trigger,
     Resource: Manual inside Trigger,
     Service: AzureFunctionsAllTriggers,
-    ParentId: Id_5,
+    ParentId: Id_7,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -143,13 +175,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_7,
+    TraceId: Id_3,
+    SpanId: Id_9,
     Name: http.request,
     Resource: GET localhost:00000/api/simple,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_6,
+    ParentId: Id_8,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -170,13 +202,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_8,
+    TraceId: Id_3,
+    SpanId: Id_10,
     Name: http.request,
     Resource: GET localhost:00000/api/exception,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_6,
+    ParentId: Id_8,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -197,13 +229,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_9,
+    TraceId: Id_3,
+    SpanId: Id_11,
     Name: http.request,
     Resource: GET localhost:00000/api/error,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_6,
+    ParentId: Id_8,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -224,13 +256,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_10,
+    TraceId: Id_3,
+    SpanId: Id_12,
     Name: http.request,
     Resource: GET localhost:00000/api/badrequest,
     Service: AzureFunctionsAllTriggers-http-client,
     Type: http,
-    ParentId: Id_6,
+    ParentId: Id_8,
     Error: 1,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
@@ -253,13 +285,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_11,
+    TraceId: Id_3,
+    SpanId: Id_13,
     Name: azure_functions.invoke,
     Resource: GET /api/simple,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_7,
+    ParentId: Id_9,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -290,13 +322,13 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_12,
+    TraceId: Id_3,
+    SpanId: Id_14,
     Name: azure_functions.invoke,
     Resource: GET /api/exception,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_8,
+    ParentId: Id_10,
     Error: 1,
     Tags: {
       aas.environment.extension_version: unknown,
@@ -336,13 +368,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_13,
+    TraceId: Id_3,
+    SpanId: Id_15,
     Name: azure_functions.invoke,
     Resource: GET /api/error,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_9,
+    ParentId: Id_11,
     Error: 1,
     Tags: {
       aas.environment.extension_version: unknown,
@@ -375,13 +407,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_14,
+    TraceId: Id_3,
+    SpanId: Id_16,
     Name: azure_functions.invoke,
     Resource: GET /api/badrequest,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_10,
+    ParentId: Id_12,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -412,13 +444,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_15,
+    TraceId: Id_3,
+    SpanId: Id_17,
     Name: azure_functions.invoke,
     Resource: Http SimpleHttpTrigger,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_11,
+    ParentId: Id_13,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -445,13 +477,13 @@ at Samples.AzureFunctions.V4Isolated.DirectFunctionExecutor.ExecuteAsync(Functio
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_16,
+    TraceId: Id_3,
+    SpanId: Id_18,
     Name: azure_functions.invoke,
     Resource: Http Exception,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_12,
+    ParentId: Id_14,
     Error: 1,
     Tags: {
       aas.environment.extension_version: unknown,
@@ -484,13 +516,13 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_17,
+    TraceId: Id_3,
+    SpanId: Id_19,
     Name: azure_functions.invoke,
     Resource: Http ServerError,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_13,
+    ParentId: Id_15,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -517,13 +549,13 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_18,
+    TraceId: Id_3,
+    SpanId: Id_20,
     Name: azure_functions.invoke,
     Resource: Http BadRequest,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_14,
+    ParentId: Id_16,
     Tags: {
       aas.environment.extension_version: unknown,
       aas.environment.instance_id: unknown,
@@ -550,38 +582,10 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_19,
+    TraceId: Id_3,
+    SpanId: Id_21,
     Name: Manual inside Simple,
     Resource: Manual inside Simple,
-    Service: AzureFunctionsAllTriggers,
-    ParentId: Id_15,
-    Tags: {
-      aas.site.name: AzureFunctionsAllTriggers,
-      aas.site.type: function,
-      env: integration_tests,
-      language: dotnet
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_20,
-    Name: Manual inside Exception,
-    Resource: Manual inside Exception,
-    Service: AzureFunctionsAllTriggers,
-    ParentId: Id_16,
-    Tags: {
-      aas.site.name: AzureFunctionsAllTriggers,
-      aas.site.type: function,
-      env: integration_tests,
-      language: dotnet
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_21,
-    Name: Manual inside ServerError,
-    Resource: Manual inside ServerError,
     Service: AzureFunctionsAllTriggers,
     ParentId: Id_17,
     Tags: {
@@ -592,12 +596,40 @@ at Samples.AzureFunctions.AllTriggers.AllTriggers.Exception(HttpRequestData req,
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_3,
     SpanId: Id_22,
+    Name: Manual inside Exception,
+    Resource: Manual inside Exception,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_18,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_23,
+    Name: Manual inside ServerError,
+    Resource: Manual inside ServerError,
+    Service: AzureFunctionsAllTriggers,
+    ParentId: Id_19,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_24,
     Name: Manual inside BadRequest,
     Resource: Manual inside BadRequest,
     Service: AzureFunctionsAllTriggers,
-    ParentId: Id_18,
+    ParentId: Id_20,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Samples.AzureFunctions.V4Isolated.AspNetCore.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.AspNetCore/Samples.AzureFunctions.V4Isolated.AspNetCore.csproj
@@ -11,8 +11,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.4" />
   </ItemGroup>
+  
   <!-- Just reducing duplication, we can evolve these separate if we need to later (Program.cs is different here)-->
   <ItemGroup>
     <Compile Include="..\Samples.AzureFunctions.V4Isolated\AllTriggers.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />


### PR DESCRIPTION
## Summary of changes

Filter out the "exit" span from Azure Functions tests

## Reason for change

The presence of the span is flaky, so filter it out to resolve issues.

## Implementation details

Our current approach to killing the azure functions sample is a bit hacky, and can sometimes result in us creating a span. This can be reproduced locally in particular. To avoid issues and flakiness around it, just filter out the span.

## Test coverage

Covered by existing

## Other details

Discovered as part of https://github.com/DataDog/dd-trace-dotnet/pull/7170
