### PR TITLE
Update Managed DevOps pools images

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -334,7 +334,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -397,7 +397,7 @@ stages:
       timeoutInMinutes: 60 #default value
       dependsOn: []
       pool:
-        name: azure-managed-linux-x64-2
+        name: azure-managed-linux-x64-1
       
       steps:
         - template: steps/clone-repo.yml
@@ -460,7 +460,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -511,7 +511,7 @@ stages:
           artifactSuffix: linux-musl-x64
           useNativeSdkVersion: ""
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -573,7 +573,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -665,7 +665,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -708,7 +708,7 @@ stages:
     dependsOn: []
 
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -758,7 +758,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -800,7 +800,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -848,7 +848,7 @@ stages:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1105,7 +1105,7 @@ stages:
           artifactSuffix: linux-musl-x64
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1152,7 +1152,7 @@ stages:
           artifactSuffix: linux-musl-arm64
 
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -1202,7 +1202,7 @@ stages:
           useNativeSdkVersion: ""
           artifactSuffix: linux-musl-x64
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
       - template: steps/clone-repo.yml
@@ -1253,7 +1253,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
     workspace:
       clean: all
     steps:
@@ -1405,7 +1405,7 @@ stages:
       matrix:
         $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_x64_matrix'] ]
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -1462,7 +1462,7 @@ stages:
         matrix:
           $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_arm64_matrix'] ]
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
       workspace:
         clean: all
       steps:
@@ -1931,7 +1931,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2015,7 +2015,7 @@ stages:
   - job: Linux
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2199,7 +2199,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2275,7 +2275,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2391,7 +2391,7 @@ stages:
           publishTargetFramework: "net9.0"
           lambdaBaseImage: "public.ecr.aws/lambda/dotnet:9"
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2570,7 +2570,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2732,7 +2732,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2823,7 +2823,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
     - template: steps/clone-repo.yml
@@ -2904,7 +2904,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     steps:
 
@@ -3009,7 +3009,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -3079,7 +3079,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -3192,7 +3192,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -3347,7 +3347,7 @@ stages:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_linux_matrix'] ]
 
     pool:
-      name: azure-managed-linux-x64-2
+      name: azure-managed-linux-x64-1
 
     # Enable the Datadog Agent service for this job
     services:
@@ -3741,22 +3741,22 @@ stages:
         x64:
           baseImage: debian
           artifactSuffix: linux-x64
-          poolName: azure-managed-linux-x64-2
+          poolName: azure-managed-linux-x64-1
           targetArch: x64
         alpine_x64:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
-          poolName: azure-managed-linux-x64-2
+          poolName: azure-managed-linux-x64-1
           targetArch: x64
         arm64:
           baseImage: debian
           artifactSuffix: linux-arm64
-          poolname: azure-managed-linux-arm64-1
+          poolname: azure-managed-linux-arm64-2
           targetArch: arm64
         alpine_arm64:
           baseImage: alpine
           artifactSuffix: linux-musl-arm64
-          poolname: azure-managed-linux-arm64-1
+          poolname: azure-managed-linux-arm64-2
           targetArch: arm64
 
     pool:
@@ -4860,7 +4860,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-smoke-2
+      name: azure-managed-linux-smoke
 
     steps:
     - template: steps/clone-repo.yml
@@ -4942,7 +4942,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-smoke-2
+        name: azure-managed-linux-smoke
       
       steps:
         - template: steps/clone-repo.yml
@@ -5021,7 +5021,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-smoke-2
+      name: azure-managed-linux-smoke
 
     steps:
     - template: steps/clone-repo.yml
@@ -5110,7 +5110,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-smoke-2
+        name: azure-managed-linux-smoke
 
       steps:
         - template: steps/clone-repo.yml
@@ -5183,7 +5183,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-smoke-2
+      name: azure-managed-linux-smoke
 
     steps:
     - template: steps/clone-repo.yml
@@ -5247,7 +5247,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-smoke-2
+      name: azure-managed-linux-smoke
 
     steps:
     - template: steps/clone-repo.yml
@@ -5319,7 +5319,7 @@ stages:
       installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb"
       linuxArtifacts: "linux-packages-linux-x64"
     pool:
-      name: azure-managed-linux-smoke-2
+      name: azure-managed-linux-smoke
 
     steps:
     - template: steps/clone-repo.yml
@@ -5391,7 +5391,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -5474,7 +5474,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml
@@ -5553,7 +5553,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/clone-repo.yml
@@ -5643,7 +5643,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      name: azure-managed-linux-arm64-1
+      name: azure-managed-linux-arm64-2
 
     steps:
     - template: steps/download-artifact.yml
@@ -6376,7 +6376,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: azure-managed-linux-arm64-1
+        name: azure-managed-linux-arm64-2
 
       steps:
         - template: steps/clone-repo.yml


### PR DESCRIPTION
## Summary of changes

Updates the VM images to be based on Ubuntu 24.04 instead of 20.04

## Reason for change

We've been plagued by `##[error]The remote provider was unable to process the request.` errors which cause jobs to just never start. After a call with Microsoft, they suggested the issue was related to using Ubuntu 20.04 as our base image for the VMs. Updating the images to test it out.

## Implementation details

Rebuild the Linux VMs to use the new base images. The bulk of the implementation happens in dockerfiles so hopefully there won't be any issues

## Test coverage

This is the test

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
