### PR TITLE
fix(telemetry): correct heartbeat interval calculation

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -408,7 +408,7 @@ namespace Datadog.Trace
                     {
                         telemetryClientConfiguration = new TelemetryClientConfiguration
                         {
-                            Interval = (ulong)telemetrySettings.HeartbeatInterval.Milliseconds,
+                            Interval = (ulong)telemetrySettings.HeartbeatInterval.TotalMilliseconds,
                             RuntimeId = new CharSlice(Tracer.RuntimeId),
                             DebugEnabled = telemetrySettings.DebugEnabled
                         };


### PR DESCRIPTION
## Summary of changes (generated)

This pull request makes a minor update to how the telemetry heartbeat interval is calculated in the `TracerManagerFactory`. Specifically, it changes the property used to obtain the interval value from `Milliseconds` to `TotalMilliseconds` to ensure the correct duration is set.

* Changed the assignment of `Interval` in `TelemetryClientConfiguration` to use `telemetrySettings.HeartbeatInterval.TotalMilliseconds` instead of `Milliseconds`, ensuring the interval accurately reflects the total duration in milliseconds.

## Reason for change

Milliseconds gives the ms component which is not the intention here.

FYI https://learn.microsoft.com/en-us/dotnet/api/system.timespan?view=net-8.0#properties

## Implementation details

- Replaced `Milliseconds` with `TotalMilliseconds`

On libdatadog side we don't set the hearbeat if it is zero https://github.com/DataDog/libdatadog/blob/15e0225766b7b3d137c4b723cfd7180c5436667e/data-pipeline/src/telemetry/mod.rs#L70 and more often than not, Millisecond component is zero.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
