### PR TITLE
Move partial flush settings from `ExporterSettings` to `TracerSettings`

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
@@ -27,7 +27,7 @@ internal class ApmAgentWriter : IEventWriter
 
     public ApmAgentWriter(TracerSettings settings, Action<Dictionary<string, float>> updateSampleRates, IDiscoveryService discoveryService, int maxBufferSize = DefaultMaxBufferSize)
     {
-        var partialFlushEnabled = settings.Exporter.PartialFlushEnabled;
+        var partialFlushEnabled = settings.PartialFlushEnabled;
         var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
         var api = new Api(apiRequestFactory, null, updateSampleRates, partialFlushEnabled);
         var statsAggregator = StatsAggregator.Create(api, settings, discoveryService);

--- a/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManager.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Ci
                 dynamicConfigurationManager,
                 tracerFlareManager,
                 spanEventsManager,
-                GetProcessors(settings.Exporter.PartialFlushEnabled, agentWriter is CIVisibilityProtocolWriter))
+                GetProcessors(settings.PartialFlushEnabled, agentWriter is CIVisibilityProtocolWriter))
         {
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -72,13 +72,13 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key to enable sending partial traces to the agent
         /// </summary>
-        /// <seealso cref="ExporterSettings.PartialFlushEnabled"/>
+        /// <seealso cref="PartialFlushEnabled"/>
         public const string PartialFlushEnabled = "DD_TRACE_PARTIAL_FLUSH_ENABLED";
 
         /// <summary>
         /// Configuration key to set the minimum number of closed spans in a trace before it's partially flushed
         /// </summary>
-        /// <seealso cref="ExporterSettings.PartialFlushMinSpans"/>
+        /// <seealso cref="PartialFlushMinSpans"/>
         public const string PartialFlushMinSpans = "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS";
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -130,11 +130,6 @@ namespace Datadog.Trace.Configuration
                                  .WithKeys(ConfigurationKeys.TracesPipeTimeoutMs)
                                  .AsInt32(500, value => value > 0)
                                  .Value;
-
-            PartialFlushEnabled = config.WithKeys(ConfigurationKeys.PartialFlushEnabled).AsBool(false);
-            PartialFlushMinSpans = config
-                                  .WithKeys(ConfigurationKeys.PartialFlushMinSpans)
-                                  .AsInt32(500, value => value > 0).Value;
         }
 
         /// <summary>
@@ -201,16 +196,6 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DogStatsdPort"/>
         public int DogStatsdPort { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether partial flush is enabled
-        /// </summary>
-        public bool PartialFlushEnabled { get; }
-
-        /// <summary>
-        /// Gets the minimum number of closed spans in a trace before it's partially flushed
-        /// </summary>
-        public int PartialFlushMinSpans { get; }
 
         /// <summary>
         /// Gets the transport used to send traces to the Agent.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -894,6 +894,11 @@ namespace Datadog.Trace.Configuration
                 telemetry.Record(ConfigTelemetryData.AasAppType, AzureAppServiceMetadata.SiteType, recordValue: true, ConfigurationOrigins.Default);
             }
 
+            PartialFlushEnabled = config.WithKeys(ConfigurationKeys.PartialFlushEnabled).AsBool(false);
+            PartialFlushMinSpans = config
+                                  .WithKeys(ConfigurationKeys.PartialFlushMinSpans)
+                                  .AsInt32(500, value => value > 0).Value;
+
             GraphQLErrorExtensions = TrimSplitString(
                 config.WithKeys(ConfigurationKeys.GraphQLErrorExtensions).AsString(),
                 commaSeparator);
@@ -1500,6 +1505,16 @@ namespace Datadog.Trace.Configuration
         /// Gets the disabled ADO.NET Command Types that won't have spans generated for them.
         /// </summary>
         internal HashSet<string> DisabledAdoNetCommandTypes { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether partial flush is enabled
+        /// </summary>
+        public bool PartialFlushEnabled { get; }
+
+        /// <summary>
+        /// Gets the minimum number of closed spans in a trace before it's partially flushed
+        /// </summary>
+        public int PartialFlushMinSpans { get; }
 
         internal ImmutableDynamicSettings DynamicSettings { get; init; } = new();
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -153,7 +153,7 @@ namespace Datadog.Trace
 
         public void CloseSpan(Span span)
         {
-            bool ShouldTriggerPartialFlush() => Tracer.Settings.Exporter.PartialFlushEnabled && _spans.Count >= Tracer.Settings.Exporter.PartialFlushMinSpans;
+            bool ShouldTriggerPartialFlush() => Tracer.Settings.PartialFlushEnabled && _spans.Count >= Tracer.Settings.PartialFlushMinSpans;
 
             ArraySegment<Span> spansToWrite = default;
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -463,10 +463,10 @@ namespace Datadog.Trace
                     }
 
                     writer.WritePropertyName("partialflush_enabled");
-                    writer.WriteValue(instanceSettings.Exporter.PartialFlushEnabled);
+                    writer.WriteValue(instanceSettings.PartialFlushEnabled);
 
                     writer.WritePropertyName("partialflush_minspans");
-                    writer.WriteValue(instanceSettings.Exporter.PartialFlushMinSpans);
+                    writer.WriteValue(instanceSettings.PartialFlushMinSpans);
 
                     writer.WritePropertyName("runtime_id");
                     writer.WriteValue(Tracer.RuntimeId);

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -445,7 +445,7 @@ namespace Datadog.Trace
                 }
             }
 
