### PR TITLE
[IAST] Fix NRE in Native IAST ModuleInfo->GetFullName()

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -413,17 +413,26 @@ HRESULT Dataflow::ModuleLoaded(ModuleID moduleId, ModuleInfo** pModuleInfo)
     }
 
     AppDomainInfo* appDomain = GetAppDomain(appDomainId);
+    if (appDomain == nullptr)
+    {
+        trace::Logger::Error("GetAppDomain failed for AppDomainId ", appDomainId);
+        return E_FAIL;
+    }
+
     WSTRING moduleName = WSTRING(wszName);
     WSTRING modulePath = WSTRING(wszPath);
-
     ModuleInfo* moduleInfo = new ModuleInfo(this, appDomain, moduleId, modulePath, assemblyId, moduleName);
+    if (trace::Logger::IsDebugEnabled())
+    {
+        trace::Logger::Debug("Dataflow::ModuleLoaded -> Loaded Module ", shared::ToString(moduleInfo->GetModuleFullName()));
+    }
+
     CSGUARD(_cs);
     _modules[moduleId] = moduleInfo;
     if (pModuleInfo)
     {
         *pModuleInfo = moduleInfo;
     }
-    trace::Logger::Debug("Dataflow::ModuleLoaded -> Loaded Module ", shared::ToString(moduleInfo->GetModuleFullName()));
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -71,7 +71,7 @@ bool ModuleInfo::IsCoreLib()
 WSTRING ModuleInfo::GetModuleFullName()
 {
     std::stringstream res;
-    res << "(" << Hex((ULONG)_id) << ") " << shared::ToString(_name) << " [" << shared::ToString(_appDomain.Name) << "]  on "
+    res << "(" << Hex((ULONG)_id) << ") " << shared::ToString(_name) << " [" << shared::ToString(_appDomain.Name) << "]  on " 
         << shared::ToString(_path);
     return ToWSTRING(res.str());
 }
@@ -821,7 +821,7 @@ mdToken ModuleInfo::DefineMemberRef(const WSTRING& moduleName, const WSTRING& ty
         moduleInfo = GetModuleInfoByName(moduleName);
         if (!moduleInfo)
         {
-            trace::Logger::Info("Module ", moduleName, " NOT FOUND for ", GetModuleFullName());
+            trace::Logger::Info("Module ", moduleName, " NOT FOUND");
             return 0;
         }
         mdAssemblyRef assemblyRef;
@@ -864,8 +864,11 @@ mdToken ModuleInfo::DefineMemberRef(const WSTRING& moduleName, const WSTRING& ty
     {
         _mMemberImports[memberKey] = methodRef;
         auto memberRefInfo = GetMemberRefInfo(methodRef);
-        trace::Logger::Debug("DefineMemberRef : ", Hex(methodRef), " for ", memberKey,
-                             " MethodName: ", memberRefInfo->GetFullName(), " Module: ", GetModuleFullName());
+        if (trace::Logger::IsDebugEnabled())
+        {
+            trace::Logger::Debug("DefineMemberRef : ", Hex(methodRef), " for ", memberKey,
+                                 " MethodName: ", memberRefInfo->GetFullName(), " Module: ", GetModuleFullName());
+        }
         return methodRef;
     }
     else


### PR DESCRIPTION
## Summary of changes
Avoid calling ModuleInfo::GetFullName functions in Debug traces without a IsDebugEnabled guard

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
