### PR TITLE
[IAST] Disable all Dataflow operations until aspects are loaded

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -460,7 +460,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
         {
             Logger::Info("AssemblyLoadFinished: Datadog.Trace.dll v", assembly_version, " matched profiler version v",
                          expected_version);
-            managed_profiler_loaded_app_domains.insert({assembly_info.app_domain_id, assembly_metadata.version});
+            managed_profiler_loaded_app_domains.insert({assembly_info.app_domain_id, assembly_info.manifest_module_id});
 
             // Load defaults values if the version are the same as expected
             if (assembly_metadata.version == expected_assembly_reference.version)
@@ -481,7 +481,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
                 if (assembly_info.app_domain_id == corlib_app_domain_id)
                 {
                     Logger::Info("AssemblyLoadFinished: Datadog.Trace.dll was loaded domain-neutral");
-                    managed_profiler_loaded_domain_neutral = true;
+                    managed_profiler_domain_neutral_module_id = assembly_info.manifest_module_id;
                 }
                 else
                 {
@@ -2501,11 +2501,28 @@ bool CorProfiler::GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleI
     return true;
 }
 
-bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id)
+bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id, ModuleID* pModuleId)
 {
-    return managed_profiler_loaded_domain_neutral ||
+    return managed_profiler_domain_neutral_module_id > 0 ||
            managed_profiler_loaded_app_domains.find(app_domain_id) != managed_profiler_loaded_app_domains.end();
 }
+
+ModuleID CorProfiler::GetProfilerAssemblyModuleId(AppDomainID appDomainId)
+{
+    if (managed_profiler_domain_neutral_module_id > 0)
+    {
+        return managed_profiler_domain_neutral_module_id;
+    }
+
+    auto it = managed_profiler_loaded_app_domains.find(appDomainId);
+    if (it != managed_profiler_loaded_app_domains.end())
+    {
+        return it->second;
+    }
+
+    return 0;
+}
+
 
 HRESULT CorProfiler::EmitDistributedTracerTargetMethod(const ModuleMetadata& module_metadata, ModuleID module_id)
 {

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2501,7 +2501,7 @@ bool CorProfiler::GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleI
     return true;
 }
 
-bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id, ModuleID* pModuleId)
+bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id)
 {
     return managed_profiler_domain_neutral_module_id > 0 ||
            managed_profiler_loaded_app_domains.find(app_domain_id) != managed_profiler_loaded_app_domains.end();

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -62,8 +62,8 @@ private:
     bool corlib_module_loaded = false;
     ModuleID corlib_module_id = 0;
     AppDomainID corlib_app_domain_id = 0;
-    bool managed_profiler_loaded_domain_neutral = false;
-    std::unordered_map<AppDomainID, Version> managed_profiler_loaded_app_domains;
+    ModuleID managed_profiler_domain_neutral_module_id = 0;
+    std::unordered_map<AppDomainID, ModuleID> managed_profiler_loaded_app_domains;
     std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
     bool is_desktop_iis = false;
 
@@ -122,7 +122,7 @@ private:
     static void __stdcall NativeLog(int32_t level, const WCHAR* message, int32_t length);
     bool GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleID module_id,
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
-    bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
+    bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id, ModuleID* pModuleId = nullptr);
     std::string GetILCodes(const std::string& title, ILRewriter* rewriter, const FunctionInfo& caller,
                            const ComPtr<IMetaDataImport2>& metadata_import);
     HRESULT RewriteForDistributedTracing(const ModuleMetadata& module_metadata, ModuleID module_id);
@@ -255,6 +255,11 @@ public:
     //
     bool IsCallTargetBubbleUpExceptionTypeAvailable() const;
     bool IsCallTargetBubbleUpFunctionAvailable() const;
