### PR TITLE
[Native] Safer rejitter iterations

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -427,10 +427,14 @@ HRESULT RejitHandler::NotifyReJITParameters(ModuleID moduleId, mdMethodDef metho
     FunctionControlWrapper functionControl((ICorProfilerInfo*)m_profilerInfo, moduleId, methodId);
 
     // Call all rejitters sequentially
-    auto c = m_rejittersCount;
-    for (auto x = 0; x < c; x++)
+    Rejitter* prev = nullptr;
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        hr = m_rejitters[x]->RejitMethod(functionControl);
+        const auto current = m_rejitters[x];
+        if (current != prev)
+        {
+            current->RejitMethod(functionControl);
+        }
     }
 
     return functionControl.ApplyChanges(pFunctionControl);
@@ -478,10 +482,11 @@ bool RejitHandler::HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef)
         return false;
     }
 
-    auto c = m_rejittersCount;
-    for (auto x = 0; x < c; x++)
+    Rejitter* prev = nullptr;
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        if (m_rejitters[x]->HasModuleAndMethod(moduleId, methodDef))
+        const auto current = m_rejitters[x];
+        if (current != prev && current->HasModuleAndMethod(moduleId, methodDef))
         {
             return true;
         }
@@ -497,10 +502,15 @@ void RejitHandler::RemoveModule(ModuleID moduleId)
         return;
     }
 
-    auto c = m_rejittersCount;
-    for (auto x = 0; x < c; x++)
+
+    Rejitter* prev = nullptr;
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        m_rejitters[x]->RemoveModule(moduleId);
+        const auto current = m_rejitters[x];
+        if (current != prev)
+        {
+            current->RemoveModule(moduleId);
+        }
     }
 }
 
@@ -511,10 +521,14 @@ void RejitHandler::AddNGenInlinerModule(ModuleID moduleId)
         return;
     }
 
-    auto c = m_rejittersCount;
-    for (auto x = 0; x < c; x++)
+    Rejitter* prev = nullptr;
+    for (auto x = 0; x < m_rejittersCount; x++)
     {
-        m_rejitters[x]->AddNGenInlinerModule(moduleId);
+        const auto current = m_rejitters[x];
+        if (current != prev)
+        {
+            current->AddNGenInlinerModule(moduleId);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary of changes
Avoid a possible double call when a new rejitter is inserted

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
