### PR TITLE
Extract `MutableSettings` from `TracerSettings`

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Configuration
         {
             var oldSettings = Tracer.Instance.Settings;
 
-            var headerTags = TracerSettings.InitializeHeaderTags(settings, ConfigurationKeys.HeaderTags, headerTagsNormalizationFixEnabled: true);
+            var headerTags = MutableSettings.InitializeHeaderTags(settings, ConfigurationKeys.HeaderTags, headerTagsNormalizationFixEnabled: true);
             // var serviceNameMappings = TracerSettings.InitializeServiceNameMappings(settings, ConfigurationKeys.ServiceNameMappings);
 
             var globalTags = settings.WithKeys(ConfigurationKeys.GlobalTags).AsDictionary();

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Datadog.Trace.Configuration.Telemetry;
 
@@ -13,7 +14,7 @@ namespace Datadog.Trace.Configuration
     /// <summary>
     /// Contains integration-specific settings.
     /// </summary>
-    public class IntegrationSettings
+    public class IntegrationSettings : IEquatable<IntegrationSettings>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IntegrationSettings"/> class.
@@ -82,5 +83,51 @@ namespace Datadog.Trace.Configuration
         /// that determines the sampling rate for this integration.
         /// </summary>
         public double AnalyticsSampleRate { get; }
+
+        /// <inheritdoc/>
+        public bool Equals(IntegrationSettings? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return IntegrationName == other.IntegrationName &&
+                   Enabled == other.Enabled &&
+                   AnalyticsEnabled == other.AnalyticsEnabled &&
+                   AnalyticsSampleRate.Equals(other.AnalyticsSampleRate);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((IntegrationSettings)obj);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(IntegrationName, Enabled, AnalyticsEnabled, AnalyticsSampleRate);
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
@@ -1,0 +1,753 @@
+﻿// <copyright file="MutableSettings.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Datadog.Trace.Ci;
+using Datadog.Trace.Ci.CiEnvironment;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Processors;
+using Datadog.Trace.Tagging;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Configuration;
+
+/// <summary>
+/// Settings that can change during the lifetime of the application. This can include settings updated in
+/// code or via remote configuration. Note that the specific instance is immutable, but there may be a
+/// new version in the lifetime of the application
+/// </summary>
+public class MutableSettings
+{
+    // we cached the static instance here, because is being used in the hotpath
+    // by IsIntegrationEnabled method (called from all integrations)
+    private readonly DomainMetadata _domainMetadata = DomainMetadata.Instance;
+
+    internal MutableSettings(
+        IConfigurationSource source,
+        IConfigurationTelemetry telemetry,
+        OverrideErrorLog errorLog,
+        TracerSettings tracerSettings)
+    {
+        Telemetry = telemetry;
+        ErrorLog = errorLog;
+        var config = new ConfigurationBuilder(source, Telemetry);
+
+        LogsInjectionEnabled = config
+                              .WithKeys(ConfigurationKeys.LogsInjectionEnabled)
+                              .AsBool(defaultValue: true);
+
+        var otelTags = config
+                      .WithKeys(ConfigurationKeys.OpenTelemetry.ResourceAttributes)
+                      .AsDictionaryResult(separator: '=');
+
+        Dictionary<string, string>? globalTags;
+        if (tracerSettings.ExperimentalFeaturesEnabled.Contains("DD_TAGS"))
+        {
+            // New behavior: If ExperimentalFeaturesEnabled configures DD_TAGS, we want to change DD_TAGS parsing to do the following:
+            // 1. If a comma is in the value, split on comma as before. Otherwise, split on space
+            // 2. Key-value pairs with empty values are allowed, instead of discarded
+            // 3. Key-value pairs without values (i.e. no `:` separator) are allowed and treated as key-value pairs with empty values, instead of discarded
+            Func<string, IDictionary<string, string>> updatedTagsParser = (data) =>
+            {
+                var dictionary = new ConcurrentDictionary<string, string>();
+                if (string.IsNullOrWhiteSpace(data))
+                {
+                    // return empty collection
+                    return dictionary;
+                }
+
+                char[] separatorChars = data.Contains(',') ? [','] : [' '];
+                var entries = data.Split(separatorChars, StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (var entry in entries)
+                {
+                    // we need Trim() before looking forthe separator so we can skip entries with no key
+                    // (that is, entries with a leading separator, like "<empty or whitespace>:value")
+                    var trimmedEntry = entry.Trim();
+                    if (trimmedEntry.Length == 0 || trimmedEntry[0] == ':')
+                    {
+                        continue;
+                    }
+
+                    var separatorIndex = trimmedEntry.IndexOf(':');
+                    if (separatorIndex < 0)
+                    {
+                        // entries with no separator are allowed (e.g. key1 and key3 in "key1, key2:value2, key3"),
+                        // it's a key with no value.
+                        var key = trimmedEntry;
+                        dictionary[key] = string.Empty;
+                    }
+                    else if (separatorIndex > 0)
+                    {
+                        // if a separator is present with no value, we take the value to be empty (e.g. "key1:, key2: ").
+                        // note we already did Trim() on the entire entry, so the key portion only needs TrimEnd().
+                        var key = trimmedEntry.Substring(0, separatorIndex).TrimEnd();
+                        var value = trimmedEntry.Substring(separatorIndex + 1).Trim();
+                        dictionary[key] = value;
+                    }
+                }
+
+                return dictionary;
+            };
+
+            globalTags = config
+                        .WithKeys(ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
+                        .AsDictionaryResult(parser: updatedTagsParser)
+                        .OverrideWith(
+                             RemapOtelTags(in otelTags),
+                             ErrorLog,
+                             () => new DefaultResult<IDictionary<string, string>>(new Dictionary<string, string>(), string.Empty))
+
+                         // Filter out tags with empty keys, and trim whitespace
+                        .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key))
+                        .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value?.Trim() ?? string.Empty);
+        }
+        else
+        {
+            globalTags = config
+                        .WithKeys(ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
+                        .AsDictionaryResult()
+                        .OverrideWith(
+                             RemapOtelTags(in otelTags),
+                             ErrorLog,
+                             () => new DefaultResult<IDictionary<string, string>>(new Dictionary<string, string>(), string.Empty))
+
+                         // Filter out tags with empty keys or empty values, and trim whitespace
+                        .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
+                        .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
+        }
+
+        Environment = config
+                     .WithKeys(ConfigurationKeys.Environment)
+                     .AsString();
+
+        // DD_ENV has precedence over DD_TAGS
+        Environment = GetExplicitSettingOrTag(Environment, globalTags, Tags.Env, ConfigurationKeys.Environment);
+
+        var otelServiceName = config.WithKeys(ConfigurationKeys.OpenTelemetry.ServiceName).AsStringResult();
+        var serviceName = config
+                         .WithKeys(ConfigurationKeys.ServiceName, "DD_SERVICE_NAME")
+                         .AsStringResult()
+                         .OverrideWith(in otelServiceName, ErrorLog);
+
+        // DD_SERVICE has precedence over DD_TAGS
+        serviceName = GetExplicitSettingOrTag(serviceName, globalTags, Tags.Service, ConfigurationKeys.ServiceName);
+
+        if (tracerSettings.IsRunningInCiVisibility)
+        {
+            // Set the service name if not set
+            var isUserProvidedTestServiceTag = true;
+            var ciVisServiceName = serviceName;
+            if (string.IsNullOrEmpty(serviceName))
+            {
+                // Extract repository name from the git url and use it as a default service name.
+                ciVisServiceName = TestOptimization.Instance.TracerManagement?.GetServiceNameFromRepository(CIEnvironmentValues.Instance.Repository);
+                isUserProvidedTestServiceTag = false;
+            }
+
+            globalTags[Ci.Tags.CommonTags.UserProvidedTestServiceTag] = isUserProvidedTestServiceTag ? "true" : "false";
+
+            // Normalize the service name
+            ciVisServiceName = NormalizerTraceProcessor.NormalizeService(ciVisServiceName);
+            if (ciVisServiceName != serviceName)
+            {
+                serviceName = ciVisServiceName;
+                telemetry.Record(ConfigurationKeys.ServiceName, serviceName, recordValue: true, ConfigurationOrigins.Calculated);
+            }
+        }
+
+        ServiceName = serviceName;
+
+        ServiceVersion = config
+                        .WithKeys(ConfigurationKeys.ServiceVersion)
+                        .AsString();
+
+        // DD_VERSION has precedence over DD_TAGS
+        ServiceVersion = GetExplicitSettingOrTag(ServiceVersion, globalTags, Tags.Version, ConfigurationKeys.ServiceVersion);
+
+        GitCommitSha = config
+                      .WithKeys(ConfigurationKeys.GitCommitSha)
+                      .AsString();
+
+        // DD_GIT_COMMIT_SHA has precedence over DD_TAGS
+        GitCommitSha = GetExplicitSettingOrTag(GitCommitSha, globalTags, Ci.Tags.CommonTags.GitCommit, ConfigurationKeys.GitCommitSha);
+
+        GitRepositoryUrl = config
+                          .WithKeys(ConfigurationKeys.GitRepositoryUrl)
+                          .AsString();
+
+        // DD_GIT_REPOSITORY_URL has precedence over DD_TAGS
+        GitRepositoryUrl = GetExplicitSettingOrTag(GitRepositoryUrl, globalTags, Ci.Tags.CommonTags.GitRepository, ConfigurationKeys.GitRepositoryUrl);
+
+        var otelTraceEnabled = config
+                              .WithKeys(ConfigurationKeys.OpenTelemetry.TracesExporter)
+                              .AsBoolResult(
+                                   value => string.Equals(value, "none", StringComparison.OrdinalIgnoreCase)
+                                                ? ParsingResult<bool>.Success(result: false)
+                                                : ParsingResult<bool>.Failure());
+        TraceEnabled = config
+                      .WithKeys(ConfigurationKeys.TraceEnabled)
+                      .AsBoolResult()
+                      .OverrideWith(in otelTraceEnabled, ErrorLog, defaultValue: true);
+
+        if (tracerSettings.AzureAppServiceMetadata?.IsUnsafeToTrace == true)
+        {
+            telemetry.Record(ConfigurationKeys.TraceEnabled, false, ConfigurationOrigins.Calculated);
+            TraceEnabled = false;
+        }
+
+        var disabledIntegrationNames = config.WithKeys(ConfigurationKeys.DisabledIntegrations)
+                                             .AsString()
+                                            ?.Split([';'], StringSplitOptions.RemoveEmptyEntries) ?? [];
+
+        // If Activity support is enabled, we shouldn't enable the OTel listener
+        DisabledIntegrationNames = tracerSettings.IsActivityListenerEnabled
+                                       ? new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase)
+                                       : new HashSet<string>([..disabledIntegrationNames, nameof(IntegrationId.OpenTelemetry)], StringComparer.OrdinalIgnoreCase);
+
+        Integrations = new IntegrationSettingsCollection(source, DisabledIntegrationNames);
+        RecordDisabledIntegrationsTelemetry(Integrations, Telemetry);
+
+#pragma warning disable 618 // App analytics is deprecated, but still used
+        AnalyticsEnabled = config.WithKeys(ConfigurationKeys.GlobalAnalyticsEnabled)
+                                 .AsBool(defaultValue: false);
+#pragma warning restore 618
+
+#pragma warning disable 618 // this parameter has been replaced but may still be used
+        MaxTracesSubmittedPerSecond = config
+                                     .WithKeys(ConfigurationKeys.TraceRateLimit, ConfigurationKeys.MaxTracesSubmittedPerSecond)
+#pragma warning restore 618
+                                     .AsInt32(defaultValue: 100);
+
+        // mutate dictionary to remove without "env", "version", "git.commit.sha" or "git.repository.url" tags
+        // these value are used for "Environment" and "ServiceVersion", "GitCommitSha" and "GitRepositoryUrl" properties
+        // or overriden with DD_ENV, DD_VERSION, DD_GIT_COMMIT_SHA and DD_GIT_REPOSITORY_URL respectively
+        globalTags.Remove(Tags.Service);
+        globalTags.Remove(Tags.Env);
+        globalTags.Remove(Tags.Version);
+        globalTags.Remove(Ci.Tags.CommonTags.GitCommit);
+        globalTags.Remove(Ci.Tags.CommonTags.GitRepository);
+        GlobalTags = new(globalTags);
+
+        var headerTagsNormalizationFixEnabled = config
+                                               .WithKeys(ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled)
+                                               .AsBool(defaultValue: true);
+
+        // Filter out tags with empty keys or empty values, and trim whitespaces
+        HeaderTags = InitializeHeaderTags(config, ConfigurationKeys.HeaderTags, headerTagsNormalizationFixEnabled) ?? ReadOnlyDictionary.Empty;
+
+        // Filter out tags with empty keys or empty values, and trim whitespaces
+        GrpcTags = InitializeHeaderTags(config, ConfigurationKeys.GrpcTags, headerTagsNormalizationFixEnabled: true) ?? ReadOnlyDictionary.Empty;
+
+        CustomSamplingRules = config.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString();
+
+        GlobalSamplingRate = BuildSampleRate(ErrorLog, in config);
+
+        // We need to record a default value for configuration reporting
+        // However, we need to keep GlobalSamplingRateInternal null because it changes the behavior of the tracer in subtle ways
+        // (= we don't run the sampler at all if it's null, so it changes the tagging of the spans, and it's enforced by system tests)
+        if (GlobalSamplingRate is null)
+        {
+            Telemetry.Record(ConfigurationKeys.GlobalSamplingRate, 1.0, ConfigurationOrigins.Default);
+        }
+
+        StartupDiagnosticLogEnabled = config.WithKeys(ConfigurationKeys.StartupDiagnosticLogEnabled).AsBool(defaultValue: true);
+
+        KafkaCreateConsumerScopeEnabled = config
+                                         .WithKeys(ConfigurationKeys.KafkaCreateConsumerScopeEnabled)
+                                         .AsBool(defaultValue: true);
+        ServiceNameMappings = TracerSettings.InitializeServiceNameMappings(config, ConfigurationKeys.ServiceNameMappings) ?? ReadOnlyDictionary.Empty;
+
+        TracerMetricsEnabled = config
+                              .WithKeys(ConfigurationKeys.TracerMetricsEnabled)
+                              .AsBool(defaultValue: false);
+
+        var httpServerErrorStatusCodes = config
+#pragma warning disable 618 // This config key has been replaced but may still be used
+                                        .WithKeys(ConfigurationKeys.HttpServerErrorStatusCodes, ConfigurationKeys.DeprecatedHttpServerErrorStatusCodes)
+#pragma warning restore 618
+                                        .AsString(defaultValue: "500-599");
+
+        HttpServerErrorStatusCodes = ParseHttpCodesToArray(httpServerErrorStatusCodes);
+
+        var httpClientErrorStatusCodes = config
+#pragma warning disable 618 // This config key has been replaced but may still be used
+                                        .WithKeys(ConfigurationKeys.HttpClientErrorStatusCodes, ConfigurationKeys.DeprecatedHttpClientErrorStatusCodes)
+#pragma warning restore 618
+                                        .AsString(defaultValue: "400-499");
+
+        HttpClientErrorStatusCodes = ParseHttpCodesToArray(httpClientErrorStatusCodes);
+    }
+
+    // Settings that can be set via remote config
+
+    /// <summary>
+    /// Gets a value indicating whether tracing is enabled.
+    /// Default is <c>true</c>.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
+    public bool TraceEnabled { get; }
+
+    /// <summary>
+    /// Gets a value indicating custom sampling rules.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.CustomSamplingRules"/>
+    public string? CustomSamplingRules { get; }
+
+    /// <summary>
+    /// Gets a value indicating a global rate for sampling.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.GlobalSamplingRate"/>
+    public double? GlobalSamplingRate { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether correlation identifiers are
+    /// automatically injected into the logging context.
+    /// Default is <c>true</c>.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.LogsInjectionEnabled"/>
+    public bool LogsInjectionEnabled { get; }
+
+    /// <summary>
+    /// Gets the global tags, which are applied to all <see cref="Span"/>s.
+    /// </summary>
+    public ReadOnlyDictionary<string, string> GlobalTags { get; }
+
+    /// <summary>
+    /// Gets the map of header keys to tag names, which are applied to the root <see cref="Span"/>
+    /// of incoming and outgoing HTTP requests.
+    /// </summary>
+    public ReadOnlyDictionary<string, string> HeaderTags { get; }
+
+    // Additional settings that can be set in code
+
+    // TODO: This one will be hard, we should likely consider something completely different to handle these changes
+    // public const string AgentUriKey = "DD_TRACE_AGENT_URL";
+
+    // TODO: this one is a problem - it can be changed in code, but the data pipeline needs to be enabled/disabled based on it
+    // we will likely need to make a breaking change so that it _can't_ be changed in code
+    // public const string StatsComputationEnabledKey = "DD_TRACE_STATS_COMPUTATION_ENABLED";
+
+    /// <summary>
+    /// Gets a value indicating whether the diagnostic log at startup is enabled
+    /// </summary>
+    public bool StartupDiagnosticLogEnabled { get; }
+
+    /// <summary>
+    /// Gets the default environment name applied to all spans.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.Environment"/>
+    public string? Environment { get; }
+
+    /// <summary>
+    /// Gets the service name applied to top-level spans and used to build derived service names.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.ServiceName"/>
+    public string? ServiceName { get; }
+
+    /// <summary>
+    /// Gets the version tag applied to all spans.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.ServiceVersion"/>
+    public string? ServiceVersion { get; }
+
+    /// <summary>
+    /// Gets the names of disabled integrations.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.DisabledIntegrations"/>
+    public HashSet<string> DisabledIntegrationNames { get; }
+
+    /// <summary>
+    /// Gets the map of metadata keys to tag names, which are applied to the root <see cref="Span"/>
+    /// of incoming and outgoing GRPC requests.
+    /// </summary>
+    public ReadOnlyDictionary<string, string> GrpcTags { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether internal metrics
+    /// are enabled and sent to DogStatsd.
+    /// </summary>
+    public bool TracerMetricsEnabled { get; }
+
+    /// <summary>
+    /// Gets a collection of <see cref="IntegrationSettings"/> keyed by integration name.
+    /// </summary>
+    public IntegrationSettingsCollection Integrations { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether default Analytics are enabled.
+    /// Settings this value is a shortcut for setting
+    /// <see cref="Configuration.IntegrationSettings.AnalyticsEnabled"/> on some predetermined integrations.
+    /// See the documentation for more details.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.GlobalAnalyticsEnabled"/>
+    [Obsolete(DeprecationMessages.AppAnalytics)]
+    public bool AnalyticsEnabled { get; }
+
+    /// <summary>
+    /// Gets a value indicating the maximum number of traces set to AutoKeep (p1) per second.
+    /// Default is <c>100</c>.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.TraceRateLimit"/>
+    public int MaxTracesSubmittedPerSecond { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a span context should be created on exiting a successful Kafka
+    /// Consumer.Consume() call, and closed on entering Consumer.Consume().
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.KafkaCreateConsumerScopeEnabled"/>
+    public bool KafkaCreateConsumerScopeEnabled { get; }
+
+    /// <summary>
+    /// Gets the HTTP status code that should be marked as errors for server integrations.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.HttpServerErrorStatusCodes"/>
+    internal bool[] HttpServerErrorStatusCodes { get; }
+
+    /// <summary>
+    /// Gets the HTTP status code that should be marked as errors for client integrations.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.HttpClientErrorStatusCodes"/>
+    internal bool[] HttpClientErrorStatusCodes { get; }
+
+    /// <summary>
+    /// Gets configuration values for changing service names based on configuration
+    /// </summary>
+    internal ReadOnlyDictionary<string, string> ServiceNameMappings { get; }
+
+    // These ones can't be _directly_ changed, but are dependent on things that _can_
+    // so they are _implicitly_ dynamic
+
+    /// <summary>
+    /// Gets the application's git repository url.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.GitRepositoryUrl"/>
+    internal string? GitRepositoryUrl { get; }
+
+    /// <summary>
+    /// Gets the application's git commit hash.
+    /// </summary>
+    /// <seealso cref="ConfigurationKeys.GitCommitSha"/>
+    internal string? GitCommitSha { get; }
+
+    // Infra
+    internal OverrideErrorLog ErrorLog { get; }
+
+    internal IConfigurationTelemetry Telemetry { get; }
+
+    internal static ReadOnlyDictionary<string, string>? InitializeHeaderTags(ConfigurationBuilder config, string key, bool headerTagsNormalizationFixEnabled)
+    {
+        var configurationDictionary = config
+                                     .WithKeys(key)
+                                     .AsDictionary(allowOptionalMappings: true, defaultValue: null, "[]");
+
+        if (configurationDictionary == null)
+        {
+            return null;
+        }
+
+        var headerTags = new Dictionary<string, string>(configurationDictionary.Count);
+
+        foreach (var kvp in configurationDictionary)
+        {
+            var headerName = kvp.Key.Trim();
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                continue;
+            }
+
+            if (InitializeHeaderTag(tagName: kvp.Value, headerTagsNormalizationFixEnabled, out var finalTagName))
+            {
+                headerTags.Add(headerName, finalTagName);
+            }
+        }
+
+        return new(headerTags);
+    }
+
+    internal static bool InitializeHeaderTag(
+        string? tagName,
+        bool headerTagsNormalizationFixEnabled,
+        [NotNullWhen(true)] out string? finalTagName)
+    {
+        tagName = tagName?.Trim();
+
+        if (string.IsNullOrEmpty(tagName))
+        {
+            // The user did not provide a tag name. Normalization will happen later, when adding the tag prefix.
+            finalTagName = string.Empty;
+            return true;
+        }
+
+        if (!SpanTagHelper.IsValidTagName(tagName!, out tagName))
+        {
+            // invalid tag name
+            finalTagName = null;
+            return false;
+        }
+
+        if (headerTagsNormalizationFixEnabled)
+        {
+            // Default code path: if the user provided a tag name, don't try to normalize it.
+            finalTagName = tagName;
+            return true;
+        }
+
+        // user opted via feature flag into the previous behavior,
+        // where tag names were normalized even when specified
+        // (but _not_ spaces, due to a bug in the normalization code)
+        return SpanTagHelper.TryNormalizeTagName(tagName, normalizeSpaces: false, out finalTagName);
+    }
+
+    internal static bool[] ParseHttpCodesToArray(string httpStatusErrorCodes)
+    {
+        bool[] httpErrorCodesArray = new bool[600];
+
+        void TrySetValue(int index)
+        {
+            if (index >= 0 && index < httpErrorCodesArray.Length)
+            {
+                httpErrorCodesArray[index] = true;
+            }
+        }
+
+        string[] configurationsArray = httpStatusErrorCodes.Replace(" ", string.Empty).Split(',');
+
+        foreach (string statusConfiguration in configurationsArray)
+        {
+            int startStatus;
+
+            // Checks that the value about to be used follows the `401-404` structure or single 3 digit number i.e. `401` else log the warning
+            if (!Regex.IsMatch(statusConfiguration, @"^\d{3}-\d{3}$|^\d{3}$"))
+            {
+                // TODO: this should be logged in telemetry or the ErrorLog override or something
+                // Log.Warning("Wrong format '{0}' for DD_TRACE_HTTP_SERVER/CLIENT_ERROR_STATUSES configuration.", statusConfiguration);
+            }
+
+            // If statusConfiguration equals a single value i.e. `401` parse the value and save to the array
+            else if (int.TryParse(statusConfiguration, out startStatus))
+            {
+                TrySetValue(startStatus);
+            }
+            else
+            {
+                string[] statusCodeLimitsRange = statusConfiguration.Split('-');
+
+                startStatus = int.Parse(statusCodeLimitsRange[0]);
+                int endStatus = int.Parse(statusCodeLimitsRange[1]);
+
+                if (endStatus < startStatus)
+                {
+                    startStatus = endStatus;
+                    endStatus = int.Parse(statusCodeLimitsRange[0]);
+                }
+
+                for (int statusCode = startStatus; statusCode <= endStatus; statusCode++)
+                {
+                    TrySetValue(statusCode);
+                }
+            }
+        }
+
+        return httpErrorCodesArray;
+    }
+
+    internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)
+    {
+        var source = serverStatusCode ? HttpServerErrorStatusCodes : HttpClientErrorStatusCodes;
+
+        if (source == null)
+        {
+            return false;
+        }
+
+        if (statusCode >= source.Length)
+        {
+            return false;
+        }
+
+        return source[statusCode];
+    }
+
+    internal bool IsIntegrationEnabled(IntegrationId integration, bool defaultValue = true)
+    {
+        if (TraceEnabled && !_domainMetadata.ShouldAvoidAppDomain())
+        {
+            return Integrations[integration].Enabled ?? defaultValue;
+        }
+
+        return false;
+    }
+
+    [Obsolete(DeprecationMessages.AppAnalytics)]
+    internal double? GetIntegrationAnalyticsSampleRate(IntegrationId integration, bool enabledWithGlobalSetting)
+    {
+        var integrationSettings = Integrations[integration];
+        var analyticsEnabled = integrationSettings.AnalyticsEnabled ?? (enabledWithGlobalSetting && AnalyticsEnabled);
+        return analyticsEnabled ? integrationSettings.AnalyticsSampleRate : (double?)null;
+    }
+
+    private static ConfigurationBuilder.ClassConfigurationResultWithKey<IDictionary<string, string>> RemapOtelTags(
+        in ConfigurationBuilder.ClassConfigurationResultWithKey<IDictionary<string, string>> original)
+    {
+        if (original.ConfigurationResult is { IsValid: true, Result: { } values })
+        {
+            // Update well-known service information resources
+            if (values.TryGetValue("deployment.environment", out var envValue))
+            {
+                values.Remove("deployment.environment");
+                values[Tags.Env] = envValue;
+            }
+
+            if (values.TryGetValue("service.name", out var serviceValue))
+            {
+                values.Remove("service.name");
+                values[Tags.Service] = serviceValue;
+            }
+
+            if (values.TryGetValue("service.version", out var versionValue))
+            {
+                values.Remove("service.version");
+                values[Tags.Version] = versionValue;
+            }
+        }
+
+        return original;
+    }
+
+    private static void RecordDisabledIntegrationsTelemetry(IntegrationSettingsCollection integrations, IConfigurationTelemetry telemetry)
+    {
+        // Record the final disabled settings values in the telemetry, we can't quite get this information
+        // through the IntegrationTelemetryCollector currently so record it here instead
+        StringBuilder? sb = null;
+
+        foreach (var setting in integrations.Settings)
+        {
+            if (setting.Enabled == false)
+            {
+                sb ??= StringBuilderCache.Acquire();
+                sb.Append(setting.IntegrationName);
+                sb.Append(';');
+            }
+        }
+
+        var value = sb is null ? null : StringBuilderCache.GetStringAndRelease(sb);
+        telemetry.Record(ConfigurationKeys.DisabledIntegrations, value, recordValue: true, ConfigurationOrigins.Calculated);
+    }
+
+    private static double? BuildSampleRate(OverrideErrorLog log, in ConfigurationBuilder config)
+    {
+        // The "overriding" is complex, so we can't use the usual `OverrideWith()` approach
+        var ddSampleRate = config.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDoubleResult();
+        var otelSampleType = config.WithKeys(ConfigurationKeys.OpenTelemetry.TracesSampler).AsStringResult();
+        var otelSampleRate = config.WithKeys(ConfigurationKeys.OpenTelemetry.TracesSamplerArg).AsDoubleResult();
+
+        double? ddResult = ddSampleRate.ConfigurationResult.IsValid ? ddSampleRate.ConfigurationResult.Result : null;
+
+        // more complex, so can't use built-in `Merge()` support
+        if (ddSampleRate.ConfigurationResult.IsPresent)
+        {
+            if (otelSampleType.ConfigurationResult.IsPresent)
+            {
+                log.LogDuplicateConfiguration(ddSampleRate.Key, otelSampleType.Key);
+            }
+
+            if (otelSampleRate.ConfigurationResult.IsPresent)
+            {
+                log.LogDuplicateConfiguration(ddSampleRate.Key, otelSampleRate.Key);
+            }
+        }
+        else if (otelSampleType.ConfigurationResult is { IsValid: true, Result: { } samplerName })
+        {
+            const string parentbasedAlwaysOn = "parentbased_always_on";
+            const string parentbasedAlwaysOff = "parentbased_always_off";
+            const string parentbasedTraceidratio = "parentbased_traceidratio";
+
+            string? supportedSamplerName = samplerName switch
+            {
+                parentbasedAlwaysOn => parentbasedAlwaysOn,
+                "always_on" => parentbasedAlwaysOn,
+                parentbasedAlwaysOff => parentbasedAlwaysOff,
+                "always_off" => parentbasedAlwaysOff,
+                parentbasedTraceidratio => parentbasedTraceidratio,
+                "traceidratio" => parentbasedTraceidratio,
+                _ => null,
+            };
+
+            if (supportedSamplerName is null)
+            {
+                log.EnqueueAction(
+                    (log, _) =>
+                    {
+                        log.Warning(
+                            "OpenTelemetry configuration {OpenTelemetryConfiguration}={OpenTelemetryValue} is not supported. Using default configuration.",
+                            otelSampleType.Key,
+                            samplerName);
+                    });
+                return ddResult;
+            }
+
+            if (!string.Equals(samplerName, supportedSamplerName, StringComparison.OrdinalIgnoreCase))
+            {
+                log.LogUnsupportedConfiguration(otelSampleType.Key, samplerName, supportedSamplerName);
+            }
+
+            var openTelemetrySampleRateResult = supportedSamplerName switch
+            {
+                parentbasedAlwaysOn => ConfigurationResult<double>.Valid(1.0),
+                parentbasedAlwaysOff => ConfigurationResult<double>.Valid(0.0),
+                parentbasedTraceidratio => otelSampleRate.ConfigurationResult,
+                _ => ConfigurationResult<double>.ParseFailure(),
+            };
+
+            if (openTelemetrySampleRateResult is { Result: { } sampleRateResult, IsValid: true })
+            {
+                return sampleRateResult;
+            }
+
+            log.LogInvalidConfiguration(otelSampleRate.Key);
+        }
+
+        return ddResult;
+    }
+
+    private string? GetExplicitSettingOrTag(
+        string? explicitSetting,
+        Dictionary<string, string> globalTags,
+        string tag,
+        string telemetryKey)
+    {
+        string? result = null;
+        if (!string.IsNullOrWhiteSpace(explicitSetting))
+        {
+            result = explicitSetting!.Trim();
+            if (result != explicitSetting)
+            {
+                Telemetry.Record(telemetryKey, result, recordValue: true, ConfigurationOrigins.Calculated);
+            }
+        }
+        else
+        {
+            var version = globalTags.GetValueOrDefault(tag);
+            if (!string.IsNullOrWhiteSpace(version))
+            {
+                result = version.Trim();
+                Telemetry.Record(telemetryKey, result, recordValue: true, ConfigurationOrigins.Calculated);
+            }
+        }
+
+        return result;
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -636,7 +636,7 @@ namespace Datadog.Trace.Configuration
                 config.WithKeys(ConfigurationKeys.GraphQLErrorExtensions).AsString(),
                 commaSeparator);
 
-            MutableSettings = new MutableSettings(source, telemetry, errorLog, this);
+            MutableSettings = MutableSettings.Create(source, telemetry, errorLog, this);
         }
 
         internal bool IsRunningInCiVisibility { get; }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -6,16 +6,10 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using Datadog.Trace.Agent;
-using Datadog.Trace.Ci;
-using Datadog.Trace.Ci.CiEnvironment;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
@@ -23,11 +17,9 @@ using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.LibDatadog;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
-using Datadog.Trace.Processors;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.SourceGenerators;
-using Datadog.Trace.Tagging;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
@@ -46,16 +38,6 @@ namespace Datadog.Trace.Configuration
         };
 
         private readonly IConfigurationTelemetry _telemetry;
-        // we cached the static instance here, because is being used in the hotpath
-        // by IsIntegrationEnabled method (called from all integrations)
-        private readonly DomainMetadata _domainMetadata = DomainMetadata.Instance;
-        // These values can all be overwritten by dynamic config
-        private readonly bool _traceEnabled;
-        private readonly bool _logsInjectionEnabled;
-        private readonly ReadOnlyDictionary<string, string> _headerTags;
-        private readonly ReadOnlyDictionary<string, string> _globalTags;
-        private readonly double? _globalSamplingRate;
-        private readonly string? _customSamplingRules;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values.
@@ -125,9 +107,9 @@ namespace Datadog.Trace.Configuration
             IsRunningInGCPFunctions = GCPFunctionSettings.IsGCPFunction;
 
             // We don't want/need to record this value, so explicitly use null telemetry
-            var isRunningInCiVisibility = new ConfigurationBuilder(source, NullConfigurationTelemetry.Instance)
-                                         .WithKeys(ConfigurationKeys.CIVisibility.IsRunningInCiVisMode)
-                                         .AsBool(false);
+            IsRunningInCiVisibility = new ConfigurationBuilder(source, NullConfigurationTelemetry.Instance)
+                                     .WithKeys(ConfigurationKeys.CIVisibility.IsRunningInCiVisMode)
+                                     .AsBool(false);
 
             LambdaMetadata = LambdaMetadata.Create();
 
@@ -136,177 +118,13 @@ namespace Datadog.Trace.Configuration
                 AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(source, _telemetry);
             }
 
-            var otelTags = config
-                          .WithKeys(ConfigurationKeys.OpenTelemetry.ResourceAttributes)
-                          .AsDictionaryResult(separator: '=');
-
-            Dictionary<string, string>? globalTags = default;
-            if (ExperimentalFeaturesEnabled.Contains("DD_TAGS"))
-            {
-                // New behavior: If ExperimentalFeaturesEnabled configures DD_TAGS, we want to change DD_TAGS parsing to do the following:
-                // 1. If a comma is in the value, split on comma as before. Otherwise, split on space
-                // 2. Key-value pairs with empty values are allowed, instead of discarded
-                // 3. Key-value pairs without values (i.e. no `:` separator) are allowed and treated as key-value pairs with empty values, instead of discarded
-                Func<string, IDictionary<string, string>> updatedTagsParser = (data) =>
-                {
-                    var dictionary = new ConcurrentDictionary<string, string>();
-                    if (string.IsNullOrWhiteSpace(data))
-                    {
-                        // return empty collection
-                        return dictionary;
-                    }
-
-                    char[] separatorChars = data.Contains(',') ? [','] : [' '];
-                    var entries = data.Split(separatorChars, StringSplitOptions.RemoveEmptyEntries);
-
-                    foreach (var entry in entries)
-                    {
-                        // we need Trim() before looking forthe separator so we can skip entries with no key
-                        // (that is, entries with a leading separator, like "<empty or whitespace>:value")
-                        var trimmedEntry = entry.Trim();
-                        if (trimmedEntry.Length == 0 || trimmedEntry[0] == ':')
-                        {
-                            continue;
-                        }
-
-                        var separatorIndex = trimmedEntry.IndexOf(':');
-                        if (separatorIndex < 0)
-                        {
-                            // entries with no separator are allowed (e.g. key1 and key3 in "key1, key2:value2, key3"),
-                            // it's a key with no value.
-                            var key = trimmedEntry;
-                            dictionary[key] = string.Empty;
-                        }
-                        else if (separatorIndex > 0)
-                        {
-                            // if a separator is present with no value, we take the value to be empty (e.g. "key1:, key2: ").
-                            // note we already did Trim() on the entire entry, so the key portion only needs TrimEnd().
-                            var key = trimmedEntry.Substring(0, separatorIndex).TrimEnd();
-                            var value = trimmedEntry.Substring(separatorIndex + 1).Trim();
-                            dictionary[key] = value;
-                        }
-                    }
-
-                    return dictionary;
-                };
-
-                globalTags = config
-                                .WithKeys(ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
-                                .AsDictionaryResult(parser: updatedTagsParser)
-                                .OverrideWith(
-                                     RemapOtelTags(in otelTags),
-                                     ErrorLog,
-                                     () => new DefaultResult<IDictionary<string, string>>(new Dictionary<string, string>(), string.Empty))
-
-                                // Filter out tags with empty keys, and trim whitespace
-                                .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key))
-                                .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value?.Trim() ?? string.Empty);
-            }
-            else
-            {
-                globalTags = config
-                                .WithKeys(ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
-                                .AsDictionaryResult()
-                                .OverrideWith(
-                                     RemapOtelTags(in otelTags),
-                                     ErrorLog,
-                                     () => new DefaultResult<IDictionary<string, string>>(new Dictionary<string, string>(), string.Empty))
-
-                                // Filter out tags with empty keys or empty values, and trim whitespace
-                                .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
-                                .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
-            }
-
-            Environment = config
-                         .WithKeys(ConfigurationKeys.Environment)
-                         .AsString();
-
-            // DD_ENV has precedence over DD_TAGS
-            Environment = GetExplicitSettingOrTag(Environment, globalTags!, Tags.Env, ConfigurationKeys.Environment);
-
-            var otelServiceName = config.WithKeys(ConfigurationKeys.OpenTelemetry.ServiceName).AsStringResult();
-            var serviceName = config
-                                 .WithKeys(ConfigurationKeys.ServiceName, "DD_SERVICE_NAME")
-                                 .AsStringResult()
-                                 .OverrideWith(in otelServiceName, ErrorLog);
-
-            // DD_SERVICE has precedence over DD_TAGS
-            serviceName = GetExplicitSettingOrTag(serviceName, globalTags, Tags.Service, ConfigurationKeys.ServiceName);
-
-            if (isRunningInCiVisibility)
-            {
-                // Set the service name if not set
-                var isUserProvidedTestServiceTag = true;
-                var ciVisServiceName = serviceName;
-                if (string.IsNullOrEmpty(serviceName))
-                {
-                    // Extract repository name from the git url and use it as a default service name.
-                    ciVisServiceName = TestOptimization.Instance.TracerManagement?.GetServiceNameFromRepository(CIEnvironmentValues.Instance.Repository);
-                    isUserProvidedTestServiceTag = false;
-                }
-
-                globalTags[Ci.Tags.CommonTags.UserProvidedTestServiceTag] = isUserProvidedTestServiceTag ? "true" : "false";
-
-                // Normalize the service name
-                ciVisServiceName = NormalizerTraceProcessor.NormalizeService(ciVisServiceName);
-                if (ciVisServiceName != serviceName)
-                {
-                    serviceName = ciVisServiceName;
-                    telemetry.Record(ConfigurationKeys.ServiceName, serviceName, recordValue: true, ConfigurationOrigins.Calculated);
-                }
-            }
-
-            ServiceName = serviceName;
-
-            ServiceVersion = config
-                            .WithKeys(ConfigurationKeys.ServiceVersion)
-                            .AsString();
-
-            // DD_VERSION has precedence over DD_TAGS
-            ServiceVersion = GetExplicitSettingOrTag(ServiceVersion, globalTags, Tags.Version, ConfigurationKeys.ServiceVersion);
-
-            GitCommitSha = config
-                          .WithKeys(ConfigurationKeys.GitCommitSha)
-                          .AsString();
-
-            // DD_GIT_COMMIT_SHA has precedence over DD_TAGS
-            GitCommitSha = GetExplicitSettingOrTag(GitCommitSha, globalTags, Ci.Tags.CommonTags.GitCommit, ConfigurationKeys.GitCommitSha);
-
-            GitRepositoryUrl = config
-                              .WithKeys(ConfigurationKeys.GitRepositoryUrl)
-                              .AsString();
-
-            // DD_GIT_REPOSITORY_URL has precedence over DD_TAGS
-            GitRepositoryUrl = GetExplicitSettingOrTag(GitRepositoryUrl, globalTags, Ci.Tags.CommonTags.GitRepository, ConfigurationKeys.GitRepositoryUrl);
-
             GitMetadataEnabled = config
                                 .WithKeys(ConfigurationKeys.GitMetadataEnabled)
                                 .AsBool(defaultValue: true);
 
-            var otelTraceEnabled = config
-                                  .WithKeys(ConfigurationKeys.OpenTelemetry.TracesExporter)
-                                  .AsBoolResult(
-                                       value => string.Equals(value, "none", StringComparison.OrdinalIgnoreCase)
-                                                    ? ParsingResult<bool>.Success(result: false)
-                                                    : ParsingResult<bool>.Failure());
-            _traceEnabled = config
-                                  .WithKeys(ConfigurationKeys.TraceEnabled)
-                                  .AsBoolResult()
-                                  .OverrideWith(in otelTraceEnabled, ErrorLog, defaultValue: true);
-
             ApmTracingEnabled = config
                                       .WithKeys(ConfigurationKeys.ApmTracingEnabled)
                                       .AsBool(defaultValue: true);
-
-            _logsInjectionEnabled = config
-                                         .WithKeys(ConfigurationKeys.LogsInjectionEnabled)
-                                         .AsBool(defaultValue: true);
-
-            if (AzureAppServiceMetadata?.IsUnsafeToTrace == true)
-            {
-                telemetry.Record(ConfigurationKeys.TraceEnabled, false, ConfigurationOrigins.Calculated);
-                _traceEnabled = false;
-            }
 
             var otelActivityListenerEnabled = config
                                              .WithKeys(ConfigurationKeys.OpenTelemetry.SdkDisabled)
@@ -319,47 +137,7 @@ namespace Datadog.Trace.Configuration
                                        .AsBoolResult()
                                        .OverrideWith(in otelActivityListenerEnabled, ErrorLog, defaultValue: false);
 
-            var disabledIntegrationNames = config.WithKeys(ConfigurationKeys.DisabledIntegrations)
-                                                 .AsString()
-                                                ?.Split([';'], StringSplitOptions.RemoveEmptyEntries) ?? [];
-
-            // If Activity support is enabled, we shouldn't enable the OTel listener
-            DisabledIntegrationNames = IsActivityListenerEnabled
-                                           ? new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase)
-                                           : new HashSet<string>([..disabledIntegrationNames, nameof(IntegrationId.OpenTelemetry)], StringComparer.OrdinalIgnoreCase);
-
-            Integrations = new IntegrationSettingsCollection(source, DisabledIntegrationNames);
-            RecordDisabledIntegrationsTelemetry(Integrations, Telemetry);
-
             Exporter = new ExporterSettings(source, _telemetry);
