### PR TITLE
Use mock agent in exploration tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3256,7 +3256,7 @@ stages:
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
       )
     )
-  dependsOn: [generate_variables, merge_commit_id]
+  dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3256,7 +3256,7 @@ stages:
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
       )
     )
-  dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
+  dependsOn: [generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -3273,10 +3273,6 @@ stages:
     pool:
       name: azure-managed-windows-x64-2
 
-    # Enable the Datadog Agent service for this job
-    services:
-      dd_agent: dd_agent_no_pull
-
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -3287,6 +3283,28 @@ stages:
 
     - script: tracer\build.cmd SetupExplorationTests --ExplorationTestUseCase $(explorationTestUseCase) --ExplorationTestName $(explorationTestName)
       displayName: SetupExplorationTest $(explorationTestUseCase) $(explorationTestName)
+
+    - powershell: |
+        dotnet build -c Release $(System.DefaultWorkingDirectory)\tracer\tools\MockAgent
+        $serviceName = "MockAgent"
+        $exePath = "$(System.DefaultWorkingDirectory)\tracer\tools\MockAgent\bin\release\net9.0\MockAgent.exe"
+
+        # Check if service already exists
+        if (Get-Service -Name $serviceName -ErrorAction SilentlyContinue) {
+            Write-Host "Service $serviceName already exists. Stopping and removing..."
+            Stop-Service -Name $serviceName -Force -ErrorAction SilentlyContinue
+            sc.exe delete $serviceName | Out-Null
+        }
+
+        # Install the service
+        sc.exe create $serviceName binPath= "`"$exePath`"" start= auto DisplayName= "Datadog Mock Agent"
+
+        # Start the service
+        Start-Service -Name $serviceName
+
+        # Verify
+        Get-Service -Name $serviceName
+      displayName: Start Mock Agent
 
     - script: tracer\build.cmd RunExplorationTests --ExplorationTestUseCase $(explorationTestUseCase) --ExplorationTestName $(explorationTestName)
       displayName: RunExplorationTest $(explorationTestUseCase) $(explorationTestName)

--- a/tracer/tools/MockAgent/MockAgent.csproj
+++ b/tracer/tools/MockAgent/MockAgent.csproj
@@ -1,18 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\test\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
   </ItemGroup>
-
 </Project>

--- a/tracer/tools/MockAgent/Options.cs
+++ b/tracer/tools/MockAgent/Options.cs
@@ -12,11 +12,11 @@ namespace MockAgent
         public static readonly string DefaultPipesTrace = "apm.mock.windows.pipe";
         public static readonly string DefaultPipesStats = "dsd.mock.windows.pipe";
 
-        public static readonly int DefaultPortTrace = 11126;
-        public static readonly int DefaultPortStats = 11125;
+        public static readonly int DefaultPortTrace = 8126;
+        public static readonly int DefaultPortStats = 8125;
 
         [Option('u', "uds", Required = false, HelpText = $"Receive traces and stats over unix domain sockets.")]
-        public bool UnixDomainSockets { get; set; }
+        public bool UnixDomainSockets { get; set; } = true;
 
         [Option("trace-uds-path", Required = false, HelpText = "Set the unix domain socket for traces.")]
         public string TracesUnixDomainSocketPath { get; set; } = DefaultUdsTrace;
@@ -34,12 +34,18 @@ namespace MockAgent
         public string MetricsPipeName { get; set; } = DefaultPipesStats;
 
         [Option('t', "tcp", Required = false, HelpText = "Receive traces and stats over TCP")]
-        public bool Tcp { get; set; }
+        public bool Tcp { get; set; } = true;
 
         [Option("trace-port", Required = false, HelpText = "Set the TCP port for traces.")]
         public int TracesPort { get; set; } = DefaultPortTrace;
 
         [Option("stats-port", Required = false, HelpText = "Set the UDP port for metrics.")]
         public int MetricsPort { get; set; } = DefaultPortStats;
+
+        [Option("show-traces", Required = false, HelpText = "Print traces to the logs")]
+        public bool ShowTraces { get; set; } = true;
+
+        [Option("show-metrics", Required = false, HelpText = "Print metrics to the logs")]
+        public bool ShowMetrics { get; set; } = true;
     }
 }

--- a/tracer/tools/MockAgent/Program.cs
+++ b/tracer/tools/MockAgent/Program.cs
@@ -1,117 +1,148 @@
-// See https://aka.ms/new-console-template for more information
 using CommandLine;
 using Datadog.Trace.TestHelpers;
 using MockAgent;
+using Xunit.Abstractions;
 
-var showTraces = true;
-var showMetrics = true;
+Options? options = null;
+Parser.Default.ParseArguments<Options>(args)
+    .WithParsed(o => options = o)
+    .WithNotParsed(o => throw new Exception("Error parsing options"));
 
-EventHandler<EventArgs<IList<IList<MockSpan>>>> displayTraces = (sender, args) =>
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddSingleton(options!);
+builder.Services.AddHostedService<Worker>();
+builder.Services.AddWindowsService();
+
+var host = builder.Build();
+host.Run();
+
+public class Worker : BackgroundService, ITestOutputHelper
 {
-    if (!showTraces)
+    private readonly Options _opts;
+    private readonly ILogger<Worker> _logger;
+    private readonly List<MockTracerAgent> _agents;
+    private readonly TaskCompletionSource _tcs = new();
+
+    public Worker(Options opts, ILogger<Worker> logger)
     {
-        return;
+        _opts = opts;
+        _logger = logger;
+        _agents = new List<MockTracerAgent>();
     }
 
-    var traces = args.Value;
-    foreach (var trace in traces)
+    private void DisplayTraces(object? sender, EventArgs<IList<IList<MockSpan>>> args)
     {
-        foreach (var span in trace)
+        var traces = args.Value;
+        foreach (var trace in traces)
         {
-            Console.WriteLine(span);
+            foreach (var span in trace)
+            {
+                _logger.LogInformation("{Trace}", span.ToString());
+            }
         }
     }
-};
 
-EventHandler<EventArgs<string>> displayStats = (sender, args) =>
-{
-    if (!showMetrics)
+    private void DisplayMetrics(object? sender, EventArgs<string> args)
     {
-        return;
+        _logger.LogInformation("Stats: {Stats}", args.Value);
     }
 
-    Console.WriteLine($"Stats: {args.Value}");
-};
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+       stoppingToken.Register(() => _tcs.TrySetCanceled());
 
-Parser.Default.ParseArguments<Options>(args)
-       .WithParsed<Options>(o =>
+       if (_opts.Tcp)
        {
-           var agents = new List<MockTracerAgent>();
+           var agent = MockTracerAgent.Create(this, port: _opts.TracesPort, useStatsd: true, requestedStatsDPort: _opts.MetricsPort, useTelemetry: true);
+           _agents.Add(agent);
+           _logger.LogInformation("Listening for traces on TCP port {Port}", agent.Port);
+           _logger.LogInformation("Listening for traces on UDP port {Port}", agent.StatsdPort);
 
-           try
+           if (_opts.ShowTraces)
            {
-               if (o.Tcp || args.Length == 0)
-               {
-                   var agent = new MockTracerAgent(port: o.TracesPort, useStatsd: true, requestedStatsDPort: o.MetricsPort);
-                   Console.WriteLine($"Listening for traces on TCP: {agent.Port}");
-                   Console.WriteLine($"Listening for metrics on UDP port: {agent.StatsdPort}");
-                   agent.RequestDeserialized += displayTraces;
-                   agent.MetricsReceived += displayStats;
-                   agents.Add(agent);
-               }
-
-               if (o.UnixDomainSockets || args.Length == 0)
-               {
-                   var agent = new MockTracerAgent(new UnixDomainSocketConfig(o.TracesUnixDomainSocketPath, o.MetricsUnixDomainSocketPath));
-                   Console.WriteLine($"Listening for traces on Unix Domain Socket: {agent.TracesUdsPath}");
-                   Console.WriteLine($"Listening for metrics on Unix Domain Socket: {agent.StatsUdsPath}");
-                   agent.RequestDeserialized += displayTraces;
-                   agent.MetricsReceived += displayStats;
-                   agents.Add(agent);
-               }
-
-               if (o.WindowsNamedPipe) // || args.Length == 0)
-               {
-                   var agent = new MockTracerAgent(new WindowsPipesConfig(o.TracesPipeName, o.MetricsPipeName));
-                   Console.WriteLine($"Listening for traces on Windows Named Pipe: {agent.TracesWindowsPipeName}");
-                   Console.WriteLine($"Listening for metrics on Windows Named Pipe: {agent.StatsWindowsPipeName}");
-                   agent.RequestDeserialized += displayTraces;
-                   agent.MetricsReceived += displayStats;
-                   agents.Add(agent);
-               }
-
-               var shutdown = false;
-
-               while (!shutdown)
-               {
-                   Console.WriteLine("Options - Q to exit, T to toggle show traces, M to toggle show metrics. ");
-                   var input = Console.ReadKey();
-                   var entry = input.KeyChar.ToString().ToLowerInvariant();
-                   shutdown = entry.Contains("q");
-
-                   if (entry.Contains("t"))
-                   {
-                       showTraces = !showTraces;
-                       if (showTraces)
-                       {
-                           Console.WriteLine("Showing traces.");
-                       }
-                       else
-                       {
-                           Console.WriteLine("Hiding traces.");
-                       }
-                   }
-
-                   if (entry.Contains("m"))
-                   {
-                       showMetrics = !showMetrics;
-                       if (showMetrics)
-                       {
-                           Console.WriteLine("Showing metrics.");
-                       }
-                       else
-                       {
-                           Console.WriteLine("Hiding metrics.");
-                       }
-                   }
-               }
-           }
-           finally
-           {
-               foreach (var agent in agents)
-               {
-                   agent?.Dispose();
-               }
+               agent.RequestDeserialized += DisplayTraces;
            }
 
-       });
+           if (_opts.ShowMetrics)
+           {
+               agent.MetricsReceived += DisplayMetrics;
+           }
+       }
+
+       if (_opts.UnixDomainSockets)
+       {
+           // can't enable on windows
+           string? metricsUds = null;
+           bool useMetrics = !string.IsNullOrEmpty(metricsUds);
+           if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX)
+           {
+               metricsUds = _opts.MetricsUnixDomainSocketPath;
+           }
+
+           var config = new UnixDomainSocketConfig(_opts.TracesUnixDomainSocketPath,  metricsUds)
+           {
+               UseDogstatsD = useMetrics,
+               UseTelemetry = true,
+           };
+
+           var agent = MockTracerAgent.Create(this, config);
+           _agents.Add(agent);
+           _logger.LogInformation("Listening for traces on Unix Domain Socket: {AgentTracesUdsPath}", agent.TracesUdsPath);
+
+           if (useMetrics)
+           {
+               _logger.LogInformation("Listening for metrics on Unix Domain Socket: {AgentStatsUdsPath}", agent.StatsUdsPath);
+           }
+
+           if (_opts.ShowTraces)
+           {
+               agent.RequestDeserialized += DisplayTraces;
+           }
+
+           if (useMetrics && _opts.ShowMetrics)
+           {
+               agent.MetricsReceived += DisplayMetrics;
+           }
+       }
+
+       if (_opts.WindowsNamedPipe)
+       {
+           var config = new WindowsPipesConfig(_opts.TracesPipeName, _opts.MetricsPipeName)
+           {
+               UseDogstatsD = !string.IsNullOrEmpty(_opts.MetricsPipeName),
+               UseTelemetry = true,
+           };
+
+           var agent = MockTracerAgent.Create(this, config);
+           _agents.Add(agent);
+           _logger.LogInformation("Listening for traces on Windows Named Pipe: {AgentTracesWindowsPipeName}", agent.TracesWindowsPipeName);
+           _logger.LogInformation("Listening for metrics on Windows Named Pipe: {AgentStatsWindowsPipeName}", agent.StatsWindowsPipeName);
+
+           if (_opts.ShowTraces)
+           {
+               agent.RequestDeserialized += DisplayTraces;
+           }
+
+           if (_opts.ShowMetrics)
+           {
+               agent.MetricsReceived += DisplayMetrics;
+           }
+       }
+
+       return _tcs.Task;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _logger.LogInformation("Shutting down agents");
+        foreach (var agent in _agents)
+        {
+            agent.Dispose();
+        }
+    }
+
+    public void WriteLine(string message) => _logger.LogDebug("{Message}", message);
+
+    public void WriteLine(string format, params object[] args) => _logger.LogDebug(format, args);
+}

--- a/tracer/tools/MockAgent/Program.cs
+++ b/tracer/tools/MockAgent/Program.cs
@@ -73,12 +73,11 @@ public class Worker : BackgroundService, ITestOutputHelper
        {
            // can't enable on windows
            string? metricsUds = null;
-           bool useMetrics = !string.IsNullOrEmpty(metricsUds);
            if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX)
            {
                metricsUds = _opts.MetricsUnixDomainSocketPath;
            }
-
+           bool useMetrics = !string.IsNullOrEmpty(metricsUds);
            var config = new UnixDomainSocketConfig(_opts.TracesUnixDomainSocketPath,  metricsUds)
            {
                UseDogstatsD = useMetrics,

--- a/tracer/tools/MockAgent/Program.cs
+++ b/tracer/tools/MockAgent/Program.cs
@@ -72,11 +72,10 @@ public class Worker : BackgroundService, ITestOutputHelper
        if (_opts.UnixDomainSockets)
        {
            // can't enable on windows
-           string? metricsUds = null;
-           if (Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX)
-           {
-               metricsUds = _opts.MetricsUnixDomainSocketPath;
-           }
+           var metricsUds = Environment.OSVersion.Platform is PlatformID.Unix or PlatformID.MacOSX
+                            ? _opts.MetricsUnixDomainSocketPath
+                            : null;
+
            bool useMetrics = !string.IsNullOrEmpty(metricsUds);
            var config = new UnixDomainSocketConfig(_opts.TracesUnixDomainSocketPath,  metricsUds)
            {

--- a/tracer/tools/MockAgent/Properties/launchSettings.json
+++ b/tracer/tools/MockAgent/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "profiles": {
     "MockAgent.UnixDomainSocket": {
       "commandName": "Project",


### PR DESCRIPTION
## Summary of changes

Use the mock agent in exploration tests instead of the real agent

## Reason for change

In the .NET 10 branch, we updated the VMs, and also pulled a new version of the agent. For _some_ reason, (e.g. new agent) the agent docker container often doesn't start up, making the tests super flaky, due to failing to send traces to the agent.

I've spent _far_ to long trying to get the real agent to work in CI, and in the end I give up. We absolutely don't need the "real" agent, so it's not worth the hassle IMO.

## Implementation details

- Fix the standalone "MockAgent" project (which just hosts the `MockTracerAgent` class)
- Rework it to be based on the standard .NET hosting model instead of doing custom stuff
- Run the mock agent in the Windows Exploration tests only.

## Test coverage

[It works in the .NET 10 branch](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=186178&view=logs&j=8345afb5-d2a0-5c0b-09c6-12ff46d9917b) which is the important thing.

## Other details

Yeah, we _could_ have used the Python test-agent here (dd-apm-test-agent), but we'd have to use the docker container, and rebuild all the VMs etc. Meh, this works.