+
+    //
+    // Dataflow helper methods
+    //
+    ModuleID GetProfilerAssemblyModuleId(AppDomainID appDomainId);
 };
 
 // Note: Generally you should not have a single, global callback implementation,

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -122,7 +122,7 @@ private:
     static void __stdcall NativeLog(int32_t level, const WCHAR* message, int32_t length);
     bool GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleID module_id,
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
-    bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id, ModuleID* pModuleId = nullptr);
+    bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
     std::string GetILCodes(const std::string& title, ILRewriter* rewriter, const FunctionInfo& caller,
                            const ComPtr<IMetaDataImport2>& metadata_import);
     HRESULT RewriteForDistributedTracing(const ModuleMetadata& module_metadata, ModuleID module_id);

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
@@ -105,12 +105,8 @@ namespace iast
 
         AppDomainInfo* GetAppDomain(AppDomainID id);
         ModuleInfo* GetModuleInfo(ModuleID moduleId);
-        ModuleInfo* GetModuleInfo(WSTRING moduleName, AppDomainID appDomainId, bool lookInSharedRepos = false);
-
-        mdMethodDef GetFunctionInfo(FunctionID functionId, ModuleInfo** ppModuleInfo);
-
+        ModuleInfo* GetAspectsModule(AppDomainID id);
         MethodInfo* GetMethodInfo(ModuleID moduleId, mdMethodDef methodId);
-        MethodInfo* GetMethodInfo(FunctionID functionId);
 
         bool IsInlineEnabled(ModuleID calleeModuleId, mdToken calleeMethodId);
         bool JITCompilationStarted(ModuleID moduleId, mdToken methodId);

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
@@ -66,7 +66,7 @@ namespace iast
         void LoadSecurityControls();
     protected:
         bool _initialized = true;
-        bool _loaded = false;
+        bool _aspectsLoaded = false;
         bool _setILOnJit = false;
 
         std::vector<DataflowAspectClass*> _aspectClasses;

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -88,6 +88,8 @@ namespace iast
             auto version = GetVersionInfo(versionTxt);
             if (Compare(currentVersion, version) < 0)
             {
+                DBG("DataflowAspectClass::DataflowAspectClass -> Skipping aspect class, current version ",
+                    currentVersion.ToString(), " is lower than required ", version.ToString());
                 return; // Current version is lower than minimum required
             }
         }
@@ -124,6 +126,8 @@ namespace iast
             UINT32 category = ConvertToUint(Trim(parts[part]), 0xFFFFFFFF);
             if ((category & enabledCategories) == 0)
             {
+                DBG("DataflowAspectClass::DataflowAspectClass -> Skipping aspect class, category ", category,
+                    " is not enabled in ", enabledCategories);
                 return; // Current category is not enabled
             }
         }
@@ -149,18 +153,31 @@ namespace iast
     }
 
     DataflowAspect::DataflowAspect(DataflowAspectClass* aspectClass, const WSTRING& line,
-                                   const UINT32 enabledCategories) :
+                                   const UINT32 enabledPlatforms) :
         DataflowAspect(aspectClass)
     {
         size_t offset = 0;
         auto pos0 = IndexOf(line, WStr("["), &offset);
-        if (pos0 == std::string::npos) { return; }
+        if (pos0 == std::string::npos) 
+        {
+            DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no opening [ found");
+            return; 
+        }
         pos0 = offset;
         auto pos1 = IndexOf(line, WStr("("), &offset);
-        if (pos1 == std::string::npos) { return; }
+        if (pos1 == std::string::npos) 
+        {
+            DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no opening ( found");
+            return; 
+        }
         auto aspectAttribute = line.substr(pos0, pos1 - pos0);
         _behavior = ParseAspectApplication(aspectAttribute);
-        if (_behavior == AspectBehavior::Unknown) { return; }
+        if (_behavior == AspectBehavior::Unknown) 
+        {
+            DBG("DataflowAspect::DataflowAspect -> Skipping aspect, unknown behavior ",
+                shared::ToString(aspectAttribute));
+            return; 
+        }
 
         pos0 = offset;
         pos1 = IndexOf(line, WStr(")] "), &offset);
@@ -168,13 +185,23 @@ namespace iast
         {
             // Check for version limitation
             pos1 = IndexOf(line, WStr(");V"), &offset);
-            if (pos1 == std::string::npos) { return; }
+            if (pos1 == std::string::npos) 
+            {
+                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no closing )] found");
+                return; 
+            }
             auto pos2 = IndexOf(line, WStr("] "), &offset);
-            if (pos2 == std::string::npos) { return; }
+            if (pos2 == std::string::npos) 
+            {
+                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no closing ] found");
+                return; 
+            }
             auto versionTxt = shared::ToString(line.substr(pos1 + 3, pos2 - pos1 - 3));
             auto version = GetVersionInfo(versionTxt);
             if (Compare(currentVersion, version) < 0)
             {
+                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, current version ", currentVersion.ToString(),
+                    " is lower than required ", version.ToString());
                 return; // Current version is lower than minimum required
             }
         }
