### PR TITLE
Use a 2.x version of the tracer in CI vis version mismatch test

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.CIVisibilityVersionMismatch/Samples.CIVisibilityVersionMismatch.csproj
+++ b/tracer/test/test-applications/integrations/Samples.CIVisibilityVersionMismatch/Samples.CIVisibilityVersionMismatch.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="255.1.6-prerelease" />
+    <PackageReference Include="Datadog.Trace" Version="2.60.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

Uses a 2.x version instead of a fictional 255.x.x version

## Reason for change

This scenario isn't a "real" scenario any more, as we don't ship the Datadog.Trace.dll in the nuget package. 

## Implementation details

Switch the version from our fictional (private, repack of 2.x.x) to use a real 2.x.x. Note that this hits different paths on the native side, but this scenario can actually happen whereas the previous one can't.

## Test coverage

Unchanged, except that no we test a real scenario instead of a fake one.

## Other details

Blocker for
- https://github.com/DataDog/dd-trace-dotnet/pull/7287


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
