### PR TITLE
Fix typo in dependabot yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   # Mocked projects for vendored dependency notifications
   - package-ecosystem: "nuget"
     directory: "/tracer/dependabot"
-    registries: public-nuget
+    registries: "public-nuget"
     exclude-paths:
       - "integrations"
     schedule:
@@ -31,7 +31,7 @@ updates:
   # Mocked projects for integration dependency notifications
   - package-ecosystem: "nuget"
     directory: "/tracer/dependabot/integrations"
-    registries: public-nuget
+    registries: "public-nuget"
     schedule:
       interval: "daily"
     labels:
@@ -44,7 +44,7 @@ updates:
   # Because they aren't compatible with the dotnet msbuild approach we're using
   - package-ecosystem: "nuget"
     directory: "/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated"
-    registries: public-nuget
+    registries: "public-nuget"
     schedule:
       interval: "daily"
     labels:
@@ -59,7 +59,7 @@ updates:
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace"
-    registries: public-nuget
+    registries: "public-nuget"
     schedule:
       interval: "daily"
     labels:
@@ -87,7 +87,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.OpenTracing"
-    registries: public-nuget
+    registries: "public-nuget"
     schedule:
       interval: "daily"
     labels:
@@ -112,7 +112,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
-    registries: public-nuget
+    registries: "public-nuget"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
## Summary of changes

Try to fix dependabot... again...

## Reason for change

Apparently dependabot still isn't happy:

```
The property '#/updates/0/registries' of type string did not match one or more of the required schemas
The property '#/updates/1/registries' of type string did not match one or more of the required schemas
The property '#/updates/2/registries' of type string did not match one or more of the required schemas
The property '#/updates/3/registries' of type string did not match one or more of the required schemas
The property '#/updates/4/registries' of type string did not match one or more of the required schemas
The property '#/updates/5/registries' of type string did not match one or more of the required schemas
```

## Implementation details

Make it an explicit string 🤷‍♂️ 

## Test coverage

I _wish_ I could...

## Other details

This really _Shouldn't_ fix it. but you know, YAML...


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
