### PR TITLE
Allow optimized creating of composite configuration source

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -679,6 +679,7 @@
       <type fullname="System.Predicate`1" />
       <type fullname="System.Random" />
       <type fullname="System.ReadOnlySpan`1" />
+      <type fullname="System.ReadOnlySpan`1/Enumerator" />
       <type fullname="System.Reflection.AmbiguousMatchException" />
       <type fullname="System.Reflection.Assembly" />
       <type fullname="System.Reflection.AssemblyCompanyAttribute" />

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
@@ -26,10 +26,17 @@ namespace Datadog.Trace.Configuration
             _sources = new();
         }
 
+#if NETCOREAPP3_1_OR_GREATER
+        public CompositeConfigurationSource(ReadOnlySpan<IConfigurationSource> sources)
+        {
+            _sources = [..sources];
+        }
+#else
         public CompositeConfigurationSource(IEnumerable<IConfigurationSource> sources)
         {
             _sources = [..sources];
         }
+#endif
 
         public ConfigurationOrigins Origin => ConfigurationOrigins.Unknown;
 


### PR DESCRIPTION
## Summary of changes

Use `ReadOnlySpan<>` instead of `IEnumerable<>`

## Reason for change

Spotted this while working on other stuff: when used with `[]` in particular it allows reducing allocations

## Implementation details

`#if` and `ReadOnlySpan<>`

## Test coverage

Covered by existing

## Other details

Yes this is tiny, but we can do more of this in the future 😄 