### PR TITLE
Consolidate bailout checks into native loader

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
@@ -23,8 +23,8 @@ public:
     // Sets whether the current process must run in CI Visibility mode or not.
     inline static const shared::WSTRING CiVisibilityEnabled = WStr("DD_CIVISIBILITY_ENABLED");
 
-    // Indicates whether the profiler is running in the context
-    // of Azure App Services with the extension installed
+    // Indicates whether the CLR profiler is running from
+    // the Azure App Services site extension
     inline static const shared::WSTRING IsAzureAppServicesExtension = WStr("DD_AZURE_APP_SERVICES");
 
     // The app_pool_id in the context of azure app services
@@ -33,7 +33,8 @@ public:
     // The DOTNET_CLI_TELEMETRY_PROFILE in the context of azure app services
     inline static const shared::WSTRING AzureAppServicesCliTelemetryProfilerValue = WStr("DOTNET_CLI_TELEMETRY_PROFILE");
 
-    // The FUNCTIONS_WORKER_RUNTIME in the context of azure app services
+    // The FUNCTIONS_WORKER_RUNTIME in Azure Functions.
+    // Valid values: "dotnet" (in-process functions) or "dotnet-isolated" (isolated functions).
     // Used as a flag to determine that we are running within a functions app.
     inline static const shared::WSTRING AzureAppServicesFunctionsWorkerRuntime = WStr("FUNCTIONS_WORKER_RUNTIME");
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
@@ -19,4 +19,25 @@ public:
     inline static const shared::WSTRING SingleStepInstrumentationEnabled = WStr("DD_INJECTION_ENABLED");
     inline static const shared::WSTRING ForceEolInstrumentation = WStr("DD_INJECT_FORCE");
     inline static const shared::WSTRING SingleStepInstrumentationTelemetryForwarderPath = WStr("DD_TELEMETRY_FORWARDER_PATH");
+
+    // Sets whether the current process must run in CI Visibility mode or not.
+    inline static const shared::WSTRING CiVisibilityEnabled = WStr("DD_CIVISIBILITY_ENABLED");
+
+    // Indicates whether the profiler is running in the context
+    // of Azure App Services with the extension installed
+    inline static const shared::WSTRING IsAzureAppServicesExtension = WStr("DD_AZURE_APP_SERVICES");
+
+    // The app_pool_id in the context of azure app services
+    inline static const shared::WSTRING AzureAppServicesAppPoolId = WStr("APP_POOL_ID");
+
+    // The DOTNET_CLI_TELEMETRY_PROFILE in the context of azure app services
+    inline static const shared::WSTRING AzureAppServicesCliTelemetryProfilerValue = WStr("DOTNET_CLI_TELEMETRY_PROFILE");
+
+    // The FUNCTIONS_WORKER_RUNTIME in the context of azure app services
+    // Used as a flag to determine that we are running within a functions app.
+    inline static const shared::WSTRING AzureAppServicesFunctionsWorkerRuntime = WStr("FUNCTIONS_WORKER_RUNTIME");
+
+    // Determine whether to instrument within azure functions.
+    // Default is true.
+    inline static const shared::WSTRING AzureFunctionsInstrumentationEnabled = WStr("DD_TRACE_AZURE_FUNCTIONS_ENABLED");
 };

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -250,10 +250,9 @@ namespace datadog::shared::nativeloader
         }
 
         // AAS checks
