### PR TITLE
[Native] Added DBG macro that checks for IsDebugEnabled before logging a debug trace

### DIFF
--- a/shared/src/native-src/util.h
+++ b/shared/src/native-src/util.h
@@ -298,7 +298,9 @@ namespace shared
 #else
         return false;
 #endif
-}
+    }
+
+
 
 
 }  // namespace shared

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -353,7 +353,7 @@ HRESULT GetCorLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
     if (corAssemblyProperty.ppbPublicKey != nullptr)
     {
         // the corlib module is already loaded, use that information to create the assembly ref
-        Logger::Debug("Using existing corlib reference: ", corAssemblyProperty.szName);
+        DBG("Using existing corlib reference: ", corAssemblyProperty.szName);
         return assembly_emit->DefineAssemblyRef(corAssemblyProperty.ppbPublicKey, corAssemblyProperty.pcbPublicKey,
                                                 corAssemblyProperty.szName.c_str(), &corAssemblyProperty.pMetaData,
                                                 nullptr, 0, corAssemblyProperty.assemblyFlags, corlib_ref);
@@ -992,8 +992,7 @@ bool FindTypeDefByName(const shared::WSTRING& instrumentationTargetMethodTypeNam
             // This can happen between .NET framework and .NET core, not all apis are
             // available in both. Eg: WinHttpHandler, CurlHandler, and some methods in
             // System.Data
-            Logger::Debug("Can't load the TypeDef for: ", instrumentationTargetMethodTypeName,
-                          ", Module: ", assemblyName);
+            DBG("Can't load the TypeDef for: ", instrumentationTargetMethodTypeName, ", Module: ", assemblyName);
             return false;
         }
     }
@@ -1096,10 +1095,7 @@ HRESULT ResolveTypeInternal(ICorProfilerInfo4* info,
     mdAssembly candidateAssembly;
     auto foundModule = false;
 
-    if (Logger::IsDebugEnabled())
-    {
-        Logger::Debug("[ResolveTypeInternal] Trying to resolve type ref to type def for: ", shared::WSTRING(refTypeName.data()));
-    }
+    DBG("[ResolveTypeInternal] Trying to resolve type ref to type def for: ", shared::WSTRING(refTypeName.data()));
 
     // iterate over all the loaded modules and search for the correct one that matches the assemblyRef (resolutionScope)
     for (auto& moduleId : loadedModules)
@@ -1350,7 +1346,7 @@ HRESULT ResolveType(ICorProfilerInfo4* info,
     resolvedTypeDefToken = mdTokenNil;
     if (enclosingType != mdTokenNil)
     {
-        Logger::Debug("ResolveType: Found enclosing type, try to get parent token");
+        DBG("ResolveType: Found enclosing type, try to get parent token");
         std::vector<WCHAR> enclosingRefTypeName(kNameMaxSize);
         hr = metadata_import->GetTypeRefProps(enclosingType, &resolutionScope, enclosingRefTypeName.data(),
                                               kNameMaxSize, &nameSize);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -213,7 +213,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo10), (void**) &info10);
     if (SUCCEEDED(hr))
     {
-        Logger::Debug("Interface ICorProfilerInfo10 found.");
+        DBG("Interface ICorProfilerInfo10 found.");
     }
     else
     {
@@ -225,7 +225,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo8), (void**) &info8);
     if (SUCCEEDED(hr))
     {
-        Logger::Debug("Interface ICorProfilerInfo8 found.");
+        DBG("Interface ICorProfilerInfo8 found.");
     }
     else
     {
@@ -291,7 +291,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     }
     else
     {
-        Logger::Debug("JIT Inlining is enabled.");
+        DBG("JIT Inlining is enabled.");
     }
 
     if (DisableOptimizations())
@@ -302,7 +302,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
     if (IsNGENEnabled())
     {
-        Logger::Debug("NGEN is enabled.");
+        DBG("NGEN is enabled.");
         event_mask |= COR_PRF_MONITOR_CACHE_SEARCHES;
     }
     else
@@ -407,7 +407,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
     const auto& assembly_info = GetAssemblyInfo(this->info_, assembly_id);
     if (!assembly_info.IsValid())
     {
-        Logger::Debug("AssemblyLoadFinished: ", assembly_id, " ", hr_status);
+        DBG("AssemblyLoadFinished: ", assembly_id, " ", hr_status);
         return S_OK;
     }
 
