### PR TITLE
Enable runtime metrics for macrobenchmarks

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -114,6 +114,8 @@ update-bp-infra:
     K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 0s
     K6_OPTIONS_HIGH_LOAD_VUS: 2
 
+    DD_RUNTIME_METRICS_ENABLED: true
+
 baseline-x86:
   extends: .benchmarks-x86
   variables:
@@ -292,6 +294,8 @@ profiler_cpu_timer_create-x86:
     K6_OPTIONS_HIGH_LOAD_DURATION: 5m
     K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 0s
     K6_OPTIONS_HIGH_LOAD_VUS: 2
+
+    DD_RUNTIME_METRICS_ENABLED: true
 
 baseline-arm64:
   extends: .benchmarks-arm64
@@ -480,6 +484,8 @@ profiler_cpu_timer_create-arm64:
     K6_OPTIONS_HIGH_LOAD_DURATION: 5m
     K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 0s
     K6_OPTIONS_HIGH_LOAD_VUS: 2
+
+    DD_RUNTIME_METRICS_ENABLED: true
   script:
     - source build-id.txt
     - echo "Building for the following build https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId&view=results"


### PR DESCRIPTION
## Summary of changes

We need to track GC counts in order to reliably identify the issues with memory allocations. This PR enables runtime metrics in all macrobenchmarks, so we have the needed observability.

## Reason for change

This PR is needed to reliably catch memory issues.

## Implementation details

Enables runtime metrics collection by passing env variable `DD_RUNTIME_METRICS_ENABLED: true`.

# Test

The branch with an artificial issue (https://github.com/DataDog/dd-trace-dotnet/pull/7408):
<img width="3302" height="650" alt="image" src="https://github.com/user-attachments/assets/f8087c48-db38-4ee9-bad3-311e1d8c6a6b" />

The normal behavior:
<img width="3302" height="650" alt="image" src="https://github.com/user-attachments/assets/2bbbfc50-663b-481c-b11a-c05a5d7725cf" />
