### PR TITLE
Use the global.json file to specify the .NET SDK version in GitHub Actions

### DIFF
--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Assign to vNext Milestone"
         run: ./tracer/build.sh AssignPullRequestToMilestone

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Check Snapshots"
         run: ./tracer/build.sh SummaryOfSnapshotChanges

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog

--- a/.github/workflows/auto_delete_hotfix_branch_post_release.yml
+++ b/.github/workflows/auto_delete_hotfix_branch_post_release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Output current version"
         id: versions

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Add labels"
         run: ./tracer/build.sh AssignLabelsToPullRequest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
-        dotnet-version: '10.0.100-preview.7.25380.108'
+        global-json-file: global.json
 
     - name: Download datadog-ci
       run: |
@@ -101,7 +101,7 @@ jobs:
 
     - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
-        dotnet-version: '10.0.100-preview.7.25380.108'
+        global-json-file: global.json
 
     - name: Download datadog-ci
       run: |

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -37,7 +37,7 @@ jobs:
 
     - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
-        dotnet-version: '10.0.100-preview.7.25380.108'
+        global-json-file: global.json
 
     - name: "Get current version"
       id: versions

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Configure Git Credentials"
         run: |

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion

--- a/.github/workflows/generate_package_versions.yml
+++ b/.github/workflows/generate_package_versions.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Removing existing Datadog.Trace.Trimming.xml"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" -Recurse -File | Remove-Item

--- a/.github/workflows/verify_files_without_nullability.yml
+++ b/.github/workflows/verify_files_without_nullability.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Removing existing missing-nullability-files.csv"
         run: Get-ChildItem –Path ".\tracer\missing-nullability-files.csv" | Remove-Item

--- a/.github/workflows/verify_generated_pipeline_is_updated.yml
+++ b/.github/workflows/verify_generated_pipeline_is_updated.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Running GenerateUpdateGitHubPipelineStep"
         run: .\tracer\build.ps1 GenerateUpdateGitHubPipelineStep

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/verify_solution_changes_are_persisted.yml
+++ b/.github/workflows/verify_solution_changes_are_persisted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Regenerating Solutions"
         run: .\tracer\build.ps1 RegenerateSolutions

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 Restore CompileManagedSrc

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: '10.0.100-preview.7.25380.108'
+          global-json-file: global.json
 
       - name: "Regenerate docs/span_metadata.md"
         run: .\tracer\build.ps1 GenerateSpanDocumentation


### PR DESCRIPTION
## Summary of changes

Point the `setup-dotnet` action at the global.json

## Reason for change

Means we don't need to update these when we change the version of the SDK we use

## Implementation details

Find and replace

## Test coverage

If this works, I think we're ok

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
