### PR TITLE
Add missing `GetDictionary()` method to `ConfigurationBuilder`

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -1397,7 +1397,7 @@ namespace Datadog.Trace.Configuration
         {
             var configurationDictionary = config
                    .WithKeys(key)
-                   .AsDictionary(allowOptionalMappings: true, () => new Dictionary<string, string>(), string.Empty);
+                   .AsDictionary(allowOptionalMappings: true, defaultValue: null, "[]");
 
             if (configurationDictionary == null)
             {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -243,7 +243,7 @@ public class ConfigurationTelemetryCollectorTests
         GetLatestValueFromConfig(data, "DD_APPSEC_ENABLED", ConfigurationOrigins.Default).Should().Be(false);
         GetLatestValueFromConfig(data, "DD_DATA_STREAMS_ENABLED", ConfigurationOrigins.Default).Should().Be(true);
         GetLatestValueFromConfig(data, "DD_TAGS", ConfigurationOrigins.Default).Should().Be(string.Empty);
-        GetLatestValueFromConfig(data, "DD_TRACE_HEADER_TAGS", ConfigurationOrigins.Default).Should().Be(string.Empty);
+        GetLatestValueFromConfig(data, "DD_TRACE_HEADER_TAGS", ConfigurationOrigins.Default).Should().Be(null);
         GetLatestValueFromConfig(data, "DD_LOGS_INJECTION", ConfigurationOrigins.Default).Should().Be(true);
         GetLatestValueFromConfig(data, "DD_TRACE_SAMPLE_RATE", ConfigurationOrigins.Default).Should().Be(1.0);
         GetLatestValueFromConfig(data, "instrumentation_source").Should().Be("manual");


### PR DESCRIPTION
## Summary of changes

Add missing `GetDictionary()` method to `ConfigurationBuilder`

## Reason for change

We were missing a method that allows providing a default instance for a dictionary up-front. This was forcing using other overloads that are suboptimal for telemetry.

## Implementation details

Add the missing helper that allows providing a default value. I allowed passing a null value in here, as it avoids unnecessary allocations if you don't actually need the dictionary. A good example was the fixed usage in `InitializeHeaderTags` which was creating an empty dictionary instead of taking the fast-path `null` route (and potentially actually giving _incorrect_ settings in the `DynamicSettings` I think 

## Test coverage

Meh

## Other details

Spotted when reviewing
- https://github.com/DataDog/dd-trace-dotnet/pull/7420


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