@@ -415,10 +415,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
 
     if (is_instrumentation_assembly)
     {
-        if (Logger::IsDebugEnabled())
-        {
-            Logger::Debug("AssemblyLoadFinished: ", assembly_id, " ", hr_status);
-        }
+        DBG("AssemblyLoadFinished: ", assembly_id, " ", hr_status);
 
         ComPtr<IUnknown> metadata_interfaces;
         auto hr = this->info_->GetModuleMetaData(assembly_info.manifest_module_id, ofRead,
@@ -439,11 +436,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
         // used multiple times for logging
         const auto& assembly_version = assembly_metadata.version.str();
 
-        if (Logger::IsDebugEnabled())
-        {
-            Logger::Debug("AssemblyLoadFinished: AssemblyName=", assembly_info.name,
-                          " AssemblyVersion=", assembly_version);
-        }
+        DBG("AssemblyLoadFinished: AssemblyName=", assembly_info.name, " AssemblyVersion=", assembly_version);
 
         const auto& expected_assembly_reference = trace::AssemblyReference(managed_profiler_full_assembly_version);
 
@@ -554,7 +547,7 @@ void CorProfiler::RewritingPInvokeMaps(const ModuleMetadata& module_metadata,
                 auto methodDef = *enumIterator;
 
                 const auto& caller = GetFunctionInfo(module_metadata.metadata_import, methodDef);
-                Logger::Debug("Rewriting PInvoke method: ", caller.name);
+                DBG("Rewriting PInvoke method: ", caller.name);
 
                 // Get the current PInvoke map to extract the flags and the entrypoint name
                 DWORD pdwMappingFlags;
@@ -672,8 +665,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
             const auto& methodReferences = rejit_module_method_pair.second;
             integration_definitions_.reserve(integration_definitions_.size() + methodReferences.size());
 
-            Logger::Debug("ModuleLoadFinished requesting ReJIT now for ModuleId=", module_id,
-                          ", methodReferences.size()=", methodReferences.size());
+            DBG("ModuleLoadFinished requesting ReJIT now for ModuleId=", module_id, ", methodReferences.size()=", methodReferences.size());
 
             // Push integration definitions from the given module
             for (const auto& methodReference : methodReferences)
@@ -700,7 +692,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
             if (status != std::future_status::timeout)
             {
                 const auto& numReJITs = future.get();
-                Logger::Debug("Total number of ReJIT Requested: ", numReJITs);
+                DBG("Total number of ReJIT Requested: ", numReJITs);
             }
             else
             {
@@ -751,7 +743,7 @@ std::string GetNativeLoaderFilePath()
     }
 
     // variable not set - try to infer the location instead
-    Logger::Debug("DD_INTERNAL_NATIVE_LOADER_PATH variable not found. Inferring native loader path");
+    DBG("DD_INTERNAL_NATIVE_LOADER_PATH variable not found. Inferring native loader path");
 
     auto native_loader_filename =
 #ifdef LINUX
@@ -793,13 +785,10 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
         return S_OK;
     }
 
-    if (Logger::IsDebugEnabled())
-    {
-        Logger::Debug("ModuleLoadFinished: ", module_id, " ", module_info.assembly.name, " AppDomain ",
-                      module_info.assembly.app_domain_id, " ", module_info.assembly.app_domain_name, std::boolalpha,
-                      " | IsNGEN = ", module_info.IsNGEN(), " | IsDynamic = ", module_info.IsDynamic(),
-                      " | IsResource = ", module_info.IsResource(), std::noboolalpha);
-    }
+    DBG("ModuleLoadFinished: ", module_id, " ", module_info.assembly.name, " AppDomain ",
+        module_info.assembly.app_domain_id, " ", module_info.assembly.app_domain_name, std::boolalpha,
+        " | IsNGEN = ", module_info.IsNGEN(), " | IsDynamic = ", module_info.IsDynamic(),
+        " | IsResource = ", module_info.IsResource(), std::noboolalpha);
 
     if (module_info.IsNGEN())
     {
@@ -868,7 +857,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
     {
         // We cannot obtain writable metadata interfaces on Windows Runtime modules
         // or instrument their IL.
-        Logger::Debug("ModuleLoadFinished skipping Windows Metadata module: ", module_id, " ",
+        DBG("ModuleLoadFinished skipping Windows Metadata module: ", module_id, " ",
                       module_info.assembly.name);
         return S_OK;
     }
@@ -876,14 +865,14 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
     if (module_info.IsResource())
     {
         // We don't need to load metadata on resources modules.
-        Logger::Debug("ModuleLoadFinished skipping Resources module: ", module_id, " ", module_info.assembly.name);
+        DBG("ModuleLoadFinished skipping Resources module: ", module_id, " ", module_info.assembly.name);
         return S_OK;
     }
 
     if (module_info.IsDynamic())
     {
         // For CallTarget we don't need to load metadata on dynamic modules.
-        Logger::Debug("ModuleLoadFinished skipping Dynamic module: ", module_id, " ", module_info.assembly.name);
+        DBG("ModuleLoadFinished skipping Dynamic module: ", module_id, " ", module_info.assembly.name);
         return S_OK;
     }
 
@@ -891,7 +880,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
     {
         if (module_info.assembly.name == skip_assembly)
         {
-            Logger::Debug("ModuleLoadFinished skipping known module: ", module_id, " ", module_info.assembly.name);
+            DBG("ModuleLoadFinished skipping known module: ", module_id, " ", module_info.assembly.name);
             return S_OK;
         }
     }
@@ -913,14 +902,14 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
 
             if (is_included)
             {
-                Logger::Debug("ModuleLoadFinished matched module by pattern: ", module_id, " ",
+                DBG("ModuleLoadFinished matched module by pattern: ", module_id, " ",
                               module_info.assembly.name,
                               "but assembly is explicitly included");
                 break;
             }
             else
             {
-                Logger::Debug("ModuleLoadFinished skipping module by pattern: ", module_id, " ",
+                DBG("ModuleLoadFinished skipping module by pattern: ", module_id, " ",
                               module_info.assembly.name);
                 return S_OK;
             }
@@ -1016,8 +1005,8 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                 if (runtime_information_.is_core() && assemblyImport.version > managed_profiler_assembly_reference->
                     version)
                 {
-                    Logger::Debug("Skipping version conflict fix for ", assemblyVersion,
-                                  " because running on .NET Core with a higher version than expected");
+                    DBG("Skipping version conflict fix for ", assemblyVersion,
+                        " because running on .NET Core with a higher version than expected");
                 }
                 else
                 {
@@ -1027,8 +1016,8 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
         }
         else
         {
-            Logger::Debug("Skipping version conflict fix for ", assemblyVersion,
-                          " because the version matches the expected one");
+            DBG("Skipping version conflict fix for ", assemblyVersion,
+                " because the version matches the expected one");
         }
 
         // Rewrite methods for exposing the native tracer version to managed for telemetry purposes
@@ -1084,8 +1073,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
             {
                 if (module_info.assembly.name.rfind(skip_assembly_pattern, 0) == 0)
                 {
-                    Logger::Debug("ModuleLoadFinished skipping [Trace] search for module by pattern: ", module_id, " ",
-                                  module_info.assembly.name);
+                    DBG("ModuleLoadFinished skipping [Trace] search for module by pattern: ", module_id, " ", module_info.assembly.name);
                     searchForTraceAttribute = false;
                     break;
                 }
@@ -1118,8 +1106,8 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
             if (SUCCEEDED(hr))
             {
                 foundType = true;
-                Logger::Debug("ModuleLoadFinished found the TypeDef for ", traceattribute_typename,
-                              " defined in Module ", module_info.assembly.name);
+                DBG("ModuleLoadFinished found the TypeDef for ", traceattribute_typename,
+                    " defined in Module ", module_info.assembly.name);
             }
             else
             {
@@ -1145,8 +1133,8 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                     if (TypeNameMatchesTraceAttribute(type_name, type_name_len))
                     {
                         foundType = true;
-                        Logger::Debug("ModuleLoadFinished found the TypeRef for ", traceattribute_typename,
-                                      " defined in Module ", module_info.assembly.name);
+                        DBG("ModuleLoadFinished found the TypeRef for ", traceattribute_typename,
+                            " defined in Module ", module_info.assembly.name);
                         break;
                     }
 
@@ -1277,8 +1265,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
 
                 if (trace_annotation_integration_type == nullptr)
                 {
-                    Logger::Debug(
-                        "ModuleLoadFinished pushing [Trace] methods to rejit_module_method_pairs for a later ReJIT, ModuleId=",
+                    DBG("ModuleLoadFinished pushing [Trace] methods to rejit_module_method_pairs for a later ReJIT, ModuleId=",
                         module_id,
                         ", ModuleName=", module_info.assembly.name,
                         ", methodReferences.size()=", methodReferences.size());
@@ -1290,9 +1277,9 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                 }
                 else
                 {
-                    Logger::Debug("ModuleLoadFinished including [Trace] methods for ReJIT, ModuleId=", module_id,
-                                  ", ModuleName=", module_info.assembly.name,
-                                  ", methodReferences.size()=", methodReferences.size());
+                    DBG("ModuleLoadFinished including [Trace] methods for ReJIT, ModuleId=", module_id,
+                        ", ModuleName=", module_info.assembly.name,
+                        ", methodReferences.size()=", methodReferences.size());
 
                     integration_definitions_.reserve(integration_definitions_.size() + methodReferences.size());
 
@@ -1320,7 +1307,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
             if (status != std::future_status::timeout)
             {
                 const auto& numReJITs = future.get();
-            Logger::Debug("[Tracer] Total number of ReJIT Requested: ", numReJITs);
+                DBG("[Tracer] Total number of ReJIT Requested: ", numReJITs);
             }
             else
             {
@@ -1378,15 +1365,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
     const auto& moduleInfo = GetModuleInfo(this->info_, module_id);
     if (!moduleInfo.IsValid())
     {
-        Logger::Debug("ModuleUnloadStarted: ", module_id);
+        DBG("ModuleUnloadStarted: ", module_id);
         return S_OK;
     }
 
-    if (Logger::IsDebugEnabled())
-    {
-        Logger::Debug("ModuleUnloadStarted: ", module_id, " ", moduleInfo.assembly.name, " AppDomain ",
-                      moduleInfo.assembly.app_domain_id, " ", moduleInfo.assembly.app_domain_name);
-    }
+    DBG("ModuleUnloadStarted: ", module_id, " ", moduleInfo.assembly.name, " AppDomain ",
+        moduleInfo.assembly.app_domain_id, " ", moduleInfo.assembly.app_domain_name);
 
     const auto is_instrumentation_assembly = moduleInfo.assembly.name == managed_profiler_name;
     if (is_instrumentation_assembly)
@@ -1426,11 +1410,14 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
     auto definitions = definitions_ids.Get();
 
     Logger::Info("Exiting...");
-    Logger::Debug("   ModuleIds: ", modules->size());
-    Logger::Debug("   IntegrationDefinitions: ", integration_definitions_.size());
-    Logger::Debug("   DefinitionsIds: ", definitions->size());
-    Logger::Debug("   ManagedProfilerLoadedAppDomains: ", managed_profiler_loaded_app_domains.size());
-    Logger::Debug("   FirstJitCompilationAppDomains: ", first_jit_compilation_app_domains.size());
+    if (Logger::IsDebugEnabled())
+    {
+        Logger::Debug("   ModuleIds: ", modules->size());
+        Logger::Debug("   IntegrationDefinitions: ", integration_definitions_.size());
+        Logger::Debug("   DefinitionsIds: ", definitions->size());
+        Logger::Debug("   ManagedProfilerLoadedAppDomains: ", managed_profiler_loaded_app_domains.size());
+        Logger::Debug("   FirstJitCompilationAppDomains: ", first_jit_compilation_app_domains.size());
+    }
     Logger::Info("Stats: ", Stats::Instance()->ToString());
     return S_OK;
 }
@@ -1586,8 +1573,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
     const auto& assemblyImport = metadataInterfaces.As<IMetaDataAssemblyImport>(IID_IMetaDataAssemblyImport);
     const auto& assemblyEmit = metadataInterfaces.As<IMetaDataAssemblyEmit>(IID_IMetaDataAssemblyEmit);
 
-    Logger::Debug("Temporaly allocating the ModuleMetadata for injection. ModuleId=", module_id,
-                  " ModuleName=", module_info.assembly.name);
+    DBG("Temporaly allocating the ModuleMetadata for injection. ModuleId=", module_id, " ModuleName=", module_info.assembly.name);
 
     std::unique_ptr<ModuleMetadata> module_metadata = std::make_unique<ModuleMetadata>(
         metadataImport, metadataEmit, assemblyImport, assemblyEmit, module_info.assembly.name,
@@ -1601,11 +1587,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
         return S_OK;
     }
 
-    if (Logger::IsDebugEnabled())
-    {
-        Logger::Debug("JITCompilationStarted: function_id=", function_id, " token=", function_token,
-                      " name=", caller.type.name, ".", caller.name, "()");
-    }
+    DBG("JITCompilationStarted: function_id=", function_id, " token=", function_token,
+        " name=", caller.type.name, ".", caller.name, "()");
 
     // In NETFx, NInject creates a temporary appdomain where the tracer can be loaded
     // If Runtime metrics are enabled, we can encounter a CannotUnloadAppDomainException
@@ -1671,7 +1654,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 
         if (caller.type.id == mdTypeDefNil || caller.type.id == moduleTypeDef)
         {
-            Logger::Debug("JITCompilationStarted: Startup hook skipped from <Module>.", caller.name, "()");
+            DBG("JITCompilationStarted: Startup hook skipped from <Module>.", caller.name, "()");
             return S_OK;
         }
 
@@ -1681,7 +1664,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
         {
             if (pType->id == mdTypeDefNil || pType->id == moduleTypeDef)
             {
-                Logger::Debug("JITCompilationStarted: Startup hook skipped from a type with <Module> as a parent. ", caller.type.name, ".", caller.name, "()");
+                DBG("JITCompilationStarted: Startup hook skipped from a type with <Module> as a parent. ", caller.type.name, ".", caller.name, "()");
                 return S_OK;
             }
 
@@ -1694,7 +1677,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 
         if (caller.type.name.find(WStr("<CrtImplementationDetails>")) != shared::WSTRING::npos)
         {
-            Logger::Debug("JITCompilationStarted: Startup hook skipped from ", caller.type.name, ".", caller.name, "()");
+            DBG("JITCompilationStarted: Startup hook skipped from ", caller.type.name, ".", caller.name, "()");
             return S_OK;
         }
 
@@ -1709,7 +1692,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
             hr = metadataImport->FindMethod(caller.type.id, WStr(".cctor"), 0, 0, &memberDef);
             if (FAILED(hr))
             {
-                Logger::Debug("JITCompilationStarted: No .cctor found for type ", caller.type.name);
+                DBG("JITCompilationStarted: No .cctor found for type ", caller.type.name);
             }
             else
             {
@@ -1720,18 +1703,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
                 hr = metadataImport->GetTypeDefProps(caller.type.id, nullptr, 0, nullptr, &typeDefFlags, nullptr);
                 if (FAILED(hr))
                 {
-                    Logger::Debug("JITCompilationStarted: Error calling GetTypeDefProps for type ", caller.type.name,
-                        ", allowing injection into ", caller.name, "()");
+                    DBG("JITCompilationStarted: Error calling GetTypeDefProps for type ", caller.type.name, ", allowing injection into ", caller.name, "()");
                 }
                 else if(typeDefFlags & tdBeforeFieldInit)
                 {
-                    Logger::Debug("JITCompilationStarted: Found .cctor for type ", caller.type.name,
-                        " but allowing startup hook injection as tdBeforeFieldInit indicates an implicit static constructor");
+                    DBG("JITCompilationStarted: Found .cctor for type ", caller.type.name, " but allowing startup hook injection as tdBeforeFieldInit indicates an implicit static constructor");
                 }
                 else
                 {
-                    Logger::Debug("JITCompilationStarted: Startup hook skipped from ", caller.type.name, ".",
-                        caller.name, "() as found .cctor");
+                    DBG("JITCompilationStarted: Startup hook skipped from ", caller.type.name, ".", caller.name, "() as found .cctor");
                     return S_OK;
                 }
             }
@@ -1767,7 +1747,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
             }
         }
 
-        Logger::Debug("JITCompilationStarted: Startup hook registered.");
+        DBG("JITCompilationStarted: Startup hook registered.");
     }
 
     return S_OK;
@@ -1793,7 +1773,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownFinished(AppDomainID app
     // remove appdomain metadata from map
     const auto& count = first_jit_compilation_app_domains.erase(appDomainId);
 
-    Logger::Debug("AppDomainShutdownFinished: AppDomain: ", appDomainId, ", removed ", count, " elements");
+    DBG("AppDomainShutdownFinished: AppDomain: ", appDomainId, ", removed ", count, " elements");
     return S_OK;
 }
 
@@ -1830,8 +1810,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITInlining(FunctionID callerId, Function
             )
        )
     {
-        Logger::Debug("*** JITInlining: Inlining disabled for [ModuleId=", calleeModuleId,
-                      ", MethodDef=", shared::TokenStr(&calleFunctionToken), "]");
+        DBG("*** JITInlining: Inlining disabled for [ModuleId=", calleeModuleId, ", MethodDef=", shared::TokenStr(&calleFunctionToken), "]");
         *pfShouldInline = false;
     }
 
@@ -1971,12 +1950,9 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
                 -1,
                 enable ? -1 : 0);
 
-            if (Logger::IsDebugEnabled())
-            {
-                Logger::Debug("  * Target: ", targetAssembly, " | ", targetType, ".", targetMethod, "(",
-                              signatureTypes.size(), ") { ", minVersion.str(), " - ", maxVersion.str(), " } [",
-                              integrationAssembly, " | ", integrationType, "]");
-            }
+            DBG("  * Target: ", targetAssembly, " | ", targetType, ".", targetMethod, "(",
+                signatureTypes.size(), ") { ", minVersion.str(), " - ", maxVersion.str(), " } [",
+                integrationAssembly, " | ", integrationType, "]");
 
             integrationDefinitions.push_back(integration);
         }
@@ -2025,7 +2001,7 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
 
             // wait and get the value from the future<int>
             const auto& numReJITs = future.get();
-            Logger::Debug("Total number of ReJIT Requested: ", numReJITs);
+            DBG("Total number of ReJIT Requested: ", numReJITs);
         }
 
         Logger::Info("InitializeProfiler: Total integrations in profiler: ", integration_definitions_.size());
@@ -2124,7 +2100,7 @@ long CorProfiler::RegisterCallTargetDefinitions(WCHAR* id, CallTargetDefinition3
 
             // wait and get the value from the future<int>
             numReJITs = future.get();
-            Logger::Debug("Total number of ReJIT Requested: ", numReJITs);
+            DBG("Total number of ReJIT Requested: ", numReJITs);
         }
 
         Logger::Info("RegisterCallTargetDefinitions: Added ", size, " call targets (enabled: ", enabledTargets,
@@ -2161,7 +2137,7 @@ long CorProfiler::EnableCallTargetDefinitions(UINT32 enabledCategories)
             // wait and get the value from the future<int>
             numReJITs = future.get();
         }
-        Logger::Debug("  Total number of ReJIT Requested: ", numReJITs);
+        DBG("  Total number of ReJIT Requested: ", numReJITs);
     }
     return numReJITs;
 }
@@ -2192,7 +2168,7 @@ long CorProfiler::DisableCallTargetDefinitions(UINT32 disabledCategories)
             // wait and get the value from the future<int>
             numReverts = future.get();
         }
-        Logger::Debug("  Total number of Reverts Requested: ", numReverts);
+        DBG("  Total number of Reverts Requested: ", numReverts);
     }
     return numReverts;
 }
