### PR TITLE
Fix .NET 10 RC1 bugs

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionRelatedFrames.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionRelatedFrames.cs
@@ -46,7 +46,10 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 // For reference, see the following test: ExceptionCaughtAndRethrownAsInnerTest.
 
                 var firstFrame = Frames?.FirstOrDefault();
-                var lastFrameOfInner = InnerFrame.Frames?.Reverse().FirstOrDefault();
+                // We hit the `public static void Reverse<T>(this Span<T> span)` function here on .NET 3.1+
+                // This causes this to fail to compile.
+                // Just specifying .AsEnumerable for now to minimize changes
+                var lastFrameOfInner = InnerFrame.Frames?.AsEnumerable().Reverse().FirstOrDefault();
 
                 var skipDuplicatedMethod = 0;
                 if (lastFrameOfInner?.Method == firstFrame?.Method)

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -689,8 +689,12 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         /// <returns>All the frames of the exception.</returns>
         public IEnumerable<ParticipatingFrame> GetParticipatingFrames(StackTrace stackTrace, bool isTopFrame, ParticipatingFrameState defaultState)
         {
+            // We hit the `public static void Reverse<T>(this Span<T> span)` function here on .NET 3.1+
+            // This causes this to fail to compile.
+            // Just specifying .AsEnumerable for now to minimize changes
             var frames = isTopFrame
                              ? stackTrace.GetFrames()?.
+                                          AsEnumerable().
                                           Reverse().
                                           SkipWhile(frame =>
                                           {

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -186,7 +186,10 @@ namespace Datadog.Trace.Debugger
 
             private string GetReversePath(string documentFullPath)
             {
-                var partsReverse = documentFullPath.Split(DirectorySeparatorsCrossPlatform, StringSplitOptions.None).Reverse();
+                // We hit the `public static void Reverse<T>(this Span<T> span)` function here on .NET 3.1+
+                // This causes this to fail to compile.
+                // Just specifying .AsEnumerable for now to minimize changes
+                var partsReverse = documentFullPath.Split(DirectorySeparatorsCrossPlatform, StringSplitOptions.None).AsEnumerable().Reverse();
                 // Preserve the type of slash (back- or forward- slash) that was originally inserted.
                 return string.Join(_directoryPathSeparator ?? Path.DirectorySeparatorChar.ToString(), partsReverse);
             }


### PR DESCRIPTION
## Summary of changes

Fix issues that cause failure to compile if you try to use RC1

## Reason for change

@bouwkast found these issues in https://github.com/DataDog/dd-trace-dotnet/pull/7499, but some people have already installed RC1 and are getting local failures, so this should unblock them

## Implementation details

Copy the fixes from #7499

## Test coverage

Covered by existing (hopefully)

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
