### PR TITLE
[Native] Convert Rejitters vector to a fixed array

### DIFF
--- a/shared/src/native-src/util.h
+++ b/shared/src/native-src/util.h
@@ -124,6 +124,28 @@ namespace shared
         return std::find(items.begin(), items.end(), value) != items.end();
     }
 
+    template <typename T, size_t N>
+    void Insert(T (&arr)[N], size_t& count, size_t pos, const T& value)
+    {
+        if (count >= N)
+        {
+            throw std::out_of_range("Array is full, cannot insert.");
+        }
+        if (pos > count)
+        {
+            throw std::out_of_range("Insert position is out of range.");
+        }
+
+        // Shift elements to the right
+        for (size_t i = count; i > pos; --i)
+        {
+            arr[i] = arr[i - 1];
+        }
+
+        arr[pos] = value;
+        ++count;
+    }
+
     // Singleton definition
     class UnCopyable
     {

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -160,7 +160,7 @@ AspectFilter* ModuleAspects::GetFilter(DataflowAspectFilterValue filterValue)
 
 Dataflow::Dataflow(ICorProfilerInfo* profiler, std::shared_ptr<RejitHandler> rejitHandler,
                    const RuntimeInformation& runtimeInfo) :
-    Rejitter(rejitHandler, RejitterPriority::Low)
+    Rejitter(RejitterPriority::Low)
 {
     m_runtimeType = runtimeInfo.runtime_type;
     m_runtimeVersion = VersionInfo{runtimeInfo.major_version, runtimeInfo.minor_version, runtimeInfo.build_version, 0};
@@ -180,6 +180,7 @@ Dataflow::Dataflow(ICorProfilerInfo* profiler, std::shared_ptr<RejitHandler> rej
     }
 
     _initialized = false;
+    rejitHandler->RegisterRejitter(this);
 }
 
 Dataflow::~Dataflow()

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -198,8 +198,8 @@ void Dataflow::LoadAspects(WCHAR** aspects, int aspectsLength, UINT32 enabledCat
 
     if (aspectsLength > 10)
     {
-        _aspectClasses.reserve(aspectsLength / 10);
-        _aspects.reserve(aspectsLength);
+        _aspects.reserve(aspectsLength); // We know the max number of aspects we are going to have, so reserve the space to avoid vector resizes
+        _aspectClasses.reserve(aspectsLength / 10); // We don't know exactly the number of aspects which are class aspects, but 1/10 is a fine approach
     }
 
     DataflowAspectClass* aspectClass = nullptr;

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -160,7 +160,7 @@ AspectFilter* ModuleAspects::GetFilter(DataflowAspectFilterValue filterValue)
 
 Dataflow::Dataflow(ICorProfilerInfo* profiler, std::shared_ptr<RejitHandler> rejitHandler,
                    const RuntimeInformation& runtimeInfo) :
-    Rejitter(RejitterPriority::Low)
+    Rejitter(rejitHandler, RejitterPriority::Low, false)
 {
     m_runtimeType = runtimeInfo.runtime_type;
     m_runtimeVersion = VersionInfo{runtimeInfo.major_version, runtimeInfo.minor_version, runtimeInfo.build_version, 0};

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -394,6 +394,7 @@ void RejitHandler::RegisterRejitter(Rejitter* rejitter)
     if (m_rejittersCount == 0)
     {
         m_rejitters[m_rejittersCount++] = rejitter;
+        DBG("RejitHandler::RegisterRejitter -> Registered Rejitter. Count : ", m_rejittersCount);
     }
     else
     {
@@ -407,6 +408,7 @@ void RejitHandler::RegisterRejitter(Rejitter* rejitter)
         }
 
         shared::Insert(m_rejitters, m_rejittersCount, x, rejitter);
+        DBG("RejitHandler::RegisterRejitter -> Registered Rejitter at ", x, ". Count : ", m_rejittersCount);
     }
 }
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -325,13 +325,11 @@ void RejitHandler::EnqueueRequestRejit(std::vector<MethodIdentifier>& rejitReque
 RejitHandler::RejitHandler(ICorProfilerInfo7* pInfo, std::shared_ptr<RejitWorkOffloader> work_offloader) :
     m_profilerInfo(pInfo), m_profilerInfo10(nullptr), m_work_offloader(work_offloader)
 {
-    m_rejitters.reserve(5);
 }
 
 RejitHandler::RejitHandler(ICorProfilerInfo10* pInfo, std::shared_ptr<RejitWorkOffloader> work_offloader) :
     m_profilerInfo(pInfo), m_profilerInfo10(pInfo), m_work_offloader(work_offloader)
 {
-    m_rejitters.reserve(5);
 }
 
 void RejitHandler::EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef,
@@ -376,9 +374,9 @@ void RejitHandler::Shutdown()
     WriteLock w_lock(m_shutdown_lock);
     m_shutdown.store(true);
 
-    for (auto rejitter : m_rejitters)
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        rejitter->Shutdown();
+        m_rejitters[x]->Shutdown();
     }
 
     m_profilerInfo = nullptr;
@@ -393,21 +391,22 @@ bool RejitHandler::IsShutdownRequested()
 
 void RejitHandler::RegisterRejitter(Rejitter* rejitter)
 {
-    if (m_rejitters.size() == 0)
+    if (m_rejittersCount == 0)
     {
-        m_rejitters.push_back(rejitter);
+        m_rejitters[m_rejittersCount++] = rejitter;
     }
     else
     {
-        auto it = m_rejitters.begin();
-        for (; it < m_rejitters.end(); it++)
+        size_t x = 0;
+        for (; x < m_rejittersCount; x++)
         {
-            if ((*it)->GetPriority() > rejitter->GetPriority())
+            if (m_rejitters[x]->GetPriority() > rejitter->GetPriority())
             {
                 break;
             }
         }
-        m_rejitters.insert(it, rejitter);
+
+        shared::Insert(m_rejitters, m_rejittersCount, x, rejitter);
     }
 }
 
@@ -426,9 +425,9 @@ HRESULT RejitHandler::NotifyReJITParameters(ModuleID moduleId, mdMethodDef metho
     FunctionControlWrapper functionControl((ICorProfilerInfo*)m_profilerInfo, moduleId, methodId);
 
     // Call all rejitters sequentially
-    for (auto rejitter : m_rejitters)
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        hr = rejitter->RejitMethod(functionControl);
+        hr = m_rejitters[x]->RejitMethod(functionControl);
     }
 
     return functionControl.ApplyChanges(pFunctionControl);
@@ -476,9 +475,9 @@ bool RejitHandler::HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef)
         return false;
     }
 