-        const auto isRunningInAas = TryParseBooleanEnvironmentValue(
-                                        GetEnvironmentValue(EnvironmentVariables::IsAzureAppServicesExtension),
-                                        isRunningInAas) && isRunningInAas;
-        if (isRunningInAas)
+        bool isRunningInAas;
+        if (TryParseBooleanEnvironmentValue(GetEnvironmentValue(EnvironmentVariables::IsAzureAppServicesExtension),
+                                            isRunningInAas) && isRunningInAas)
         {
             Log::Info("Azure App Services detected.");
 
@@ -283,13 +282,11 @@ namespace datadog::shared::nativeloader
             if (!functions_worker_runtime_value.empty())
             {
                 // enabled by default
-                const auto azure_functions_enabled = !TryParseBooleanEnvironmentValue(
-                                                         GetEnvironmentValue(
-                                                             EnvironmentVariables::AzureFunctionsInstrumentationEnabled),
-                                                         azure_functions_enabled)
-                                                     || azure_functions_enabled;
-
-                if (!azure_functions_enabled)
+                bool azure_functions_enabled;
+                if (!TryParseBooleanEnvironmentValue(
+                        GetEnvironmentValue(
+                            EnvironmentVariables::AzureFunctionsInstrumentationEnabled),
+                        azure_functions_enabled) || !azure_functions_enabled)
                 {
                     Log::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler explicitly disabled for Azure Functions.");
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -283,10 +283,10 @@ namespace datadog::shared::nativeloader
             {
                 // enabled by default
                 bool azure_functions_enabled;
-                if (!TryParseBooleanEnvironmentValue(
+                if (TryParseBooleanEnvironmentValue(
                         GetEnvironmentValue(
                             EnvironmentVariables::AzureFunctionsInstrumentationEnabled),
-                        azure_functions_enabled) || !azure_functions_enabled)
+                        azure_functions_enabled) && !azure_functions_enabled)
                 {
                     Log::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler explicitly disabled for Azure Functions.");
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -121,6 +121,9 @@ namespace datadog::shared::nativeloader
         const auto process_name = ::shared::GetCurrentProcessName();
         Log::Debug("ProcessName: ", process_name);
 
+        const auto [process_command_line , tokenized_command_line]  = GetCurrentProcessCommandLine();
+        Log::Info("Process CommandLine: ", process_command_line);
+
         const auto& include_process_names = GetEnvironmentValues(EnvironmentVariables::IncludeProcessNames);
 
         // if there is a process inclusion list, attach clrprofiler only if this
@@ -158,9 +161,6 @@ namespace datadog::shared::nativeloader
             // don't give useful information, add latency, and risk triggering bugs in the runtime,
             // particularly around shutdown, like this one: https://github.com/dotnet/runtime/issues/55441
             // Note that you should also consider adding to the SSI tracer/build/artifacts/requirements.json file
-           const auto [process_command_line , tokenized_command_line]  = GetCurrentProcessCommandLine();
-            Log::Info("Process CommandLine: ", process_command_line);
-
             if (!process_command_line.empty())
             {
                 const auto isDotNetProcess = process_name == WStr("dotnet") || process_name == WStr("dotnet.exe");
@@ -228,6 +228,71 @@ namespace datadog::shared::nativeloader
                             "but an unsupported command was detected");
                         return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                     }
+
+                    // Additional Special case CI Visibility checks
+                    bool is_ci_visibility_enabled = false;
+                    if (TryParseBooleanEnvironmentValue(GetEnvironmentValue(EnvironmentVariables::CiVisibilityEnabled), is_ci_visibility_enabled)
+                        && is_ci_visibility_enabled)
+                    {
+                        if (tokenized_command_line[1] != WStr("test") &&
+                            process_command_line.find(WStr("testhost")) == WSTRING::npos &&
+                            process_command_line.find(WStr("exec")) == WSTRING::npos &&
+                            process_command_line.find(WStr("datacollector")) == WSTRING::npos &&
+                            process_command_line.find(WStr("vstest.console.dll")) == WSTRING::npos)
+                        {
+                            Log::Info("The Tracer Profiler has been disabled because the process is running in CI Visibility "
+                                "mode, the name is 'dotnet' but the commandline doesn't contain 'testhost' or 'datacollector' or 'vstest.console.dll' or 'exec'");
+                            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
+                        }
+                    }
+                }
+            }
+        }
+
+        // AAS checks
+        const auto isRunningInAas = TryParseBooleanEnvironmentValue(
+                                        GetEnvironmentValue(EnvironmentVariables::IsAzureAppServicesExtension),
+                                        isRunningInAas) && isRunningInAas;
+        if (isRunningInAas)
+        {
+            Log::Info("ClrProfiler is operating within Azure App Services context.");
+
+            const auto& app_pool_id_value = GetEnvironmentValue(EnvironmentVariables::AzureAppServicesAppPoolId);
+
+            if (app_pool_id_value.size() > 1 && app_pool_id_value.at(0) == '~')
+            {
+                Log::Info(
+                    "DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", EnvironmentVariables::AzureAppServicesAppPoolId, " ",
+                    app_pool_id_value, " is recognized as an Azure App Services infrastructure process.");
+                return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
+            }
+
+            const auto& cli_telemetry_profile_value =
+                GetEnvironmentValue(EnvironmentVariables::AzureAppServicesCliTelemetryProfilerValue);
+
+            if (cli_telemetry_profile_value == WStr("AzureKudu"))
+            {
+                Log::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", app_pool_id_value,
+                             " is recognized as Kudu, an Azure App Services reserved process.");
+                return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
+            }
+
+            const auto& functions_worker_runtime_value =
+                GetEnvironmentValue(EnvironmentVariables::AzureAppServicesFunctionsWorkerRuntime);
+
+            if (!functions_worker_runtime_value.empty())
+            {
+                // enabled by default
+                const auto azure_functions_enabled = !TryParseBooleanEnvironmentValue(
+                                                         GetEnvironmentValue(
+                                                             EnvironmentVariables::AzureFunctionsInstrumentationEnabled),
+                                                         azure_functions_enabled)
+                                                     || azure_functions_enabled;
+
+                if (!azure_functions_enabled)
+                {
+                    Log::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler explicitly disabled for Azure Functions.");
+                    return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
             }
         }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -255,7 +255,7 @@ namespace datadog::shared::nativeloader
                                         isRunningInAas) && isRunningInAas;
         if (isRunningInAas)
         {
-            Log::Info("ClrProfiler is operating within Azure App Services context.");
+            Log::Info("Azure App Services detected.");
 
             const auto& app_pool_id_value = GetEnvironmentValue(EnvironmentVariables::AzureAppServicesAppPoolId);
 
@@ -263,7 +263,7 @@ namespace datadog::shared::nativeloader
             {
                 Log::Info(
                     "DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", EnvironmentVariables::AzureAppServicesAppPoolId, " ",
-                    app_pool_id_value, " is recognized as an Azure App Services infrastructure process.");
+                    app_pool_id_value, " is an Azure App Services infrastructure process.");
                 return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
             }
 
