### PR TITLE
Handle TypeLoadException when retrieving HostingEnvironment

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -590,9 +590,9 @@ namespace Datadog.Trace
                     return true;
                 }
             }
-            catch (TypeLoadException)
+            catch (TypeLoadException ex)
             {
-                Log.Warning("Unable to determine ASP.NET site name: HostingEnvironment type could not be loaded. This is expected when running ASP.NET Core on the .NET Framework CLR, which is not supported.");
+                Log.Warning(ex, "Unable to determine ASP.NET site name: HostingEnvironment type could not be loaded. This is expected when running ASP.NET Core on the .NET Framework CLR, which is not supported.");
             }
 #endif
             siteName = default;

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -579,15 +579,21 @@ namespace Datadog.Trace
         private static bool TryLoadAspNetSiteName(out string siteName)
         {
 #if NETFRAMEWORK
-            // System.Web.dll is only available on .NET Framework
-            if (System.Web.Hosting.HostingEnvironment.IsHosted)
+            try
             {
-                // if this app is an ASP.NET application, return "SiteName/ApplicationVirtualPath".
-                // note that ApplicationVirtualPath includes a leading slash.
-                siteName = (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
-                return true;
+                // System.Web.dll is only available on .NET Framework
+                if (System.Web.Hosting.HostingEnvironment.IsHosted)
+                {
+                    // if this app is an ASP.NET application, return "SiteName/ApplicationVirtualPath".
+                    // note that ApplicationVirtualPath includes a leading slash.
+                    siteName = (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
+                    return true;
+                }
             }
-
+            catch (TypeLoadException)
+            {
+                Log.Warning("Unable to determine ASP.NET site name: HostingEnvironment type could not be loaded. This is expected when running ASP.NET Core on the .NET Framework CLR, which is not supported.");
+            }
 #endif
             siteName = default;
             return false;


### PR DESCRIPTION
## Summary of changes

This PR improves resilience in the application name resolution logic for ASP.NET sites.

When the tracer is loaded into w3wp.exe, it attempts to probe System.Web.Hosting.HostingEnvironment to determine the IIS site name. In scenarios where ASP.NET Core is running on the .NET Framework CLR (an unsupported hosting model), HostingEnvironment cannot be loaded and triggers a TypeLoadException.

Previously, this bubbled up into error tracking, creating noisy/unhelpful error reports.

Changes:
Wrap the System.Web.Hosting.HostingEnvironment probe in a try/catch block.
On TypeLoadException, log a warning instead of letting the exception propagate.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
