### PR TITLE
[Native] Add native string unit tests

### DIFF
--- a/tracer/test/Datadog.Tracer.Native.Tests/CMakeLists.txt
+++ b/tracer/test/Datadog.Tracer.Native.Tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(${TEST_EXECUTABLE_NAME}
     integration_test.cpp
     version_struct_test.cpp
     iast_util_test.cpp
+    string_test.cpp
 )
 
 # Define directories includes

--- a/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj
+++ b/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj
@@ -99,6 +99,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="string_test.cpp" />
     <ClCompile Include="version_struct_test.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj.filters
+++ b/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClCompile Include="metadata_builder_test.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="version_struct_test.cpp" />
+    <ClCompile Include="string_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/tracer/test/Datadog.Tracer.Native.Tests/string_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/string_test.cpp
@@ -1,0 +1,34 @@
+﻿#include "pch.h"
+
+#include "../../../shared/src/native-src/string.h"
+
+using namespace shared;
+
+#define ASSERT_EQ_TOSTR(x) EXPECT_EQ(ToString(WStr(x)), x);
+#define ASSERT_EQ_TOWSTR(x) EXPECT_EQ(ToWSTRING(x), WStr(x));
+
+TEST(StringTests, ToString)
+{
+    ASSERT_EQ_TOSTR("Hello World");
+    ASSERT_EQ_TOSTR("C:\\MyPath\\_path1\\a.txt");
+    ASSERT_EQ_TOSTR("/MyPath/_path1/a.txt");
+    ASSERT_EQ_TOSTR("/my_path/_path1/a.txt");
+    ASSERT_EQ_TOSTR("~/my_path/_path1/a.txt");
+    ASSERT_EQ_TOSTR("Asterix comics swearing $%&/#@|)(!\"'[]{}");
+    ASSERT_EQ_TOSTR("2025-08-19 12:57:49.297 +02:00 [DBG] Logger retrieved for: Datadog.Trace.RemoteConfigurationManagement.RcmSubscriptionManager, Datadog.Trace, Version=3.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb  { MachineName: \".\", Process: \"[6520 Samples.Security.AspNetCore5]\", AppDomain: \"[1 Samples.Security.AspNetCore5]\", AssemblyLoadContext: \"\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #2\", TracerVersion: \"3.24.0.0\"}");
+    EXPECT_EQ(ToString(WStr("C:\\Users\\用户\\文档\\我的文件.txt")), "C:\\Users\\\xE7\x94\xA8\xE6\x88\xB7\\\xE6\x96\x87\xE6\xA1\xA3\\\xE6\x88\x91\xE7\x9A\x84\xE6\x96\x87\xE4\xBB\xB6.txt");
+    EXPECT_EQ(ToString(WStr("~/my_path/_path1/a.txt🙈")), "~/my_path/_path1/a.txt\xF0\x9F\x99\x88");
+}
+
+TEST(StringTests, ToWString)
+{
+    ASSERT_EQ_TOWSTR("Hello World");
+    ASSERT_EQ_TOWSTR("C:\\MyPath\\_path1\\a.txt");
+    ASSERT_EQ_TOWSTR("/MyPath/_path1/a.txt");
+    ASSERT_EQ_TOWSTR("/my_path/_path1/a.txt");
+    ASSERT_EQ_TOWSTR("~/my_path/_path1/a.txt");
+    ASSERT_EQ_TOWSTR("Asterix comics swearing $%&/#@|)(!\"'[]{}");
+    ASSERT_EQ_TOWSTR("2025-08-19 12:57:49.297 +02:00 [DBG] Logger retrieved for: Datadog.Trace.RemoteConfigurationManagement.RcmSubscriptionManager, Datadog.Trace, Version=3.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb  { MachineName: \".\", Process: \"[6520 Samples.Security.AspNetCore5]\", AppDomain: \"[1 Samples.Security.AspNetCore5]\", AssemblyLoadContext: \"\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #2\", TracerVersion: \"3.24.0.0\"}");
+    EXPECT_EQ(ToWSTRING("C:\\Users\\\xE7\x94\xA8\xE6\x88\xB7\\\xE6\x96\x87\xE6\xA1\xA3\\\xE6\x88\x91\xE7\x9A\x84\xE6\x96\x87\xE4\xBB\xB6.txt"), WStr("C:\\Users\\用户\\文档\\我的文件.txt"));
+    EXPECT_EQ(ToWSTRING("~/my_path/_path1/a.txt\xF0\x9F\x99\x88"), WStr("~/my_path/_path1/a.txt🙈"));
+}


### PR DESCRIPTION
## Summary of changes
Unit tests to check correct string converisons to WChar back and forth were missing

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
