### PR TITLE
Fix variable generation for `linux-arm64` unit tests

### DIFF
--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -21,9 +21,6 @@ partial class Build
     [Parameter("Optimize generated code. Used for debugger integrations tests", List = false)]
     readonly bool? Optimize;
 
-    TargetFramework[] TestingFrameworksDebugger =>
-        TargetFramework.GetFrameworks(except: new[] { TargetFramework.NET461, TargetFramework.NETSTANDARD2_0, TargetFramework.NETCOREAPP3_0, TargetFramework.NET5_0 });
-
     Project DebuggerIntegrationTests => Solution.GetProject(Projects.DebuggerIntegrationTests);
 
     Project DebuggerSamples => Solution.GetProject(Projects.DebuggerSamples);

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -159,11 +159,10 @@ partial class Build : NukeBuild
 
             void GenerateUnitTestFrameworkMatrices()
             {
-                GenerateTfmsMatrix("unit_tests_windows_matrix", TestingFrameworks);
-                var unixFrameworks = TestingFrameworks.Except(new[] { TargetFramework.NET461, TargetFramework.NET48, TargetFramework.NETSTANDARD2_0 }).ToList();
-                GenerateTfmsMatrix("unit_tests_macos_matrix", unixFrameworks);
-                GenerateLinuxMatrix("x64", unixFrameworks);
-                GenerateLinuxMatrix("arm64", unixFrameworks);
+                GenerateTfmsMatrix("unit_tests_windows_matrix", GetTestingFrameworks(PlatformFamily.Windows));
+                GenerateTfmsMatrix("unit_tests_macos_matrix", GetTestingFrameworks(PlatformFamily.OSX));
+                GenerateLinuxMatrix("x64", GetTestingFrameworks(PlatformFamily.Linux));
+                GenerateLinuxMatrix("arm64", GetTestingFrameworks(PlatformFamily.Linux, isArm64: true));
 
                 void GenerateTfmsMatrix(string name, IEnumerable<TargetFramework> frameworks)
                 {
@@ -211,7 +210,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsWindowsMatrix()
             {
-                var targetFrameworks = TestingFrameworks;
+                var targetFrameworks = GetTestingFrameworks(PlatformFamily.Windows);
                 var targetPlatforms = new[] { "x86", "x64" };
                 var areas = new[] { TracerArea, AsmArea };
                 var matrix = new Dictionary<string, object>();
@@ -235,7 +234,7 @@ partial class Build : NukeBuild
             }
             void GenerateIntegrationTestsDebuggerWindowsMatrix()
             {
-                var targetFrameworks = TestingFrameworksDebugger;
+                var targetFrameworks = GetTestingFrameworks(PlatformFamily.Windows);
                 var targetPlatforms = new[] { "x86", "x64" };
                 var debugTypes = new[] { "portable", "full" };
                 var optimizations = new[] { "true", "false" };
@@ -356,7 +355,7 @@ partial class Build : NukeBuild
                     (baseImage: "alpine", artifactSuffix: "linux-musl-x64"),
                 };
 
-                var targetFrameworks = TestingFrameworks.Except(new[] { TargetFramework.NET461, TargetFramework.NET48, TargetFramework.NETSTANDARD2_0 });
+                var targetFrameworks = GetTestingFrameworks(PlatformFamily.Linux);
 
                 var matrix = new Dictionary<string, object>();
                 foreach (var framework in targetFrameworks)
@@ -395,7 +394,7 @@ partial class Build : NukeBuild
                     (baseImage: "alpine", artifactSuffix: "linux-musl-arm64"),
                 };
 
-                var targetFrameworks = GetTestingFrameworks(isArm64: true).Except(new[] { TargetFramework.NET461, TargetFramework.NET48, TargetFramework.NETSTANDARD2_0 });
+                var targetFrameworks = GetTestingFrameworks(PlatformFamily.Linux, isArm64: true);
 
                 var matrix = new Dictionary<string, object>();
                 foreach (var framework in targetFrameworks)
@@ -420,7 +419,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsDebuggerLinuxMatrix()
             {
-                var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET48 });
+                var targetFrameworks = GetTestingFrameworks(PlatformFamily.Linux);
                 var baseImages = new []
                 {
                     (baseImage: "debian", artifactSuffix: "linux-x64"),
@@ -1690,7 +1689,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsDebuggerArm64Matrices()
             {
-                var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET48, TargetFramework.NETCOREAPP2_1, TargetFramework.NETCOREAPP3_1,  });
+                var targetFrameworks = GetTestingFrameworks(PlatformFamily.Linux, isArm64: true);
                 var baseImages = new []
                 {
                     (baseImage: "debian", artifactSuffix: "linux-arm64"),


### PR DESCRIPTION
## Summary of changes

Fix variable generation for `linux-arm64` unit tests

## Reason for change

We had a minor scare when I saw this in the build logs:
```
No test result files matching '[ 'artifacts/build_data/results/**/*.trx' ]' were found.
unit_tests_arm64 • test glibc_netcoreapp3.0 • publish test results
No test result files matching '[ 'artifacts/build_data/results/**/*.trx' ]' were found.
unit_tests_arm64 • test musl_netcoreapp3.0 • publish test results
No test result files matching '[ 'artifacts/build_data/results/**/*.trx' ]' were found.
unit_tests_arm64 • test glibc_netcoreapp3.1 • publish test results
No test result files matching '[ 'artifacts/build_data/results/**/*.trx' ]' were found.
unit_tests_arm64 • test musl_netcoreapp3.1 • publish test results
```

as it means we weren't running any tests in these scenarios. Luckily, we aren't _supposed_ to run tests in these scenarios, (<.NET 5 linux-arm64) so we can just stop creating these jobs entirely.


## Implementation details

The confusion is that the `TestingFrameworks` property uses ambient properties of the env to decide which frameworks to run (i.e. platform, arm64, test all TFms enabled), but we generate the variable list in a single job (on Windows). 

This PR makes it possible to ask what frameworks a platform/bitness combination _would_ run, and uses that for generating the job matrix.

## Test coverage

This is the test, but I'll do an "all TFMs" test to confirm too
