### PR TITLE
Add support .NET 10 RC 1

### DIFF
--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -7,7 +7,7 @@ pr:
 
 # Global variables
 variables:
-  dotnetCoreSdkLatestVersion: 10.0.100-preview.7.25380.108
+  dotnetCoreSdkLatestVersion: 10.0.100-rc.1.25451.107
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])] # required by update-github-status
   TargetBranch: $[variables['System.PullRequest.TargetBranch']]
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -56,10 +56,10 @@ schedules:
 # Global variables
 variables:
   buildConfiguration: Release
-  dotnetCoreSdkLatestVersion: 10.0.100-preview.7.25380.108
+  dotnetCoreSdkLatestVersion: 10.0.100-rc.1.25451.107
   # This is required until we're out of rc.
   # After GA we can do a find and replace and get rid of this
-  dotnetCoreSdkLatestVersionShort: 10.0.100-preview.7
+  dotnetCoreSdkLatestVersionShort: 10.0.100-rc.1
   nativeBuildDotnetSdkVersion: 7.0.306
   # These are the Managed DevOps pool names we use
   linuxTasksPool: azure-managed-linux-tasks

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "context": "../tracer/build/_build",
   "build": {
     "args": {
-      "DOTNETSDK_VERSION": "10.0.100-preview.7.25380.108"
+      "DOTNETSDK_VERSION": "10.0.100-rc.1.25451.107"
     }
   },
   // Allow access to host machine

--- a/.github/actions/run-in-docker/action.yml
+++ b/.github/actions/run-in-docker/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         docker build \
-          --build-arg DOTNETSDK_VERSION=10.0.100-preview.7.25380.108 \
+          --build-arg DOTNETSDK_VERSION=10.0.100-rc.1.25451.107 \
           --tag dd-trace-dotnet/${{ inputs.baseImage }}-builder \
           --target builder \
           --file "${GITHUB_WORKSPACE}/tracer/build/_build/docker/${{ inputs.baseImage }}.dockerfile" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,8 +332,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
     command: dotnet /build/bin/Debug/_build.dll BuildAndRunProfilerIntegrationTests
     volumes:
       - ./:/project
@@ -383,8 +383,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -479,8 +479,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project
@@ -531,8 +531,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -588,8 +588,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests
     volumes:
       - ./:/project
@@ -662,8 +662,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
     command: dotnet /build/bin/Debug/_build.dll RunIntegrationTests
     volumes:
       - ./:/project
@@ -760,8 +760,8 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
-    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-preview.7.25380.108}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
+    image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-10.0.100-rc.1.25451.107}
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.7.25380.108",
+    "version": "10.0.100-rc.1.25451.107",
     "rollForward": "minor"
   }
 }

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -31,9 +31,9 @@ RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION -Sha256 $ENV
 
 # Install .NET 10
 # To find these links, visit https://dotnet.microsoft.com/en-us/download, click the Windows, x64 installer, and grab the download url + SHA512 hash
-ENV DOTNET_VERSION="10.0.100-preview.7.25380.108" \
-    DOTNET_DOWNLOAD_URL="https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-preview.7.25380.108/dotnet-sdk-10.0.100-preview.7.25380.108-win-x64.exe" \
-    DOTNET_SHA512="5101cb87b0acd2704badc044c3874be02b6338fc21de059c22c695491aa58b5e3e91bea9ba068dfd5c1ebe8523ec843d3fd991628dbafcaf7b3e36ab2b0bc9ae"
+ENV DOTNET_VERSION="10.0.100-rc.1.25451.107" \
+    DOTNET_DOWNLOAD_URL="https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.100-rc.1.25451.107/dotnet-sdk-10.0.100-rc.1.25451.107-win-x64.exe" \
+    DOTNET_SHA512="92926100cd94d7e3e936c9f433609707c0563dc12cdb591a2cdd92f6a332e92b312cb4ca1174956e16d68f6a42521c30214f878e492990ef3a98db08c03dc75a"
 
 COPY install_dotnet.ps1 .
 RUN powershell -Command .\install_dotnet.ps1  -Version $ENV:DOTNET_VERSION -Sha512 $ENV:DOTNET_SHA512 $ENV:DOTNET_DOWNLOAD_URL

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -11,7 +11,7 @@ $BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 $IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 &docker build `
-   --build-arg DOTNETSDK_VERSION=10.0.100-preview.7.25380.108 `
+   --build-arg DOTNETSDK_VERSION=10.0.100-rc.1.25451.107 `
    --tag $IMAGE_NAME `
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -7,7 +7,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=10.0.100-preview.7.25380.108 \
+   --build-arg DOTNETSDK_VERSION=10.0.100-rc.1.25451.107 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/alpine.dockerfile" \
    "$BUILD_DIR"

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionRelatedFrames.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionRelatedFrames.cs
@@ -46,7 +46,10 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 // For reference, see the following test: ExceptionCaughtAndRethrownAsInnerTest.
 
                 var firstFrame = Frames?.FirstOrDefault();