-
-#pragma warning disable 618 // App analytics is deprecated, but still used
-            AnalyticsEnabled = config.WithKeys(ConfigurationKeys.GlobalAnalyticsEnabled)
-                                                   .AsBool(defaultValue: false);
-#pragma warning restore 618
-
-#pragma warning disable 618 // this parameter has been replaced but may still be used
-            MaxTracesSubmittedPerSecond = config
-                                         .WithKeys(ConfigurationKeys.TraceRateLimit, ConfigurationKeys.MaxTracesSubmittedPerSecond)
-#pragma warning restore 618
-                                         .AsInt32(defaultValue: 100);
-
-            // mutate dictionary to remove without "env", "version", "git.commit.sha" or "git.repository.url" tags
-            // these value are used for "Environment" and "ServiceVersion", "GitCommitSha" and "GitRepositoryUrl" properties
-            // or overriden with DD_ENV, DD_VERSION, DD_GIT_COMMIT_SHA and DD_GIT_REPOSITORY_URL respectively
-            globalTags.Remove(Tags.Service);
-            globalTags.Remove(Tags.Env);
-            globalTags.Remove(Tags.Version);
-            globalTags.Remove(Ci.Tags.CommonTags.GitCommit);
-            globalTags.Remove(Ci.Tags.CommonTags.GitRepository);
-            _globalTags = new(globalTags);
-
-            var headerTagsNormalizationFixEnabled = config
-                                               .WithKeys(ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled)
-                                               .AsBool(defaultValue: true);
-
-            // Filter out tags with empty keys or empty values, and trim whitespaces
-            _headerTags = InitializeHeaderTags(config, ConfigurationKeys.HeaderTags, headerTagsNormalizationFixEnabled) ?? ReadOnlyDictionary.Empty;
 
             PeerServiceTagsEnabled = config
                .WithKeys(ConfigurationKeys.PeerServiceDefaultsEnabled)
