### PR TITLE
Use P/Invoke to call  `lstat` instead of shelling out to `stat` to retrieve the inode

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/NativeMethods.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/NativeMethods.cs
@@ -243,6 +243,23 @@ namespace Datadog.Trace.ClrProfiler
             }
         }
 
+        public static bool TryGetInodeForPath(string path, out long result)
+        {
+            if (IsWindows)
+            {
+                result = -1;
+                return false;
+            }
+
+            result = NonWindows.GetInodeForPath(path);
+            if (result < 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         // the "dll" extension is required on .NET Framework
         // and optional on .NET Core
         // The DllImport methods are re-written by cor_profiler to have the correct vales
@@ -330,6 +347,9 @@ namespace Datadog.Trace.ClrProfiler
 
             [DllImport("Datadog.Tracer.Native", CharSet = CharSet.Unicode)]
             public static extern int GetUserStrings(int arrSize, [In, Out] UserStringInterop[] arr);
+
+            [DllImport("Datadog.Tracer.Native")]
+            public static extern long GetInodeForPath([MarshalAs(UnmanagedType.LPWStr)]string path);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.NetFramework.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.NetFramework.cs
@@ -1,0 +1,37 @@
+// <copyright file="ContainerMetadata.NetFramework.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+#if NETFRAMEWORK
+
+namespace Datadog.Trace.PlatformHelpers;
+
+/// <summary>
+/// Utility class with methods to interact with container hosts.
+/// </summary>
+internal static class ContainerMetadata
+{
+    /// <summary>
+    /// Gets the id of the container executing the code.
+    /// Return <c>null</c> if code is not executing inside a supported container.
+    /// </summary>
+    /// <returns>The container id or <c>null</c>.</returns>
+    public static string? GetContainerId() => null;
+
+    /// <summary>
+    /// Gets the unique identifier of the container executing the code.
+    /// Return values may be:
+    /// <list type="bullet">
+    /// <item>"ci-&lt;containerID&gt;" if the container id is available.</item>
+    /// <item>"in-&lt;inode&gt;" if the cgroup node controller's inode is available.
+    ///        We use the memory controller on cgroupv1 and the root cgroup on cgroupv2.</item>
+    /// <item><c>null</c> if neither are available.</item>
+    /// </list>
+    /// </summary>
+    /// <returns>The entity id or <c>null</c>.</returns>
+    public static string? GetEntityId() => null;
+}
+#endif

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#if !NETFRAMEWORK
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -346,3 +348,4 @@ namespace Datadog.Trace.PlatformHelpers
         }
     }
 }
+#endif

--- a/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.def
+++ b/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.def
@@ -24,5 +24,6 @@ EXPORTS
     ShouldHeal
     ReportSuccessfulInstrumentation
     GetUserStrings
+    GetInodeForPath
     InitEmbeddedCallSiteDefinitions
     InitEmbeddedCallTargetDefinitions

--- a/tracer/src/Datadog.Tracer.Native/interop.cpp
+++ b/tracer/src/Datadog.Tracer.Native/interop.cpp
@@ -268,7 +268,37 @@ EXTERN_C BOOL STDAPICALLTYPE ShouldHeal(ModuleID moduleId, int methodToken, WCHA
     return trace::profiler->ShouldHeal(moduleId, methodToken, instrumentationId, products);
 }
 
+EXTERN_C u_long STDAPICALLTYPE GetInodeForPath(const WCHAR* path)
+{
+#ifdef _WIN32
+    // We don't need to support this on Windows
+    return -1;
+#else
+    if (!path)
+    {
+        return -1;
+    }
+
+    const std::string str = ToString(path);
+    if (str.empty())
+    {
+        return -1;
+    }
+
+    // We use lstat, because that matches the behaviour of the 'stat' command
+    // i.e. don't follow symlinks
+    struct stat st {};
+    if (lstat(str.c_str(), &st) != 0)
+    {
+        return -errno;
+    }
+
+    return st.st_ino;
+#endif
+}
+
 #ifndef _WIN32
