### PR TITLE
chore: add logging for data pipeline status in TracerSettings

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -590,6 +590,10 @@ namespace Datadog.Trace
                     }
 
                     writer.WriteEndArray();
+
+                    writer.WritePropertyName("trace_data_pipeline_enabled");
+                    writer.WriteValue(instanceSettings.DataPipelineEnabled);
+
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }


### PR DESCRIPTION
## Summary of changes
Added an informational log message to indicate when the data pipeline is enabled.

## Reason for change
To provide visibility into the data pipeline's status during runtime.

We are logging for all the cases, where data pipeline is getting disabled due to some other env or config, but not emitting a log when we have it enabled. This is going to be helpful in debugging issues.

## Implementation details
Included a log statement within the existing conditional check for DataPipelineEnabled.

## Test coverage
N/A

## Other details
<!-- Fixes #{issue} -->