### PR TITLE
chore: update malformed telemetry name

### DIFF
--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -39,7 +39,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleInjected => "context_header_style.injected",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleExtracted => "context_header_style.extracted",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderTruncated => "context_header.truncated",
-            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header.malformed",
+            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header_style.malformed",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -178,7 +178,7 @@ internal partial class MetricsTelemetryCollector
             // context_header.truncated, index = 140
             new(new[] { "truncation_reason:baggage_item_count_exceeded" }),
             new(new[] { "truncation_reason:baggage_byte_count_exceeded" }),
-            // context_header.malformed, index = 142
+            // context_header_style.malformed, index = 142
             new(new[] { "header_style:baggage" }),
             // stats_api.requests, index = 143
             new(null),

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -39,7 +39,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleInjected => "context_header_style.injected",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleExtracted => "context_header_style.extracted",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderTruncated => "context_header.truncated",
-            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header.malformed",
+            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header_style.malformed",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -178,7 +178,7 @@ internal partial class MetricsTelemetryCollector
             // context_header.truncated, index = 140
             new(new[] { "truncation_reason:baggage_item_count_exceeded" }),
             new(new[] { "truncation_reason:baggage_byte_count_exceeded" }),
-            // context_header.malformed, index = 142
+            // context_header_style.malformed, index = 142
             new(new[] { "header_style:baggage" }),
             // stats_api.requests, index = 143
             new(null),

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -39,7 +39,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleInjected => "context_header_style.injected",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleExtracted => "context_header_style.extracted",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderTruncated => "context_header.truncated",
-            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header.malformed",
+            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header_style.malformed",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -178,7 +178,7 @@ internal partial class MetricsTelemetryCollector
             // context_header.truncated, index = 140
             new(new[] { "truncation_reason:baggage_item_count_exceeded" }),
             new(new[] { "truncation_reason:baggage_byte_count_exceeded" }),
-            // context_header.malformed, index = 142
+            // context_header_style.malformed, index = 142
             new(new[] { "header_style:baggage" }),
             // stats_api.requests, index = 143
             new(null),

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -39,7 +39,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleInjected => "context_header_style.injected",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderStyleExtracted => "context_header_style.extracted",
             Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderTruncated => "context_header.truncated",
-            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header.malformed",
+            Datadog.Trace.Telemetry.Metrics.Count.ContextHeaderMalformed => "context_header_style.malformed",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -178,7 +178,7 @@ internal partial class MetricsTelemetryCollector
             // context_header.truncated, index = 140
             new(new[] { "truncation_reason:baggage_item_count_exceeded" }),
             new(new[] { "truncation_reason:baggage_byte_count_exceeded" }),
-            // context_header.malformed, index = 142
+            // context_header_style.malformed, index = 142
             new(new[] { "header_style:baggage" }),
             // stats_api.requests, index = 143
             new(null),

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -109,7 +109,7 @@ internal enum Count
     /// <summary>
     /// The number of times a context propagation header is dropped because it is malformed, tagged by the header style (`header_style:baggage`)
     /// </summary>
-    [TelemetryMetric<MetricTags.ContextHeaderMalformed>("context_header.malformed")] ContextHeaderMalformed,
+    [TelemetryMetric<MetricTags.ContextHeaderMalformed>("context_header_style.malformed")] ContextHeaderMalformed,
 
     /// <summary>
     /// The number of requests sent to the stats endopint in the agent, regardless of success

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -304,7 +304,7 @@
       "send_to_user": false,
       "user_tags": []
     },
-    "context_header.malformed": {
+    "context_header_style.malformed": {
       "tags": [
         "header_style"
       ],


### PR DESCRIPTION
## Summary of changes
- update malformed baggage telemetry name to `context_header_style.malformed` 
- this follows [dd-go naming ](https://github.com/DataDog/dd-go/blob/b11d80373c74d5a1900ff459a09274cca6223972/trace/apps/tracer-telemetry-intake/telemetry-metrics/static/common_metrics.json#L1713)

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
