### PR TITLE
chore(configuration): enable DataPipelineEnabled on AAS + Windows

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -411,7 +411,7 @@ namespace Datadog.Trace.Configuration
 
             DataPipelineEnabled = config
                                   .WithKeys(ConfigurationKeys.TraceDataPipelineEnabled)
-                                  .AsBool(defaultValue: false);
+                                  .AsBool(defaultValue: EnvironmentHelpers.IsAzureAppServices() && FrameworkDescription.Instance.IsWindows());
 
             if (DataPipelineEnabled)
             {


### PR DESCRIPTION
## Summary of changes

## Reason for change

Due to limitation AAS extension https://github.com/DataDog/datadog-aas-extension/pull/388

TLDR; customer set env var have lower priority than the AAS configs.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