+
 EXTERN_C void *dddlopen (const char *__file, int __mode)
 {
     return dlopen(__file, __mode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -18,6 +18,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         public VersionConflict2xTests(ITestOutputHelper output)
             : base("VersionConflict.2x", output)
         {
+            // We disable the process integration to prevent the `stat` process spans that
+            // _may_ be present depending on the underlying host system (cgroup v1/v2).
+            // The "do not trace" helper that normally blocks tracing these spans doesn't
+            // work in version conflict scenarios.
+            SetEnvironmentVariable("DD_TRACE_Process_ENABLED", "0");
         }
 
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -255,5 +255,21 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             success.Should().BeTrue();
             inode.Should().BeGreaterThan(0);
         }
+
+        [SkippableFact]
+        public void Parse_TryGetInode_ShouldGetSameValueFromPinvokeAndProcess()
+        {
+            SkipOn.Platform(SkipOn.PlatformValue.Windows);
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
+            string currentDirectory = Environment.CurrentDirectory;
+            bool success1 = ContainerMetadata.TryGetInodeUsingStat(currentDirectory, out long inode1);
+            bool success2 = ContainerMetadata.TryGetInodeUsingPInvoke(currentDirectory, out long inode2);
+
+            success1.Should().BeTrue();
+            success2.Should().BeTrue();
+            inode1.Should().BeGreaterThan(0);
+            inode2.Should().Be(inode1);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#if !NETFRAMEWORK
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -273,3 +275,5 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         }
     }
 }
+
+#endif


### PR DESCRIPTION
## Summary of changes

Adds a P/Invoke path for retrieving the inode on linux and only later falls back to using `stat -c %i <path>`

## Reason for change

Calling `stat` will fail if `stat` isn't available (as in chiseled containers, for example). It also results in additional spans being created when we're running in a version-mismatch scenario(because the `Process` invocation is traced)

## Implementation details

Based my initial PoC on P/Invoking into `System.Native`, which is a shim shipped with recent .NET that  handles a bunch of marshalling issues etc and returns [this type](https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Stat.cs). That's [how recent .NET versions](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs#L498) handle various bits like this.

However, System.Native only gives the correct inode value in .NET 7+ (from my local testing) and isn't available in early .NET Core. I then tried the "raw" route, trying to P/Invoke directly into `libc`. I also investigated making the syscall directly, but libc papers over differences in old kernels etc, so it seemed the easiest route. However, older versions of `libc` don't export the `lstat` or `fstatat` symbols as public symbols, and instead they're just macros.

Finally settled on a similar approach to System.Native, i.e. we P/Invoke into Datadog.Trace.Native which then makes the `lstat` call.

## Test coverage

Should _mostly_ be covered by existing tests (and smoke tests). I added an additional unit test to make sure the `stat -c %i` call and the P/Invoke give the same value, otherwise we should be covered. 

I also rebased on top of [this branch](https://github.com/DataDog/dd-trace-dotnet/pull/7446) which is where the error appeared - and did a [full-installer run](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=186579&view=results), and it fixed all the issues, so we should be good 🤞 And we still have the existing fallback if not

Note that I explicitly disabled the process spans in the version-conflict tests, as whether we get the spans or not is dependent on the underlying host system, which is a bit gross.

## Other details

~~AI assisted in various places, including generating the structs.~~ None of that worked in the end. Great job AI.

I made the failure an error as it _shouldn't_ fail in normal execution, and we'd like to report if it does, however there are some cases where the P/Invoke calls aren't re-written so we know this won't work. In case of failure, we explicitly check for that, and log the error as debug instead.

To get everything to compile easily I split the `ContainerMetadata` implementation for .NET FX as it's not supported in that scenario anyway.

Also, to be able to unit test the P/Invoke work, I copied the native libs into the test directories.

Finally, it's worth us looking into [this method](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.nativelibrary.setdllimportresolver?view=net-9.0) to allow P/Invokes to happen in the native runner, given we know where the native libs are, they're just not re-written. Something to think about in a separate PR I think