@@ -2296,7 +2272,7 @@ void CorProfiler::InitializeTraceMethods(WCHAR* id, WCHAR* integration_assembly_
                 *trace_annotation_integration_type.get(), configuration_string);
             auto modules = module_ids.Get();
 
-            Logger::Debug("InitializeTraceMethods: Total number of modules to analyze: ", modules->size());
+            DBG("InitializeTraceMethods: Total number of modules to analyze: ", modules->size());
             if (rejit_handler != nullptr)
             {
                 auto promise = std::make_shared<std::promise<ULONG>>();
@@ -2307,7 +2283,7 @@ void CorProfiler::InitializeTraceMethods(WCHAR* id, WCHAR* integration_assembly_
 
                 // wait and get the value from the future<int>
                 const auto& numReJITs = future.get();
-                Logger::Debug("Total number of ReJIT Requested: ", numReJITs);
+                DBG("Total number of ReJIT Requested: ", numReJITs);
             }
 
             integration_definitions_.reserve(integration_definitions_.size() + integrationDefinitions.size());
@@ -2371,8 +2347,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
 {
     if (IsAzureAppServices())
     {
-        Logger::Debug(
-            "GetAssemblyReferences skipping entire callback because this is running in Azure App Services, which "
+        DBG("GetAssemblyReferences skipping entire callback because this is running in Azure App Services, which "
             "isn't yet supported for this feature. AssemblyPath=",
             wszAssemblyPath);
         return S_OK;
@@ -2402,8 +2377,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
     {
         if (assembly_name.rfind(skip_assembly_pattern, 0) == 0)
         {
-            Logger::Debug("GetAssemblyReferences skipping module by pattern: Name=", assembly_name,
-                          " Path=", wszAssemblyPath);
+            DBG("GetAssemblyReferences skipping module by pattern: Name=", assembly_name, " Path=", wszAssemblyPath);
             return S_OK;
         }
     }
@@ -2412,8 +2386,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
     {
         if (assembly_name == skip_assembly)
         {
-            Logger::Debug("GetAssemblyReferences skipping known assembly: Name=", assembly_name,
-                          " Path=", wszAssemblyPath);
+            DBG("GetAssemblyReferences skipping known assembly: Name=", assembly_name, " Path=", wszAssemblyPath);
             return S_OK;
         }
     }
@@ -2461,8 +2434,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
         return S_OK;
     }
 
-    Logger::Debug("GetAssemblyReferences extending assembly closure for ", assembly_name, " to include ",
-                  asmRefInfo.szName, ". Path=", wszAssemblyPath);
+    DBG("GetAssemblyReferences extending assembly closure for ", assembly_name, " to include ", asmRefInfo.szName, ". Path=", wszAssemblyPath);
 
     return S_OK;
 }
@@ -2753,7 +2725,7 @@ HRESULT CorProfiler::RewriteForDistributedTracing(const ModuleMetadata& module_m
                                 module_metadata.metadata_import));
     }
 