-            return new Api(apiRequestFactory, statsd, updateSampleRates, settings.Exporter.PartialFlushEnabled);
+            return new Api(apiRequestFactory, statsd, updateSampleRates, settings.PartialFlushEnabled);
         }
 
         private static string GetUrl(TracerSettings settings)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -62,36 +62,6 @@ namespace Datadog.Trace.Tests.Configuration
             CheckDefaultValues(settingsFromSource, "DogStatsdPort");
         }
 
-        [Fact]
-        public void PartialFlushEnabled()
-        {
-            var param = true;
-            var settingsFromSource = Setup("DD_TRACE_PARTIAL_FLUSH_ENABLED", param.ToString());
-
-            settingsFromSource.PartialFlushEnabled.Should().Be(param);
-
-            CheckDefaultValues(settingsFromSource, "PartialFlushEnabled");
-        }
-
-        [Fact]
-        public void PartialFlushMinSpans()
-        {
-            var param = 200;
-            var settingsFromSource = Setup("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", param.ToString());
-
-            settingsFromSource.PartialFlushMinSpans.Should().Be(param);
-
-            CheckDefaultValues(settingsFromSource, "PartialFlushMinSpans");
-        }
-
-        [Fact]
-        public void InvalidPartialFlushMinSpans()
-        {
-            var param = -200;
-            var settingsFromSource = Setup("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", param.ToString());
-            settingsFromSource.PartialFlushMinSpans.Should().Be(500);
-        }
-
         [Theory]
         [InlineData("udp://someurl", ExporterSettings.DefaultDogstatsdPort)]
         [InlineData("udp://someurl:1234", 1234)]
@@ -402,16 +372,6 @@ namespace Datadog.Trace.Tests.Configuration
             if (!paramToIgnore.Contains(nameof(settings.MetricsHostname)))
             {
                 settings.MetricsHostname.Should().Be(ExporterSettings.DefaultDogstatsdHostname);
-            }
-
-            if (!paramToIgnore.Contains("PartialFlushEnabled"))
-            {
-                settings.PartialFlushEnabled.Should().BeFalse();
-            }
-
-            if (!paramToIgnore.Contains("PartialFlushMinSpans"))
-            {
-                settings.PartialFlushMinSpans.Should().Be(500);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1517,6 +1517,28 @@ namespace Datadog.Trace.Tests.Configuration
             settings.OtlpMetricsHeaders.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split('=').First(), v => v.Split('=').Last()));
         }
 
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void PartialFlushEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource(("DD_TRACE_PARTIAL_FLUSH_ENABLED", value));
+            var settings = new TracerSettings(source);
+            settings.PartialFlushEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("", 500)]
+        [InlineData("200", 200)]
+        [InlineData("1", 1)]
+        [InlineData("0", 500)]
+        [InlineData("-200", 500)]
+        public void PartialFlushMinSpans(string value, int expected)
+        {
+            var source = CreateConfigurationSource(("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", value));
+            var settings = new TracerSettings(source);
+            settings.PartialFlushMinSpans.Should().Be(expected);
+        }
+
         private void ValidateErrorStatusCodes(bool[] result, string newErrorKeyValue, string deprecatedErrorKeyValue, string expectedErrorRange)
         {
             if (newErrorKeyValue is not null || deprecatedErrorKeyValue is not null)


### PR DESCRIPTION
## Summary of changes

Moves two partial flush settings from `ExporterSettings` to `TracerSettings`

## Reason for change

While _technically_ related to "agent" stuff, partial flush configuration isn't primarily concerned with _how_ we talk to the agent, which is the purpose of `ExporterSettings`

More important right now, these values don't change at runtime, while technically pretty much everything  else in `ExporterSettings` _can_ change due to config in code, and the inter-dependency between settings.

## Implementation details

- Move the settings to `TracerSettings`
- Update usages
- Move/expand unit tests for the setting

## Test coverage

Essentially the same, although added a couple of other test cases

## Other details

Part of a config stack

https://datadoghq.atlassian.net/browse/LANGPLAT-819


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
