### PR TITLE
Update `tracer_home_smoke_tests` stage to use MS hosted windows images

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5989,7 +5989,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-windows-x64-2
+      vmImage: windows-2022
 
     steps:
     - template: steps/install-docker-compose-v1.yml


### PR DESCRIPTION
## Summary of changes

Update `tracer_home_smoke_tests` stage to use MS hosted windows images

## Reason for change

We saw some flake due to rate limiting. All the other smoke tests use the Microsoft Hosted Windows images, so it makes sense to do the same in the flaky stage

## Implementation details

Switch to the hosted images

## Test coverage

This is the test

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