-    Logger::Debug("MethodDef was added as an internal rewrite: ", getDistributedTraceMethodDef);
+    DBG("MethodDef was added as an internal rewrite: ", getDistributedTraceMethodDef);
     getDistributedTraceMethodDef_ = getDistributedTraceMethodDef;
     return hr;
 }
@@ -2828,7 +2800,7 @@ HRESULT CorProfiler::RewriteForTelemetry(const ModuleMetadata& module_metadata, 
     }
 
     // Store this methodDef token in the internal tokens list
-    Logger::Debug("MethodDef was added as an internal rewrite: ", getNativeTracerVersionMethodDef);
+    DBG("MethodDef was added as an internal rewrite: ", getNativeTracerVersionMethodDef);
     getNativeTracerVersionMethodDef_ = getNativeTracerVersionMethodDef;
 
     return hr;
@@ -2894,7 +2866,7 @@ HRESULT CorProfiler::RewriteIsManualInstrumentationOnly(const ModuleMetadata& mo
     }
 
     // Store this methodDef token in the internal tokens list
-    Logger::Debug("MethodDef was added as an internal rewrite: ", isAutoEnabledMethodDef);
+    DBG("MethodDef was added as an internal rewrite: ", isAutoEnabledMethodDef);
     isManualInstrumentationOnlyMethodDef_ = isAutoEnabledMethodDef;
 
     return hr;
@@ -3228,7 +3200,7 @@ bool CorProfiler::EnsureCallTargetBubbleUpExceptionTypeAvailable(const ModuleMet
     // *** Ensure Datadog.Trace.ClrProfiler.CallTarget.CallTargetBubbleUpException available
     const auto bubble_up_type_name = calltargetbubbleexception_tracer_type_name.c_str();
     const auto found_call_target_bubble_up_exception_type = module_metadata.metadata_import->FindTypeDefByName(bubble_up_type_name, mdTokenNil, typeDef);
-    Logger::Debug("CallTargetBubbleUpException type available test, hresult is: ", found_call_target_bubble_up_exception_type);
+    DBG("CallTargetBubbleUpException type available test, hresult is: ", found_call_target_bubble_up_exception_type);
     return SUCCEEDED(found_call_target_bubble_up_exception_type);
 }
 
@@ -3240,7 +3212,7 @@ bool CorProfiler::EnsureIsCallTargetBubbleUpExceptionFunctionAvailable(const Mod
     const auto found_call_target_bubble_up_exception_function = module_metadata.metadata_import->FindMethod(typeDef, bubble_up_function_name, 0, 0, &methodDef);
 
     auto res = SUCCEEDED(found_call_target_bubble_up_exception_function);
-    Logger::Debug("CallTargetBubbleUpException.IsCallTargetBubbleUpException method found: ", res);
+    DBG("CallTargetBubbleUpException.IsCallTargetBubbleUpException method found: ", res);
     return res;
 }
 
@@ -3253,11 +3225,11 @@ bool CorProfiler::EnsureCallTargetStateSkipMethodBodyFunctionAvailable(const Mod
         mdMethodDef methodDef = mdTokenNil;
         const auto function_found = module_metadata.metadata_import->FindMethod(typeDef, calltargetstate_skipmethodbody_function_name.c_str(), 0, 0, &methodDef);
         const auto res = SUCCEEDED(function_found);
-        Logger::Debug("CallTargetState.SkipMethodBody property found: ", res);
+        DBG("CallTargetState.SkipMethodBody property found: ", res);
         return res;
     }
 
-    Logger::Debug("CallTargetState.SkipMethodBody property not found: ", type_found);
+    DBG("CallTargetState.SkipMethodBody property not found: ", type_found);
     return false;
 }
 
@@ -3751,8 +3723,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     }
 
     shared::WSTRING native_profiler_file = shared::GetCurrentModuleFileName();
