### PR TITLE
[Phase 2] chore(trace-exporter): enable data pipeline based on Windows

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -411,7 +411,7 @@ namespace Datadog.Trace.Configuration
 
             DataPipelineEnabled = config
                                   .WithKeys(ConfigurationKeys.TraceDataPipelineEnabled)
-                                  .AsBool(defaultValue: false);
+                                  .AsBool(defaultValue: FrameworkDescription.Instance.IsWindows());
 
             if (DataPipelineEnabled)
             {

--- a/tracer/src/Datadog.Trace/FrameworkDescription.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.cs
@@ -69,6 +69,11 @@ namespace Datadog.Trace
             return string.Equals(OSPlatform, OSPlatformName.Windows, StringComparison.OrdinalIgnoreCase);
         }
 
+        public bool IsLinux()
+        {
+            return string.Equals(OSPlatform, OSPlatformName.Linux, StringComparison.OrdinalIgnoreCase);
+        }
+
         public override string ToString()
         {
             // examples:


### PR DESCRIPTION
## Summary of changes

Where is phase 1?
https://github.com/DataDog/datadog-aas-extension/pull/336

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
