### PR TITLE
Don't call `ToUpperInvariant` if we don't need to

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Helpers/HttpBypassHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Helpers/HttpBypassHelper.cs
@@ -27,6 +27,16 @@ namespace Datadog.Trace.ClrProfiler.Helpers
 
         private static bool UriContainsAnyOfSlow(Uri requestUri, string[] substrings)
         {
+#if NETCOREAPP3_1_OR_GREATER
+            var uriString = requestUri.ToString();
+            foreach (var substring in substrings)
+            {
+                if (uriString.Contains(substring, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+#else
             var uriString = requestUri.ToString().ToUpperInvariant();
 
             for (var index = 0; index < substrings.Length; index++)
@@ -36,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.Helpers
                     return true;
                 }
             }
-
+#endif
             return false;
         }
     }


### PR DESCRIPTION
## Summary of changes

Don't call `ToUpperInvariant` if we don't need to

## Reason for change

Saw it when looking at the code and made me upset

## Implementation details

Split implementation for when we can do `Contains(substring, StringComparison.OrdinalIgnoreCase)`.

## Test coverage

Covered by existing tests

## Other details

It would be nice if we didn't have to call `ToString()` on the Uri and could just split host/path comparisons, but meh