@@ -273,7 +273,7 @@ namespace datadog::shared::nativeloader
             if (cli_telemetry_profile_value == WStr("AzureKudu"))
             {
                 Log::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", app_pool_id_value,
-                             " is recognized as Kudu, an Azure App Services reserved process.");
+                             " is Kudu, an Azure App Services reserved process.");
                 return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
             }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -75,34 +75,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     const auto process_name = shared::GetCurrentProcessName();
     Logger::Info("ProcessName: ", process_name);
 
-    const auto [process_command_line , tokenized_command_line ] = GetCurrentProcessCommandLine();
-    Logger::Info("Process CommandLine: ", process_command_line);
-
-    // CI visibility checks
-    if (!process_command_line.empty())
-    {
-        bool is_ci_visibility_enabled = false;
-        if (shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(environment::ci_visibility_enabled),
-                                                    is_ci_visibility_enabled) &&
-            is_ci_visibility_enabled)
-        {
-            const auto isDotNetProcess = process_name == WStr("dotnet") || process_name == WStr("dotnet.exe");
-            const auto token_count = tokenized_command_line.size();
-            if (isDotNetProcess &&
-                token_count > 1 &&
-                tokenized_command_line[1] != WStr("test") &&
-                process_command_line.find(WStr("testhost")) == WSTRING::npos &&
-                process_command_line.find(WStr("exec")) == WSTRING::npos &&
-                process_command_line.find(WStr("datacollector")) == WSTRING::npos &&
-                process_command_line.find(WStr("vstest.console.dll")) == WSTRING::npos)
-            {
-                Logger::Info("The Tracer Profiler has been disabled because the process is running in CI Visibility "
-                    "mode, the name is 'dotnet' but the commandline doesn't contain 'testhost' or 'datacollector' or 'vstest.console.dll' or 'exec'");
-                return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
-            }
-        }
-    }
-
 #if !defined(_WIN32) && (defined(ARM64) || defined(ARM))
     //
     // In ARM64 and ARM, complete ReJIT support is only available from .NET 5.0 (on .NET Core)
@@ -129,39 +101,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         return E_FAIL;
     }
 
-    const auto& include_process_names = shared::GetEnvironmentValues(environment::include_process_names);
-
-    // if there is a process inclusion list, attach clrprofiler only if this
-    // process's name is on the list
-    if (!include_process_names.empty() && !shared::Contains(include_process_names, process_name))
-    {
-        Logger::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", process_name, " not found in ",
-                     environment::include_process_names, ".");
-        return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
-    }
-
-    // if we were on the explicit include list, don't check the block list
-    if (include_process_names.empty())
-    {
-        // attach clrprofiler only if this process's name is NOT on the blocklists
-        const auto& exclude_process_names = shared::GetEnvironmentValues(environment::exclude_process_names);
-        if (!exclude_process_names.empty() && shared::Contains(exclude_process_names, process_name))
-        {
-            Logger::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", process_name, " found in ",
-                         environment::exclude_process_names, ".");
-            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
-        }
-
-        for (auto&& exclude_assembly : default_exclude_assemblies)
-        {
-            if (process_name == exclude_assembly)
-            {
-                Logger::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", process_name," found in default exclude list");
-                return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
-            }
-        }
-    }
-
     Logger::Info("Environment variables:");
     for (auto&& env_var : env_vars_to_display)
     {
@@ -169,40 +108,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         if (IsDebugEnabled() || !env_var_value.empty())
         {
             Logger::Info("  ", env_var, "=", env_var_value);
-        }
-    }
-
-    if (isRunningInAas)
-    {
-        Logger::Info("Profiler is operating within Azure App Services context.");
-
-        const auto& app_pool_id_value = shared::GetEnvironmentValue(environment::azure_app_services_app_pool_id);
-
-        if (app_pool_id_value.size() > 1 && app_pool_id_value.at(0) == '~')
-        {
-            Logger::Info(
-                "DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", environment::azure_app_services_app_pool_id, " ",
-                app_pool_id_value, " is recognized as an Azure App Services infrastructure process.");
-            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
-        }
-
-        const auto& cli_telemetry_profile_value =
-            shared::GetEnvironmentValue(environment::azure_app_services_cli_telemetry_profile_value);
-
-        if (cli_telemetry_profile_value == WStr("AzureKudu"))
-        {
-            Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", app_pool_id_value,
-                         " is recognized as Kudu, an Azure App Services reserved process.");
-            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
-        }
-
-        const auto& functions_worker_runtime_value =
-            shared::GetEnvironmentValue(environment::azure_app_services_functions_worker_runtime);
-
-        if (!functions_worker_runtime_value.empty() && !IsAzureFunctionsEnabled())
-        {
-            Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler explicitly disabled for Azure Functions.");
-            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
         }
     }
 

