### PR TITLE
Decrease Nuke restore verbosity job

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -275,15 +275,7 @@ partial class Build
                 NuGetTasks.NuGetRestore(s => s
                     .SetTargetPath(Solution)
                     .SetVerbosity(NuGetVerbosity.Normal)
-                    .SetProcessCustomLogger((type, text) =>
-                    {
-                        if (type == OutputType.Std && IsServerBuild && (!text.StartsWith("Restored", StringComparison.OrdinalIgnoreCase) && !text.Contains("Warning", StringComparison.OrdinalIgnoreCase)))
-                        {
-                            return;
-                        }
-
-                        Serilog.Log.Information(text);
-                    })
+                    .SetProcessLogOutput(!IsServerBuild)
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
                         o.SetPackagesDirectory(NugetPackageDirectory)));
             }


### PR DESCRIPTION
## Summary of changes

This PR decreases the verbosity of the restore job that currently displays thousand of lines in the logs, flooding the gitlab output and surpassing the limit, which hides later logs.

In windows, we use Nuget.exe. Locally, we still will get the same messages, but in CI, we will only get the messages sent to Stderr for errors and warnings.

In the case of Linux, we use dotnet restore. Setting it to a minimal log level would be enough to suppress the too detailed logs and keep the warnings and errors.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