@@ -384,12 +162,6 @@ namespace Datadog.Trace.Configuration
                                             _ => ParsingResult<SchemaVersion>.Failure(),
                                         },
                                         validator: null);
-
-            ServiceNameMappings = InitializeServiceNameMappings(config, ConfigurationKeys.ServiceNameMappings) ?? ReadOnlyDictionary.Empty;
-
-            TracerMetricsEnabled = config
-                                  .WithKeys(ConfigurationKeys.TracerMetricsEnabled)
-                                  .AsBool(defaultValue: false);
 
             StatsComputationInterval = config.WithKeys(ConfigurationKeys.StatsComputationInterval).AsInt32(defaultValue: 10);
 
@@ -547,9 +319,6 @@ namespace Datadog.Trace.Configuration
 
             // We should also be writing telemetry for OTEL_LOGS_EXPORTER similar to OTEL_METRICS_EXPORTER, but we don't have a corresponding Datadog config
             // When we do, we can insert that here
-
-            _customSamplingRules = config.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString();
-
             CustomSamplingRulesFormat = config.WithKeys(ConfigurationKeys.CustomSamplingRulesFormat)
                                               .GetAs(
                                                    defaultValue: new DefaultResult<string>(SamplingRulesFormat.Glob, "glob"),
@@ -579,34 +348,6 @@ namespace Datadog.Trace.Configuration
 
             SpanSamplingRules = config.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString();
 
-            _globalSamplingRate = BuildSampleRate(ErrorLog, in config);
-
-            // We need to record a default value for configuration reporting
-            // However, we need to keep GlobalSamplingRateInternal null because it changes the behavior of the tracer in subtle ways
-            // (= we don't run the sampler at all if it's null, so it changes the tagging of the spans, and it's enforced by system tests)
-            if (GlobalSamplingRate is null)
-            {
-                _telemetry.Record(ConfigurationKeys.GlobalSamplingRate, 1.0, ConfigurationOrigins.Default);
-            }
-
-            StartupDiagnosticLogEnabled = config.WithKeys(ConfigurationKeys.StartupDiagnosticLogEnabled).AsBool(defaultValue: true);
-
-            var httpServerErrorStatusCodes = config
-#pragma warning disable 618 // This config key has been replaced but may still be used
-                                            .WithKeys(ConfigurationKeys.HttpServerErrorStatusCodes, ConfigurationKeys.DeprecatedHttpServerErrorStatusCodes)
-#pragma warning restore 618
-                                            .AsString(defaultValue: "500-599");
-
-            HttpServerErrorStatusCodes = ParseHttpCodesToArray(httpServerErrorStatusCodes);
-
-            var httpClientErrorStatusCodes = config
-#pragma warning disable 618 // This config key has been replaced but may still be used
-                                            .WithKeys(ConfigurationKeys.HttpClientErrorStatusCodes, ConfigurationKeys.DeprecatedHttpClientErrorStatusCodes)
-#pragma warning restore 618
-                                            .AsString(defaultValue: "400-499");
-
-            HttpClientErrorStatusCodes = ParseHttpCodesToArray(httpClientErrorStatusCodes);
-
             TraceBufferSize = config
                              .WithKeys(ConfigurationKeys.BufferSize)
                              .AsInt32(defaultValue: 1024 * 1024 * 10); // 10MB
@@ -626,10 +367,6 @@ namespace Datadog.Trace.Configuration
             ExpandRouteTemplatesEnabled = config
                                          .WithKeys(ConfigurationKeys.ExpandRouteTemplatesEnabled)
                                          .AsBool(defaultValue: !RouteTemplateResourceNamesEnabled); // disabled by default if route template resource names enabled
-
-            KafkaCreateConsumerScopeEnabled = config
-                                             .WithKeys(ConfigurationKeys.KafkaCreateConsumerScopeEnabled)
-                                             .AsBool(defaultValue: true);
 
             DelayWcfInstrumentationEnabled = config
                                             .WithKeys(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
@@ -734,10 +471,6 @@ namespace Datadog.Trace.Configuration
                           .WithKeys(ConfigurationKeys.TraceMethods)
                           .AsString(string.Empty);
 
-            // Filter out tags with empty keys or empty values, and trim whitespaces
-            GrpcTags = InitializeHeaderTags(config, ConfigurationKeys.GrpcTags, headerTagsNormalizationFixEnabled: true)
-                     ?? ReadOnlyDictionary.Empty;
-
             OutgoingTagPropagationHeaderMaxLength = config
                                                    .WithKeys(ConfigurationKeys.TagPropagation.HeaderMaxLength)
                                                    .AsInt32(
@@ -790,7 +523,7 @@ namespace Datadog.Trace.Configuration
                                    .WithKeys(ConfigurationKeys.HttpClientExcludedUrlSubstrings)
                                    .AsString(GetDefaultHttpClientExclusions());
 
-            if (isRunningInCiVisibility)
+            if (IsRunningInCiVisibility)
             {
                 // always add the additional exclude in ci vis
                 const string fakeSessionEndpoint = "/session/FakeSessionIdForPollingPurposes";
@@ -903,26 +636,10 @@ namespace Datadog.Trace.Configuration
                 config.WithKeys(ConfigurationKeys.GraphQLErrorExtensions).AsString(),
                 commaSeparator);
 
-            static void RecordDisabledIntegrationsTelemetry(IntegrationSettingsCollection integrations, IConfigurationTelemetry telemetry)
-            {
-                // Record the final disabled settings values in the telemetry, we can't quite get this information
-                // through the IntegrationTelemetryCollector currently so record it here instead
-                StringBuilder? sb = null;
-
-                foreach (var setting in integrations.Settings)
-                {
-                    if (setting.Enabled == false)
-                    {
-                        sb ??= StringBuilderCache.Acquire();
-                        sb.Append(setting.IntegrationName);
-                        sb.Append(';');
-                    }
-                }
-
-                var value = sb is null ? null : StringBuilderCache.GetStringAndRelease(sb);
-                telemetry.Record(ConfigurationKeys.DisabledIntegrations, value, recordValue: true, ConfigurationOrigins.Calculated);
-            }
+            MutableSettings = new MutableSettings(source, telemetry, errorLog, this);
         }
+
+        internal bool IsRunningInCiVisibility { get; }
 
         internal HashSet<string> ExperimentalFeaturesEnabled { get; }
 
@@ -930,35 +647,22 @@ namespace Datadog.Trace.Configuration
 
         internal IConfigurationTelemetry Telemetry => _telemetry;
 
-        /// <summary>
-        /// Gets the default environment name applied to all spans.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.Environment"/>
-        public string? Environment { get; }
+        internal MutableSettings MutableSettings { get; }
 
-        /// <summary>
-        /// Gets the service name applied to top-level spans and used to build derived service names.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.ServiceName"/>
-        public string? ServiceName { get; }
+        /// <inheritdoc cref="MutableSettings.Environment"/>
+        public string? Environment => MutableSettings.Environment;
 
-        /// <summary>
-        /// Gets the version tag applied to all spans.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.ServiceVersion"/>
-        public string? ServiceVersion { get; }
+        /// <inheritdoc cref="MutableSettings.ServiceName"/>
+        public string? ServiceName => MutableSettings.ServiceName;
 
-        /// <summary>
-        /// Gets the application's git repository url.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.GitRepositoryUrl"/>
-        internal string? GitRepositoryUrl { get; }
+        /// <inheritdoc cref="MutableSettings.ServiceVersion"/>
+        public string? ServiceVersion => MutableSettings.ServiceVersion;
 
-        /// <summary>
-        /// Gets the application's git commit hash.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.GitCommitSha"/>
-        internal string? GitCommitSha { get; }
+        /// <inheritdoc cref="MutableSettings.GitRepositoryUrl"/>
+        internal string? GitRepositoryUrl => MutableSettings.GitRepositoryUrl;
+
+        /// <inheritdoc cref="MutableSettings.GitCommitSha"/>
+        internal string? GitCommitSha => MutableSettings.GitCommitSha;
 
         /// <summary>
         /// Gets a value indicating whether we should tag every telemetry event with git metadata.
@@ -967,12 +671,8 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.GitMetadataEnabled"/>
         internal bool GitMetadataEnabled { get; }
 
-        /// <summary>
-        /// Gets a value indicating whether tracing is enabled.
-        /// Default is <c>true</c>.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
-        public bool TraceEnabled => DynamicSettings.TraceEnabled ?? _traceEnabled;
+        /// <inheritdoc cref="MutableSettings.TraceEnabled"/>
+        public bool TraceEnabled => DynamicSettings.TraceEnabled ?? MutableSettings.TraceEnabled;
 
         /// <summary>
         /// Gets a value indicating whether APM traces are enabled.
@@ -981,11 +681,8 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.ApmTracingEnabled"/>
         internal bool ApmTracingEnabled { get; }
 
-        /// <summary>
-        /// Gets the names of disabled integrations.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.DisabledIntegrations"/>
-        public HashSet<string> DisabledIntegrationNames { get; }
+        /// <inheritdoc cref="MutableSettings.DisabledIntegrationNames"/>
+        public HashSet<string> DisabledIntegrationNames => MutableSettings.DisabledIntegrationNames;
 
         /// <summary>
         /// Gets a value indicating whether OpenTelemetry Metrics are enabled.
@@ -1072,36 +769,18 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public ExporterSettings Exporter { get; }
 
-        /// <summary>
-        /// Gets a value indicating whether default Analytics are enabled.
-        /// Settings this value is a shortcut for setting
-        /// <see cref="Configuration.IntegrationSettings.AnalyticsEnabled"/> on some predetermined integrations.
-        /// See the documentation for more details.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.GlobalAnalyticsEnabled"/>
+        /// <inheritdoc cref="MutableSettings.AnalyticsEnabled"/>
         [Obsolete(DeprecationMessages.AppAnalytics)]
-        public bool AnalyticsEnabled { get; }
+        public bool AnalyticsEnabled => MutableSettings.AnalyticsEnabled;
 
-        /// <summary>
-        /// Gets a value indicating whether correlation identifiers are
-        /// automatically injected into the logging context.
-        /// Default is <c>true</c>.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.LogsInjectionEnabled"/>
-        public bool LogsInjectionEnabled => DynamicSettings.LogsInjectionEnabled ?? _logsInjectionEnabled;
+        /// <inheritdoc cref="MutableSettings.LogsInjectionEnabled"/>
+        public bool LogsInjectionEnabled => DynamicSettings.LogsInjectionEnabled ?? MutableSettings.LogsInjectionEnabled;
 
-        /// <summary>
-        /// Gets a value indicating the maximum number of traces set to AutoKeep (p1) per second.
-        /// Default is <c>100</c>.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.TraceRateLimit"/>
-        public int MaxTracesSubmittedPerSecond { get; }
+        /// <inheritdoc cref="MutableSettings.MaxTracesSubmittedPerSecond"/>
+        public int MaxTracesSubmittedPerSecond => MutableSettings.MaxTracesSubmittedPerSecond;
 
-        /// <summary>
-        /// Gets a value indicating custom sampling rules.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.CustomSamplingRules"/>
-        public string? CustomSamplingRules => DynamicSettings.SamplingRules ?? _customSamplingRules;
+        /// <inheritdoc cref="MutableSettings.CustomSamplingRules"/>
+        public string? CustomSamplingRules => DynamicSettings.SamplingRules ?? MutableSettings.CustomSamplingRules;
 
         internal bool CustomSamplingRulesIsRemote => DynamicSettings.SamplingRules != null;
 
@@ -1118,27 +797,17 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.SpanSamplingRules"/>
         internal string? SpanSamplingRules { get; }
 
-        /// <summary>
-        /// Gets a value indicating a global rate for sampling.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.GlobalSamplingRate"/>
-        public double? GlobalSamplingRate => DynamicSettings.GlobalSamplingRate ?? _globalSamplingRate;
+        /// <inheritdoc cref="MutableSettings.GlobalSamplingRate"/>
+        public double? GlobalSamplingRate => DynamicSettings.GlobalSamplingRate ?? MutableSettings.GlobalSamplingRate;
 
-        /// <summary>
-        /// Gets a collection of <see cref="IntegrationSettings"/> keyed by integration name.
-        /// </summary>
-        public IntegrationSettingsCollection Integrations { get; }
+        /// <inheritdoc cref="MutableSettings.Integrations"/>
+        public IntegrationSettingsCollection Integrations => MutableSettings.Integrations;
 
-        /// <summary>
-        /// Gets the global tags, which are applied to all <see cref="Span"/>s.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> GlobalTags => DynamicSettings.GlobalTags ?? _globalTags;
+        /// <inheritdoc cref="MutableSettings.GlobalTags"/>
+        public IReadOnlyDictionary<string, string> GlobalTags => DynamicSettings.GlobalTags ?? MutableSettings.GlobalTags;
 
-        /// <summary>
-        /// Gets the map of header keys to tag names, which are applied to the root <see cref="Span"/>
-        /// of incoming and outgoing HTTP requests.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> HeaderTags => DynamicSettings.HeaderTags ?? _headerTags;
+        /// <inheritdoc cref="MutableSettings.HeaderTags"/>
+        public IReadOnlyDictionary<string, string> HeaderTags => DynamicSettings.HeaderTags ?? MutableSettings.HeaderTags;
 
         /// <summary>
         /// Gets a custom request header configured to read the ip from. For backward compatibility, it fallbacks on DD_APPSEC_IPHEADER
@@ -1150,17 +819,11 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         internal bool IpHeaderEnabled { get; }
 
-        /// <summary>
-        /// Gets the map of metadata keys to tag names, which are applied to the root <see cref="Span"/>
-        /// of incoming and outgoing GRPC requests.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> GrpcTags { get; }
+        /// <inheritdoc cref="MutableSettings.GrpcTags"/>
+        public IReadOnlyDictionary<string, string> GrpcTags => MutableSettings.GrpcTags;
 
-        /// <summary>
-        /// Gets a value indicating whether internal metrics
-        /// are enabled and sent to DogStatsd.
-        /// </summary>
-        public bool TracerMetricsEnabled { get; }
+        /// <inheritdoc cref="MutableSettings.TracerMetricsEnabled"/>
+        public bool TracerMetricsEnabled => MutableSettings.TracerMetricsEnabled;
 
         /// <summary>
         /// Gets a value indicating whether stats are computed on the tracer side
@@ -1187,12 +850,8 @@ namespace Datadog.Trace.Configuration
             }
         }
 
