### PR TITLE
Improve PR labelling and release note generation

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -5,11 +5,23 @@ labels:
   - name: "area:ci-visibility"
     title: "^\\[?(?i)(ci visibility)"
 
+  - name: "area:ci-visibility"
+    title: "^\\[?(?i)(test optimization)"
+
   - name: "area:serverless"
     title: "^\\[?(?i)serverless"
 
+  - name: "area:serverless"
+    title: "^\\[?(?i)(azure functions)"
+
   - name: "area:asm"
     title: "^\\[?(?i)ASM"
+
+  - name: "area:asm"
+    title: "^\\[?(?i)aap"
+
+  - name: "area:asm-iast"
+    title: "^\\[?(?i)iast"
   
   - name: "area:remote-config"
     title: "^\\[?(?i)(RCM|remote config)"
@@ -23,14 +35,29 @@ labels:
   - name: "area:debugger"
     title: "^\\[?(?i)(dynamic instrumentation)"
 
+  - name: "area:debugger,exception-replay"
+    title: "^\\[?(?i)(exception replay)"
+
+  - name: "area:data-streams-monitoring"
+    title: "^\\[?(?i)(dsm)"
+
+  - name: "area:data-streams-monitoring"
+    title: "^\\[?(?i)(data stream monitoring)"
+
   - name: "area:builds"
     title: "^\\[?(?i)build"
+
+  - name: "area:ssi"
+    title: "^\\[?(?i)(fleet installer)"
 
   - name: "area:profiler"
     allFilesIn: "profiler\/.*"
 
+  - name: "area:data-streams-monitoring"
+    allFilesIn: "tracer\/src\/Datadog\\.Trace\/DataStreamsMonitoring\/.*"
+
   - name: "area:debugger"
-    allFilesIn: "debugger\/.*"
+    allFilesIn: "tracer\/src\/Datadog\\.Trace\/Debugger\/.*"
 
   - name: "area:builds"
     allFilesIn: "\\.github\/.*|tracer\/build\/.*|\\.azure-pipelines\/.*|gitlab-ci\\.yml"

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -51,6 +51,7 @@ jobs:
           base: master
           title: "[Test Package Versions Bump] Updating package versions "
           milestone: "${{steps.rename.outputs.milestone}}"
+          labels: "area:dependabot,area:test-apps,dependencies"
           body: |
             Updates the package versions for integration tests.
 

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -100,7 +100,6 @@ jobs:
         id: release_notes
         run: ./tracer/build.sh GenerateReleaseNotes
         env:
-          PIPELINE_ARTIFACTS_LINK: ${{steps.assets.outputs.artifacts_link}}
           GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: "Rename vNext milestone"

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -577,7 +577,6 @@ partial class Build
             const string debugger = "Debugger";
             const string serverless = "Serverless";
 
-            var artifactsLink = Environment.GetEnvironmentVariable("PIPELINE_ARTIFACTS_LINK");
             var nextVersion = FullVersion;
 
             var client = GetGitHubClient();

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -576,6 +576,7 @@ partial class Build
             const string profiler = "Continuous Profiler";
             const string debugger = "Debugger";
             const string serverless = "Serverless";
+            const string dsm = "Data Streams Monitoring";
 
             var nextVersion = FullVersion;
 
@@ -663,9 +664,11 @@ partial class Build
                     { "area:tracer", tracer },
                     { "area:ci-visibility", ciVisibility },
                     { "area:asm", appSecMonitoring },
+                    { "asm-iast", appSecMonitoring },
                     { "area:profiler", profiler },
                     { "area:debugger", debugger },
-                    { "area:serverless", serverless }
+                    { "area:serverless", serverless },
+                    { "area:data-streams-monitoring", dsm },
                 };
 
                 var buildAndTestIssues = new []

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -219,7 +219,7 @@ partial class Build
 
             // Fixes an issue (ambiguous argument) when we do git diff in the Action.
             GitTasks.Git("fetch origin master:master", logOutput: false);
-            var changedFiles = GitTasks.Git("diff --name-only master").Select(f => f.Text);
+            var changedFiles = GitTasks.Git("diff --name-only master").Select(f => f.Text).ToList();
             var config = GetLabellerConfiguration();
             Console.WriteLine($"Checking labels for PR {PullRequestNumber}");
 
@@ -242,7 +242,7 @@ partial class Build
 
             Console.WriteLine($"PR labels updated");
 
-            HashSet<String> ComputeLabels(LabbelerConfiguration config, string prTitle, IEnumerable<string> labels, IEnumerable<string> changedFiles)
+            static HashSet<string> ComputeLabels(LabbelerConfiguration config, string prTitle, IEnumerable<string> labels, ICollection<string> changedFiles)
             {
                 var updatedLabels = new HashSet<string>(labels);
 
@@ -257,7 +257,7 @@ partial class Build
                             if (regex.IsMatch(prTitle))
                             {
                                 Console.WriteLine("Yes it does. Adding label " + label.Name);
-                                updatedLabels.Add(label.Name);
+                                updatedLabels.AddRange(label.Name.Split(','));
                             }
                         }
                         else if (!string.IsNullOrEmpty(label.AllFilesIn))
@@ -267,7 +267,7 @@ partial class Build
                             if(!changedFiles.Any(x => !regex.IsMatch(x)))
                             {
                                 Console.WriteLine("Yes they do. Adding label " + label.Name);
-                                updatedLabels.Add(label.Name);
+                                updatedLabels.AddRange(label.Name.Split(','));
                             }
                         }
                     }


### PR DESCRIPTION
## Summary of changes

Improves PR labelling and release note generation

## Reason for change

Less grunt work at the start of a release

## Implementation details

- Add more labels, including commonly-used prefixes e.g.
  - `[Test Optimization]`
  - `[AAP]`
  - `[Azure Functions]`
  - `[IAST]`
  - `[Exception Replay]`
  - `[DSM]`
  - etc
- Add a DSM section to the release notes
- Auto-label the dependabot package update PRs
- Remove unused variable from release note generation job

## Test coverage

Not really, but it's a minor update that we can fix if needs be
