### PR TITLE
Attempt to improve Kafka timeout flake in tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Kafka/Producer.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Producer.cs
@@ -132,11 +132,6 @@ namespace Samples.Kafka
                     {
                         producer.Produce(topic, message, deliveryHandler);
                     }
-
-                    if (numMessages % FlushInterval == 0)
-                    {
-                        producer.Flush(FlushTimeout);
-                    }
                 }
                 Flush(producer);
 


### PR DESCRIPTION
## Summary of changes

We've been seeing timeouts of produced messages in the Kafka tests.
This increases the timeout slightly from 3 seconds to 5 seconds.
This also removes what appeared to be an accidental flush after every single synchronous produce.

## Reason for change

We've been seeing timeouts of produced messages in the Kafka tests.

## Implementation details

Changed `3000` -> `5_000`

Removed the flush call (after all messages are produced it still flushes).

## Test coverage

Same tests

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
