### PR TITLE
Try fixing ASAN job crashes

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2831,6 +2831,9 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
 
+    - script: |
+        sudo sysctl vm.mmap_rnd_bits=28
+
     - template: steps/run-in-docker.yml
       parameters:
         build: true

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -7,6 +7,7 @@
 #include "corprof.h"
 // end
 
+/* TO REMOVE before merging. Added to force ASAN/UBSAN/TSAN jobs */
 #include "CorProfilerCallback.h"
 
 #include <inttypes.h>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -7,7 +7,6 @@
 #include "corprof.h"
 // end
 
-/* TO REMOVE before merging. Added to force ASAN/UBSAN/TSAN jobs */
 #include "CorProfilerCallback.h"
 
 #include <inttypes.h>


### PR DESCRIPTION
## Summary of changes

This PR fixes the ASAN job which started crashing recently.

## Reason for change

This PR is the same as #7452 where we fix TSAN job which failed since a kernel update (6.6+). 
There are information [here](https://stackoverflow.com/questions/78293129/c-programs-fail-with-asan-addresssanitizerdeadlysignal) 
## Implementation details

Same as TSAN: set the Linux kernel parameter controlling the number of randomization bits used for memory regions allocated via mmap.

## Test coverage

ASAN job must be green.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
