### PR TITLE
[Tracer] Updating Statsd in RuntimeEventListener

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -6,6 +6,7 @@
 #if NETFRAMEWORK
 
 using System;
+using System.Threading;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -19,7 +20,7 @@ namespace Datadog.Trace.RuntimeMetrics
         private const string GarbageCollectionMetrics = $"{MetricsNames.Gen0HeapSize}, {MetricsNames.Gen1HeapSize}, {MetricsNames.Gen2HeapSize}, {MetricsNames.LohSize}, {MetricsNames.Gen0CollectionsCount}, {MetricsNames.Gen1CollectionsCount}, {MetricsNames.Gen2CollectionsCount}";
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AzureAppServicePerformanceCounters>();
-        private readonly IDogStatsd _statsd;
+        private IDogStatsd _statsd;
 
         private int? _previousGen0Count;
         private int? _previousGen1Count;
@@ -68,6 +69,11 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen2Count = gen2;
 
             Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GarbageCollectionMetrics);
+        }
+
+        public void UpdateStatsd(IDogStatsd statsd)
+        {
+            Interlocked.Exchange(ref _statsd, statsd);
         }
 
         private class PerformanceCountersValue

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/IRuntimeMetricsListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/IRuntimeMetricsListener.cs
@@ -4,11 +4,14 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.RuntimeMetrics
 {
     internal interface IRuntimeMetricsListener : IDisposable
     {
         void Refresh();
+
+        void UpdateStatsd(IDogStatsd statsd);
     }
 }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
@@ -8,6 +8,7 @@
 using System;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
@@ -20,8 +21,9 @@ namespace Datadog.Trace.RuntimeMetrics
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<MemoryMappedCounters>();
 
-        private readonly IDogStatsd _statsd;
         private readonly int _processId;
+
+        private IDogStatsd _statsd;
 
         private int? _previousGen0Count;
         private int? _previousGen1Count;
@@ -170,6 +172,11 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen2Count = gen2;
 
             Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GarbageCollectionMetrics);
+        }
+
+        public void UpdateStatsd(IDogStatsd statsd)
+        {
+            Interlocked.Exchange(ref _statsd, statsd);
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
@@ -23,9 +24,10 @@ namespace Datadog.Trace.RuntimeMetrics
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<PerformanceCountersListener>();
 
-        private readonly IDogStatsd _statsd;
         private readonly string _processName;
         private readonly int _processId;
+
+        private IDogStatsd _statsd;
 
         private string _instanceName;
         private PerformanceCounterCategory _memoryCategory;
@@ -112,6 +114,11 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen2Count = gen2;
 
             Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GarbageCollectionMetrics);
+        }
+
+        public void UpdateStatsd(IDogStatsd statsd)
+        {
+            Interlocked.Exchange(ref _statsd, statsd);
         }
 
         protected virtual void InitializePerformanceCounters()

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -37,11 +37,11 @@ namespace Datadog.Trace.RuntimeMetrics
 
         private static readonly IReadOnlyDictionary<string, string> MetricsMapping;
 
-        private readonly IDogStatsd _statsd;
-
         private readonly Timing _contentionTime = new Timing();
 
         private readonly string _delayInSeconds;
+
+        private IDogStatsd _statsd;
 
         private long _contentionCount;
 
@@ -79,6 +79,11 @@ namespace Datadog.Trace.RuntimeMetrics
             _statsd.Gauge(MetricsNames.ThreadPoolWorkersCount, ThreadPool.ThreadCount);
 
             Log.Debug("Sent the following metrics to the DD agent: {Metrics}", ThreadStatsMetrics);
+        }
+
+        public void UpdateStatsd(IDogStatsd statsd)
+        {
+            Interlocked.Exchange(ref _statsd, statsd);
         }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -161,6 +161,7 @@ namespace Datadog.Trace.RuntimeMetrics
         internal void UpdateStatsd(IDogStatsd statsd)
         {
             Interlocked.Exchange(ref _statsd, statsd);
+            _listener?.UpdateStatsd(statsd);
         }
 
         internal void PushEvents()

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.RuntimeMetrics;


### PR DESCRIPTION
## Summary of changes
Fixed runtime metrics reinitialization issue by added the option to `UpdateStatsd` to IRuntimeMetricsListener and implementing it in related classes.

## Reason for change
Customer helped us noriced runtime metrics system was experiencing issues where:
- Metrics were missing after upgrade
- The Statsd object wasn't being properly updated during reinitialization
- Runtime metrics listeners were holding onto stale Statsd references

## Implementation details
- Added `UpdateStatsd` method to `IRuntimeMetricsListener.cs` interface
- Modified `RuntimeEventListener.cs `and related classes to properly handle reinitialization scenarios
- Updated `RuntimeMetricsWriter.cs` to use newly created _statsd_ object
- Changed `_statsd` field from readonly to mutable in all runtime metrics listener implementations

## Test coverage
Added test `UpdateStatsdOnReinitialization` to confirm the metrics are being sent where expected.

## Other details
Fixes Jira [APMS-17172](https://datadoghq.atlassian.net/browse/APMS-17172)


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->


[APMS-17172]: https://datadoghq.atlassian.net/browse/APMS-17172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