### PR TITLE
Try to fix dynamic instrumentation tests

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -463,6 +463,10 @@ namespace Datadog.Trace.ClrProfiler
                         }
                     });
             }
+            else
+            {
+                Log.Information($"Dynamic Instrumentation is disabled. To enable it, please set {ConfigurationKeys.Debugger.DynamicInstrumentationEnabled} environment variable to 'true'.");
+            }
         }
 
         // /!\ This method is called by reflection in the SampleHelpers


### PR DESCRIPTION
## Summary of changes

Try to fix dynamic instrumentation tests

## Reason for change

The debugger tests are broken in master because #7398 didn't trigger the debugger tests to run

## Implementation details

Add the log message it expects

## Test coverage

Will trigger a dedicated test run to make sure we test the debugger

## Other details

We should probably update the `Instrumentation` file to be co-owned, to make sure this kind of thing doesn't happen again
- https://github.com/DataDog/dd-trace-dotnet/pull/7416