### PR TITLE
Fix dependabot again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
 
 registries:
@@ -13,7 +14,7 @@ updates:
   # Mocked projects for vendored dependency notifications
   - package-ecosystem: "nuget"
     directory: "/tracer/dependabot"
-    registries: "public-nuget"
+    registries: ["public-nuget"]
     exclude-paths:
       - "integrations"
     schedule:
@@ -31,7 +32,7 @@ updates:
   # Mocked projects for integration dependency notifications
   - package-ecosystem: "nuget"
     directory: "/tracer/dependabot/integrations"
-    registries: "public-nuget"
+    registries: ["public-nuget"]
     schedule:
       interval: "daily"
     labels:
@@ -44,7 +45,7 @@ updates:
   # Because they aren't compatible with the dotnet msbuild approach we're using
   - package-ecosystem: "nuget"
     directory: "/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated"
-    registries: "public-nuget"
+    registries: ["public-nuget"]
     schedule:
       interval: "daily"
     labels:
@@ -59,7 +60,7 @@ updates:
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace"
-    registries: "public-nuget"
+    registries: ["public-nuget"]
     schedule:
       interval: "daily"
     labels:
@@ -87,7 +88,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.OpenTracing"
-    registries: "public-nuget"
+    registries: ["public-nuget"]
     schedule:
       interval: "daily"
     labels:
@@ -112,7 +113,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
-    registries: "public-nuget"
+    registries: ["public-nuget"]
     schedule:
       interval: "daily"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,10 @@
 version: 2
 
 registries:
-  azure-nuget:
-    type: nuget-feed
-    url: https://pkgs.dev.azure.com/datadoghq/dd-trace-dotnet/_packaging/Public_Feed/nuget/v3/index.json
+# Dependabot doesn't need to use this, so try to stop it doing so
+#  azure-nuget:
+#    type: nuget-feed
+#    url: https://pkgs.dev.azure.com/datadoghq/dd-trace-dotnet/_packaging/Public_Feed/nuget/v3/index.json
   public-nuget:
     type: nuget-feed
     url: https://api.nuget.org/v3/index.json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,6 @@ updates:
     labels:
       - "dependencies"
       - "area:dependabot"
-    reviewers:
-      - "DataDog/apm-idm-dotnet"
     ignore:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
       - dependency-name: "*" # Ignore patches for all integrations
@@ -38,8 +36,6 @@ updates:
     labels:
       - "dependencies"
       - "area:dependabot"
-    reviewers:
-      - "DataDog/apm-idm-dotnet"
 
   # Azure functions explicit testing - we can't include these with our "normal" process checks
   # Because they aren't compatible with the dotnet msbuild approach we're using
@@ -51,8 +47,6 @@ updates:
     labels:
       - "dependencies"
       - "area:dependabot"
-    reviewers:
-      - "DataDog/apm-idm-dotnet"
     ignore:
       - dependency-name: "*" # Ignore patches for all integrations
         update-types: ["version-update:semver-patch"]
@@ -66,8 +60,6 @@ updates:
     labels:
       - "dependencies"
       - "area:tracer"
-    reviewers:
-      - "DataDog/apm-idm-dotnet"
     ignore:
       ### Start Datadog.Trace.csproj ignored dependencies
       # DiagnosticSource is kept at the lowest supported version for widest compatibility
@@ -94,8 +86,6 @@ updates:
     labels:
       - "dependencies"
       - "area:opentracing"
-    reviewers:
-      - "DataDog/apm-idm-dotnet"
     ignore:
       ### Start Datadog.Trace.csproj ignored dependencies
       # DiagnosticSource is kept at the lowest supported version for widest compatibility
@@ -119,8 +109,6 @@ updates:
     labels:
       - "dependencies"
       - "area:benchmarks"
-    reviewers:
-      - "DataDog/apm-idm-dotnet"
     ignore:
       ### Start Datadog.Trace.csproj ignored dependencies
       # DiagnosticSource is kept at the lowest supported version for widest compatibility


### PR DESCRIPTION
## Summary of changes

Fix the remaining schema issues

## Reason for change

It was still broken

## Implementation details

Installed the YAML extension (from Red Hat) in VS Code and fixed the issues it highlighted
- `registries` needs to be an array
- `reviewers` doesn't exist

## Test coverage

YOLO

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
