### PR TITLE
Fix incorrect usages of TracerManager PerTraceSettings

### DIFF
--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace.AspNet
                 // Attempt to set Resource Name to something that will be close to what is expected
                 // Note: we will go and re-do it in OnEndRequest, but doing it here will allow for resource-based sampling
                 // this likely won't be perfect - but we need something to try and allow resource-based sampling to function
-                var resourceName = tracer.TracerManager.PerTraceSettings.HasResourceBasedSamplingRule
+                var resourceName = tracer.CurrentTraceSettings.HasResourceBasedSamplingRule
                                        ? BuildResourceName(tracer, httpRequest)
                                        : null;
                 scope.Span.DecorateWebServerSpan(resourceName: resourceName, httpMethod, host, url, userAgent, tags);

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -440,7 +440,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     // If we don't, update it in OnHostingHttpRequestInStop or OnHostingUnhandledException
                     // If the app is using resource-based sampling rules, then we need to set a resource straight
                     // away, so force that by using null.
-                    var resourceName = tracer.TracerManager.PerTraceSettings.HasResourceBasedSamplingRule ? null : string.Empty;
+                    var resourceName = tracer.CurrentTraceSettings.HasResourceBasedSamplingRule ? null : string.Empty;
                     var scope = AspNetCoreRequestHandler.StartAspNetCorePipelineScope(tracer, CurrentSecurity, httpContext, resourceName);
                     if (shouldSecure)
                     {


### PR DESCRIPTION
## Summary of changes

Fix incorrect direct-usages of `PerTraceSettings`

## Reason for change

The whole point of `PerTraceSettings` is that they may change, but that they're constant _per trace_. Therefore we should always access them directly on the `Tracer` instance, as that insures we use the "cached" settings on the `TraceContext` if a trace has already started.

## Implementation details

Use `Tracer.CurrentTracerSettings` instead of `Tracer.TracerManager.PerTraceSettings`.

## Test coverage

Covered by existing, only different in some dynamic config scenarios, so not explicitly tested (and not easy to do so)

## Other details

IMO there's a bunch of usability/naming and correctness issues:
- `CurrentTracerSettings` returns a `PerTraceSettings` instance
- `PerTraceSettings` doesn't just contain settings
- `PerTraceSettings` should contain _more_ values that can change at runtime, basically everything changeable by dynamic config or config in code.

Addressing those issues is something I'm trying to do soon, so this is part of a general stack of changes coming related to config.

https://datadoghq.atlassian.net/browse/LANGPLAT-819
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
