### PR TITLE
Disable debugger initialization if it's not enabled initially

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -445,18 +445,24 @@ namespace Datadog.Trace.ClrProfiler
 
         private static void InitializeDebugger(TracerSettings tracerSettings)
         {
-            _ = Task.Run(
-                async () =>
-                {
-                    try
+            var manager = DebuggerManager.Instance;
+            if (manager.DebuggerSettings.CodeOriginForSpansEnabled
+                || manager.DebuggerSettings.DynamicInstrumentationEnabled
+                || manager.ExceptionReplaySettings.Enabled)
+            {
+                _ = Task.Run(
+                    async () =>
                     {
-                        await DebuggerManager.Instance.UpdateConfiguration(tracerSettings).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "Error initializing debugger");
-                    }
-                });
+                        try
+                        {
+                            await DebuggerManager.Instance.UpdateConfiguration(tracerSettings).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "Error initializing debugger");
+                        }
+                    });
+            }
         }
 
         // /!\ This method is called by reflection in the SampleHelpers


### PR DESCRIPTION
## Summary of changes

Disables the debugger initialization if it's not explicitly enabled

## Reason for change

We have been seeing some hangs in CI which seem to be caused by the debugger (based on log messages) and I suspect are due to [this refactoring](https://github.com/DataDog/dd-trace-dotnet/commit/015d21801674f10d8d72c17276723ec9c322df69). Rather than revert that large piece of refactoring (and causing massive conflicts for the [remote-enablement PR](https://github.com/DataDog/dd-trace-dotnet/pull/7366)), for now we primarily want to ensure customers _not_ using the debugger are not impacted.

## Implementation details

Check the debugger and exception replay settings to see if the debugger is required. If not, bail out of initialization immediately.

## Test coverage

This is the test