--- a/tracer/src/Datadog.Tracer.Native/environment_variables.h
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables.h
@@ -89,16 +89,8 @@ namespace environment
     // The DOTNET_CLI_TELEMETRY_PROFILE in the context of azure app services
     const shared::WSTRING azure_app_services_cli_telemetry_profile_value = WStr("DOTNET_CLI_TELEMETRY_PROFILE");
 
-    // The FUNCTIONS_WORKER_RUNTIME in the context of azure app services
-    // Used as a flag to determine that we are running within a functions app.
-    const shared::WSTRING azure_app_services_functions_worker_runtime = WStr("FUNCTIONS_WORKER_RUNTIME");
-
     // Sets whether the Tracer will automatically instrument methods that are decorated with a recognized trace attribute
     const shared::WSTRING trace_annotations_enabled = WStr("DD_TRACE_ANNOTATIONS_ENABLED");
-
-    // Determine whether to instrument within azure functions.
-    // Default is true.
-    const shared::WSTRING azure_functions_enabled = WStr("DD_TRACE_AZURE_FUNCTIONS_ENABLED");
 
     // Enable the profiler to dump the IL original code and modification to the log.
     const shared::WSTRING dump_il_rewrite_enabled = WStr("DD_DUMP_ILREWRITE_ENABLED");

--- a/tracer/src/Datadog.Tracer.Native/environment_variables_util.cpp
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables_util.cpp
@@ -38,11 +38,6 @@ bool IsTraceAnnotationEnabled()
     ToBooleanWithDefault(shared::GetEnvironmentValue(environment::trace_annotations_enabled), true);
 }
 
-bool IsAzureFunctionsEnabled()
-{
-    ToBooleanWithDefault(shared::GetEnvironmentValue(environment::azure_functions_enabled), true);
-}
-
 bool IsVersionCompatibilityEnabled()
 {
     ToBooleanWithDefault(shared::GetEnvironmentValue(environment::internal_version_compatibility), true);

--- a/tracer/src/Datadog.Tracer.Native/environment_variables_util.h
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables_util.h
@@ -56,7 +56,6 @@ bool IsDebugEnabled();
 bool IsDumpILRewriteEnabled();
 bool IsAzureAppServices();
 bool IsTraceAnnotationEnabled();
-bool IsAzureFunctionsEnabled();
 bool IsVersionCompatibilityEnabled();
 bool IsIastEnabled();
 bool IsRaspEnabled();


### PR DESCRIPTION
## Summary of changes

Move some of the bail-out checks from the native loader into the native tracer

## Reason for change

As far as I can tell, these checks really _should_ be in the native loader, and they're only in the native tracer currently for historical reasons. This results in both duplication of work _and_ mismatch between traced processes for the profiler and the tracer. This was discovered as part of the work in #7287.

## Implementation details

- Removed duplicate checks (process name variables) from the native tracer
- Moved the additional CI Visibility checks to the native loader. I'll defer to @tonyredondo if we want to tidy these up at all
- Moved the AAS checks to the native loader. I'll defer to @lucaspimentel if we want to change any of these.

## Test coverage

This should be covered by the existing tests in general, but I may add an additional instrumentation test to make sure we get no tracer logs for previous cases where we would have done.

## Other details

Currently the native tracer prints a bunch of env vars for debugging purposes. We could move this to the native loader too if we prefer.


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