@@ -235,12 +262,14 @@ namespace iast
             _aspectMethodName = aspectMethod.substr(0, pos0);
             _aspectMethodParams = aspectMethod.substr(pos0);
         }
-        if ((int) parts.size() > ++part) // Category
+        if ((int) parts.size() > ++part) // Platform
         {
-            UINT32 category = ConvertToUint(Trim(parts[part]), 0xFFFFFFFF);
-            if ((category & enabledCategories) == 0)
+            UINT32 platform = ConvertToUint(Trim(parts[part]), 0xFFFFFFFF);
+            if ((platform & enabledPlatforms) == 0)
             {
-                return; // Current category is not enabled
+                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, platform ", platform, " is not enabled in ",
+                    enabledPlatforms);
+                return; // Current platform is not enabled
             }
         }
 
@@ -498,9 +527,8 @@ namespace iast
         if (_aspectMemberRef == 0)
         {
             // Import aspect
-            _aspectMemberRef = _module->DefineMemberRef(Constants::AspectsAssemblyName,
-                                                        _aspect->_aspectClass->_aspectTypeName,
-                                                        _aspect->_aspectMethodName, _aspect->_aspectMethodParams);
+            _aspectMemberRef = _module->DefineAspectMemberRef(_aspect->_aspectClass->_aspectTypeName,
+                                                              _aspect->_aspectMethodName, _aspect->_aspectMethodParams);
         }
 
         if (_aspect->IsGeneric() && _aspectMemberRef != 0 && methodSpec != nullptr)

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -74,22 +74,34 @@ namespace iast
     {
         size_t offset = 0;
         auto pos0 = IndexOf(line, WStr("[AspectClass("), &offset);
-        if (pos0 == std::string::npos) { return; }
+        if (pos0 == std::string::npos) 
+        {
+            DBG("DataflowAspectClass::DataflowAspectClass -> Skipping aspect class, no opening [AspectClass( found. Line: ", line);
+            return; 
+        }
         pos0 = offset;
         auto pos1 = IndexOf(line, WStr(")] "), &offset);
         if (pos1 == std::string::npos) 
         {
             //Check for version limitation
             pos1 = IndexOf(line, WStr(");V"), &offset);
-            if (pos1 == std::string::npos) { return; }
+            if (pos1 == std::string::npos) 
+            {
+                DBG("DataflowAspectClass::DataflowAspectClass -> Skipping aspect class, no closing )] found. Line: ", line);
+                return; 
+            }
             auto pos2 = IndexOf(line, WStr("] "), &offset);
-            if (pos2 == std::string::npos) { return; }
+            if (pos2 == std::string::npos) 
+            {
+                DBG("DataflowAspectClass::DataflowAspectClass -> Skipping aspect class, no closing ] found. Line: ", line);
+                return; 
+            }
             auto versionTxt = shared::ToString(line.substr(pos1 + 3, pos2 - pos1 - 3));
             auto version = GetVersionInfo(versionTxt);
             if (Compare(currentVersion, version) < 0)
             {
                 DBG("DataflowAspectClass::DataflowAspectClass -> Skipping aspect class, current version ",
-                    currentVersion.ToString(), " is lower than required ", version.ToString());
+                    currentVersion.ToString(), " is lower than required ", version.ToString(), ". Line: ", line);
                 return; // Current version is lower than minimum required
             }
         }
