### PR TITLE
Timeout error installer_smoke_tests

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -201,6 +201,9 @@ steps:
       dockerTag: $(dockerTag)
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
     displayName: Check logs for evidence of crash output
+    # This job sometimes hangs, and when it does, we lose all the logs, so explicitly end it early instead
+    # and retry instead. It should be very unlikely to hang on both trys, and if it does, we should probably
+    # investigate the cause of the hang further.
     timeoutInMinutes: 5
     retryCountOnTaskFailure: 2
     condition: and(succeeded(), eq(variables['runCrashTest'], 'true'))

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -1,4 +1,4 @@
-parameters:
+﻿parameters:
   - name: 'target'
     type: 'string'
 
@@ -158,31 +158,53 @@ steps:
 # Run crash tests
 - ${{ if and(eq(parameters.isLinux, true), eq(parameters.isNoop, false)) }}:
   - bash: |
-      LOGS=""
-      while IFS= read -r line
-      do
-        echo "$line"  # Output the log line to stdout in real-time
-        LOGS+="$line"$'\n'  # Capture each line into LOGS variable
-        # Profiling is disabled using DD_PROFILING_ENABLED=0 because there is a flaky freeze we are working around
-        # Once we figure out the freeze, we can re-enable
-      done < <(${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run --rm -e dockerTag=$(dockerTag) -e DD_PROFILING_ENABLED=0 -e CRASH_APP_ON_STARTUP=1 -e DD_CRASHTRACKING_INTERNAL_LOG_TO_CONSOLE=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }} 2>&1)
+      set -u -o pipefail
 
-      # check logs for evidence of crash detection in the output
-      expected="The crash may have been caused by automatic instrumentation"
-      if [[ $LOGS == *"$expected"* ]]; then
-        echo "Correctly found evidence of crash detection"
-      else
-        echo "Did not find required evidence of crash detection running"
-        exit 1;
+      TMPLOG="$(mktemp)"
+      COMPOSE="${{ parameters.dockerComposePath }}"
+      PROJ="ddtrace_$(Build.BuildNumber)"
+
+      # Build the compose run command; -T disables TTY (prevents buffering/hangs)
+      CMD=( "$COMPOSE" -f "$(COMPOSE_PATH)" -p "$PROJ" run --rm -T \
+            -e dockerTag="$(dockerTag)" \
+            -e DD_PROFILING_ENABLED=0 \
+            -e CRASH_APP_ON_STARTUP=1 \
+            -e DD_CRASHTRACKING_INTERNAL_LOG_TO_CONSOLE=1 \
+            -e COMPlus_DbgEnableMiniDump=0 \
+            ${{ parameters.target }} )
+
+      echo "Running: ${CMD[*]}"
+
+      # Bound execution to avoid indefinite hangs; force line-buffered stdout/stderr
+      # (stdbuf is available on Alpine-based agents; if not, remove it)
+      if ! timeout 240s stdbuf -oL -eL "${CMD[@]}" 2>&1 | tee "$TMPLOG" ; then
+        # Don't fail the step yet—crash is expected; just record exit code.
+        rc=${PIPESTATUS[0]}
+        echo "compose run exited with code $rc (non-zero is expected in a crash test)."
       fi
 
+      echo "--- Last 100 lines of output ---"
+      tail -n 100 "$TMPLOG" || true
+      echo "--------------------------------"
+
+      expected="The crash may have been caused by automatic instrumentation"
+      if grep -Fq "$expected" "$TMPLOG"; then
+        echo "✅ Correctly found evidence of crash detection"
+      else
+        echo "❌ Did not find required evidence of crash detection"
+        # Helpful diagnostics before failing
+        "$COMPOSE" -f "$(COMPOSE_PATH)" -p "$PROJ" ps || true
+        "$COMPOSE" -f "$(COMPOSE_PATH)" -p "$PROJ" logs --no-color || true
+        # Fail the task
+        exit 1
+      fi
+
+      # Always cleanup to avoid orphans impacting subsequent runs
+      "$COMPOSE" -f "$(COMPOSE_PATH)" -p "$PROJ" down -v --remove-orphans || true
     env:
       dockerTag: $(dockerTag)
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
     displayName: Check logs for evidence of crash output
-    # This job sometimes hangs, and when it does, we lose all the logs, so explicitly end it early instead
-    # and retry instead. It should be very unlikely to hang on both trys, and if it does, we should probably
-    # investigate the cause of the hang further.
     timeoutInMinutes: 5
     retryCountOnTaskFailure: 2
     condition: and(succeeded(), eq(variables['runCrashTest'], 'true'))

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -183,10 +183,6 @@ steps:
         echo "compose run exited with code $rc (non-zero is expected in a crash test)."
       fi
 
-      echo "--- Last 100 lines of output ---"
-      tail -n 100 "$TMPLOG" || true
-      echo "--------------------------------"
-
       expected="The crash may have been caused by automatic instrumentation"
       if grep -Fq "$expected" "$TMPLOG"; then
         echo "✅ Correctly found evidence of crash detection"


### PR DESCRIPTION
## Summary of changes

We are getting task timeout errors when running the stages installer_smoke_tests and nuget_installer_smoke_tests due to a timeout in Alpine:

```
========================== Starting Command Output ===========================
/usr/bin/bash /mnt/vss/_work/_temp/7e70edbf-6c43-483a-8887-89af502ac510.sh
 Network ddtrace_20250903-21_default  Creating
 Network ddtrace_20250903-21_default  Created
time="2025-09-03T12:50:22Z" level=warning msg="Found orphan containers ([ddtrace_20250903-21-nuget-dddotnet-smoke-tests-run-b040880c74eb]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up."
 Container ddtrace_20250903-21-test-agent-1  Creating
 Container ddtrace_20250903-21-test-agent-1  Created
 Container ddtrace_20250903-21-test-agent-1  Starting
 Container ddtrace_20250903-21-test-agent-1  Started

Unhandled Exception: System.BadImageFormatException: Expected
   at AspNetCoreSmokeTest.Program.Main(String[] args) in /src/Program.cs:line 58
   at AspNetCoreSmokeTest.Program.<Main>(String[] args)

##[error]The task has timed out.
Finishing: Check logs for evidence of crash output

```

This PR updates the pipeline’s crash test step to improve reliability. Previously, the step used a while read loop with process substitution to capture and stream logs. In some cases, the container’s TTY stream would not close cleanly after the intentional crash, causing the loop to hang and the task to time out.

The new implementation avoids this by:
* Replacing the while read loop with tee to stream logs to both the console and a temporary file.
* Adding -T to docker compose run to disable TTY allocation, preventing dangling open streams on crash.
* Wrapping the run command with timeout to ensure the job always terminates, even if Docker misbehaves.
* Running docker compose down -v --remove-orphans after the check to guarantee cleanup.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
