### PR TITLE
Ensure `execution_benchmarks` download the profiler

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4322,7 +4322,7 @@ stages:
           GITHUB_TOKEN: $(GITHUB_APP_TOKEN)
 
 - stage: execution_benchmarks
-  dependsOn: [build_windows_tracer, merge_commit_id]
+  dependsOn: [build_windows_tracer, build_windows_profiler, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -4354,7 +4354,7 @@ stages:
 
     - template: steps/download-artifact.yml
       parameters:
-        artifact: windows-tracer-home
+        artifact: windows-profiler-home
         path: $(monitoringHome)
         retryCountOnTaskFailure: 5
 


### PR DESCRIPTION
## Summary of changes

Ensure the profiler files are available in the execution benchmarks

## Reason for change

While working on #7287, we discovered that the profiler was not downloaded, which was causing a stable config PInvoke to fail. To more closely replicate customer environments, we should ensure the profiler is available in these benchmarks, as it will impact startup time etc.

> Note that we are introducing a separate mitigation in #7287 to handle the scenario where the profiler is not available, e.g. in serverless environments

## Implementation details

Download the `windows-profiler-home` artifact. Note that the `windows-tracer-home` artifact is _already_ available thanks to the `restore-working-directory` step, so it's not necessary to re-download it.

## Test coverage

This is the test, we'll examine the benchmarks out of interest to see if there's any impact, but fundamentally this is the more "correct" behaviour anyway.

## Other details

Blocks #7287