-        /// <summary>
-        /// Gets a value indicating whether a span context should be created on exiting a successful Kafka
-        /// Consumer.Consume() call, and closed on entering Consumer.Consume().
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.KafkaCreateConsumerScopeEnabled"/>
-        public bool KafkaCreateConsumerScopeEnabled { get; }
+        /// <inheritdoc cref="MutableSettings.KafkaCreateConsumerScopeEnabled"/>
+        public bool KafkaCreateConsumerScopeEnabled => MutableSettings.KafkaCreateConsumerScopeEnabled;
 
         /// <summary>
         /// Gets a value indicating whether to enable the updated WCF instrumentation that delays execution
@@ -1245,7 +904,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets a value indicating whether the diagnostic log at startup is enabled
         /// </summary>
-        public bool StartupDiagnosticLogEnabled { get; }
+        public bool StartupDiagnosticLogEnabled => MutableSettings.StartupDiagnosticLogEnabled;
 
         /// <summary>
         /// Gets the time interval (in seconds) for sending stats
@@ -1324,22 +983,14 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.HttpClientExcludedUrlSubstrings"/>
         internal string[] HttpClientExcludedUrlSubstrings { get; }
 
-        /// <summary>
-        /// Gets the HTTP status code that should be marked as errors for server integrations.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.HttpServerErrorStatusCodes"/>
-        internal bool[] HttpServerErrorStatusCodes { get; }
+        /// <inheritdoc cref="MutableSettings.HttpServerErrorStatusCodes"/>
+        internal bool[] HttpServerErrorStatusCodes => MutableSettings.HttpServerErrorStatusCodes;
 
-        /// <summary>
-        /// Gets the HTTP status code that should be marked as errors for client integrations.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.HttpClientErrorStatusCodes"/>
-        internal bool[] HttpClientErrorStatusCodes { get; }
+        /// <inheritdoc cref="MutableSettings.HttpClientErrorStatusCodes"/>
+        internal bool[] HttpClientErrorStatusCodes => MutableSettings.HttpClientErrorStatusCodes;
 
-        /// <summary>
-        /// Gets configuration values for changing service names based on configuration
-        /// </summary>
-        internal IReadOnlyDictionary<string, string> ServiceNameMappings { get; }
+        /// <inheritdoc cref="MutableSettings.ServiceNameMappings"/>
+        internal IReadOnlyDictionary<string, string> ServiceNameMappings => MutableSettings.ServiceNameMappings;
 
         /// <summary>
         /// Gets configuration values for changing peer service names based on configuration
@@ -1552,71 +1203,6 @@ namespace Datadog.Trace.Configuration
             return mappings is not null ? new(mappings) : null;
         }
 
-        internal static ReadOnlyDictionary<string, string>? InitializeHeaderTags(ConfigurationBuilder config, string key, bool headerTagsNormalizationFixEnabled)
-        {
-            var configurationDictionary = config
-                   .WithKeys(key)
-                   .AsDictionary(allowOptionalMappings: true, defaultValue: null, "[]");
-
-            if (configurationDictionary == null)
-            {
-                return null;
-            }
-
-            var headerTags = new Dictionary<string, string>(configurationDictionary.Count);
-
-            foreach (var kvp in configurationDictionary)
-            {
-                var headerName = kvp.Key.Trim();
-
-                if (string.IsNullOrEmpty(headerName))
-                {
-                    continue;
-                }
-
-                if (InitializeHeaderTag(tagName: kvp.Value, headerTagsNormalizationFixEnabled, out var finalTagName))
-                {
-                    headerTags.Add(headerName, finalTagName);
-                }
-            }
-
-            return new(headerTags);
-        }
-
-        internal static bool InitializeHeaderTag(
-            string? tagName,
-            bool headerTagsNormalizationFixEnabled,
-            [NotNullWhen(true)] out string? finalTagName)
-        {
-            tagName = tagName?.Trim();
-
-            if (string.IsNullOrEmpty(tagName))
-            {
-                // The user did not provide a tag name. Normalization will happen later, when adding the tag prefix.
-                finalTagName = string.Empty;
-                return true;
-            }
-
-            if (!SpanTagHelper.IsValidTagName(tagName!, out tagName))
-            {
-                // invalid tag name
-                finalTagName = null;
-                return false;
-            }
-
-            if (headerTagsNormalizationFixEnabled)
-            {
-                // Default code path: if the user provided a tag name, don't try to normalize it.
-                finalTagName = tagName;
-                return true;
-            }
-
-            // user opted via feature flag into the previous behavior,
-            // where tag names were normalized even when specified
-            // (but _not_ spaces, due to a bug in the normalization code)
-            return SpanTagHelper.TryNormalizeTagName(tagName, normalizeSpaces: false, out finalTagName);
-        }
-
         internal static string[] TrimSplitString(string? textValues, char[] separators)
         {
             if (string.IsNullOrWhiteSpace(textValues))
@@ -1642,106 +1228,15 @@ namespace Datadog.Trace.Configuration
             return list.ToArray();
         }
 
-        internal static bool[] ParseHttpCodesToArray(IEnumerable<int> httpStatusErrorCodes)
-        {
-            var httpErrorCodesArray = new bool[600];
-            foreach (var errorCode in httpStatusErrorCodes)
-            {
-                if (errorCode >= 0 && errorCode < httpErrorCodesArray.Length)
-                {
-                    httpErrorCodesArray[errorCode] = true;
-                }
-            }
-
-            return httpErrorCodesArray;
-        }
-
-        internal static bool[] ParseHttpCodesToArray(string httpStatusErrorCodes)
-        {
-            bool[] httpErrorCodesArray = new bool[600];
-
-            void TrySetValue(int index)
-            {
-                if (index >= 0 && index < httpErrorCodesArray.Length)
-                {
-                    httpErrorCodesArray[index] = true;
-                }
-            }
-
-            string[] configurationsArray = httpStatusErrorCodes.Replace(" ", string.Empty).Split(',');
-
-            foreach (string statusConfiguration in configurationsArray)
-            {
-                int startStatus;
-
-                // Checks that the value about to be used follows the `401-404` structure or single 3 digit number i.e. `401` else log the warning
-                if (!Regex.IsMatch(statusConfiguration, @"^\d{3}-\d{3}$|^\d{3}$"))
-                {
-                    Log.Warning("Wrong format '{0}' for DD_TRACE_HTTP_SERVER/CLIENT_ERROR_STATUSES configuration.", statusConfiguration);
-                }
-
-                // If statusConfiguration equals a single value i.e. `401` parse the value and save to the array
-                else if (int.TryParse(statusConfiguration, out startStatus))
-                {
-                    TrySetValue(startStatus);
-                }
-                else
-                {
-                    string[] statusCodeLimitsRange = statusConfiguration.Split('-');
-
-                    startStatus = int.Parse(statusCodeLimitsRange[0]);
-                    int endStatus = int.Parse(statusCodeLimitsRange[1]);
-
-                    if (endStatus < startStatus)
-                    {
-                        startStatus = endStatus;
-                        endStatus = int.Parse(statusCodeLimitsRange[0]);
-                    }
-
-                    for (int statusCode = startStatus; statusCode <= endStatus; statusCode++)
-                    {
-                        TrySetValue(statusCode);
-                    }
-                }
-            }
-
-            return httpErrorCodesArray;
-        }
-
         internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)