@@ -127,7 +139,7 @@ namespace iast
             if ((category & enabledCategories) == 0)
             {
                 DBG("DataflowAspectClass::DataflowAspectClass -> Skipping aspect class, category ", category,
-                    " is not enabled in ", enabledCategories);
+                    " is not enabled in ", enabledCategories, ". Line: ", line);
                 return; // Current category is not enabled
             }
         }
@@ -160,14 +172,14 @@ namespace iast
         auto pos0 = IndexOf(line, WStr("["), &offset);
         if (pos0 == std::string::npos) 
         {
-            DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no opening [ found");
+            DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no opening [ found. Line: ", line);
             return; 
         }
         pos0 = offset;
         auto pos1 = IndexOf(line, WStr("("), &offset);
         if (pos1 == std::string::npos) 
         {
-            DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no opening ( found");
+            DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no opening ( found. Line: ", line);
             return; 
         }
         auto aspectAttribute = line.substr(pos0, pos1 - pos0);
@@ -175,7 +187,7 @@ namespace iast
         if (_behavior == AspectBehavior::Unknown) 
         {
             DBG("DataflowAspect::DataflowAspect -> Skipping aspect, unknown behavior ",
-                shared::ToString(aspectAttribute));
+                shared::ToString(aspectAttribute), ". Line: ", line);
             return; 
         }
 
@@ -187,13 +199,13 @@ namespace iast
             pos1 = IndexOf(line, WStr(");V"), &offset);
             if (pos1 == std::string::npos) 
             {
-                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no closing )] found");
+                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no closing )] found. Line: ", line);
                 return; 
             }
             auto pos2 = IndexOf(line, WStr("] "), &offset);
             if (pos2 == std::string::npos) 
             {
-                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no closing ] found");
+                DBG("DataflowAspect::DataflowAspect -> Skipping aspect, no closing ] found. Line: ", line);
                 return; 
             }
             auto versionTxt = shared::ToString(line.substr(pos1 + 3, pos2 - pos1 - 3));
@@ -201,7 +213,7 @@ namespace iast
             if (Compare(currentVersion, version) < 0)
             {
                 DBG("DataflowAspect::DataflowAspect -> Skipping aspect, current version ", currentVersion.ToString(),
-                    " is lower than required ", version.ToString());
+                    " is lower than required ", version.ToString(), ". Line: ", line);
                 return; // Current version is lower than minimum required
             }
         }
@@ -268,7 +280,7 @@ namespace iast
             if ((platform & enabledPlatforms) == 0)
             {
                 DBG("DataflowAspect::DataflowAspect -> Skipping aspect, platform ", platform, " is not enabled in ",
-                    enabledPlatforms);
+                    enabledPlatforms, ". Line: ", line);
                 return; // Current platform is not enabled
             }
         }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.h
@@ -96,7 +96,7 @@ namespace iast
 
     public:
         DataflowAspectClass* _aspectClass = nullptr;
-        AspectBehavior _behavior;
+        AspectBehavior _behavior = AspectBehavior::Unknown;
         WSTRING _aspectMethodName = EmptyWStr;
         WSTRING _aspectMethodParams = EmptyWStr;
 

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
@@ -718,7 +718,14 @@ namespace iast
             if (instruction->IsDirty())
             {
                 memberName = shared::ToString(GetMemberName(body, instruction->m_originalArg32));
-                argument = argument + " Original: [" + Hex(instruction->m_originalArg32) + "] " + memberName;
+                if (instruction->IsNew())
+                {
+                    argument = argument + " NEW ";
+                }
+                else
+                {
+                    argument = argument + " Original: [" + Hex(instruction->m_originalArg32) + "] " + memberName;
+                }
             }
             break;
         case 1 | OPCODEFLAGS_BranchTarget:

