### PR TITLE
[Azure Functions] bump `Datadog.Serverless.Compat` nuget package reference

### DIFF
--- a/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
+++ b/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
@@ -31,7 +31,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Datadog.Trace.Annotations\Datadog.Trace.Annotations.csproj" />
 
     <!-- Use PrivateAssets="none" to stop excluding content files by default -->
-    <PackageReference Include="Datadog.Serverless.Compat" Version="1.0.0" PrivateAssets="none" />
+    <PackageReference Include="Datadog.Serverless.Compat" Version="1.1.0" PrivateAssets="none" />
 
     <!-- managed assemblies -->
     <None Include="$(SourcePath)/net6.0/Datadog.Trace.dll" Pack="true" Visible="false" PackagePath="contentFiles/any/any/datadog/net6.0/">


### PR DESCRIPTION
## Summary of changes

Bump `Datadog.Serverless.Compat` nuget package reference from `1.0.0` to `1.1.0`

- `Datadog.Serverless.Compat` [v1.1.0](https://github.com/DataDog/datadog-serverless-compat-dotnet/releases/tag/v1.1.0)
  - adds startup hook to initialize agent process without code changes
    ```
    # Windows
    DOTNET_STARTUP_HOOKS=C:\home\site\wwwroot\Datadog.Serverless.Compat.dll

    # Linux
    DOTNET_STARTUP_HOOKS=/home/site/wwwroot/Datadog.Serverless.Compat.dll
    ```
- updates agent binary to [v0.18.0](https://github.com/DataDog/serverless-components/releases/tag/datadog-serverless-compat/v0.18.0)

## Reason for change

Shiny new things.

## Implementation details

```diff
- <PackageReference Include="Datadog.Serverless.Compat" Version="1.0.0" PrivateAssets="none" />
+ <PackageReference Include="Datadog.Serverless.Compat" Version="1.1.0" PrivateAssets="none" />
```

## Test coverage

...

## Other details
Fixes APMSVLS-173


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
