### PR TITLE
[AAP] Add Forwarded header as ip source

### DIFF
--- a/tracer/src/Datadog.Trace/Headers/Ip/IpExtractor.cs
+++ b/tracer/src/Datadog.Trace/Headers/Ip/IpExtractor.cs
@@ -36,15 +36,16 @@ namespace Datadog.Trace.Headers.Ip
         /// </summary>
         /// <param name="headerValue">the extracted values from releveant ip related header</param>
         /// <param name="https">is a secure connection</param>
+        /// <param name="extractor">function that extracts the potential IP from the header fragment</param>
         /// <returns>return ip and port, may be null</returns>
-        internal static IpInfo? RealIpFromValue(string headerValue, bool https)
+        internal static IpInfo? RealIpFromValue(string headerValue, bool https, Func<string?, string?> extractor)
         {
             IpInfo? privateIpInfo = null;
             var values = headerValue.Split(',');
             foreach (var potentialIp in values)
             {
-                var consideredPotentialIp = potentialIp.Trim();
-                if (string.IsNullOrEmpty(consideredPotentialIp))
+                var consideredPotentialIp = extractor(potentialIp);
+                if (consideredPotentialIp is null || consideredPotentialIp.Length == 0)
                 {
                     continue;
                 }

--- a/tracer/src/Datadog.Trace/Headers/Ip/IpExtractor.cs
+++ b/tracer/src/Datadog.Trace/Headers/Ip/IpExtractor.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Headers.Ip
         internal static IpInfo? RealIpFromValue(string headerValue, bool https, Func<string?, string?> extractor)
         {
             IpInfo? privateIpInfo = null;
-            var values = headerValue.Split(',');
+            var values = headerValue.Split(',', ';');
             foreach (var potentialIp in values)
             {
                 var consideredPotentialIp = extractor(potentialIp);

--- a/tracer/test/Datadog.Trace.Tests/Headers/Ip/IpExtractionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Headers/Ip/IpExtractionTests.cs
@@ -83,6 +83,7 @@ namespace Datadog.Trace.Tests.Headers.Ip
         [InlineData("192.168.1.1", 80, "for=192.168.1.1,for=172.16.32.41,for=172.16.32.43,by=172.31.255.255,")]
         [InlineData("83.204.236.243", 80, "for=127.0.0.1,for=83.204.236.243")]
         [InlineData("83.204.236.243", 80, "for=169.254.0.3,for=83.204.236.243")]
+        [InlineData("83.204.236.243", 80, "for=169.254.0.3;for=83.204.236.243")]
         public void ForwardedIpv4PublicDetectedLocalIgnored(string expectedIp, int expectedPort, string headerValue)
         {
             var ip = IpExtractor.RealIpFromValue(headerValue, https: false, RequestIpExtractor.ForwardedHeaderComponentParser);

--- a/tracer/test/Datadog.Trace.Tests/Headers/Ip/IpExtractionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Headers/Ip/IpExtractionTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Tests.Headers.Ip
         [InlineData("83.204.236.243", 80, "169.254.0.3, 83.204.236.243")]
         public void Ipv4PublicDetectedLocalIgnored(string expectedIp, int expectedPort, string headerValue)
         {
-            var ip = IpExtractor.RealIpFromValue(headerValue, https: false);
+            var ip = IpExtractor.RealIpFromValue(headerValue, https: false, RequestIpExtractor.DefaultHeaderComponentParser);
             Assert.Equal(expectedIp, ip.IpAddress);
             Assert.Equal(expectedPort, ip.Port);
         }
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tests.Headers.Ip
         [InlineData("fe80::20e:cff:fe3b:883c", 80, "fe80::20e:cff:fe3b:883c, fe80::5525:2a3f:6fa6:cd4e%14, FE80::240:D0FF:FE48:4672")]
         public void Ipv6PublicDetectedPrivateIgnored(string expectedIp, int expectedPort, string headerValue)
         {
-            var ip = IpExtractor.RealIpFromValue(headerValue, https: false);
+            var ip = IpExtractor.RealIpFromValue(headerValue, https: false, RequestIpExtractor.DefaultHeaderComponentParser);
             Assert.Equal(expectedIp, ip.IpAddress);
             Assert.Equal(expectedPort, ip.Port);
         }
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tests.Headers.Ip
         [InlineData("129.144.52.37", 553, "::FFFF:192.168.1.26, [::FFFF:129.144.52.37]:553, ::ffff:191.239.213.197")]
         public void Ipv4OverIpv6(string expectedIp, int expectedPort, string headerValue)
         {
-            var ip = IpExtractor.RealIpFromValue(headerValue,   https: false);
+            var ip = IpExtractor.RealIpFromValue(headerValue, https: false, RequestIpExtractor.DefaultHeaderComponentParser);
             Assert.Equal(expectedIp, ip.IpAddress);
             Assert.Equal(expectedPort, ip.Port);
         }
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Tests.Headers.Ip
         public void Ipv6UnicastLocalIgnored()
         {
             var expectedIp = "81.202.236.243";
-            var ip = IpExtractor.RealIpFromValue($"fdf8:f53b:82e4::53, {expectedIp}:82", false);
+            var ip = IpExtractor.RealIpFromValue($"fdf8:f53b:82e4::53, {expectedIp}:82", https: false, RequestIpExtractor.DefaultHeaderComponentParser);
             Assert.Equal(expectedIp, ip.IpAddress);
             Assert.Equal(expected: 82, ip.Port);
         }
@@ -71,9 +71,34 @@ namespace Datadog.Trace.Tests.Headers.Ip
         public void Ipv6LinkLocalIgnored()
         {
             const string expectedIp = "81.202.236.243";
-            var ip = IpExtractor.RealIpFromValue("fe80::9656:d028:8652:66b6, 81.202.236.243:82", https: false);
+            var ip = IpExtractor.RealIpFromValue("fe80::9656:d028:8652:66b6, 81.202.236.243:82", https: false, RequestIpExtractor.DefaultHeaderComponentParser);
             Assert.Equal(expectedIp, ip.IpAddress);
             Assert.Equal(expected: 82, ip.Port);
+        }
+
+        [Theory]
+        [InlineData("172.217.22.14", 80, "for=172.217.22.14,by=81.202.236.243:5001")]
+        [InlineData("81.202.236.243", 5001, "by=172.217.22.14,for=81.202.236.243:5001")]
+        [InlineData("83.204.236.243", 443, "for=172.16.2.4,by=172.217.22.14,for=172.31.255.255,for=192.168.255.255,for=10.145.255.255,for=83.204.236.243:443")]
+        [InlineData("192.168.1.1", 80, "for=192.168.1.1,for=172.16.32.41,for=172.16.32.43,by=172.31.255.255,")]
+        [InlineData("83.204.236.243", 80, "for=127.0.0.1,for=83.204.236.243")]
+        [InlineData("83.204.236.243", 80, "for=169.254.0.3,for=83.204.236.243")]
+        public void ForwardedIpv4PublicDetectedLocalIgnored(string expectedIp, int expectedPort, string headerValue)
+        {
+            var ip = IpExtractor.RealIpFromValue(headerValue, https: false, RequestIpExtractor.ForwardedHeaderComponentParser);
+            Assert.Equal(expectedIp, ip.IpAddress);
+            Assert.Equal(expectedPort, ip.Port);
+        }
+
+        [Theory]
+        [InlineData("2001:db8:3333:4444:5555:6666:7777:8888", 80, "for=fe80::20e:cff:fe3b:883c,for=2001:db8:3333:4444:5555:6666:7777:8888")]
+        [InlineData("2001:db8:3333:4444:5555:6666:7777:8888", 53, "for=fe80::20e:cff:fe3b:883c,for=fe80::5525:2a3f:6fa6:cd4e%14,for=[2001:db8:3333:4444:5555:6666:7777:8888]:53")]
+        [InlineData("fe80::20e:cff:fe3b:883c", 80, "for=fe80::20e:cff:fe3b:883c,for=fe80::5525:2a3f:6fa6:cd4e%14,for=FE80::240:D0FF:FE48:4672")]
+        public void ForwardedIpv6PublicDetectedPrivateIgnored(string expectedIp, int expectedPort, string headerValue)
+        {
+            var ip = IpExtractor.RealIpFromValue(headerValue, https: false, RequestIpExtractor.ForwardedHeaderComponentParser);
+            Assert.Equal(expectedIp, ip.IpAddress);
+            Assert.Equal(expectedPort, ip.Port);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Headers/Ip/RequestHeadersHelpersTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Headers/Ip/RequestHeadersHelpersTests.cs
@@ -23,7 +23,8 @@ namespace Datadog.Trace.Tests.Headers.Ip
                         { "referer", "https://example.com/" },
                         { "hello-world", "irrelevant" },
                         { "x-forwarded-for", "80.19.10.10:32" },
-                        { "true-client-ip", "81.202.236.243:82" }
+                        { "true-client-ip", "81.202.236.243:82" },
+                        { "forwarded", "82.20.36.23:800" }
                     },
                     name: "http headers should be read in order",
                     customIpHeader: string.Empty,
@@ -38,8 +39,27 @@ namespace Datadog.Trace.Tests.Headers.Ip
                     data: new()
                     {
                         { "user-agent", "Mozilla firefox" },
+                        { "referer", "https://example.com/" },
+                        { "hello-world", "irrelevant" },
+                        { "forwarded", "for=80.19.10.10:32" },
+                        { "true-client-ip", "81.202.236.243:82" }
+                    },
+                    name: "forwarded header is parsed correctly",
+                    customIpHeader: string.Empty,
+                    expectedIp: "80.19.10.10",
+                    expectedPort: 32,
+                    peerIp: "80.19.14.16",
+                    peerPort: 32)
+            },
+            new object[]
+            {
+                new TestScenario(
+                    data: new()
+                    {
+                        { "user-agent", "Mozilla firefox" },
                         { "referer", "https://example1.com/" },
                         { "hello-world", "irrelevant" },
+                        { "forwarded", "82.20.36.23:800" },
                         { "x-forwarded-for", "80.19.10.10:32" },
                         { "custom-header3", "81.202.236.243:82" }
                     },


### PR DESCRIPTION
## Summary of changes
Use forwarded header value as client ip source

## Reason for change
[JIRA](https://datadoghq.atlassian.net/browse/APPSEC-58240)
[DOC](https://datadoghq.atlassian.net/wiki/spaces/SAAL/pages/2118779066/Client+IP+addresses+resolution#Forwarded-vs-X-Forwarded-For-Formats)

## Implementation details
Added forwarded header with its parser (forwarded header has its own format) to the `RequestIpExtractor`

## Test coverage
Added unit tests

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