--- a/tracer/src/Datadog.Tracer.Native/iast/iast_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/iast_constants.h
@@ -29,8 +29,6 @@ namespace iast
         const WSTRING AspNetCoreMvcViewFeatures = WStr("Microsoft.AspNetCore.Mvc.ViewFeatures");
 
         const WSTRING AspectsAssemblyName = WStr("Datadog.Trace");
-        const WSTRING AspectsAssemblyFileName = AspectsAssemblyName + WStr(".dll");
-        const WSTRING AspectsFileName = AspectsAssemblyName + WStr(".aspects");
 
         const WSTRING VulnerabilityType_SqlInjection = WStr("SQL_INJECTION");
         const WSTRING VulnerabilityType_XSS = WStr("XSS");

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -766,30 +766,6 @@ HRESULT ModuleInfo::CommitILRewriter(ILRewriter** rewriter)
     return hr;
 }
 
-/*
-ModuleInfo* ModuleInfo::GetModuleInfoByName(WSTRING moduleName)
-{
-    auto res = _dataflow->GetModuleInfo(moduleName, _appDomain.Id);
-    if (res)
-    {
-        return res;
-    }
-    if (moduleName == managed_profiler_name)
-    {
-        // In .NetFramework, "Datadog.trace" might be in the shared assembly repository
-        res = _dataflow->GetModuleInfo(moduleName, _appDomain.Id, true);
-
-        if (res) 
-        {
-            return res;
-        }            
-    }
-    
-    trace::Logger::Info("Module ", moduleName, " NOT FOUND for AppDomain ", _appDomain.Name, " using fallback...");
-    return res;
-}
-*/
-
 mdToken ModuleInfo::DefineAspectMemberRef(const WSTRING& typeName, const WSTRING& methodName, const WSTRING& methodParams)
 {
     HRESULT hr = S_OK;

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -766,7 +766,7 @@ HRESULT ModuleInfo::CommitILRewriter(ILRewriter** rewriter)
     return hr;
 }
 
-
+/*
 ModuleInfo* ModuleInfo::GetModuleInfoByName(WSTRING moduleName)
 {
     auto res = _dataflow->GetModuleInfo(moduleName, _appDomain.Id);
@@ -788,16 +788,14 @@ ModuleInfo* ModuleInfo::GetModuleInfoByName(WSTRING moduleName)
     trace::Logger::Info("Module ", moduleName, " NOT FOUND for AppDomain ", _appDomain.Name, " using fallback...");
     return res;
 }
+*/
 