-    for (auto rejitter : m_rejitters)
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        if (rejitter->HasModuleAndMethod(moduleId, methodDef))
+        if (m_rejitters[x]->HasModuleAndMethod(moduleId, methodDef))
         {
             return true;
         }
@@ -494,9 +493,9 @@ void RejitHandler::RemoveModule(ModuleID moduleId)
         return;
     }
 
-    for (auto rejitter : m_rejitters)
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        rejitter->RemoveModule(moduleId);
+        m_rejitters[x]->RemoveModule(moduleId);
     }
 }
 
@@ -507,9 +506,9 @@ void RejitHandler::AddNGenInlinerModule(ModuleID moduleId)
         return;
     }
 
-    for (auto rejitter : m_rejitters)
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        rejitter->AddNGenInlinerModule(moduleId);
+        m_rejitters[x]->AddNGenInlinerModule(moduleId);
     }
 }
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -112,7 +112,9 @@ private:
     bool enable_by_ref_instrumentation = false;
     bool enable_calltarget_state_by_ref = false;
 
-    std::vector<Rejitter*> m_rejitters;
+    #define MAX_REJITTERS 4 // Increase this number when a new rejitter is added
+    Rejitter* m_rejitters[MAX_REJITTERS];
+    size_t m_rejittersCount = 0;
 
     Lock m_rejit_history_lock;
     std::vector<std::tuple<ModuleID, mdMethodDef>> m_rejit_history;

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -9,14 +9,13 @@
 namespace trace
 {
 // Rejitter
-Rejitter::Rejitter(RejitterPriority priority) : 
-    m_priority(priority)
+Rejitter::Rejitter(std::shared_ptr<RejitHandler> handler, RejitterPriority priority, bool registerRejitter) :
+    m_rejitHandler(handler), m_priority(priority)
 {
-}
-Rejitter::Rejitter(std::shared_ptr<RejitHandler> handler, RejitterPriority priority) :
-    m_priority(priority)
-{
-    handler->RegisterRejitter(this);
+    if (registerRejitter)
+    {
+        handler->RegisterRejitter(this);
+    }
 }
 
 Rejitter::~Rejitter()

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -9,9 +9,12 @@
 namespace trace
 {
 // Rejitter
-
+Rejitter::Rejitter(RejitterPriority priority) : 
+    m_priority(priority)
+{
+}
 Rejitter::Rejitter(std::shared_ptr<RejitHandler> handler, RejitterPriority priority) :
-    m_rejitHandler(handler), m_priority(priority)
+    m_priority(priority)
 {
     handler->RegisterRejitter(this);
 }

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -32,6 +32,7 @@ protected:
     RejitterPriority m_priority;
 
 public:
+    Rejitter(RejitterPriority priority);
     Rejitter(std::shared_ptr<RejitHandler> handler, RejitterPriority priority);
     virtual ~Rejitter();
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -32,8 +32,7 @@ protected:
     RejitterPriority m_priority;
 
 public:
-    Rejitter(RejitterPriority priority);
-    Rejitter(std::shared_ptr<RejitHandler> handler, RejitterPriority priority);
+    Rejitter(std::shared_ptr<RejitHandler> handler, RejitterPriority priority, bool registerRejitter = true);
     virtual ~Rejitter();
 
     inline RejitterPriority GetPriority(){ return m_priority; }

--- a/tracer/test/Datadog.Tracer.Native.Tests/CMakeLists.txt
+++ b/tracer/test/Datadog.Tracer.Native.Tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(${TEST_EXECUTABLE_NAME}
     version_struct_test.cpp
     iast_util_test.cpp
     string_test.cpp
+	util_test.cpp
 )
 
 # Define directories includes

--- a/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj
+++ b/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj
@@ -100,6 +100,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="string_test.cpp" />
+    <ClCompile Include="util_test.cpp" />
     <ClCompile Include="version_struct_test.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj.filters
+++ b/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj.filters
@@ -8,6 +8,7 @@
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="version_struct_test.cpp" />
     <ClCompile Include="string_test.cpp" />
+    <ClCompile Include="util_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/tracer/test/Datadog.Tracer.Native.Tests/util_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/util_test.cpp
@@ -1,0 +1,86 @@
+#include "pch.h"
+
+#include "../../../shared/src/native-src/util.h"
+
+using namespace shared;
+
+// === Helper to compare arrays ===
+template <typename T>
+void assertArrayEquals(const T* arr, const T* expected, size_t count)
+{
+    for (size_t i = 0; i < count; i++)
+    {
+        assert(arr[i] == expected[i]);
+    }
+}
+
+// === Test cases ===
+TEST(UtilTests, ArrayInsert_Middle)
+{
+    int arr[10] = {1, 2, 3, 4, 5};
+    size_t count = 5;
+
+    Insert(arr, count, 2, 99);
+    int expected[] = {1, 2, 99, 3, 4, 5};
+
+    assert(count == 6);
+    assertArrayEquals(arr, expected, count);
+}
+
+TEST(UtilTests, ArrayInsert_Beginning)
+{
+    int arr[10] = {10, 20, 30};
+    size_t count = 3;
+
+    Insert(arr, count, 0, 5);
+    int expected[] = {5, 10, 20, 30};
+
+    assert(count == 4);
+    assertArrayEquals(arr, expected, count);
+}
+
+TEST(UtilTests, ArrayInsert_End)
+{
+    int arr[10] = {7, 8, 9};
+    size_t count = 3;
+
+    Insert(arr, count, 3, 99);
+    int expected[] = {7, 8, 9, 99};
+
+    assert(count == 4);
+    assertArrayEquals(arr, expected, count);
+}
+
+TEST(UtilTests, ArrayInsert_OutOfRange)
+{
+    int arr[5] = {1, 2, 3};
+    size_t count = 3;
+
+    bool thrown = false;
+    try
+    {
+        Insert(arr, count, 5, 99); // invalid position
+    }
+    catch (const std::out_of_range&)
+    {
+        thrown = true;
+    }
+    assert(thrown);
+}
+
+TEST(UtilTests, ArrayInsert_FullArray)
+{
+    int arr[3] = {1, 2, 3};
+    size_t count = 3;
+
+    bool thrown = false;
+    try
+    {
+        Insert(arr, count, 1, 99); // array is already full
+    }
+    catch (const std::out_of_range&)
+    {
+        thrown = true;
+    }
+    assert(thrown);
+}

--- a/tracer/test/Datadog.Tracer.Native.Tests/util_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/util_test.cpp
@@ -56,16 +56,8 @@ TEST(UtilTests, ArrayInsert_OutOfRange)
     int arr[5] = {1, 2, 3};
     size_t count = 3;
 
-    bool thrown = false;
-    try
-    {
-        Insert(arr, count, 5, 99); // invalid position
-    }
-    catch (const std::out_of_range&)
-    {
-        thrown = true;
-    }
-    ASSERT_TRUE(thrown);
+    // invalid position
+    ASSERT_THROW(Insert(arr, count, 5, 99), std::out_of_range);
 }
 
 TEST(UtilTests, ArrayInsert_FullArray)
@@ -73,14 +65,6 @@ TEST(UtilTests, ArrayInsert_FullArray)
     int arr[3] = {1, 2, 3};
     size_t count = 3;
 
-    bool thrown = false;
-    try
-    {
-        Insert(arr, count, 1, 99); // array is already full
-    }
-    catch (const std::out_of_range&)
-    {
-        thrown = true;
-    }
-    ASSERT_TRUE(thrown);
+    // array is already full
+    ASSERT_THROW(Insert(arr, count, 1, 99), std::out_of_range);
 }

