### PR TITLE
Remove smoke test image that won't work

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1365,18 +1365,6 @@ partial class Build : NukeBuild
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
                     );
 
-                    // Microsoft stopped pushing debian tags in .NET 10, so using separate repo
-                    AddToDotNetToolSmokeTestsMatrix(
-                        matrix,
-                        "debian",
-                        new SmokeTestImage[]
-                        {
-                            new (publishFramework: TargetFramework.NET10_0, "trixie-10.0-preview", "debian", "trixie"),
-                        },
-                        platformSuffix: "linux-x64",
-                        dockerName: "andrewlock/dotnet-debian"
-                    );
-
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "alpine",


### PR DESCRIPTION
## Summary of changes

Removes one of the smoke test images which is failing on master

## Reason for change

The image only has the ASP.NET Core runtime installed, but it's being used in the dotnet-tool nuget smoke tests, which require the SDK to be installed, so it's failing

## Implementation details

Just delete the offending image

## Test coverage

Meh

## Other details

I clearly failed to do an "all installer tests" run on the final configuration before merging #7170, my bad 😬 


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
