### PR TITLE
Revert "[Profiler] Make `timer_create`-based CPU profiler default (#7322)"

### DIFF
--- a/profiler/build/CpuWallTime.linux.json
+++ b/profiler/build/CpuWallTime.linux.json
@@ -26,7 +26,6 @@
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
         "DD_INTERNAL_USE_BACKTRACE2": "1",
-        "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
         "DD_TRACE_ENABLED" : "0"
       }
     },
@@ -36,19 +35,17 @@
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
-        "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
         "DD_INTERNAL_USE_BACKTRACE2": "0",
         "DD_TRACE_ENABLED" : "0"
       }
     },
     {
-      "name": "Profiler_cpu_walltime_manual",
+      "name": "Profiler_cpu_walltime_timer_create",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
-        "DD_INTERNAL_USE_BACKTRACE2": "1",
-        "DD_INTERNAL_CPU_PROFILER_TYPE": "ManualCpuTime",
+        "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
         "DD_TRACE_ENABLED" : "0"
       }
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -93,22 +93,6 @@ bool ProfilerSignalManager::UnRegisterHandler()
     return true;
 }
 
-bool ProfilerSignalManager::IgnoreSignal() {
-    struct sigaction sampleAction;
-    sampleAction.sa_handler = SIG_IGN;
-    sigemptyset(&sampleAction.sa_mask);
-    sampleAction.sa_flags = 0;
-
-    int32_t result = sigaction(_signalToSend, &sampleAction, nullptr);
-    if (result != 0)
-    {
-        Log::Error("ProfilerSignalManager::IgnoreSignal: Failed mark ", strsignal(_signalToSend), " as ignored. Reason: ",
-                   strerror(errno), ".");
-        return false;
-    }
-    return true;
-}
-
 void ProfilerSignalManager::SetSignal(int32_t signal)
 {
     _signalToSend = signal;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -18,7 +18,6 @@ public:
 
     bool RegisterHandler(HandlerFn_t handler);
     bool UnRegisterHandler();
-    bool IgnoreSignal();
     int32_t SendSignal(pid_t threadId);
     bool CheckSignalHandler();
     bool IsHandlerInPlace() const;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -17,7 +17,7 @@
 #include <ucontext.h>
 #include <unistd.h>
 
-std::atomic<TimerCreateCpuProfiler*> TimerCreateCpuProfiler::Instance = nullptr;
+TimerCreateCpuProfiler* TimerCreateCpuProfiler::Instance = nullptr;
 
 TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     IConfiguration* pConfiguration,
@@ -29,8 +29,7 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     _pSignalManager{pSignalManager}, // put it as parameter for better testing
     _pManagedThreadsList{pManagedThreadsList},
     _pProvider{pProvider},
-    _samplingInterval{pConfiguration->GetCpuProfilingInterval()},
-    _nbThreadsInSignalHandler{0}
+    _samplingInterval{pConfiguration->GetCpuProfilingInterval()}
 {
     Log::Info("Cpu profiling interval: ", _samplingInterval.count(), "ms");
     Log::Info("timer_create Cpu profiler is enabled");
@@ -92,15 +91,6 @@ bool TimerCreateCpuProfiler::StartImpl()
 
 bool TimerCreateCpuProfiler::StopImpl()
 {
-    Instance = nullptr;
-    // we cannot unregister. We would replace the current action by the default one
-    // which will cause the termination of the process
-    // Instead, mark SIGPROF as ignored.
-    if (!_pSignalManager->IgnoreSignal())
-    {
-        Log::Warn("Failed to mark the signal SIGPROF as ignored.");
-    }
-
     {
         std::unique_lock lock(_registerLock);
 
@@ -109,27 +99,15 @@ bool TimerCreateCpuProfiler::StopImpl()
         _pManagedThreadsList->ForEach([this](ManagedThreadInfo* thread) { UnregisterThreadImpl(thread); });
     }
 
-    std::uint64_t nbThreadsInSignalHandler = _nbThreadsInSignalHandler;
-    if (nbThreadsInSignalHandler != 0)
-    {
-        Log::Info("Waiting for all threads exiting the signal handler (#threads ", _nbThreadsInSignalHandler, ")");
-    
-        // TODO: for now we sleep.
-        std::this_thread::sleep_for(500ms);
-        if (_nbThreadsInSignalHandler != 0)
-        {
-            Log::Warn("There are threads that are still executing the signal handler: ", _nbThreadsInSignalHandler);
-            return false;
-        }
-        Log::Info("All threads exited the signal handler");
-    }
+    Instance = nullptr;
+    _pSignalManager->UnRegisterHandler();
 
     return true;
 }
 
 bool TimerCreateCpuProfiler::CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext)
 {
-    auto instance = Instance.load();
+    auto instance = Instance;
     if (instance == nullptr)
     {
         return false;
@@ -144,6 +122,7 @@ extern "C" unsigned long long dd_inside_wrapped_functions() __attribute__((weak)
 
 bool TimerCreateCpuProfiler::CanCollect(void* ctx)
 {
+    // TODO (in another PR): add metrics about reasons we could not collect
     if (dd_inside_wrapped_functions != nullptr && dd_inside_wrapped_functions() != 0)
     {
         _discardMetrics->Incr<DiscardReason::InsideWrappedFunction>();
@@ -210,14 +189,12 @@ private:
 
 bool TimerCreateCpuProfiler::Collect(void* ctx)
 {
-    _nbThreadsInSignalHandler++;
     _totalSampling->Incr();
 
     auto threadInfo = ManagedThreadInfo::CurrentThreadInfo;
     if (threadInfo == nullptr)
     {
         _discardMetrics->Incr<DiscardReason::UnknownThread>();
-        _nbThreadsInSignalHandler--;
         // Ooops should never happen
         return false;
     }
@@ -226,13 +203,11 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
     if (!l.IsLockAcquired())
     {
         _discardMetrics->Incr<DiscardReason::FailedAcquiringLock>();
-        _nbThreadsInSignalHandler--;
         return false;
     }
 
     if (!CanCollect(ctx))
     {
-        _nbThreadsInSignalHandler--;
         return false;
     }
 
@@ -242,7 +217,6 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
     auto rawCpuSample = _pProvider->GetRawSample();
     if (!rawCpuSample)
     {
-        _nbThreadsInSignalHandler--;
         return false;
     }
 
@@ -255,7 +229,6 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
     {
         rawCpuSample.Discard();
         _discardMetrics->Incr<DiscardReason::EmptyBacktrace>();
-        _nbThreadsInSignalHandler--;
         return false;
     }
 
@@ -267,7 +240,6 @@ bool TimerCreateCpuProfiler::Collect(void* ctx)
     rawCpuSample->AppDomainId = threadInfo->GetAppDomainId();
     rawCpuSample->ThreadInfo = std::move(threadInfo);
     rawCpuSample->Duration = _samplingInterval;
-    _nbThreadsInSignalHandler--;
     return true;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -42,7 +42,7 @@ public:
 
 private:
     static bool CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext);
-    static std::atomic<TimerCreateCpuProfiler*> Instance;
+    static TimerCreateCpuProfiler* Instance;
 
     bool CanCollect(void* context);
     bool Collect(void* ucontext);
@@ -59,5 +59,4 @@ private:
     std::shared_mutex _registerLock;
     std::shared_ptr<CounterMetric> _totalSampling;
     std::shared_ptr<DiscardMetrics> _discardMetrics;
-    std::atomic<std::uint64_t> _nbThreadsInSignalHandler;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -26,12 +26,6 @@ std::string const Configuration::DefaultEmptyString = "";
 std::chrono::seconds const Configuration::DefaultDevUploadInterval = 20s;
 std::chrono::seconds const Configuration::DefaultProdUploadInterval = 60s;
 std::chrono::milliseconds const Configuration::DefaultCpuProfilingInterval = 9ms;
-CpuProfilerType const Configuration::DefaultCpuProfilerType =
-#ifdef _WINDOWS
-    CpuProfilerType::ManualCpuTime;
-#else
-    CpuProfilerType::TimerCreate;
-#endif
 
 Configuration::Configuration()
 {
@@ -113,7 +107,7 @@ Configuration::Configuration()
         );
     _httpRequestDurationThreshold = ExtractHttpRequestDurationThreshold();
     _forceHttpSampling = GetEnvironmentValue(EnvironmentVariables::ForceHttpSampling, false);
-    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
+    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, CpuProfilerType::ManualCpuTime);
     _isWaitHandleProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::WaitHandleProfilingEnabled, false);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -120,7 +120,6 @@ private:
     static std::chrono::seconds const DefaultDevUploadInterval;
     static std::chrono::seconds const DefaultProdUploadInterval;
     static std::chrono::milliseconds const DefaultCpuProfilingInterval;
-    static CpuProfilerType const DefaultCpuProfilerType;
 
     bool _isProfilingEnabled;
     bool _isCpuProfilingEnabled;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -72,30 +72,6 @@
 
 #include <cmath>
 
-void LogServiceStart(bool success, const char* name )
-{
-    if (success)
-    {
-        Log::Info(name, " started successfully.");
-    }
-    else
-    {
-        Log::Info(name, " failed to start. This service might have been started earlier.");
-    }
-}
-
-void LogServiceStop(bool success, const char* name )
-{
-    if (success)
-    {
-        Log::Info(name, " stopped successfully.");
-    }
-    else
-    {
-        Log::Info(name, " failed to stopped. This service might have been stopped earlier.");
-    }
-}
-
 IClrLifetime* CorProfilerCallback::GetClrLifetime() const
 {
     return _pClrLifetime.get();
@@ -544,9 +520,7 @@ void CorProfilerCallback::InitializeServices()
 #ifdef LINUX
     if (_pConfiguration->IsCpuProfilingEnabled() && _pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
     {
-        // Other alternative in case of crash-at-shutdown, do not register it as a service
-        // we will have to start it by hand (already stopped by hand)
-        _pCpuProfiler = std::make_unique<TimerCreateCpuProfiler>(
+        _pCpuProfiler = RegisterService<TimerCreateCpuProfiler>(
             _pConfiguration.get(),
             ProfilerSignalManager::Get(SIGPROF),
             _pManagedThreadList,
@@ -740,21 +714,16 @@ bool CorProfilerCallback::StartServices()
     {
         auto name = service->GetName();
         success = service->Start();
-        LogServiceStart(success, name);
+        if (success)
+        {
+            Log::Info(name, " started successfully.");
+        }
+        else
+        {
+            Log::Info(name, " failed to start. This service might have been started earlier.");
+        }
         result &= success;
     }
-
-#ifdef LINUX
-    // We cannot add the timer_create-based CPU profiler to the _services list
-    // we have to control the Stop
-    // If we fail to stop, we mustn't release the memory associated to it
-    // otherwise we might crash.
-    if (_pCpuProfiler != nullptr)
-    {
-        auto success = _pCpuProfiler->Start();
-        LogServiceStart(success, _pCpuProfiler->GetName());
-    }
-#endif
 
     return result;
 }
@@ -790,7 +759,14 @@ bool CorProfilerCallback::StopServices()
         const auto& service = _services[i - 1];
         const auto* name = service->GetName();
         success = service->Stop();
-        LogServiceStop(success, name);
+        if (success)
+        {
+            Log::Info(name, " stopped successfully.");
+        }
+        else
+        {
+            Log::Info(name, " failed to stop. This service might have been stopped earlier.");
+        }
         result &= success;
     }
 
@@ -1537,16 +1513,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown()
 #ifdef LINUX
     if (_pCpuProfiler != nullptr)
     {
-        // if we failed at stopping the time_create-based CPU profiler,
-        // it's safer to not release the memory.
-        // Otherwise, we might crash the application.
-        // Reason: one thread could be executing the signal handler and accessing some field
-        auto stopped = _pCpuProfiler->Stop();
-        LogServiceStop(stopped, _pCpuProfiler->GetName());
-        if (stopped)
-        {
-            _pCpuProfiler = nullptr;
-        }
+        _pCpuProfiler->Stop();
     }
 #endif
 
@@ -1809,7 +1776,7 @@ void CorProfilerCallback::OnThreadRoutineFinished()
         return;
     }
 
-    auto* cpuProfiler = myThis->_pCpuProfiler.get();
+    auto* cpuProfiler = myThis->_pCpuProfiler;
     if (cpuProfiler == nullptr)
     {
         return;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -34,11 +34,8 @@
 #include "ProxyMetric.h"
 #include "IAllocationsRecorder.h"
 #include "IMetadataProvider.h"
-#include "shared/src/native-src/string.h"
 #include "ThreadLifetimeProvider.h"
-#ifdef LINUX
-#include "TimerCreateCpuProfiler.h"
-#endif
+#include "shared/src/native-src/string.h"
 #include "IEtwEventsManager.h"
 #include "ISsiLifetime.h"
 
@@ -57,6 +54,7 @@ class IConfiguration;
 class IExporter;
 class RawSampleTransformer;
 class RuntimeIdStore;
+class TimerCreateCpuProfiler;
 class CpuSampleProvider;
 class NetworkProvider;
 
@@ -256,7 +254,7 @@ private :
     RuntimeIdStore* _pRuntimeIdStore = nullptr;
 #ifdef LINUX
     SystemCallsShield* _systemCallsShield = nullptr;
-    std::unique_ptr<TimerCreateCpuProfiler> _pCpuProfiler = nullptr;
+    TimerCreateCpuProfiler* _pCpuProfiler = nullptr;
     CpuSampleProvider* _pCpuSampleProvider = nullptr;
 #endif
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
@@ -47,14 +47,10 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var logFile = Directory.GetFiles(runner.Environment.LogDir)
                 .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
 
-            
-            File.ReadLines(logFile)
-                .Count(l => l.Contains("Successfully setup signal handler for User defined signal 1 signal"))
-                .Should().Be(1);
+            var nbSignalHandlerInstallation = File.ReadLines(logFile)
+                .Count(l => l.Contains("Successfully setup signal handler for"));
 
-            File.ReadLines(logFile)
-                .Count(l => l.Contains("Successfully setup signal handler for Profiling timer expired signal"))
-                .Should().Be(1);
+            nbSignalHandlerInstallation.Should().Be(1);
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
@@ -25,7 +25,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         }
 
         [TestAppFact("Samples.Computer01")]
-        public void CheckTimerCreateIsDefault(string appName, string framework, string appAssembly)
+        public void CheckTimerCreateIsNotDefault(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
             // disable default profilers except CPU
@@ -41,8 +41,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             var logLines = File.ReadLines(logFile);
 
-            logLines.Should().ContainMatch("*timer_create Cpu profiler is enabled*");
-            logLines.Should().NotContainMatch("*Manual Cpu profiler is enabled*");
+            logLines.Should().NotContainMatch("*timer_create Cpu profiler is enabled*");
+            logLines.Should().ContainMatch("*Manual Cpu profiler is enabled*");
 
             SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotBeEmpty("No samples were found");
         }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1101,38 +1101,20 @@ TEST_F(ConfigurationTest, CheckDefaultCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr(""));
     auto configuration = Configuration{};
-    auto expected =
-#ifdef _WINDOWS
-        CpuProfilerType::ManualCpuTime;
-#else
-        CpuProfilerType::TimerCreate;
-#endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
 }
 
 TEST_F(ConfigurationTest, CheckDefaultCpuProfilerTypeWhenEnvVarNotSet)
 {
     auto configuration = Configuration{};
-    auto expected =
-#ifdef _WINDOWS
-        CpuProfilerType::ManualCpuTime;
-#else
-        CpuProfilerType::TimerCreate;
-#endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
 }
 
 TEST_F(ConfigurationTest, CheckUnknownCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("UnknownCpuProfilerType"));
     auto configuration = Configuration{};
-    auto expected =
-#ifdef _WINDOWS
-        CpuProfilerType::ManualCpuTime;
-#else
-        CpuProfilerType::TimerCreate;
-#endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
 }
 
 TEST_F(ConfigurationTest, CheckManualCpuProfilerType)


### PR DESCRIPTION
## Summary of changes

This reverts commit 5676931004042cfb4af0468567f00c056d2d467f.

## Reason for change

We noticed a lot of (flaky) crashing on the _trimmed_ smoke tests, shortly after #7322  was merged. Investigating this by testing a revert of the PR and re-running in CI resulted in no crashes. Out of an abundance of caution, we are choosing to revert the change to investigate before the next release.

## Implementation details

This reverts commit 5676931004042cfb4af0468567f00c056d2d467f 
- #7322

## Test coverage

This is the test, but I also re-ran all the trimmed tests 6 times and saw no failures

## Other details

We'll aim to revert this revert and investigate next week


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