-                var lastFrameOfInner = InnerFrame.Frames?.Reverse().FirstOrDefault();
+                // We hit the `public static void Reverse<T>(this Span<T> span)` function here on .NET 3.1+
+                // This causes this to fail to compile.
+                // Just specifying .AsEnumerable for now to minimize changes
+                var lastFrameOfInner = InnerFrame.Frames?.AsEnumerable().Reverse().FirstOrDefault();
 
                 var skipDuplicatedMethod = 0;
                 if (lastFrameOfInner?.Method == firstFrame?.Method)

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -689,8 +689,12 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         /// <returns>All the frames of the exception.</returns>
         public IEnumerable<ParticipatingFrame> GetParticipatingFrames(StackTrace stackTrace, bool isTopFrame, ParticipatingFrameState defaultState)
         {
+            // We hit the `public static void Reverse<T>(this Span<T> span)` function here on .NET 3.1+
+            // This causes this to fail to compile.
+            // Just specifying .AsEnumerable for now to minimize changes
             var frames = isTopFrame
                              ? stackTrace.GetFrames()?.
+                                          AsEnumerable().
                                           Reverse().
                                           SkipWhile(frame =>
                                           {

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -186,7 +186,10 @@ namespace Datadog.Trace.Debugger
 
             private string GetReversePath(string documentFullPath)
             {
-                var partsReverse = documentFullPath.Split(DirectorySeparatorsCrossPlatform, StringSplitOptions.None).Reverse();
+                // We hit the `public static void Reverse<T>(this Span<T> span)` function here on .NET 3.1+
+                // This causes this to fail to compile.
+                // Just specifying .AsEnumerable for now to minimize changes
+                var partsReverse = documentFullPath.Split(DirectorySeparatorsCrossPlatform, StringSplitOptions.None).AsEnumerable().Reverse();
                 // Preserve the type of slash (back- or forward- slash) that was originally inserted.
                 return string.Join(_directoryPathSeparator ?? Path.DirectorySeparatorChar.ToString(), partsReverse);
             }

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -387,8 +387,10 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             bool expandRouteParameters = false)
             where T : class
         {
+#pragma warning disable ASPDEPR004 // WebHostBuilder is deprecated but we need it for net core 2.1 FIXME
             var builder = new WebHostBuilder()
                .UseStartup<T>();
+#pragma warning restore ASPDEPR004
 
             var testServer = new TestServer(builder);
             var client = testServer.CreateClient();


### PR DESCRIPTION
## Summary of changes

This adds support for .NET 10 RC 1, updating from .NET 10 Preview 7 to it.

## Reason for change

https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/rc1/libraries.md

## Implementation details

- Ctrl + F and replace
- Fixed a few compilation issues due to some LINQ extension methods getting swapped to newer `MemoryExtensions public static void Reverse<T>(this Span<T> span)` - I just did a `AsEnumerable` for the time being
- Had to ignore `ASPDEPR008` in which the `WebHostBuilder` is now deprecated in one of the test files

## Test coverage

- Ran some locally and seem to work, but will need to rely on CI for most

## Other details
<!-- Fixes #{issue} -->

I don't have permissions to do most of the stuff with the managed pools :(
I initially had more instances of `NU1510`, but I am only getting those in VS 22, they don't show up in VS 26 🤷 

https://datadoghq.atlassian.net/browse/LANGPLAT-758 
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