-        {
-            var source = serverStatusCode ? HttpServerErrorStatusCodes : HttpClientErrorStatusCodes;
-
-            if (source == null)
-            {
-                return false;
-            }
-
-            if (statusCode >= source.Length)
-            {
-                return false;
-            }
-
-            return source[statusCode];
-        }
+            => MutableSettings.IsErrorStatusCode(statusCode, serverStatusCode);
 
         internal bool IsIntegrationEnabled(IntegrationId integration, bool defaultValue = true)
-        {
-            if (TraceEnabled && !_domainMetadata.ShouldAvoidAppDomain())
-            {
-                return Integrations[integration].Enabled ?? defaultValue;
-            }
-
-            return false;
-        }
+            => MutableSettings.IsIntegrationEnabled(integration, defaultValue);
 
         [Obsolete(DeprecationMessages.AppAnalytics)]
         internal double? GetIntegrationAnalyticsSampleRate(IntegrationId integration, bool enabledWithGlobalSetting)
-        {
-            var integrationSettings = Integrations[integration];
-            var analyticsEnabled = integrationSettings.AnalyticsEnabled ?? (enabledWithGlobalSetting && AnalyticsEnabled);
-            return analyticsEnabled ? integrationSettings.AnalyticsSampleRate : (double?)null;
-        }
+            => MutableSettings.GetIntegrationAnalyticsSampleRate(integration, enabledWithGlobalSetting);
 
         internal string GetDefaultHttpClientExclusions()
         {
@@ -1804,138 +1299,6 @@ namespace Datadog.Trace.Configuration
             {
                 exporterTelemetry.CopyTo(destination);
             }
-        }
-
-        private static double? BuildSampleRate(OverrideErrorLog log, in ConfigurationBuilder config)
-        {
-            // The "overriding" is complex, so we can't use the usual `OverrideWith()` approach
-            var ddSampleRate = config.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDoubleResult();
-            var otelSampleType = config.WithKeys(ConfigurationKeys.OpenTelemetry.TracesSampler).AsStringResult();
-            var otelSampleRate = config.WithKeys(ConfigurationKeys.OpenTelemetry.TracesSamplerArg).AsDoubleResult();
-
-            double? ddResult = ddSampleRate.ConfigurationResult.IsValid ? ddSampleRate.ConfigurationResult.Result : null;
-
-            // more complex, so can't use built-in `Merge()` support
-            if (ddSampleRate.ConfigurationResult.IsPresent)
-            {
-                if (otelSampleType.ConfigurationResult.IsPresent)
-                {
-                    log.LogDuplicateConfiguration(ddSampleRate.Key, otelSampleType.Key);
-                }
-
-                if (otelSampleRate.ConfigurationResult.IsPresent)
-                {
-                    log.LogDuplicateConfiguration(ddSampleRate.Key, otelSampleRate.Key);
-                }
-            }
-            else if (otelSampleType.ConfigurationResult is { IsValid: true, Result: { } samplerName })
-            {
-                const string parentbasedAlwaysOn = "parentbased_always_on";
-                const string parentbasedAlwaysOff = "parentbased_always_off";
-                const string parentbasedTraceidratio = "parentbased_traceidratio";
-
-                string? supportedSamplerName = samplerName switch
-                {
-                    parentbasedAlwaysOn => parentbasedAlwaysOn,
-                    "always_on" => parentbasedAlwaysOn,
-                    parentbasedAlwaysOff => parentbasedAlwaysOff,
-                    "always_off" => parentbasedAlwaysOff,
-                    parentbasedTraceidratio => parentbasedTraceidratio,
-                    "traceidratio" => parentbasedTraceidratio,
-                    _ => null,
-                };
-
-                if (supportedSamplerName is null)
-                {
-                    log.EnqueueAction(
-                        (log, _) =>
-                        {
-                            log.Warning(
-                                "OpenTelemetry configuration {OpenTelemetryConfiguration}={OpenTelemetryValue} is not supported. Using default configuration.",
-                                otelSampleType.Key,
-                                samplerName);
-                        });
-                    return ddResult;
-                }
-
-                if (!string.Equals(samplerName, supportedSamplerName, StringComparison.OrdinalIgnoreCase))
-                {
-                    log.LogUnsupportedConfiguration(otelSampleType.Key, samplerName, supportedSamplerName);
-                }
-
-                var openTelemetrySampleRateResult = supportedSamplerName switch
-                {
-                    parentbasedAlwaysOn => ConfigurationResult<double>.Valid(1.0),
-                    parentbasedAlwaysOff => ConfigurationResult<double>.Valid(0.0),
-                    parentbasedTraceidratio => otelSampleRate.ConfigurationResult,
-                    _ => ConfigurationResult<double>.ParseFailure(),
-                };
-
-                if (openTelemetrySampleRateResult is { Result: { } sampleRateResult, IsValid: true })
-                {
-                    return sampleRateResult;
-                }
-
-                log.LogInvalidConfiguration(otelSampleRate.Key);
-            }
-
-            return ddResult;
-        }
-
-        private static ConfigurationBuilder.ClassConfigurationResultWithKey<IDictionary<string, string>> RemapOtelTags(
-            in ConfigurationBuilder.ClassConfigurationResultWithKey<IDictionary<string, string>> original)
-        {
-            if (original.ConfigurationResult is { IsValid: true, Result: { } values })
-            {
-                // Update well-known service information resources
-                if (values.TryGetValue("deployment.environment", out var envValue))
-                {
-                    values.Remove("deployment.environment");
-                    values[Tags.Env] = envValue;
-                }
-
-                if (values.TryGetValue("service.name", out var serviceValue))
-                {
-                    values.Remove("service.name");
-                    values[Tags.Service] = serviceValue;
-                }
-
-                if (values.TryGetValue("service.version", out var versionValue))
-                {
-                    values.Remove("service.version");
-                    values[Tags.Version] = versionValue;
-                }
-            }
-
-            return original;
-        }
-
-        private string? GetExplicitSettingOrTag(
-            string? explicitSetting,
-            Dictionary<string, string> globalTags,
-            string tag,
-            string telemetryKey)
-        {
-            string? result = null;
-            if (!string.IsNullOrWhiteSpace(explicitSetting))
-            {
-                result = explicitSetting!.Trim();
-                if (result != explicitSetting)
-                {
-                    _telemetry.Record(telemetryKey, result, recordValue: true, ConfigurationOrigins.Calculated);
-                }
-            }
-            else
-            {
-                var version = globalTags.GetValueOrDefault(tag);
-                if (!string.IsNullOrWhiteSpace(version))
-                {
-                    result = version.Trim();
-                    _telemetry.Record(telemetryKey, result, recordValue: true, ConfigurationOrigins.Calculated);
-                }
-            }
-
-            return result;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
@@ -1,0 +1,703 @@
+﻿// <copyright file="MutableSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Sampling;
+using Datadog.Trace.Telemetry.Metrics;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.TestTracer;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class MutableSettingsTests : SettingsTestsBase
+    {
+        private readonly Mock<IAgentWriter> _writerMock;
+        private readonly Mock<ITraceSampler> _samplerMock;
+
+        public MutableSettingsTests()
+        {
+            _writerMock = new Mock<IAgentWriter>();
+            _samplerMock = new Mock<ITraceSampler>();
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var properties = typeof(MutableSettings)
+                            .GetProperties()
+                            .Select(x => x.Name)
+                            .ToList();
+
+            properties.Should().NotBeEmpty();
+
+            // precondition checks
+            GetSettings(string.Empty, null)
+               .Equals(GetSettings(string.Empty, null))
+               .Should()
+               .BeTrue("when there's no config, two settings objects should be equal");
+
+            foreach (var test in GetTestValues())
+            {
+                var settings1 = GetSettings(test.Key, test.Value1);
+                var settings2 = GetSettings(test.Key, test.Value1);
+                var settings3 = GetSettings(test.Key, test.Value2);
+
+                settings1.Equals(settings2).Should().BeTrue($"the same {test.Property} should give the same result");
+                settings1.Equals(settings3).Should().BeFalse($"changing {test.Property} should change equality");
+
+                properties.Remove(test.Property).Should().BeTrue($"the {test.Property} property should exist");
+
+                settings1.GetHashCode().Should().Be(settings2.GetHashCode());
+            }
+
+            // TODO: test that changing this changes the settings. Currently this is always false, so can't test it
+            properties.Remove(nameof(MutableSettings.CustomSamplingRulesIsRemote));
+            properties.Should().BeEmpty("should compare all properties as part of MutableSettings, but some properties were not used");
+        }
+
+        [Theory]
+        [InlineData(ConfigurationKeys.Environment, Tags.Env, null)]
+        [InlineData(ConfigurationKeys.Environment, Tags.Env, "custom-env")]
+        [InlineData(ConfigurationKeys.ServiceVersion, Tags.Version, null)]
+        [InlineData(ConfigurationKeys.ServiceVersion, Tags.Version, "custom-version")]
+        public async Task ConfiguredTracerSettings_DefaultTagsSetFromEnvironmentVariable(string environmentVariableKey, string tagKey, string value)
+        {
+            var collection = new NameValueCollection { { environmentVariableKey, value } };
+
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var settings = new TracerSettings(source);
+
+            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
+            var span = tracer.StartSpan("Operation");
+
+            Assert.Equal(span.GetTag(tagKey), value);
+        }
+
+        [Theory]
+        [InlineData(ConfigurationKeys.Environment, Tags.Env)]
+        [InlineData(ConfigurationKeys.ServiceVersion, Tags.Version)]
+        public async Task DDVarTakesPrecedenceOverDDTags(string envKey, string tagKey)
+        {
+            string envValue = $"ddenv-custom-{tagKey}";
+            string tagsLine = $"{tagKey}:ddtags-custom-{tagKey}";
+            var collection = new NameValueCollection { { envKey, envValue }, { ConfigurationKeys.GlobalTags, tagsLine } };
+
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var settings = new TracerSettings(source);
+
+            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
+            var span = tracer.StartSpan("Operation");
+
+            Assert.Equal(span.GetTag(tagKey), envValue);
+        }
+
+        [Theory]
+        [InlineData(Tags.Env, "deployment.environment")]
+        [InlineData(Tags.Version, "service.version")]
+        public async Task OtelTagsSetsServiceInformation(string ddTagKey, string otelTagKey)
+        {
+            string expectedValue = $"ddtags-custom-{otelTagKey}";
+            string tagsLine = $"{otelTagKey}=ddtags-custom-{otelTagKey}";
+            var collection = new NameValueCollection { { ConfigurationKeys.OpenTelemetry.ResourceAttributes, tagsLine } };
+
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.GlobalTags.Should().NotContainKey(otelTagKey);
+
+            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
+            var span = tracer.StartSpan("Operation");
+
+            Assert.Equal(span.GetTag(ddTagKey), expectedValue);
+        }
+
+        [Theory]
+        [InlineData(Tags.Env, "deployment.environment")]
+        [InlineData(Tags.Version, "service.version")]
+        public async Task DDTagsTakesPrecedenceOverOtelTags(string ddTagKey, string otelTagKey)
+        {
+            string expectedValue = $"ddtags-custom-{ddTagKey}";
+            string ddTagsLine = $"{ddTagKey}:ddtags-custom-{ddTagKey}";
+            string otelTagsLine = $"{otelTagKey}=ddtags-custom-{otelTagKey}";
+            var collection = new NameValueCollection { { ConfigurationKeys.GlobalTags, ddTagsLine }, { ConfigurationKeys.OpenTelemetry.ResourceAttributes, otelTagsLine } };
+
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.GlobalTags.Should().NotContainKey(otelTagKey);
+
+            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
+            var span = tracer.StartSpan("Operation");
+
+            Assert.Equal(span.GetTag(ddTagKey), expectedValue);
+        }
+
+        [Theory]
+        [InlineData("", null, true, null)]
+        [InlineData("", "random", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("", "none", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("1", null, true, null)]
+        [InlineData("1", "none", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("0", "random", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("0", "none", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData(null, "random", true, (int)Count.OpenTelemetryConfigInvalid)]
+        [InlineData(null, "none", false, null)]
+        public async Task TraceEnabled(string value, string otelValue, bool areTracesEnabled, int? metric)
+        {
+            var settings = new NameValueCollection
+            {
+                { ConfigurationKeys.TraceEnabled, value },
+                { ConfigurationKeys.OpenTelemetry.TracesExporter, otelValue },
+            };
+
+            var errorLog = new OverrideErrorLog();
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings), NullConfigurationTelemetry.Instance, errorLog);
+
+            Assert.Equal(areTracesEnabled, tracerSettings.TraceEnabled);
+            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.TracesExporter.ToLowerInvariant(), ConfigurationKeys.TraceEnabled.ToLowerInvariant());
+
+            _writerMock.Invocations.Clear();
+
+            await using var tracer = TracerHelper.Create(tracerSettings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
+            var span = tracer.StartSpan("TestTracerDisabled");
+            span.Dispose();
+
+            var assertion = areTracesEnabled ? Times.Once() : Times.Never();
+
+            _writerMock.Verify(w => w.WriteTrace(It.IsAny<ArraySegment<Span>>()), assertion);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
+        public void Environment(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.Environment, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.Environment.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("test", null, null, "test")]
+        // This is the current behaviour - _should_ it be, or should the result be normalized, is a separate question...
+        [InlineData("My Service Name!", null, null, "My Service Name!")]
+        [InlineData("test", null, "ignored_otel", "test")]
+        [InlineData("test", "error", "ignored_otel", "test")]
+        [InlineData(null, "test", null, "test")]
+        [InlineData(null, "test", "ignored_otel", "test")]
+        [InlineData("", "test", "ignored_otel", null)]
+        [InlineData(null, null, "otel", "otel")]
+        [InlineData(null, null, null, null)]
+        public void ServiceName(string value, string legacyValue, string otelValue, string expected)
+        {
+            const string legacyServiceName = "DD_SERVICE_NAME";
+            const string otelKey = ConfigurationKeys.OpenTelemetry.ServiceName;
+
+            var source = CreateConfigurationSource((ConfigurationKeys.ServiceName, value), (legacyServiceName, legacyValue), (otelKey, otelValue));
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.ServiceName.Should().Be(expected);
+            Count? metric = otelValue switch
+            {
+                "ignored_otel" => Count.OpenTelemetryConfigHiddenByDatadogConfig,
+                _ => null,
+            };
+            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.ServiceName.ToLowerInvariant(), ConfigurationKeys.ServiceName.ToLowerInvariant());
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
+        public void ServiceVersion(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ServiceVersion, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.ServiceVersion.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
+        public void GitCommitSha(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.GitCommitSha, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.GitCommitSha.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
+        public void GitRepositoryUrl(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.GitRepositoryUrl, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.GitRepositoryUrl.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, true, new string[0])]
+        [InlineData(null, false, new[] { "OpenTelemetry" })]
+        [InlineData("", true, new string[0])]
+        [InlineData("test", false, new[] { "test", "OpenTelemetry" })]
+        [InlineData("test1;TEST1;test2", true, new[] { "test1", "test2" })]
+        public void DisabledIntegrationNames(string value, bool isOpenTelemetryEnabled, string[] expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.DisabledIntegrations, value),
+                (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isOpenTelemetryEnabled ? "1" : "0"));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.DisabledIntegrationNames.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void AnalyticsEnabled(string value, bool expected)
+        {
+#pragma warning disable 618 // App analytics is deprecated, but still used
+            var source = CreateConfigurationSource((ConfigurationKeys.GlobalAnalyticsEnabled, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.AnalyticsEnabled.Should().Be(expected);
+#pragma warning restore 618
+        }
+
+        [Fact]
+        public void Integrations()
+        {
+            // Further testing is done in IntegrationSettingsTests
+            var source = CreateConfigurationSource(
+                ($"DD_{IntegrationRegistry.Names[1]}_ENABLED", "0"),
+                ($"DD_{IntegrationRegistry.Names[2]}_ENABLED", "1"));
+
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.Integrations[IntegrationRegistry.Names[0]].Enabled.Should().BeNull();
+            mutable.Integrations[IntegrationRegistry.Names[1]].Enabled.Should().BeFalse();
+            mutable.Integrations[IntegrationRegistry.Names[2]].Enabled.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("10", null, 10)]
+        [InlineData("10", "50", 10)]
+        [InlineData(null, "10", 10)]
+        [InlineData("", "10", 10)]
+        [InlineData("", "", 100)]
+        [InlineData("A", "A", 100)]
+        public void MaxTracesSubmittedPerSecond(string value, string legacyValue, int expected)
+        {
+#pragma warning disable 618 // this parameter has been replaced but may still be used
+            var source = CreateConfigurationSource((ConfigurationKeys.TraceRateLimit, value), (ConfigurationKeys.MaxTracesSubmittedPerSecond, legacyValue));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.MaxTracesSubmittedPerSecond.Should().Be(expected);
+#pragma warning restore 618
+        }
+
+        [Theory]
+        [InlineData("key1:value1,key2:value2", "key3:value3", "otel_key=otel_value", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("key1 :value1,invalid,key2: value2", "key3:value3", "otel_key=otel_value", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("invalid", "key1:value1,key2:value2", "otel_key=otel_value", new string[0])]
+        [InlineData(null, "key1:value1,key2:value2", "otel_key=otel_value", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("", "key1:value1,key2:value2", "otel_key=otel_value", new string[0])]
+        [InlineData("", "", "otel_key=otel_value", new string[0])]
+        [InlineData("invalid", "invalid", "otel_key=otel_value", new string[0])]
+        [InlineData(null, null, "otel_key=otel_value", new[] { "otel_key:otel_value" })]
+        public void GlobalTags(string value, string legacyValue, string otelValue, string[] expected)
+        {
+            const string legacyGlobalTagsKey = "DD_TRACE_GLOBAL_TAGS";
+            const string otelKey = ConfigurationKeys.OpenTelemetry.ResourceAttributes;
+
+            var source = CreateConfigurationSource((ConfigurationKeys.GlobalTags, value), (legacyGlobalTagsKey, legacyValue), (otelKey, otelValue));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.GlobalTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+        }
+
+        [Theory]
+        // null, empty, whitespace
+        [InlineData(null, true, new string[0])]
+        [InlineData("", true, new string[0])]
+        [InlineData("   ", true, new string[0])]
+        // nominal
+        [InlineData("key1:value1,key2:value2,key3", true, new[] { "key1|value1", "key2|value2", "key3|" })]
+        // trim whitespace
+        [InlineData(" key1 : value1 ", true, new[] { "key1|value1" })]
+        // other normalization
+        [InlineData("key1:val.u e1?!", true, new[] { "key1|val.u e1?!" })]
+        [InlineData("k.e y?!1", false, new[] { "k.e y?!1|" })]
+        [InlineData(":leadingcolon", false, new string[0])]
+        [InlineData(":leadingcolon", true, new string[0])]
+        [InlineData("one:two:three", true, new[] { "one:two|three" })]
+        public void HeaderTags(string value, bool normalizationFixEnabled, string[] expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.HeaderTags, value),
+                (ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled, normalizationFixEnabled ? "1" : "0"));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.HeaderTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Substring(0, v.IndexOf('|')), v => v.Substring(v.IndexOf('|') + 1)));
+        }
+
+        [Theory]
+        // null, empty, whitespace
+        [InlineData(null, true, new string[0])]
+        [InlineData("", true, new string[0])]
+        [InlineData("   ", true, new string[0])]
+        // nominal
+        [InlineData("key1:value1,key2:value2,key3", true, new[] { "key1:value1", "key2:value2", "key3:" })]
+        // trim whitespace
+        [InlineData(" key1 : value1 ", true, new[] { "key1:value1" })]
+        // other normalization
+        [InlineData("key1:val.u e1?!", true, new[] { "key1:val.u e1?!" })]
+        [InlineData("k.e y?!1", false, new[] { "k.e y?!1:" })]
+        public void GrpcTags(string value, bool normalizationFixEnabled, string[] expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.GrpcTags, value),
+                (ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled, normalizationFixEnabled ? "1" : "0"));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.GrpcTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+        }
+
+        [Theory]
+        [InlineData("key1:value1,key2:value2", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("key1 :value1,invalid,key2: value2", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("invalid", new string[0])]
+        [InlineData(null, new string[0])]
+        [InlineData("", new string[0])]
+        public void ServiceNameMappings(string value, string[] expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ServiceNameMappings, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.ServiceNameMappings.Should().BeEquivalentTo(expected?.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void TracerMetricsEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.TracerMetricsEnabled, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.TracerMetricsEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void CustomSamplingRules(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CustomSamplingRules, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.CustomSamplingRules.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("1.5", null, null, 1.5d)]
+        [InlineData("1", "parentbased_traceidratio", "0.5", 1.0d)]
+        [InlineData("0", "parentbased_traceidratio", null, 0.0d)]
+        [InlineData("-1", "parentbased_traceidratio", null, -1.0d)]
+        [InlineData("A", null, null, null)]
+        [InlineData("", "parentbased_always_on", null, null)]
+        [InlineData("", "parentbased_always_off", null, null)]
+        [InlineData(null, "parentbased_traceidratio", "0.5", 0.5d)]
+        [InlineData(null, "parentbased_traceidratio", "1", 1.0d)]
+        [InlineData(null, "parentbased_traceidratio", null, null)]
+        [InlineData(null, "traceidratio", "0.5", 0.5d)]
+        [InlineData(null, "traceidratio", "1", 1.0d)]
+        [InlineData(null, "traceidratio", null, null)]
+        [InlineData(null, "parentbased_always_on", null, 1.0d)]
+        [InlineData(null, "always_on", null, 1.0d)]
+        [InlineData(null, "parentbased_always_off", null, 0.0d)]
+        [InlineData(null, "always_off", null, 0.0d)]
+        [InlineData(null, "traceidratio", "invalid", null)]
+        [InlineData(null, "parentbased_always_on", "invalid", 1.0d)]
+        [InlineData(null, "always_on", "invalid", 1.0d)]
+        [InlineData(null, "parentbased_always_off", "invalid", 0.0d)]
+        [InlineData(null, "always_off", "invalid", 0.0d)]
+        [InlineData(null, "invalid", null, null)]
+        [InlineData(null, "invalid", "invalid", null)]
+        public void GlobalSamplingRate(string value, string otelSampler, string otelSampleRate, double? expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.GlobalSamplingRate, value),
+                (ConfigurationKeys.OpenTelemetry.TracesSampler, otelSampler),
+                (ConfigurationKeys.OpenTelemetry.TracesSamplerArg, otelSampleRate));
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
+            var mutable = GetMutableSettings(source, settings);
+
+            // confirm the logs/metrics
+            mutable.GlobalSamplingRate.Should().Be(expected);
+            var metrics = new List<(Count?, string, string)>();
+
+            if (value is not null)
+            {
+                // hidden metrics
+                if (otelSampler is not null)
+                {
+                    metrics.Add((Count.OpenTelemetryConfigHiddenByDatadogConfig, ConfigurationKeys.OpenTelemetry.TracesSampler.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
+                }
+
+                if (otelSampleRate is not null)
+                {
+                    metrics.Add((Count.OpenTelemetryConfigHiddenByDatadogConfig, ConfigurationKeys.OpenTelemetry.TracesSamplerArg.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
+                }
+            }
+            else if (otelSampler is "invalid")
+            {
+                // we _don't_ report this one as invalid, and it "prevents" reporting the invalid arg
+            }
+            else if (otelSampler is "traceidratio" or "parentbased_traceidratio"
+                  && otelSampleRate is "invalid" or null)
+            {
+                // we _only_ report this one if we need to use it
+                metrics.Add((Count.OpenTelemetryConfigInvalid, ConfigurationKeys.OpenTelemetry.TracesSamplerArg.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
+            }
+
+            errorLog.ShouldHaveExpectedOtelMetric(metrics.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void StartupDiagnosticLogEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.StartupDiagnosticLogEnabled, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.StartupDiagnosticLogEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void KafkaCreateConsumerScopeEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.KafkaCreateConsumerScopeEnabled, value));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.KafkaCreateConsumerScopeEnabled.Should().Be(expected);
+        }
+
+        [Fact]
+        public void DisableTracerIfNoApiKeyInAas()
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.SiteNameKey, "site-name"));
+            var settings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, settings);
+
+            mutable.TraceEnabled.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(null, null, "500-599")]
+        [InlineData(null, "400", "400")]
+        [InlineData("444", null, "444")]
+        [InlineData("444", "424", "444")]
+        public void ValidateServerErrorStatusCodes(string newServerErrorKeyValue, string deprecatedServerErrorKeyValue, string expectedServerErrorCodes)
+        {
+            const string httpServerErrorStatusCodes = "DD_TRACE_HTTP_SERVER_ERROR_STATUSES";
+            const string deprecatedHttpServerErrorStatusCodes = "DD_HTTP_SERVER_ERROR_STATUSES";
+
+            var source = CreateConfigurationSource(
+                (httpServerErrorStatusCodes, newServerErrorKeyValue),
+                (deprecatedHttpServerErrorStatusCodes, deprecatedServerErrorKeyValue));
+
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
+            var tracerSettings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, tracerSettings);
+            var result = mutable.HttpServerErrorStatusCodes;
+
+            ValidateErrorStatusCodes(result, newServerErrorKeyValue, deprecatedServerErrorKeyValue, expectedServerErrorCodes);
+        }
+
+        [Theory]
+        [InlineData(null, null, "400-499")]
+        [InlineData(null, "500", "500")]
+        [InlineData("555", null, "555")]
+        [InlineData("555", "525", "555")]
+        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string deprecatedClientErrorKeyValue, string expectedClientErrorCodes)
+        {
+            const string httpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";
+            const string deprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
+
+            var source = CreateConfigurationSource(
+                (httpClientErrorStatusCodes, newClientErrorKeyValue),
+                (deprecatedHttpClientErrorStatusCodes, deprecatedClientErrorKeyValue));
+
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
+            var tracerSettings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, tracerSettings);
+            var result = mutable.HttpClientErrorStatusCodes;
+
+            ValidateErrorStatusCodes(result, newClientErrorKeyValue, deprecatedClientErrorKeyValue, expectedClientErrorCodes);
+        }
+
+        [Fact]
+        public void DDTagsSetsServiceInformation()
+        {
+            var source = new NameValueConfigurationSource(new()
+            {
+                { "DD_TAGS", "env:datadog_env,service:datadog_service,version:datadog_version,git.repository_url:https://Myrepository,git.commit.sha:42" },
+            });
+
+            var tracerSettings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, tracerSettings);
+
+            mutable.Environment.Should().Be("datadog_env");
+            mutable.ServiceVersion.Should().Be("datadog_version");
+            mutable.ServiceName.Should().Be("datadog_service");
+            mutable.GitRepositoryUrl.Should().Be("https://Myrepository");
+            mutable.GitCommitSha.Should().Be("42");
+        }
+
+        [Fact]
+        public void OTELTagsSetsServiceInformation()
+        {
+            var source = new NameValueConfigurationSource(new()
+            {
+                { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=datadog_env,service.name=datadog_service,service.version=datadog_version" },
+            });
+
+            var tracerSettings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, tracerSettings);
+
+            mutable.Environment.Should().Be("datadog_env");
+            mutable.ServiceVersion.Should().Be("datadog_version");
+            mutable.ServiceName.Should().Be("datadog_service");
+        }
+
+        [Fact]
+        public void DDTagsTakesPrecedenceOverOTELTags()
+        {
+            var source = new NameValueConfigurationSource(new()
+            {
+                { "DD_TAGS", "env:datadog_env" },
+                { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=datadog_env,service.name=datadog_service,service.version=datadog_version" },
+            });
+
+            var errorLog = new OverrideErrorLog();
+            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
+            var mutable = GetMutableSettings(source, tracerSettings);
+
+            mutable.Environment.Should().Be("datadog_env");
+
+            // Since the DD_TAGS config is set, the OTEL_RESOURCE_ATTRIBUTES config is ignored
+            mutable.ServiceVersion.Should().NotBe("datadog_version");
+            mutable.ServiceName.Should().NotBe("datadog_service");
+            errorLog.ShouldHaveExpectedOtelMetric(Count.OpenTelemetryConfigHiddenByDatadogConfig, "OTEL_RESOURCE_ATTRIBUTES".ToLowerInvariant(), "DD_TAGS".ToLowerInvariant());
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void LogsInjectionEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.LogsInjectionEnabled, value));
+            var tracerSettings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, tracerSettings);
+
+            mutable.LogsInjectionEnabled.Should().Be(expected);
+        }
+
+        private static (string Key, string Property, object Value1, object Value2)[] GetTestValues()
+            =>
+            [
+                (ConfigurationKeys.TraceEnabled, nameof(MutableSettings.TraceEnabled), true, false),
+                (ConfigurationKeys.CustomSamplingRules, nameof(MutableSettings.CustomSamplingRules), "a", "b"),
+                // (ConfigurationKeys.CustomSamplingRulesIsRemote, nameof(MutableSettings.CustomSamplingRulesIsRemote), true, false),
+                (ConfigurationKeys.GlobalSamplingRate, nameof(MutableSettings.GlobalSamplingRate), 0.2, 0.3),
+                (ConfigurationKeys.LogsInjectionEnabled, nameof(MutableSettings.LogsInjectionEnabled), true, false),
+                (ConfigurationKeys.GlobalTags, nameof(MutableSettings.GlobalTags), "a:b", "c:d"),
+                (ConfigurationKeys.HeaderTags, nameof(MutableSettings.HeaderTags), "a", "b"),
+                (ConfigurationKeys.StartupDiagnosticLogEnabled, nameof(MutableSettings.StartupDiagnosticLogEnabled), true, false),
+                (ConfigurationKeys.Environment, nameof(MutableSettings.Environment), "a", "b"),
+                (ConfigurationKeys.ServiceName, nameof(MutableSettings.ServiceName), "a", "b"),
+                (ConfigurationKeys.ServiceVersion, nameof(MutableSettings.ServiceVersion), "a", "b"),
+                (ConfigurationKeys.DisabledIntegrations, nameof(MutableSettings.DisabledIntegrationNames), "a", "b"),
+                (ConfigurationKeys.GrpcTags, nameof(MutableSettings.GrpcTags), "a", "b"),
+                (ConfigurationKeys.TracerMetricsEnabled, nameof(MutableSettings.TracerMetricsEnabled), true, false),
+                ("DD_TRACE_Process_ENABLED", nameof(MutableSettings.Integrations), true, false),
+#pragma warning disable CS0618 // Type or member is obsolete
+                (ConfigurationKeys.GlobalAnalyticsEnabled, nameof(MutableSettings.AnalyticsEnabled), true, false),
+                (ConfigurationKeys.MaxTracesSubmittedPerSecond, nameof(MutableSettings.MaxTracesSubmittedPerSecond), 10, 20),
+#pragma warning restore CS0618 // Type or member is obsolete
+                (ConfigurationKeys.KafkaCreateConsumerScopeEnabled, nameof(MutableSettings.KafkaCreateConsumerScopeEnabled), true, false),
+                (ConfigurationKeys.HttpServerErrorStatusCodes, nameof(MutableSettings.HttpServerErrorStatusCodes), "400-499", "400-599"),
+                (ConfigurationKeys.HttpClientErrorStatusCodes, nameof(MutableSettings.HttpClientErrorStatusCodes), "400-499", "400-599"),
+                (ConfigurationKeys.ServiceNameMappings, nameof(MutableSettings.ServiceNameMappings), "a:b", "c:d"),
+                (ConfigurationKeys.GitRepositoryUrl, nameof(MutableSettings.GitRepositoryUrl), "a", "b"),
+                (ConfigurationKeys.GitCommitSha, nameof(MutableSettings.GitCommitSha), "a", "b"),
+            ];
+
+        private static MutableSettings.InitialMutableSettings GetSettings(string key, object value)
+        {
+            var source = new DictionaryConfigurationSource(new Dictionary<string, string> { { key, value?.ToString() } });
+            return new MutableSettings.InitialMutableSettings(
+                source,
+                NullConfigurationTelemetry.Instance,
+                new OverrideErrorLog(),
+                new TracerSettings());
+        }
+
+        private static MutableSettings GetMutableSettings(IConfigurationSource source, TracerSettings tracerSettings)
+            => MutableSettings.CreateInitialMutableSettings(
+                source,
+                NullConfigurationTelemetry.Instance,
+                new OverrideErrorLog(),
+                tracerSettings);
+
+        private static void ValidateErrorStatusCodes(bool[] result, string newErrorKeyValue, string deprecatedErrorKeyValue, string expectedErrorRange)
+        {
+            if (newErrorKeyValue is not null || deprecatedErrorKeyValue is not null)
+            {
+                Assert.True(result[int.Parse(expectedErrorRange)]);
+            }
+            else
+            {
+                var statusCodeLimitsRange = expectedErrorRange.Split('-');
+                for (var i = int.Parse(statusCodeLimitsRange[0]); i <= int.Parse(statusCodeLimitsRange[1]); i++)
+                {
+                    Assert.True(result[i]);
+                }
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -184,7 +184,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("400-403, 500-501-234, s342, 500-503", "400,401,402,403,500,501,502,503")]
         public void ParseHttpCodes(string original, string expected)
         {
-            bool[] errorStatusCodesArray = TracerSettings.ParseHttpCodesToArray(original);
+            bool[] errorStatusCodesArray = MutableSettings.ParseHttpCodesToArray(original);
             string[] expectedKeysArray = expected.Split(new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var value in expectedKeysArray)
@@ -1172,7 +1172,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("1my-tag", false, false, null)]
         public void InitializeHeaderTag(string tagName, bool headerTagsNormalizationFixEnabled, bool expectedValid, string expectedTagName)
         {
-            TracerSettings.InitializeHeaderTag(tagName, headerTagsNormalizationFixEnabled, out var finalTagName)
+            MutableSettings.InitializeHeaderTag(tagName, headerTagsNormalizationFixEnabled, out var finalTagName)
                           .Should()
                           .Be(expectedValid);
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
-using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
@@ -18,135 +16,14 @@ using Datadog.Trace.Tagging;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.TestHelpers;
-using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Configuration
 {
     public class TracerSettingsTests : SettingsTestsBase
     {
-        private readonly Mock<IAgentWriter> _writerMock;
-        private readonly Mock<ITraceSampler> _samplerMock;
-
-        public TracerSettingsTests()
-        {
-            _writerMock = new Mock<IAgentWriter>();
-            _samplerMock = new Mock<ITraceSampler>();
-        }
-
-        [Theory]
-        [InlineData(ConfigurationKeys.Environment, Tags.Env, null)]
-        [InlineData(ConfigurationKeys.Environment, Tags.Env, "custom-env")]
-        [InlineData(ConfigurationKeys.ServiceVersion, Tags.Version, null)]
-        [InlineData(ConfigurationKeys.ServiceVersion, Tags.Version, "custom-version")]
-        public async Task ConfiguredTracerSettings_DefaultTagsSetFromEnvironmentVariable(string environmentVariableKey, string tagKey, string value)
-        {
-            var collection = new NameValueCollection { { environmentVariableKey, value } };
-
-            IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var settings = new TracerSettings(source);
-
-            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
-            var span = tracer.StartSpan("Operation");
-
-            Assert.Equal(span.GetTag(tagKey), value);
-        }
-
-        [Theory]
-        [InlineData(ConfigurationKeys.Environment, Tags.Env)]
-        [InlineData(ConfigurationKeys.ServiceVersion, Tags.Version)]
-        public async Task DDVarTakesPrecedenceOverDDTags(string envKey, string tagKey)
-        {
-            string envValue = $"ddenv-custom-{tagKey}";
-            string tagsLine = $"{tagKey}:ddtags-custom-{tagKey}";
-            var collection = new NameValueCollection { { envKey, envValue }, { ConfigurationKeys.GlobalTags, tagsLine } };
-
-            IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var settings = new TracerSettings(source);
-
-            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
-            var span = tracer.StartSpan("Operation");
-
-            Assert.Equal(span.GetTag(tagKey), envValue);
-        }
-
-        [Theory]
-        [InlineData(Tags.Env, "deployment.environment")]
-        [InlineData(Tags.Version, "service.version")]
-        public async Task OtelTagsSetsServiceInformation(string ddTagKey, string otelTagKey)
-        {
-            string expectedValue = $"ddtags-custom-{otelTagKey}";
-            string tagsLine = $"{otelTagKey}=ddtags-custom-{otelTagKey}";
-            var collection = new NameValueCollection { { ConfigurationKeys.OpenTelemetry.ResourceAttributes, tagsLine } };
-
-            IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var settings = new TracerSettings(source);
-            settings.GlobalTags.Should().NotContainKey(otelTagKey);
-
-            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
-            var span = tracer.StartSpan("Operation");
-
-            Assert.Equal(span.GetTag(ddTagKey), expectedValue);
-        }
-
-        [Theory]
-        [InlineData(Tags.Env, "deployment.environment")]
-        [InlineData(Tags.Version, "service.version")]
-        public async Task DDTagsTakesPrecedenceOverOtelTags(string ddTagKey, string otelTagKey)
-        {
-            string expectedValue = $"ddtags-custom-{ddTagKey}";
-            string ddTagsLine = $"{ddTagKey}:ddtags-custom-{ddTagKey}";
-            string otelTagsLine = $"{otelTagKey}=ddtags-custom-{otelTagKey}";
-            var collection = new NameValueCollection { { ConfigurationKeys.GlobalTags, ddTagsLine }, { ConfigurationKeys.OpenTelemetry.ResourceAttributes, otelTagsLine } };
-
-            IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var settings = new TracerSettings(source);
-            settings.GlobalTags.Should().NotContainKey(otelTagKey);
-
-            await using var tracer = TracerHelper.Create(settings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
-            var span = tracer.StartSpan("Operation");
-
-            Assert.Equal(span.GetTag(ddTagKey), expectedValue);
-        }
-
-        [Theory]
-        [InlineData("", null, true, null)]
-        [InlineData("", "random", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
-        [InlineData("", "none", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
-        [InlineData("1", null, true, null)]
-        [InlineData("1", "none", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
-        [InlineData("0", "random", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
-        [InlineData("0", "none", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
-        [InlineData(null, "random", true, (int)Count.OpenTelemetryConfigInvalid)]
-        [InlineData(null, "none", false, null)]
-        public async Task TraceEnabled(string value, string otelValue, bool areTracesEnabled, int? metric)
-        {
-            var settings = new NameValueCollection
-            {
-                { ConfigurationKeys.TraceEnabled, value },
-                { ConfigurationKeys.OpenTelemetry.TracesExporter, otelValue },
-            };
-
-            var errorLog = new OverrideErrorLog();
-            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings), NullConfigurationTelemetry.Instance, errorLog);
-
-            Assert.Equal(areTracesEnabled, tracerSettings.TraceEnabled);
-            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.TracesExporter.ToLowerInvariant(), ConfigurationKeys.TraceEnabled.ToLowerInvariant());
-
-            _writerMock.Invocations.Clear();
-
-            await using var tracer = TracerHelper.Create(tracerSettings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
-            var span = tracer.StartSpan("TestTracerDisabled");
-            span.Dispose();
-
-            var assertion = areTracesEnabled ? Times.Once() : Times.Never();
-
-            _writerMock.Verify(w => w.WriteTrace(It.IsAny<ArraySegment<Span>>()), assertion);
-        }
-
         [Theory]
         [InlineData("http://localhost:7777/agent?querystring", "http://127.0.0.1:7777/agent?querystring")]
         [InlineData("http://datadog:7777/agent?querystring", "http://datadog:7777/agent?querystring")]
@@ -208,75 +85,6 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
-        public void Environment(string value, string expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.Environment, value));
-            var settings = new TracerSettings(source);
-
-            settings.Environment.Should().Be(expected);
-        }
-
-        [Theory]
-        [InlineData("test", null, null, "test")]
-        // This is the current behaviour - _should_ it be, or should the result be normalized, is a separate question...
-        [InlineData("My Service Name!", null, null, "My Service Name!")]
-        [InlineData("test", null, "ignored_otel", "test")]
-        [InlineData("test", "error", "ignored_otel", "test")]
-        [InlineData(null, "test", null, "test")]
-        [InlineData(null, "test", "ignored_otel", "test")]
-        [InlineData("", "test", "ignored_otel", null)]
-        [InlineData(null, null, "otel", "otel")]
-        [InlineData(null, null, null, null)]
-        public void ServiceName(string value, string legacyValue, string otelValue, string expected)
-        {
-            const string legacyServiceName = "DD_SERVICE_NAME";
-            const string otelKey = ConfigurationKeys.OpenTelemetry.ServiceName;
-
-            var source = CreateConfigurationSource((ConfigurationKeys.ServiceName, value), (legacyServiceName, legacyValue), (otelKey, otelValue));
-            var errorLog = new OverrideErrorLog();
-            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
-
-            settings.ServiceName.Should().Be(expected);
-            Count? metric = otelValue switch
-            {
-                "ignored_otel" => Count.OpenTelemetryConfigHiddenByDatadogConfig,
-                _ => null,
-            };
-            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.ServiceName.ToLowerInvariant(), ConfigurationKeys.ServiceName.ToLowerInvariant());
-        }
-
-        [Theory]
-        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
-        public void ServiceVersion(string value, string expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.ServiceVersion, value));
-            var settings = new TracerSettings(source);
-
-            settings.ServiceVersion.Should().Be(expected);
-        }
-
-        [Theory]
-        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
-        public void GitCommitSha(string value, string expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.GitCommitSha, value));
-            var settings = new TracerSettings(source);
-
-            settings.GitCommitSha.Should().Be(expected);
-        }
-
-        [Theory]
-        [MemberData(nameof(StringTestCases), null, Strings.DisallowEmpty)]
-        public void GitRepositoryUrl(string value, string expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.GitRepositoryUrl, value));
-            var settings = new TracerSettings(source);
-
-            settings.GitRepositoryUrl.Should().Be(expected);
-        }
-
-        [Theory]
         [MemberData(nameof(BooleanTestCases), true)]
         public void GitMetadataEnabled(string value, bool expected)
         {
@@ -284,133 +92,6 @@ namespace Datadog.Trace.Tests.Configuration
             var settings = new TracerSettings(source);
 
             settings.GitMetadataEnabled.Should().Be(expected);
-        }
-
-        [Theory]
-        [InlineData(null, true, new string[0])]
-        [InlineData(null, false, new[] { "OpenTelemetry" })]
-        [InlineData("", true, new string[0])]
-        [InlineData("test", false, new[] { "test", "OpenTelemetry" })]
-        [InlineData("test1;TEST1;test2", true, new[] { "test1", "test2" })]
-        public void DisabledIntegrationNames(string value, bool isOpenTelemetryEnabled, string[] expected)
-        {
-            var source = CreateConfigurationSource(
-                (ConfigurationKeys.DisabledIntegrations, value),
-                (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isOpenTelemetryEnabled ? "1" : "0"));
-            var settings = new TracerSettings(source);
-
-            settings.DisabledIntegrationNames.Should().BeEquivalentTo(expected);
-        }
-
-        [Theory]
-        [MemberData(nameof(BooleanTestCases), false)]
-        public void AnalyticsEnabled(string value, bool expected)
-        {
-#pragma warning disable 618 // App analytics is deprecated, but still used
-            var source = CreateConfigurationSource((ConfigurationKeys.GlobalAnalyticsEnabled, value));
-            var settings = new TracerSettings(source);
-
-            settings.AnalyticsEnabled.Should().Be(expected);
-#pragma warning restore 618
-        }
-
-        [Fact]
-        public void Integrations()
-        {
-            // Further testing is done in IntegrationSettingsTests
-            var source = CreateConfigurationSource(
-                ($"DD_{IntegrationRegistry.Names[1]}_ENABLED", "0"),
-                ($"DD_{IntegrationRegistry.Names[2]}_ENABLED", "1"));
-
-            var settings = new TracerSettings(source);
-
-            settings.Integrations[IntegrationRegistry.Names[0]].Enabled.Should().BeNull();
-            settings.Integrations[IntegrationRegistry.Names[1]].Enabled.Should().BeFalse();
-            settings.Integrations[IntegrationRegistry.Names[2]].Enabled.Should().BeTrue();
-        }
-
-        [Theory]
-        [InlineData("10", null, 10)]
-        [InlineData("10", "50", 10)]
-        [InlineData(null, "10", 10)]
-        [InlineData("", "10", 10)]
-        [InlineData("", "", 100)]
-        [InlineData("A", "A", 100)]
-        public void MaxTracesSubmittedPerSecond(string value, string legacyValue, int expected)
-        {
-#pragma warning disable 618 // this parameter has been replaced but may still be used
-            var source = CreateConfigurationSource((ConfigurationKeys.TraceRateLimit, value), (ConfigurationKeys.MaxTracesSubmittedPerSecond, legacyValue));
-            var settings = new TracerSettings(source);
-
-            settings.MaxTracesSubmittedPerSecond.Should().Be(expected);
-#pragma warning restore 618
-        }
-
-        [Theory]
-        [InlineData("key1:value1,key2:value2", "key3:value3", "otel_key=otel_value", new[] { "key1:value1", "key2:value2" })]
-        [InlineData("key1 :value1,invalid,key2: value2", "key3:value3", "otel_key=otel_value", new[] { "key1:value1", "key2:value2" })]
-        [InlineData("invalid", "key1:value1,key2:value2", "otel_key=otel_value", new string[0])]
-        [InlineData(null, "key1:value1,key2:value2", "otel_key=otel_value", new[] { "key1:value1", "key2:value2" })]
-        [InlineData("", "key1:value1,key2:value2", "otel_key=otel_value", new string[0])]
-        [InlineData("", "", "otel_key=otel_value", new string[0])]
-        [InlineData("invalid", "invalid", "otel_key=otel_value", new string[0])]
-        [InlineData(null, null, "otel_key=otel_value", new[] { "otel_key:otel_value" })]
-        public void GlobalTags(string value, string legacyValue, string otelValue, string[] expected)
-        {
-            const string legacyGlobalTagsKey = "DD_TRACE_GLOBAL_TAGS";
-            const string otelKey = ConfigurationKeys.OpenTelemetry.ResourceAttributes;
-
-            var source = CreateConfigurationSource((ConfigurationKeys.GlobalTags, value), (legacyGlobalTagsKey, legacyValue), (otelKey, otelValue));
-            var settings = new TracerSettings(source);
-
-            settings.GlobalTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
-        }
-
-        [Theory]
-        // null, empty, whitespace
-        [InlineData(null, true, new string[0])]
-        [InlineData("", true, new string[0])]
-        [InlineData("   ", true, new string[0])]
-        // nominal
-        [InlineData("key1:value1,key2:value2,key3", true, new[] { "key1|value1", "key2|value2", "key3|" })]
-        // trim whitespace
-        [InlineData(" key1 : value1 ", true, new[] { "key1|value1" })]
-        // other normalization
-        [InlineData("key1:val.u e1?!", true, new[] { "key1|val.u e1?!" })]
-        [InlineData("k.e y?!1", false, new[] { "k.e y?!1|" })]
-        [InlineData(":leadingcolon", false, new string[0])]
-        [InlineData(":leadingcolon", true, new string[0])]
-        [InlineData("one:two:three", true, new[] { "one:two|three" })]
-        public void HeaderTags(string value, bool normalizationFixEnabled, string[] expected)
-        {
-            var source = CreateConfigurationSource(
-                (ConfigurationKeys.HeaderTags, value),
-                (ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled, normalizationFixEnabled ? "1" : "0"));
-            var settings = new TracerSettings(source);
-
-            settings.HeaderTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Substring(0, v.IndexOf('|')), v => v.Substring(v.IndexOf('|') + 1)));
-        }
-
-        [Theory]
-        // null, empty, whitespace
-        [InlineData(null, true, new string[0])]
-        [InlineData("", true, new string[0])]
-        [InlineData("   ", true, new string[0])]
-        // nominal
-        [InlineData("key1:value1,key2:value2,key3", true, new[] { "key1:value1", "key2:value2", "key3:" })]
-        // trim whitespace
-        [InlineData(" key1 : value1 ", true, new[] { "key1:value1" })]
-        // other normalization
-        [InlineData("key1:val.u e1?!", true, new[] { "key1:val.u e1?!" })]
-        [InlineData("k.e y?!1", false, new[] { "k.e y?!1:" })]
-        public void GrpcTags(string value, bool normalizationFixEnabled, string[] expected)
-        {
-            var source = CreateConfigurationSource(
-                (ConfigurationKeys.GrpcTags, value),
-                (ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled, normalizationFixEnabled ? "1" : "0"));
-            var settings = new TracerSettings(source);
-
-            settings.GrpcTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
         }
 
         [Theory]
@@ -431,20 +112,6 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("key1:value1,key2:value2", new[] { "key1:value1", "key2:value2" })]
         [InlineData("key1 :value1,invalid,key2: value2", new[] { "key1:value1", "key2:value2" })]
         [InlineData("invalid", new string[0])]
-        [InlineData(null, new string[0])]
-        [InlineData("", new string[0])]
-        public void ServiceNameMappings(string value, string[] expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.ServiceNameMappings, value));
-            var settings = new TracerSettings(source);
-
-            settings.ServiceNameMappings.Should().BeEquivalentTo(expected?.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
-        }
-
-        [Theory]
-        [InlineData("key1:value1,key2:value2", new[] { "key1:value1", "key2:value2" })]
-        [InlineData("key1 :value1,invalid,key2: value2", new[] { "key1:value1", "key2:value2" })]
-        [InlineData("invalid", new string[0])]
         [InlineData(null, null)]
         [InlineData("", new string[0])]
         public void PeerServiceNameMappings(string value, string[] expected)
@@ -453,16 +120,6 @@ namespace Datadog.Trace.Tests.Configuration
             var settings = new TracerSettings(source);
 
             settings.PeerServiceNameMappings.Should().BeEquivalentTo(expected?.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
-        }
-
-        [Theory]
-        [MemberData(nameof(BooleanTestCases), false)]
-        public void TracerMetricsEnabled(string value, bool expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.TracerMetricsEnabled, value));
-            var settings = new TracerSettings(source);
-
-            settings.TracerMetricsEnabled.Should().Be(expected);
         }
 
         [Theory]
