### PR TITLE
Improve logging for `InstrumentationTests` and update dynamic code scenario

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -222,6 +222,7 @@ namespace Foo
         [Trait("RunOnWindows", "True")]
         public async Task WhenUsingRelativeTracerHome_InstrumentsApp()
         {
+            SetLogDirectory();
             // the working dir when we run the app is the _test_ project, not the app itself, so we need to be relative to that
             // This is a perfect example of why we don't recommend using relative paths for these variables
             var workingDir = Environment.CurrentDirectory;
@@ -240,6 +241,7 @@ namespace Foo
         [Trait("RunOnWindows", "True")]
         public async Task WhenUsingPathWithDotsInInTracerHome_InstrumentsApp()
         {
+            SetLogDirectory();
             var path = Path.Combine(EnvironmentHelper.MonitoringHome, "..", Path.GetFileName(EnvironmentHelper.MonitoringHome)!);
             Output.WriteLine("Using DD_DOTNET_TRACER_HOME " + path);
             SetEnvironmentVariable("DD_DOTNET_TRACER_HOME", path);
@@ -623,6 +625,7 @@ namespace Foo
         [Trait("RunOnWindows", "True")]
         public async Task WhenDynamicCodeIsEnabled_InstrumentsApp()
         {
+            SetLogDirectory();
             var dotnetRuntimeArgs = CreateRuntimeConfigWithDynamicCodeEnabled(true);
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
@@ -635,6 +638,7 @@ namespace Foo
         [Trait("RunOnWindows", "True")]
         public async Task WhenDynamicCodeIsDisabled_DoesNotInstrument()
         {
+            SetLogDirectory();
             var dotnetRuntimeArgs = CreateRuntimeConfigWithDynamicCodeEnabled(false);
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -638,7 +638,18 @@ namespace Foo
         [Trait("RunOnWindows", "True")]
         public async Task WhenDynamicCodeIsDisabled_DoesNotInstrument()
         {
-            SetLogDirectory();
+            // We move the logs to a throw-away temp location so that they're not checked by the logs-checker in CI.
+            // That's because in this scenario the Profiler will never receive the stable config results, so will
+            // never initialize, because we bail-out in the managed loader (i.e. we never initialize the tracer).
+            // This isn't ideal - we'd rather bail out in the native loader - but it's not possible to check the context
+            // switch on the native side AFAIK (though we should check again to see if we can).
+            // Regardless, the CP is loaded, and generates an error in its logs, but as this isn't a supported scenario
+            // anyway, that's fine.
+
+            var logDir = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
+            Directory.CreateDirectory(logDir);
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+
             var dotnetRuntimeArgs = CreateRuntimeConfigWithDynamicCodeEnabled(false);
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);


### PR DESCRIPTION
## Summary of changes

- Add some missing `SetLogDirectory()` calls for `InstrumentationTests`
- Update the "dynamic code" instrumentation tests to throw away the logs

## Reason for change

`InstrumentationTests` tests a bunch of very different scenarios. To make it easier to understand the failures, we generally put the logs for each test into its own subfolder by calling `SetLogDirectory()`. We were missing this call for some tests, so added them.

Additionally, while working on #7287 we found a scenario which is currently "broken"
- We instrument an app that has "dynamic code disabled"
- We don't support this, so we bail out in the _managed loader_
- The `Tracer` is never initialized
- The Continuous Profiler writes an error on shutdown because the Tracer never sends the stable config.
- In `CheckBuildLogsForErrors` we fail the CI because of the error log.

_Ideally_ we would bail out in the _native_ loader so that nothing's loaded, but we don't know how to read the context switch on the native side ATM, so we can't. However, as this isn't a supported scenario, we're ok with the error log being there, and don't think it's worth trying to avoid it at this stage.

## Implementation details

- Add missing `SetLogDirectory()`
- Write the "dynamic code" logs to a "temp" directory so that they're not checked by the `CheckBuildLogsForErrors` stage

## Test coverage

Coverage is the same

## Other details

Blocker for 
- https://github.com/DataDog/dd-trace-dotnet/pull/7287