--- a/tracer/test/Datadog.Tracer.Native.Tests/util_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/util_test.cpp
@@ -10,7 +10,7 @@ void assertArrayEquals(const T* arr, const T* expected, size_t count)
 {
     for (size_t i = 0; i < count; i++)
     {
-        assert(arr[i] == expected[i]);
+        ASSERT_EQ(expected[i], arr[i]);
     }
 }
 
@@ -23,7 +23,7 @@ TEST(UtilTests, ArrayInsert_Middle)
     Insert(arr, count, 2, 99);
     int expected[] = {1, 2, 99, 3, 4, 5};
 
-    assert(count == 6);
+    ASSERT_EQ(6, count);
     assertArrayEquals(arr, expected, count);
 }
 
@@ -35,7 +35,7 @@ TEST(UtilTests, ArrayInsert_Beginning)
     Insert(arr, count, 0, 5);
     int expected[] = {5, 10, 20, 30};
 
-    assert(count == 4);
+    ASSERT_EQ(4, count);
     assertArrayEquals(arr, expected, count);
 }
 
@@ -47,7 +47,7 @@ TEST(UtilTests, ArrayInsert_End)
     Insert(arr, count, 3, 99);
     int expected[] = {7, 8, 9, 99};
 
-    assert(count == 4);
+    ASSERT_EQ(4, count);
     assertArrayEquals(arr, expected, count);
 }
 
@@ -65,7 +65,7 @@ TEST(UtilTests, ArrayInsert_OutOfRange)
     {
         thrown = true;
     }
-    assert(thrown);
+    ASSERT_TRUE(thrown);
 }
 
 TEST(UtilTests, ArrayInsert_FullArray)
@@ -82,5 +82,5 @@ TEST(UtilTests, ArrayInsert_FullArray)
     {
         thrown = true;
     }
-    assert(thrown);
+    ASSERT_TRUE(thrown);
 }


### PR DESCRIPTION
## Summary of changes
After converting the creation of Dataflow to dynamic, when adding it to the rejiters vector, this could cause a race condition when it grows. So, in order to avoid this, the rejitters vector has been converted to a fixed array.

As there are 3 known rejitters, ATM, the size of the array has been set to 4 to have a minimal buffer.

## Reason for change
Previous vector reserve implementation could be unsafe if a new rejitter was added without modifying the reserved size. This way if a new one is added without modifying the max count, an exception will be thrown

## Implementation details
Replace the previous rejitters vector with a fixed array.

## Test coverage
Unit tests have been added for the array insert function

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