@@ -521,16 +178,6 @@ namespace Datadog.Trace.Tests.Configuration
             };
 
             errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.MetricsExporter.ToLowerInvariant(), ConfigurationKeys.RuntimeMetricsEnabled.ToLowerInvariant());
-        }
-
-        [Theory]
-        [MemberData(nameof(StringTestCases))]
-        public void CustomSamplingRules(string value, string expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.CustomSamplingRules, value));
-            var settings = new TracerSettings(source);
-
-            settings.CustomSamplingRules.Should().Be(expected);
         }
 
         [Theory]
@@ -600,81 +247,6 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [InlineData("1.5", null, null, 1.5d)]
-        [InlineData("1", "parentbased_traceidratio", "0.5", 1.0d)]
-        [InlineData("0", "parentbased_traceidratio", null, 0.0d)]
-        [InlineData("-1", "parentbased_traceidratio", null, -1.0d)]
-        [InlineData("A", null, null, null)]
-        [InlineData("", "parentbased_always_on", null, null)]
-        [InlineData("", "parentbased_always_off", null, null)]
-        [InlineData(null, "parentbased_traceidratio", "0.5", 0.5d)]
-        [InlineData(null, "parentbased_traceidratio", "1", 1.0d)]
-        [InlineData(null, "parentbased_traceidratio", null, null)]
-        [InlineData(null, "traceidratio", "0.5", 0.5d)]
-        [InlineData(null, "traceidratio", "1", 1.0d)]
-        [InlineData(null, "traceidratio", null, null)]
-        [InlineData(null, "parentbased_always_on", null, 1.0d)]
-        [InlineData(null, "always_on", null, 1.0d)]
-        [InlineData(null, "parentbased_always_off", null, 0.0d)]
-        [InlineData(null, "always_off", null, 0.0d)]
-        [InlineData(null, "traceidratio", "invalid", null)]
-        [InlineData(null, "parentbased_always_on", "invalid", 1.0d)]
-        [InlineData(null, "always_on", "invalid", 1.0d)]
-        [InlineData(null, "parentbased_always_off", "invalid", 0.0d)]
-        [InlineData(null, "always_off", "invalid", 0.0d)]
-        [InlineData(null, "invalid", null, null)]
-        [InlineData(null, "invalid", "invalid", null)]
-        public void GlobalSamplingRate(string value, string otelSampler, string otelSampleRate, double? expected)
-        {
-            var source = CreateConfigurationSource(
-                (ConfigurationKeys.GlobalSamplingRate, value),
-                (ConfigurationKeys.OpenTelemetry.TracesSampler, otelSampler),
-                (ConfigurationKeys.OpenTelemetry.TracesSamplerArg, otelSampleRate));
-            var errorLog = new OverrideErrorLog();
-            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
-
-            // confirm the logs/metrics
-            settings.GlobalSamplingRate.Should().Be(expected);
-            var metrics = new List<(Count?, string, string)>();
-
-            if (value is not null)
-            {
-                // hidden metrics
-                if (otelSampler is not null)
-                {
-                    metrics.Add((Count.OpenTelemetryConfigHiddenByDatadogConfig, ConfigurationKeys.OpenTelemetry.TracesSampler.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
-                }
-
-                if (otelSampleRate is not null)
-                {
-                    metrics.Add((Count.OpenTelemetryConfigHiddenByDatadogConfig, ConfigurationKeys.OpenTelemetry.TracesSamplerArg.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
-                }
-            }
-            else if (otelSampler is "invalid")
-            {
-                // we _don't_ report this one as invalid, and it "prevents" reporting the invalid arg
-            }
-            else if (otelSampler is "traceidratio" or "parentbased_traceidratio"
-                  && otelSampleRate is "invalid" or null)
-            {
-                // we _only_ report this one if we need to use it
-                metrics.Add((Count.OpenTelemetryConfigInvalid, ConfigurationKeys.OpenTelemetry.TracesSamplerArg.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
-            }
-
-            errorLog.ShouldHaveExpectedOtelMetric(metrics.ToArray());
-        }
-
-        [Theory]
-        [MemberData(nameof(BooleanTestCases), true)]
-        public void StartupDiagnosticLogEnabled(string value, bool expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.StartupDiagnosticLogEnabled, value));
-            var settings = new TracerSettings(source);
-
-            settings.StartupDiagnosticLogEnabled.Should().Be(expected);
-        }
-
-        [Theory]
         [MemberData(nameof(Int32TestCases), 1024 * 1024 * 10)]
         public void TraceBufferSize(string value, int expected)
         {
@@ -722,16 +294,6 @@ namespace Datadog.Trace.Tests.Configuration
             var settings = new TracerSettings(source);
 
             settings.ExpandRouteTemplatesEnabled.Should().Be(expected);
-        }
-
-        [Theory]
-        [MemberData(nameof(BooleanTestCases), true)]
-        public void KafkaCreateConsumerScopeEnabled(string value, bool expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.KafkaCreateConsumerScopeEnabled, value));
-            var settings = new TracerSettings(source);
-
-            settings.KafkaCreateConsumerScopeEnabled.Should().Be(expected);
         }
 
         [Theory]
@@ -1042,15 +604,6 @@ namespace Datadog.Trace.Tests.Configuration
             settings.IsRunningInAzureFunctions.Should().Be(expected);
         }
 
-        [Fact]
-        public void DisableTracerIfNoApiKeyInAas()
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.SiteNameKey, "site-name"));
-            var settings = new TracerSettings(source);
-
-            settings.TraceEnabled.Should().BeFalse();
-        }
-
         // The HttpClientExcludedUrlSubstrings tests rely on Lambda.Create() which uses environment variables
         // See TracerSettingsServerlessTests for tests which rely on environment variables
 
