### PR TITLE
Make sure we generate a build-id using SHA-1

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(${API_WRAPPER_SHARED_LIB_NAME} SHARED
 target_link_libraries(${API_WRAPPER_SHARED_LIB_NAME}
     -pthread
     -ldl
-    -Wl,--build-id
+    -Wl,--build-id=sha1
 )
 
 set_target_properties(${API_WRAPPER_SHARED_LIB_NAME} PROPERTIES PREFIX "")

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -142,7 +142,7 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     -lstdc++fs
     -pthread
     -ldl
-    -Wl,--build-id
+    -Wl,--build-id=sha1
 )
 
 add_dependencies(${PROFILER_STATIC_LIB_NAME} libdatadog-lib libunwind-lib coreclr spdlog-headers PPDB)

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -221,7 +221,7 @@ elseif(ISLINUX)
         $<$<BOOL:${LIBDL}>:dl>
         coreclr
         spdlog-headers
-        -Wl,--build-id
+        -Wl,--build-id=sha1
         -Wl,-version-script=${dd_profiling_linker_script}
         -Wl,--no-undefined
     )

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -251,7 +251,7 @@ elseif(ISLINUX)
         ${CMAKE_DL_LIBS}
         -static-libgcc
         -static-libstdc++
-        -Wl,--build-id
+        -Wl,--build-id=sha1
     )
 endif()
 


### PR DESCRIPTION
## Summary of changes

Make sure build-id for native libraries are generated using SHA-1

## Reason for change

The deobfuscation-api requires build-id to be generated by `SHA-1`. For some reason, build-ids for tracer and profiler were generated using SHA-1 but build-ids for universal binaries look like MD5 hash.

## Implementation details

In CMake files use `-Wl,--build-id=sha1`

## Test coverage

Downloaded the binaries and checked that the build-id correct:
for x86_64
<img width="2769" height="137" alt="image" src="https://github.com/user-attachments/assets/6921c349-f625-4b3a-9f29-10de1e132d0b" />
<img width="2795" height="141" alt="image" src="https://github.com/user-attachments/assets/377b3fe1-93ef-4059-aed8-d70c82227082" />

for aarch64
<img width="2787" height="330" alt="image" src="https://github.com/user-attachments/assets/7f214f2a-c04a-4876-91e3-be6a2e158862" />

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
