### PR TITLE
Try to fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,19 @@
 version: 2
+
+registries:
+  azure-nuget:
+    type: nuget-feed
+    url: https://pkgs.dev.azure.com/datadoghq/dd-trace-dotnet/_packaging/Public_Feed/nuget/v3/index.json
+  public-nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+
+
 updates:
   # Mocked projects for vendored dependency notifications
   - package-ecosystem: "nuget"
     directory: "/tracer/dependabot"
+    registries: public-nuget
     exclude-paths:
       - "integrations"
     schedule:
@@ -20,6 +31,7 @@ updates:
   # Mocked projects for integration dependency notifications
   - package-ecosystem: "nuget"
     directory: "/tracer/dependabot/integrations"
+    registries: public-nuget
     schedule:
       interval: "daily"
     labels:
@@ -32,6 +44,7 @@ updates:
   # Because they aren't compatible with the dotnet msbuild approach we're using
   - package-ecosystem: "nuget"
     directory: "/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated"
+    registries: public-nuget
     schedule:
       interval: "daily"
     labels:
@@ -46,6 +59,7 @@ updates:
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace"
+    registries: public-nuget
     schedule:
       interval: "daily"
     labels:
@@ -73,6 +87,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.OpenTracing"
+    registries: public-nuget
     schedule:
       interval: "daily"
     labels:
@@ -94,8 +109,10 @@ updates:
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
       ### End Datadog.Trace.csproj ignored dependencies
+
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
+    registries: public-nuget
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
## Summary of changes

Tries to fix the broken dependabot updates

## Reason for change

Dependabot doesn't like our extra registry in the nuget.config, complaining that it's private and can't auth (even though it's public and doesn't need auth)

## Implementation details

- Defined the registries at the top level
- Added access _only_ to the public one (there's no point in it checking our azure registry because it just includes fake Datadog.Trace versions).


## Test coverage

Can't test this until we merge...

## Other details

This feels like pointless fragile duplication, but ah well


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