@@ -1179,48 +732,6 @@ namespace Datadog.Trace.Tests.Configuration
             finalTagName.Should().Be(expectedTagName);
         }
 
-        [Theory]
-        [InlineData(null, null, "500-599")]
-        [InlineData(null, "400", "400")]
-        [InlineData("444", null, "444")]
-        [InlineData("444", "424", "444")]
-        public void ValidateServerErrorStatusCodes(string newServerErrorKeyValue, string deprecatedServerErrorKeyValue, string expectedServerErrorCodes)
-        {
-            const string httpServerErrorStatusCodes = "DD_TRACE_HTTP_SERVER_ERROR_STATUSES";
-            const string deprecatedHttpServerErrorStatusCodes = "DD_HTTP_SERVER_ERROR_STATUSES";
-
-            var source = CreateConfigurationSource(
-                (httpServerErrorStatusCodes, newServerErrorKeyValue),
-                (deprecatedHttpServerErrorStatusCodes, deprecatedServerErrorKeyValue));
-
-            var errorLog = new OverrideErrorLog();
-            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
-            var result = settings.HttpServerErrorStatusCodes;
-
-            ValidateErrorStatusCodes(result, newServerErrorKeyValue, deprecatedServerErrorKeyValue, expectedServerErrorCodes);
-        }
-
-        [Theory]
-        [InlineData(null, null, "400-499")]
-        [InlineData(null, "500", "500")]
-        [InlineData("555", null, "555")]
-        [InlineData("555", "525", "555")]
-        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string deprecatedClientErrorKeyValue, string expectedClientErrorCodes)
-        {
-            const string httpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";
-            const string deprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
-
-            var source = CreateConfigurationSource(
-                (httpClientErrorStatusCodes, newClientErrorKeyValue),
-                (deprecatedHttpClientErrorStatusCodes, deprecatedClientErrorKeyValue));
-
-            var errorLog = new OverrideErrorLog();
-            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
-            var result = settings.HttpClientErrorStatusCodes;
-
-            ValidateErrorStatusCodes(result, newClientErrorKeyValue, deprecatedClientErrorKeyValue, expectedClientErrorCodes);
-        }
-
         [Fact]
         public void OnlyHasReadOnlyProperties()
         {
@@ -1299,58 +810,6 @@ namespace Datadog.Trace.Tests.Configuration
                   .Contain(expected);
         }
 