-    Logger::Debug("GenerateVoidILStartupMethod: Setting the PInvoke native profiler library path to ",
-                  native_profiler_file);
+    DBG("GenerateVoidILStartupMethod: Setting the PInvoke native profiler library path to ", native_profiler_file);
 
     mdModuleRef profiler_ref;
     hr = metadata_emit->DefineModuleRef(native_profiler_file.c_str(), &profiler_ref);
@@ -4372,7 +4343,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdM
         return S_OK;
     }
 
-    Logger::Debug("GetReJITParameters: [moduleId: ", moduleId, ", methodId: ", Hex(methodId), "]");
+    DBG("GetReJITParameters: [moduleId: ", moduleId, ", methodId: ", Hex(methodId), "]");
 
     // we notify the reJIT handler of this event and pass the module_metadata.
     return rejit_handler->NotifyReJITParameters(moduleId, methodId, pFunctionControl);
@@ -4502,7 +4473,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
 
     if (!has_loader_injected_in_appdomain)
     {
-        Logger::Debug("JITCachedFunctionSearchStarted: Disabling NGEN due to missing loader.");
+        DBG("JITCachedFunctionSearchStarted: Disabling NGEN due to missing loader.");
         // The loader is missing in this AppDomain, we skip the NGEN image to allow the JITCompilationStart inject
         // it.
         *pbUseCachedFunction = false;

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler_base.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler_base.cpp
@@ -19,73 +19,73 @@ CorProfilerBase::~CorProfilerBase()
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::Initialize(IUnknown* pICorProfilerInfoUnk)
 {
-    Logger::Debug("Initialize");
+    DBG("Initialize");
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::Shutdown()
 {
-    Logger::Debug("Shutdown");
+    DBG("Shutdown");
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainCreationStarted(AppDomainID appDomainId)
 {
-    Logger::Debug("AppDomainCreationStarted: ", appDomainId);
+    DBG("AppDomainCreationStarted: ", appDomainId);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainCreationFinished(AppDomainID appDomainId, HRESULT hrStatus)
 {
-    Logger::Debug("AppDomainCreationFinished: ", appDomainId, " hrStatus=", hrStatus);
+    DBG("AppDomainCreationFinished: ", appDomainId, " hrStatus=", hrStatus);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainShutdownStarted(AppDomainID appDomainId)
 {
-    Logger::Debug("AppDomainShutdownStarted: ", appDomainId);
+    DBG("AppDomainShutdownStarted: ", appDomainId);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus)
 {
-    Logger::Debug("AppDomainShutdownFinished: ", appDomainId, " ", hrStatus);
+    DBG("AppDomainShutdownFinished: ", appDomainId, " ", hrStatus);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyLoadStarted(AssemblyID assemblyId)
 {
-    Logger::Debug("AssemblyLoadStarted: ", assemblyId);
+    DBG("AssemblyLoadStarted: ", assemblyId);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus)
 {
-    Logger::Debug("AssemblyLoadFinished: ", assemblyId, " ", hrStatus);
+    DBG("AssemblyLoadFinished: ", assemblyId, " ", hrStatus);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyUnloadStarted(AssemblyID assemblyId)
 {
-    Logger::Debug("AssemblyUnloadStarted: ", assemblyId);
+    DBG("AssemblyUnloadStarted: ", assemblyId);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyUnloadFinished(AssemblyID assemblyId, HRESULT hrStatus)
 {
-    Logger::Debug("AssemblyUnloadFinished: ", assemblyId, " ", hrStatus);
+    DBG("AssemblyUnloadFinished: ", assemblyId, " ", hrStatus);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleLoadStarted(ModuleID moduleId)
 {
-    Logger::Debug("ModuleLoadStarted: ", moduleId);
+    DBG("ModuleLoadStarted: ", moduleId);
     return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus)
 {
-    Logger::Debug("ModuleLoadFinished: ", moduleId, " ", hrStatus);
+    DBG("ModuleLoadFinished: ", moduleId, " ", hrStatus);
     return S_OK;
 }
 
@@ -96,7 +96,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleUnloadStarted(ModuleID moduleId
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus)
 {
-    Logger::Debug("ModuleUnloadFinished: ", moduleId, " ", hrStatus);
+    DBG("ModuleUnloadFinished: ", moduleId, " ", hrStatus);
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -198,7 +198,7 @@ void Dataflow::Destroy()
 void Dataflow::LoadAspects(WCHAR** aspects, int aspectsLength, UINT32 enabledCategories, UINT32 platform)
 {
     // Init aspects
-    trace::Logger::Debug("Dataflow::LoadAspects -> Processing aspects... ", aspectsLength, " ", enabledCategories, " ", platform);
+    DBG("Dataflow::LoadAspects -> Processing aspects... ", aspectsLength, " ", enabledCategories, " ", platform);
 
     DataflowAspectClass* aspectClass = nullptr;
     for (int x = 0; x < aspectsLength; x++)
@@ -209,7 +209,7 @@ void Dataflow::LoadAspects(WCHAR** aspects, int aspectsLength, UINT32 enabledCat
             aspectClass = new DataflowAspectClass(this, line, enabledCategories);
             if (!aspectClass->IsValid())
             {
-                trace::Logger::Debug("Dataflow::LoadAspects -> Detected invalid aspect class ", line);
+                DBG("Dataflow::LoadAspects -> Detected invalid aspect class ", line);
                 DEL(aspectClass);
             }
             else
@@ -223,7 +223,7 @@ void Dataflow::LoadAspects(WCHAR** aspects, int aspectsLength, UINT32 enabledCat
             auto aspect = new DataflowAspect(aspectClass, line, platform);
             if (!aspect->IsValid())
             {
-                trace::Logger::Debug("Dataflow::LoadAspects -> Detected invalid aspect ", line);
+                DBG("Dataflow::LoadAspects -> Detected invalid aspect ", line);
                 DEL(aspect);
             }
             else
@@ -250,8 +250,7 @@ void Dataflow::LoadSecurityControls()
     {
         DataflowAspectClass* aspectClass = nullptr;
 
-        trace::Logger::Debug("Dataflow::LoadSecurityControls -> Processing Security Controls Config... ",
-                             securityControlsConfig);
+        DBG("Dataflow::LoadSecurityControls -> Processing Security Controls Config... ", securityControlsConfig);
         auto securityControls = shared::Split(securityControlsConfig, ';');
         for (auto const& securityControlLine : securityControls)
         {
@@ -343,24 +342,24 @@ void Dataflow::LoadSecurityControls()
             {
                 aspectClass = new SecurityControlAspectClass(this);
                 _aspectClasses.push_back(aspectClass);
-                trace::Logger::Debug("Dataflow::LoadSecurityControls -> Created AspectClass");
+                DBG("Dataflow::LoadSecurityControls -> Created AspectClass");
             }
 
             auto aspect = new SecurityControlAspect(aspectClass, secureMarks, securityControlType, targetAssembly,
                                                     targetType, targetMethod, targetParams, parameterIndexes);
 
-            if (trace::Logger::IsDebugEnabled())
+            if (Logger::IsDebugEnabled())
             {
                 auto params = iast::Join(parameterIndexes, ",");
-                trace::Logger::Debug("Dataflow::LoadSecurityControls -> Created Aspect: ", (int) securityControlType,
-                                     "  ", targetAssembly, " | ", targetType, " :: ", targetMethod, "  ", targetParams,
-                                     " [", params, "]");
+                Logger::Debug("Dataflow::LoadSecurityControls -> Created Aspect: ", (int) securityControlType,
+                              "  ", targetAssembly, " | ", targetType, " :: ", targetMethod, "  ", targetParams,
+                              " [", params, "]");
             }
 
             _aspects.push_back(aspect);
         }
 
-        trace::Logger::Debug("Dataflow::LoadSecurityControls -> Exit");
+        DBG("Dataflow::LoadSecurityControls -> Exit");
     }
 }
 
@@ -371,8 +370,7 @@ HRESULT Dataflow::AppDomainShutdown(AppDomainID appDomainId)
     auto it = _appDomains.find(appDomainId);
     if (it != _appDomains.end())
     {
-        trace::Logger::Debug("AppDomainShutdown: AppDomainId = ", Hex((ULONG) appDomainId), " [ ", it->second->Name,
-                             " ] ");
+        DBG("AppDomainShutdown: AppDomainId = ", Hex((ULONG) appDomainId), " [ ", it->second->Name, " ] ");
         DEL(it->second);
         _appDomains.erase(appDomainId);
         return S_OK;
@@ -422,10 +420,7 @@ HRESULT Dataflow::ModuleLoaded(ModuleID moduleId, ModuleInfo** pModuleInfo)
     WSTRING moduleName = WSTRING(wszName);
     WSTRING modulePath = WSTRING(wszPath);
     ModuleInfo* moduleInfo = new ModuleInfo(this, appDomain, moduleId, modulePath, assemblyId, moduleName);
-    if (trace::Logger::IsDebugEnabled())
-    {
-        trace::Logger::Debug("Dataflow::ModuleLoaded -> Loaded Module ", shared::ToString(moduleInfo->GetModuleFullName()));
-    }
+    DBG("Dataflow::ModuleLoaded -> Loaded Module ", shared::ToString(moduleInfo->GetModuleFullName()));
 
     CSGUARD(_cs);
     _modules[moduleId] = moduleInfo;
@@ -452,13 +447,12 @@ HRESULT Dataflow::ModuleUnloaded(ModuleID moduleId)
         auto it = _modules.find(moduleId);
         if (it != _modules.end())
         {
-            trace::Logger::Debug("ModuleUnloadFinished: ModuleID = ", Hex((ULONG) moduleId), " [ ",
-                                 it->second->_appDomain.Name, " ] ", it->second->_name);
+            DBG("ModuleUnloadFinished: ModuleID = ", Hex((ULONG) moduleId), " [ ", it->second->_appDomain.Name, " ] ", it->second->_name);
             DEL(it->second);
         }
         else
         {
-            trace::Logger::Debug("ModuleUnloadFinished: ModuleID = ", Hex((ULONG) moduleId), " (Not found)");
+            DBG("ModuleUnloadFinished: ModuleID = ", Hex((ULONG) moduleId), " (Not found)");
         }
         _modules.erase(moduleId);
     }
@@ -741,7 +735,7 @@ HRESULT Dataflow::RewriteMethod(MethodInfo* method, trace::FunctionControlWrappe
             {
                 std::vector<ModuleID> modulesVector = {module->_id};
                 std::vector<mdMethodDef> methodsVector = {method->GetMemberId()}; // methodId
-                trace::Logger::Debug("RewriteMethod: REJIT requested for ", method->GetKey());
+                DBG("RewriteMethod: REJIT requested for ", method->GetKey());
                 m_rejitHandler->RequestRejit(modulesVector, methodsVector);
             }
         }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
@@ -758,6 +758,11 @@ namespace iast
     {
         try
         {
+            if (debugLevel && !trace::Logger::IsDebugEnabled())
+            {
+                return;
+            }
+
             auto method = _body->GetMethodInfo();
             auto module = method->GetModuleInfo();
             Log(debugLevel, "Dumping IL ", extraMessage, " : ", method->GetFullName(), " ",

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -377,13 +377,13 @@ namespace iast
     HRESULT MethodInfo::SetMethodIL(ULONG nSize, LPCBYTE pMethodIL, ICorProfilerFunctionControl* pFunctionControl)
     {
         bool isRejit = pFunctionControl != nullptr;
-        trace::Logger::Debug("Setting temp IL ", isRejit ? "ReJit" : "  Jit", " for method ", GetKey());
+        DBG("Setting temp IL ", isRejit ? "ReJit" : "  Jit", " for method ", GetKey());
         _isWritten = false;
         FreeBuffer();
 
         if (pMethodIL == _pOriginalMehodIL || pMethodIL == _pMethodIL)
         {
-            trace::Logger::Debug("Same function body detected. Skipping SetMethodIL ", GetKey());
+            DBG("Same function body detected. Skipping SetMethodIL ", GetKey());
             return S_FALSE;
         }
 
@@ -393,7 +393,7 @@ namespace iast
 
         if (!_rewriter)
         {
-            trace::Logger::Debug("MethodInfo::SetMethodIL -> No rewritter present. Creating one to verify new IL...");
+            DBG("MethodInfo::SetMethodIL -> No rewritter present. Creating one to verify new IL...");
                 
             _rewriter = new ILRewriter(this);
             if (FAILED(_rewriter->Import(pMethodIL)))
@@ -405,7 +405,7 @@ namespace iast
         }
         else
         {
-            trace::Logger::Debug("MethodInfo::SetMethodIL -> Rewritter present. Verify new IL...");
+            DBG("MethodInfo::SetMethodIL -> Rewritter present. Verify new IL...");
         }
 
         if (_rewriter)
@@ -438,12 +438,12 @@ namespace iast
 
             if (pFunctionControl)
             {
-                trace::Logger::Debug("MethodInfo::SetMethodIL -> ReJIT : Setting IL for ", GetFullName());
+                DBG("MethodInfo::SetMethodIL -> ReJIT : Setting IL for ", GetFullName());
                 ApplyFinalInstrumentation(pFunctionControl);
             }
             else
             {
-                trace::Logger::Debug("MethodInfo::SetMethodIL ->   JIT : Setting IL for ", GetFullName());
+                DBG("MethodInfo::SetMethodIL ->   JIT : Setting IL for ", GetFullName());
             }
         }
         else
@@ -462,12 +462,11 @@ namespace iast
             if (HasChanges())
             {
                 hr = pFunctionControl->SetILFunctionBody(_nMethodIL, _pMethodIL);
-                trace::Logger::Debug("MethodInfo::ApplyFinalInstrumentation ReJIT from ", _nOriginalMehodIL, " to ",
-                                     _nMethodIL, " on ", GetKey(), " hr=", Hex(hr));
+                DBG("MethodInfo::ApplyFinalInstrumentation ReJIT from ", _nOriginalMehodIL, " to ", _nMethodIL, " on ", GetKey(), " hr=", Hex(hr));
             }
             else
             {
-                trace::Logger::Debug("MethodInfo::ApplyFinalInstrumentation ReJIT SKIPPED (method did not change)");
+                DBG("MethodInfo::ApplyFinalInstrumentation ReJIT SKIPPED (method did not change)");
             }
         }
         else
@@ -476,7 +475,7 @@ namespace iast
             {
                 if (_pOriginalMehodIL)
                 {
-                    trace::Logger::Debug("MethodInfo::ApplyFinalInstrumentation WARNING, Reinstrumentation detected. Restore DISABLED ", GetKey());
+                    DBG("MethodInfo::ApplyFinalInstrumentation WARNING, Reinstrumentation detected. Restore DISABLED ", GetKey());
                 }
                 return hr;
             }
@@ -505,7 +504,7 @@ namespace iast
             }
             _isWritten = true;
 
-            trace::Logger::Debug("MethodInfo::ApplyFinalInstrumentation   JIT from ", _nOriginalMehodIL, " to ", _nMethodIL, " on ", GetKey());
+            DBG("MethodInfo::ApplyFinalInstrumentation   JIT from ", _nOriginalMehodIL, " to ", _nMethodIL, " on ", GetKey());
         }
 
         FreeBuffer(); //To save memory

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -845,7 +845,7 @@ mdToken ModuleInfo::DefineMemberRef(const WSTRING& moduleName, const WSTRING& ty
     auto methodInfo = moduleInfo->GetMethod(typeName, methodName, methodParams);
     if (methodInfo == nullptr)
     {
-        trace::Logger::Debug("DefineMemberRef : Could not find Method ", shared::ToString(typeName), ".", shared::ToString(methodName), shared::ToString(methodParams));
+        DBG("DefineMemberRef : Could not find Method ", shared::ToString(typeName), ".", shared::ToString(methodName), shared::ToString(methodParams));
         return 0;
     }
 
@@ -864,11 +864,7 @@ mdToken ModuleInfo::DefineMemberRef(const WSTRING& moduleName, const WSTRING& ty
     {
         _mMemberImports[memberKey] = methodRef;
         auto memberRefInfo = GetMemberRefInfo(methodRef);
-        if (trace::Logger::IsDebugEnabled())
-        {
-            trace::Logger::Debug("DefineMemberRef : ", Hex(methodRef), " for ", memberKey,
-                                 " MethodName: ", memberRefInfo->GetFullName(), " Module: ", GetModuleFullName());
-        }
+        DBG("DefineMemberRef : ", Hex(methodRef), " for ", memberKey, " MethodName: ", memberRefInfo->GetFullName(), " Module: ", GetModuleFullName());
         return methodRef;
     }
     else

--- a/tracer/src/Datadog.Tracer.Native/logger.h
+++ b/tracer/src/Datadog.Tracer.Native/logger.h
@@ -88,4 +88,6 @@ public:
     }
 };
 
+    #define DBG if (Logger::IsDebugEnabled()) Logger::Debug
+
 } // namespace trace

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -87,8 +87,7 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
             std::vector<mdMethodDef> methods;
             while (methodEnum->Next(1, &method, nullptr) == S_OK)
             {
-                Logger::Debug("NGEN:: Asking rewrite for inliner [ModuleId=", method.moduleId,
-                              ",MethodDef=", method.methodId, "]");
+                DBG("NGEN:: Asking rewrite for inliner [ModuleId=", method.moduleId, ",MethodDef=", method.methodId, "]");
                 modules.push_back(method.moduleId);
                 methods.push_back(method.methodId);
                 total++;
@@ -346,7 +345,7 @@ void RejitHandler::EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::ve
         return;
     }
 
-    Logger::Debug("RejitHandler::EnqueueForRejit");
+    DBG("RejitHandler::EnqueueForRejit");
 
     std::function<void()> action = [=, modules = std::move(modulesVector), methods = std::move(modulesMethodDef),
                                     localPromise = promise, callRevertExplicitly = callRevertExplicitly]() mutable {
@@ -366,7 +365,7 @@ void RejitHandler::EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::ve
 
 void RejitHandler::Shutdown()
 {
-    Logger::Debug("RejitHandler::Shutdown");
+    DBG("RejitHandler::Shutdown");
 
     // Wait for exiting the thread
     m_work_offloader->Enqueue(RejitWorkItem::CreateTerminatingWorkItem());

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -36,7 +36,7 @@ RejitPreprocessor<RejitRequestDefinition>::RejitPreprocessor(CorProfiler* corPro
 template <class RejitRequestDefinition>
 void RejitPreprocessor<RejitRequestDefinition>::Shutdown()
 {
-    Logger::Debug("RejitPreprocessor::Shutdown");
+    DBG("RejitPreprocessor::Shutdown");
 
     std::lock_guard<std::mutex> moduleGuard(m_modules_lock);
     std::lock_guard<std::mutex> ngenModuleGuard(m_ngenInlinersModules_lock);
@@ -273,8 +273,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(
     const bool wildcard_enabled = target_method.method_name == tracemethodintegration_wildcardmethodname;
     const bool iterate_explicit_interface_methods = is_interface && !wildcard_enabled;
 
-    Logger::Debug("  Looking for '", target_method.type.name, ".", target_method.method_name, "(",
-                  (target_method.signature_types.size() - 1), " params)' method implementation.");
+    DBG("  Looking for '", target_method.type.name, ".", target_method.method_name, "(", (target_method.signature_types.size() - 1), " params)' method implementation.");
 
     // Now we enumerate all methods with the same target method name. (All overloads of the method)
     auto enumMethods = Enumerator<mdMethodDef>(
@@ -341,7 +340,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(
             Logger::Warn(
                     "    * Skipping [ModuleId=", moduleInfo.id, ", MethodDef=", shared::TokenStr(&methodDef),
                     ", Type=", caller.type.name, ", Method=", caller.name, "]", ": could not parse method signature.");
-            Logger::Debug("    Method signature is: ", functionInfo.method_signature.str());
+            DBG("    Method signature is: ", functionInfo.method_signature.str());
             continue;
         }
 
@@ -376,21 +375,21 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(
         }
         if (moduleHandler->GetModuleMetadata() == nullptr)
         {
-            Logger::Debug("Creating ModuleMetadata...");
+            DBG("Creating ModuleMetadata...");
 
             const auto moduleMetadata =
                 new ModuleMetadata(metadataImport, metadataEmit, assemblyImport, assemblyEmit, moduleInfo.assembly.name,
                                    moduleInfo.assembly.app_domain_id, pCorAssemblyProperty,
                                    enable_by_ref_instrumentation, enable_calltarget_state_by_ref);
 
-            Logger::Debug("ReJIT handler stored metadata for ", moduleInfo.id, " ", moduleInfo.assembly.name,
-                          " AppDomain ", moduleInfo.assembly.app_domain_id, " ", moduleInfo.assembly.app_domain_name);
+            DBG("ReJIT handler stored metadata for ", moduleInfo.id, " ", moduleInfo.assembly.name,
+                " AppDomain ", moduleInfo.assembly.app_domain_id, " ", moduleInfo.assembly.app_domain_name);
 
             moduleHandler->SetModuleMetadata(moduleMetadata);
         }
 
-        Logger::Debug("Method enqueued for ReJIT for ", caller.type.name, ".", caller.name,
-                  "(", caller.method_signature.NumberOfArguments(), " params).");
+        DBG("Method enqueued for ReJIT for ", caller.type.name, ".", caller.name, "(", caller.method_signature.NumberOfArguments(), " params).");
+
         EnqueueNewMethod(definition, metadataImport, metadataEmit, moduleInfo, typeDef, rejitRequests, methodDef,
                          functionInfo, moduleHandler);
 
@@ -398,8 +397,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(
         // enumerators.
         if (explicitMode)
         {
-            Logger::Debug("      Explicit interface implementation found, skipping normal methods search. [",
-                          caller.type.name, ".", caller.name, "]");
+            DBG("      Explicit interface implementation found, skipping normal methods search. [", caller.type.name, ".", caller.name, "]");
             break;
         }
     }
@@ -488,7 +486,7 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejit(std::vector<
         return;
     }
 
-    Logger::Debug("RejitHandler::EnqueueRequestRejit");
+    DBG("RejitHandler::EnqueueRequestRejit");
 
     std::function<void()> action = [=, requests = std::move(rejitRequests), localPromise = promise,
                                     callRevertExplicitly = callRevertExplicitly]() mutable {
@@ -526,7 +524,7 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejitForLoadedModu
         return;
     }
 
-    Logger::Debug("RejitHandler::EnqueueRequestRejitForLoadedModules");
+    DBG("RejitHandler::EnqueueRequestRejitForLoadedModules");
     auto enqueueMeasure = trace::Stats::Instance()->EnqueueRequestRejitForLoadedModulesMeasure();
 
     std::function<void()> action = [=, modules = std::move(modulesVector), definitions = std::move(definitions),
@@ -568,7 +566,7 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::PreprocessRejitRequests(
             continue;
         }
 
-        Logger::Debug("Requesting Rejit for Module: ", moduleInfo.assembly.name);
+        DBG("Requesting Rejit for Module: ", moduleInfo.assembly.name);
 
         ComPtr<IUnknown> metadataInterfaces;
         ComPtr<IMetaDataImport2> metadataImport;
@@ -589,7 +587,7 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::PreprocessRejitRequests(
                 // Abstract methods handling.
                 if (assemblyMetadata == nullptr)
                 {
-                    Logger::Debug("  Loading Assembly Metadata...");
+                    DBG("  Loading Assembly Metadata...");
                     auto hr = corProfilerInfo->GetModuleMetaData(moduleInfo.id, ofRead | ofWrite, IID_IMetaDataImport2,
                                                                  metadataInterfaces.GetAddressOf());
                     if (hr != S_OK)
@@ -604,8 +602,7 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::PreprocessRejitRequests(
                     assemblyImport = metadataInterfaces.As<IMetaDataAssemblyImport>(IID_IMetaDataAssemblyImport);
                     assemblyEmit = metadataInterfaces.As<IMetaDataAssemblyEmit>(IID_IMetaDataAssemblyEmit);
                     assemblyMetadata = std::make_unique<AssemblyMetadata>(GetAssemblyImportMetadata(assemblyImport));
-                    Logger::Debug("  Assembly Metadata loaded for: ", assemblyMetadata->name, "(",
-                                  assemblyMetadata->version.str(), ").");
+                    DBG("  Assembly Metadata loaded for: ", assemblyMetadata->name, "(", assemblyMetadata->version.str(), ").");
                 }
 
                 // If the integration is in a different assembly than the target method
@@ -812,7 +809,7 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::PreprocessRejitRequests(
 
                 if (assemblyMetadata == nullptr)
                 {
-                    Logger::Debug("  Loading Assembly Metadata...");
+                    DBG("  Loading Assembly Metadata...");
                     auto hr = corProfilerInfo->GetModuleMetaData(moduleInfo.id, ofRead | ofWrite, IID_IMetaDataImport2,
                                                                  metadataInterfaces.GetAddressOf());
                     if (hr != S_OK)
@@ -827,8 +824,7 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::PreprocessRejitRequests(
                     assemblyImport = metadataInterfaces.As<IMetaDataAssemblyImport>(IID_IMetaDataAssemblyImport);
                     assemblyEmit = metadataInterfaces.As<IMetaDataAssemblyEmit>(IID_IMetaDataAssemblyEmit);
                     assemblyMetadata = std::make_unique<AssemblyMetadata>(GetAssemblyImportMetadata(assemblyImport));
-                    Logger::Debug("  Assembly Metadata loaded for: ", assemblyMetadata->name, "(",
-                                  assemblyMetadata->version.str(), ").");
+                    DBG("  Assembly Metadata loaded for: ", assemblyMetadata->name, "(", assemblyMetadata->version.str(), ").");
                 }
 
                 // Check min version
@@ -876,7 +872,7 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueuePreprocessRejitRequests(
         return;
     }
 
-    Logger::Debug("RejitHandler::EnqueuePreprocessRejitRequests");
+    DBG("RejitHandler::EnqueuePreprocessRejitRequests");
 
     std::function<void()> action = [=, modules = std::move(modulesVector), definitions = std::move(definitions),
                                     localRejitRequests = rejitRequests, localPromise = promise]() mutable {
@@ -903,8 +899,8 @@ bool RejitPreprocessor<RejitRequestDefinition>::CheckExactSignatureMatch(ComPtr<
     // instrumentation target
     if (numOfArgs != targetMethod.signature_types.size() - 1)
     {
-        Logger::Debug("    * Skipping ", functionInfo.type.name, ".", functionInfo.name,
-                     ": the methoddef doesn't have the right number of arguments (", numOfArgs, " arguments).");
+        DBG("    * Skipping ", functionInfo.type.name, ".", functionInfo.name,
+            ": the methoddef doesn't have the right number of arguments (", numOfArgs, " arguments).");
         return false;
     }
 
@@ -912,12 +908,12 @@ bool RejitPreprocessor<RejitRequestDefinition>::CheckExactSignatureMatch(ComPtr<
     bool argumentsMismatch = false;
     const auto& methodArguments = functionInfo.method_signature.GetMethodArguments();
 
-    Logger::Debug("    * Comparing signature for method: ", functionInfo.type.name, ".", functionInfo.name);
+    DBG("    * Comparing signature for method: ", functionInfo.type.name, ".", functionInfo.name);
     for (unsigned int i = 0; i < numOfArgs; i++)
     {
         const auto argumentTypeName = methodArguments[i].GetTypeTokName(metadataImport);
         const auto integrationArgumentTypeName = targetMethod.signature_types[i + 1];
-        Logger::Debug("        -> ", argumentTypeName, " = ", integrationArgumentTypeName);
+        DBG("        -> ", argumentTypeName, " = ", integrationArgumentTypeName);
         if (argumentTypeName != integrationArgumentTypeName && integrationArgumentTypeName != WStr("_"))
         {
             argumentsMismatch = true;
@@ -926,8 +922,7 @@ bool RejitPreprocessor<RejitRequestDefinition>::CheckExactSignatureMatch(ComPtr<
     }
     if (argumentsMismatch)
     {
-        Logger::Debug("    * Skipping ", targetMethod.method_name,
-                     ": the methoddef doesn't have the right type of arguments.");
+        DBG("    * Skipping ", targetMethod.method_name, ": the methoddef doesn't have the right type of arguments.");
         return false;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/tracer_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/tracer_method_rewriter.cpp
@@ -140,13 +140,10 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
         return S_FALSE;
     }
 
-    if (trace::Logger::IsDebugEnabled())
-    {
-        Logger::Debug("*** CallTarget_RewriterCallback() Start: ", caller->type.name, ".", caller->name,
-                      "() [IsVoid=", isVoid, ", IsStatic=", isStatic,
-                      ", IntegrationType=", integration_definition->integration_type.name, ", Arguments=", numArgs,
-                      "]");
-    }
+    DBG("*** CallTarget_RewriterCallback() Start: ", caller->type.name, ".", caller->name,
+        "() [IsVoid=", isVoid, ", IsStatic=", isStatic,
+        ", IntegrationType=", integration_definition->integration_type.name, ", Arguments=", numArgs,
+        "]");
 
     // First we check if the managed profiler has not been loaded yet
     if (!m_corProfiler->ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata.app_domain_id))
@@ -423,7 +420,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
         filter = CreateFilterForException(&reWriterWrapper, tracerTokens->GetExceptionTypeRef(),
                                           tracerTokens->GetBubbleUpExceptionTypeRef(),
                                           tracerTokens->GetBubbleUpExceptionFunctionDef(), exceptionValueIndex);
-        Logger::Debug("Creating filter for try / catch for CallTargetBubbleUpException. (begin method)");
+        DBG("Creating filter for try / catch for CallTargetBubbleUpException. (begin method)");
         beginMethodCatchFirstInstr = reWriterWrapper.Pop();
         reWriterWrapper.LoadLocal(exceptionValueIndex);
     }
@@ -606,7 +603,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     ILInstr* endMethodCatchFirstInstr = nullptr;
     if (m_corProfiler->call_target_bubble_up_exception_available && bubbleup_exception_typeref != mdTypeRefNil)
     {
-        Logger::Debug("Creating filter for try / catch for CallTargetBubbleUpException (end method).");
+        DBG("Creating filter for try / catch for CallTargetBubbleUpException (end method).");
         filterEnd = CreateFilterForException(&reWriterWrapper, tracerTokens->GetExceptionTypeRef(),
                                              tracerTokens->GetBubbleUpExceptionTypeRef(),
                                              tracerTokens->GetBubbleUpExceptionFunctionDef(), exceptionValueEndIndex);


### PR DESCRIPTION
Checking for `IsDebugEnabled` before calling `Logger::Debug` avoids unnecessary calls to get the required arguments

## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