-mdToken ModuleInfo::DefineMemberRef(const WSTRING& moduleName, const WSTRING& typeName, const WSTRING& methodName, const WSTRING& methodParams)
+mdToken ModuleInfo::DefineAspectMemberRef(const WSTRING& typeName, const WSTRING& methodName, const WSTRING& methodParams)
 {
-    HRESULT hr = E_INVALIDARG;
+    HRESULT hr = S_OK;
     mdMemberRef methodRef = 0;
-    AssemblyImportInfo assemblyImport{0};
-    ModuleInfo* moduleInfo = nullptr;
     std::stringstream memberKeyBuilder;
-    memberKeyBuilder << shared::ToString(moduleName) << "::" << shared::ToString(typeName) << "."
-                     << shared::ToString(methodName) << shared::ToString(methodParams);
+    memberKeyBuilder << shared::ToString(typeName) << "." << shared::ToString(methodName) << shared::ToString(methodParams);
     WSTRING memberKey = ToWSTRING(memberKeyBuilder.str());
 
     auto memberValue = _mMemberImports.find(memberKey);
@@ -805,74 +803,60 @@ mdToken ModuleInfo::DefineMemberRef(const WSTRING& moduleName, const WSTRING& ty
     {
         return memberValue->second;
     }
-
-    auto value = _mAssemblyImports.find(moduleName);
-    if (value != _mAssemblyImports.end())
+    if (_aspectsAssemblyRef == 0)
     {
-        assemblyImport = value->second;
-        moduleInfo = _dataflow->GetModuleInfo(assemblyImport.moduleId);
-        if (!moduleInfo)
-        {
-            trace::Logger::Info("DefineMemberRef : FAILED GetModuleInfo ", Hex((ULONG)assemblyImport.moduleId));
-        }
-    }
-    if (FAILED(hr))
-    {
-        moduleInfo = GetModuleInfoByName(moduleName);
-        if (!moduleInfo)
-        {
-            trace::Logger::Info("Module ", moduleName, " NOT FOUND");
-            return 0;
-        }
-        mdAssemblyRef assemblyRef;
         hr = _assemblyEmit->DefineAssemblyRef((void*) Constants::DDAssemblyPublicKeyToken,
-                                             sizeof(Constants::DDAssemblyPublicKeyToken), moduleName.c_str(),
+                                              sizeof(Constants::DDAssemblyPublicKeyToken),
+                                              Constants::AspectsAssemblyName.c_str(),
                                              GetDatadogAssemblyMetadata(),
                                              nullptr, // hash blob
                                              0,    // cb of hash blob
                                              0,    // flags
-                                             &assemblyRef);
-        if (FAILED(hr) || !moduleInfo)
+                                             &_aspectsAssemblyRef);
+        if (FAILED(hr))
         {
-            trace::Logger::Info("DefineMemberRef : DefineAssemblyRef FAILED ", Hex(hr));
+            trace::Logger::Warn("ModuleInfo::DefineMemberRef -> DefineAssemblyRef for Aspects Assembly FAILED ", Hex(hr));
+            return 0;
         }
-
-        assemblyImport.moduleId = moduleInfo->_id;
-        assemblyImport.assemblyRef = assemblyRef;
-        _mAssemblyImports[moduleName] = assemblyImport;
     }
 
-    auto methodInfo = moduleInfo->GetMethod(typeName, methodName, methodParams);
-    if (methodInfo == nullptr)
+    auto aspectsModuleInfo = _dataflow->GetAspectsModule(_appDomain.Id);
+    if (aspectsModuleInfo == nullptr)
     {
-        DBG("DefineMemberRef : Could not find Method ", shared::ToString(typeName), ".", shared::ToString(methodName), shared::ToString(methodParams));
+        trace::Logger::Warn("ModuleInfo::DefineMemberRef -> Aspects Module ", Constants::AspectsAssemblyName, " NOT FOUND");
+        return 0;
+    }
+
+    auto aspectMethodInfo = aspectsModuleInfo->GetMethod(typeName, methodName, methodParams);
+    if (aspectMethodInfo == nullptr)
+    {
+        trace::Logger::Warn("ModuleInfo::DefineMemberRef -> Could not find Aspect Method ", shared::ToString(typeName), ".", shared::ToString(methodName), shared::ToString(methodParams));
         return 0;
     }
 
     mdTypeRef typeRef;
-    if (SUCCEEDED(hr))
+    hr = _metadataEmit->DefineTypeRefByName(_aspectsAssemblyRef, typeName.c_str(), &typeRef);
+    if (FAILED(hr))
     {
-        hr = _metadataEmit->DefineTypeRefByName(assemblyImport.assemblyRef, typeName.c_str(), &typeRef);
-    }
-    if (SUCCEEDED(hr))
-    {
-        hr = _metadataEmit->DefineImportMember(moduleInfo->_assemblyImport, nullptr, 0, moduleInfo->_metadataImport,
-                                               methodInfo->_id, _assemblyEmit, typeRef, &methodRef);
-    }
+        trace::Logger::Warn("ModuleInfo::DefineMemberRef -> DefineTypeRefByName failed with code ", hr , " for typeName:" , typeName);
+        return 0;
 
-    if (SUCCEEDED(hr))
-    {
-        _mMemberImports[memberKey] = methodRef;
-        auto memberRefInfo = GetMemberRefInfo(methodRef);
-        DBG("DefineMemberRef : ", Hex(methodRef), " for ", memberKey, " MethodName: ", memberRefInfo->GetFullName(), " Module: ", GetModuleFullName());
-        return methodRef;
     }
-    else
+    hr = _metadataEmit->DefineImportMember(aspectsModuleInfo->_assemblyImport, nullptr, 0,
+                                            aspectsModuleInfo->_metadataImport, aspectMethodInfo->_id, _assemblyEmit,
+                                            typeRef, &methodRef);
+    if (FAILED(hr))
     {
-        trace::Logger::Warn("DefineImportMember failed with code ", hr , " typeName:" , typeName ,
+        trace::Logger::Warn("ModuleInfo::DefineMemberRef -> DefineImportMember failed with code ", hr , " typeName:" , typeName ,
                             " methodName: " , methodName);
         return 0;
     }
+
+
+    _mMemberImports[memberKey] = methodRef;
+    auto memberRefInfo = GetMemberRefInfo(methodRef);
+    DBG("ModuleInfo::DefineMemberRef -> DefineMemberRef : ", Hex(methodRef), " for ", memberKey, " MethodName: ", memberRefInfo->GetFullName(), " Module: ", GetModuleFullName());
+    return methodRef;
 }
 
 mdMethodSpec ModuleInfo::DefineMethodSpec(mdMemberRef targetMethod, SignatureInfo* sig)

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.h
@@ -87,8 +87,6 @@ namespace iast
 
         virtual HRESULT InstrumentModule_Internal() { return S_FALSE; }
 
-        // ModuleInfo* GetModuleInfoByName(WSTRING moduleName);
-
     public:
         ModuleID                        _id = 0;
         WSTRING                         _path = EmptyWStr;

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.h
@@ -42,12 +42,7 @@ namespace iast
         friend class DataflowAspectReference;
         friend class SignatureInfo;
     private:
-        struct AssemblyImportInfo
-        {
-            ModuleID moduleId;
-            mdAssemblyRef assemblyRef;
-        };
-        std::unordered_map<WSTRING, AssemblyImportInfo> _mAssemblyImports;
+        mdAssemblyRef _aspectsAssemblyRef = 0;
         std::unordered_map<WSTRING, mdMemberRef> _mMemberImports;
        
         std::unordered_map<mdTypeDef, TypeInfo*> _types;
@@ -92,7 +87,7 @@ namespace iast
 
         virtual HRESULT InstrumentModule_Internal() { return S_FALSE; }
 
-        ModuleInfo* GetModuleInfoByName(WSTRING moduleName);
+        // ModuleInfo* GetModuleInfoByName(WSTRING moduleName);
 
     public:
         ModuleID                        _id = 0;
@@ -111,7 +106,7 @@ namespace iast
         bool IsExcluded();
         virtual bool IsCoreLib();
         WSTRING GetModuleFullName();
-        mdToken DefineMemberRef(const WSTRING& moduleName, const WSTRING& typeName, const WSTRING& methodName, const WSTRING& methodParams);
+        mdToken DefineAspectMemberRef(const WSTRING& typeName, const WSTRING& methodName, const WSTRING& methodParams);
         mdMethodSpec DefineMethodSpec(mdMemberRef targetMethod, SignatureInfo* sig);
 
         virtual bool IsInlineEnabled();


### PR DESCRIPTION
## Summary of changes
Disable all Dataflow operations (more specifically, `OnModuleLoad` and `OnModuleUnload`) when it's in iddle mode waiting for activation signal from the managed side

## Reason for change
With this change, Dataflow (call site instrumentation for IAST and RASP) is completely idle until a call to `InitEmbeddedCallSiteDefinitions` happens, effectively enabling all the mechanisms.

## Implementation details
Until now, Dataflow would collect modules info as they were loaded in the `OnModuleLoad` event. This has been disabled, and this module info retrieval happens on demand, when someone asks for it, if it's not found in the `ModuleInfo` dictionary.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