-        [Fact]
-        public void DDTagsSetsServiceInformation()
-        {
-            var source = new NameValueConfigurationSource(new()
-            {
-                { "DD_TAGS", "env:datadog_env,service:datadog_service,version:datadog_version,git.repository_url:https://Myrepository,git.commit.sha:42" },
-            });
-
-            var tracerSettings = new TracerSettings(source);
-
-            tracerSettings.Environment.Should().Be("datadog_env");
-            tracerSettings.ServiceVersion.Should().Be("datadog_version");
-            tracerSettings.ServiceName.Should().Be("datadog_service");
-            tracerSettings.GitRepositoryUrl.Should().Be("https://Myrepository");
-            tracerSettings.GitCommitSha.Should().Be("42");
-        }
-
-        [Fact]
-        public void OTELTagsSetsServiceInformation()
-        {
-            var source = new NameValueConfigurationSource(new()
-            {
-                { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=datadog_env,service.name=datadog_service,service.version=datadog_version" },
-            });
-
-            var tracerSettings = new TracerSettings(source);
-
-            tracerSettings.Environment.Should().Be("datadog_env");
-            tracerSettings.ServiceVersion.Should().Be("datadog_version");
-            tracerSettings.ServiceName.Should().Be("datadog_service");
-        }
-
-        [Fact]
-        public void DDTagsTakesPrecedenceOverOTELTags()
-        {
-            var source = new NameValueConfigurationSource(new()
-            {
-                { "DD_TAGS", "env:datadog_env" },
-                { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=datadog_env,service.name=datadog_service,service.version=datadog_version" },
-            });
-
-            var errorLog = new OverrideErrorLog();
-            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
-
-            tracerSettings.Environment.Should().Be("datadog_env");
-
-            // Since the DD_TAGS config is set, the OTEL_RESOURCE_ATTRIBUTES config is ignored
-            tracerSettings.ServiceVersion.Should().NotBe("datadog_version");
-            tracerSettings.ServiceName.Should().NotBe("datadog_service");
-            errorLog.ShouldHaveExpectedOtelMetric(Count.OpenTelemetryConfigHiddenByDatadogConfig, "OTEL_RESOURCE_ATTRIBUTES".ToLowerInvariant(), "DD_TAGS".ToLowerInvariant());
-        }
-
         [Theory]
         [MemberData(nameof(BooleanTestCases), false)]
         public void InferredProxySpansEnabled(string value, bool expected)
@@ -1374,16 +833,6 @@ namespace Datadog.Trace.Tests.Configuration
             var settings = new TracerSettings(source);
 
             settings.GraphQLErrorExtensions.Should().BeEquivalentTo(expected);
-        }
-
-        [Theory]
-        [MemberData(nameof(BooleanTestCases), true)]
-        public void LogsInjectionEnabled(string value, bool expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.LogsInjectionEnabled, value));
-            var tracerSettings = new TracerSettings(source);
-
-            tracerSettings.LogsInjectionEnabled.Should().Be(expected);
         }
 
         [Theory]
@@ -1537,22 +986,6 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource(("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", value));
             var settings = new TracerSettings(source);
             settings.PartialFlushMinSpans.Should().Be(expected);
-        }
-
-        private void ValidateErrorStatusCodes(bool[] result, string newErrorKeyValue, string deprecatedErrorKeyValue, string expectedErrorRange)
-        {
-            if (newErrorKeyValue is not null || deprecatedErrorKeyValue is not null)
-            {
-                Assert.True(result[int.Parse(expectedErrorRange)]);
-            }
-            else
-            {
-                var statusCodeLimitsRange = expectedErrorRange.Split('-');
-                for (var i = int.Parse(statusCodeLimitsRange[0]); i <= int.Parse(statusCodeLimitsRange[1]); i++)
-                {
-                    Assert.True(result[i]);
-                }
-            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/SettingsInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/SettingsInstrumentationTests.cs
@@ -208,8 +208,8 @@ public class SettingsInstrumentationTests
 
         AssertEquivalent(manual, automatic);
         automatic.ServiceNameMappings.Should().Equal(mappings);
-        automatic.HttpClientErrorStatusCodes.Should().Equal(TracerSettings.ParseHttpCodesToArray(string.Join(",", clientErrors)));
-        automatic.HttpServerErrorStatusCodes.Should().Equal(TracerSettings.ParseHttpCodesToArray(string.Join(",", serverErrors)));
+        automatic.HttpClientErrorStatusCodes.Should().Equal(MutableSettings.ParseHttpCodesToArray(string.Join(",", clientErrors)));
+        automatic.HttpServerErrorStatusCodes.Should().Equal(MutableSettings.ParseHttpCodesToArray(string.Join(",", serverErrors)));
 
         automatic.Integrations[IntegrationId.OpenTelemetry].Enabled.Should().BeFalse();
         automatic.Integrations[IntegrationId.Kafka].Enabled.Should().BeFalse();


### PR DESCRIPTION
## Summary of changes

- Extract a `MutableSettings` type from `TracerSettings`
- Extract a `Raw` type from `ExporterSettings`

## Reason for change

We're working on refactoring how we handle dynamic/remote/config in code settings i.e. settings which can change at runtime. As a first step, this PR extracts those settings to their own type, called `MutableSettings` because they mutable during the lifetime of the app.

> Feel free to suggest other names for this type, or we can alternatively bikeshed it later.

Additionally, extracted the "raw" settings from `ExporterSettings`. These are the values which are read from config sources. The actual values of `ExporterSettings` are set based on these values, using a highly convoluted (backward compatible) series of methods, but the idea is: if the `Raw` settings haven't changed, the `ExporterSettings` haven't changed.

> This isn't _strictly_ true due to the `File.Exists` call we have, but I believe this is good enough for our purposes.

## Implementation details

- Create `MutableSettings` and move all the properties from `TracerSettings` that _can_ change to it.
- Update `TracerSettings` to create an instance of `MutableSettings`, and simply pass-through properties to it.
  - This should mean existing functionality is unaffected by this PR
- Implement `IEquatable<MutableSettings>` for future comparisons between `MutableSettings` instances
  - Unfortunately, can't use a `record` here or auto-gen the implementation, because we need to handle equivalence of the dictionaries.
- Extract the "raw" setting reading to an `ExporterSettings` nested-type
  - Opted for nested here, because unlike `MutableSettings` (which will eventually live separately from `TracerSettings`) we won't expose `Raw` to consumers -  they'll still use `ExporterSettings`

## Test coverage

This is just a refactoring, so it's covered by existing tests.

Additionally, I added a test for the `IEquatable` implementation (which is similar to the test we have for `ImmutableDynamicSettings`) to ensure the implementation is updated if we add more properties.

## Other details

https://datadoghq.atlassian.net/browse/LANGPLAT-819

Part of a config stack


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
