### PR TITLE
Hide problematic public APIs using `[EditorBrowsable]`

### DIFF
--- a/tracer/src/Datadog.Trace.Manual/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace.Manual/Configuration/ExporterSettings.cs
@@ -24,6 +24,11 @@ public sealed class ExporterSettings
     /// Gets or sets the Uri where the Tracer can connect to the Agent.
     /// Default is <c>"http://localhost:8126"</c>.
     /// </summary>
+    /// <remarks>As of tracer version 3.27.0, this property cannot be used to set the
+    /// agent URI. You must instead use a static configuration source such
+    /// as environment variables or datadog.json to set the value instead. This
+    /// property will be marked obsolete and removed in a future version of Datadog.Trace.
+    /// </remarks>
     [Obsolete("This property is obsolete and will be removed in a future version. To set the AgentUri, use the TracerSettings.AgentUri property")]
     public Uri AgentUri
     {

--- a/tracer/src/Datadog.Trace.Manual/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace.Manual/Configuration/ExporterSettings.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.ComponentModel;
+
 namespace Datadog.Trace.Configuration;
 
 /// <summary>
@@ -26,6 +28,8 @@ public sealed class ExporterSettings
     public Uri AgentUri
     {
         get => _tracerSettings.AgentUri;
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         set => _tracerSettings.AgentUri = value;
     }
 }

--- a/tracer/src/Datadog.Trace.Manual/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace.Manual/Configuration/TracerSettings.cs
@@ -45,6 +45,9 @@ public sealed class TracerSettings
     /// <summary>
     /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values.
     /// </summary>
+    /// <remarks>As of tracer version 3.27.0, this method is hidden, as it encourages the pattern of
+    /// not reading from the default configuration sources, which is discouraged. Use
+    /// <see cref="FromDefaultSources" /> instead.</remarks>
     [Instrumented]
     [MethodImpl(MethodImplOptions.NoInlining)]
     [Browsable(false)]
@@ -62,6 +65,9 @@ public sealed class TracerSettings
     /// or initializes the configuration from environment variables and configuration files.
     /// Calling <c>new TracerSettings(true)</c> is equivalent to calling <c>TracerSettings.FromDefaultSources()</c>
     /// </summary>
+    /// <remarks>As of tracer version 3.27.0, this method is hidden, as it encourages the pattern of
+    /// not reading from the default configuration sources, which is discouraged. Use
+    /// <see cref="FromDefaultSources" /> instead.</remarks>
     /// <param name="useDefaultSources">If <c>true</c>, creates a <see cref="TracerSettings"/> populated from
     /// the default sources such as environment variables etc. If <c>false</c>, uses the default values.</param>
     [Instrumented]
@@ -144,11 +150,11 @@ public sealed class TracerSettings
     /// of System.Diagnostics.DiagnosticSource is enabled.
     /// Default is <c>true</c>.
     /// </summary>
-    /// <remark>
+    /// <remarks>
     /// This value cannot be set in code. Instead,
     /// set it using the <c>DD_DIAGNOSTIC_SOURCE_ENABLED</c>
     /// environment variable or in configuration files.
-    /// </remark>
+    /// </remarks>
     public bool DiagnosticSourceEnabled
     {
         [Instrumented]
@@ -359,12 +365,12 @@ public sealed class TracerSettings
 
     /// <summary>
     /// Gets or sets a value indicating whether stats are computed on the tracer side.
-    ///
-    /// NOTE: as of tracer version 3.27.0, this property cannot be used to enable or
+    /// </summary>
+    /// <remarks>As of tracer version 3.27.0, this property cannot be used to enable or
     /// disable stats computation. You must use a static configuration source such
     /// as environment variables or datadog.json to set the property instead. This
     /// property will be marked obsolete and removed in a future version of Datadog.Trace.
-    /// </summary>
+    /// </remarks>
     public bool StatsComputationEnabled
     {
         [Instrumented]
@@ -379,6 +385,11 @@ public sealed class TracerSettings
     /// Gets or sets the Uri where the Tracer can connect to the Agent.
     /// Default is <c>"http://localhost:8126"</c>.
     /// </summary>
+    /// <remarks>As of tracer version 3.27.0, this property cannot be used to set the
+    /// agent URI. You must instead use a static configuration source such
+    /// as environment variables or datadog.json to set the value instead. This
+    /// property will be marked obsolete and removed in a future version of Datadog.Trace.
+    /// </remarks>
     public Uri AgentUri
     {
         [Instrumented]

--- a/tracer/src/Datadog.Trace.Manual/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace.Manual/Configuration/TracerSettings.cs
@@ -370,6 +370,8 @@ public sealed class TracerSettings
         [Instrumented]
         [MethodImpl(MethodImplOptions.NoInlining)]
         get => _statsComputationEnabled.Value;
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         set => _statsComputationEnabled = _statsComputationEnabled.Override(value);
     }
 

--- a/tracer/src/Datadog.Trace.Manual/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace.Manual/Configuration/TracerSettings.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation;
 using Datadog.Trace.SourceGenerators;
@@ -46,6 +47,8 @@ public sealed class TracerSettings
     /// </summary>
     [Instrumented]
     [MethodImpl(MethodImplOptions.NoInlining)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public TracerSettings()
         : this(PopulateDictionary(new(), useDefaultSources: false), isFromDefaultSources: false)
     {
@@ -63,6 +66,8 @@ public sealed class TracerSettings
     /// the default sources such as environment variables etc. If <c>false</c>, uses the default values.</param>
     [Instrumented]
     [MethodImpl(MethodImplOptions.NoInlining)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public TracerSettings(bool useDefaultSources)
         : this(PopulateDictionary(new(), useDefaultSources), useDefaultSources)
     {
@@ -153,6 +158,8 @@ public sealed class TracerSettings
         [Obsolete("This value cannot be set in code. Instead, set it using the DD_DIAGNOSTIC_SOURCE_ENABLED environment variable, or in configuration files")]
         [Instrumented]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         set
         {
             // As this was previously obsolete, we could just remove it?
@@ -351,7 +358,12 @@ public sealed class TracerSettings
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether stats are computed on the tracer side
+    /// Gets or sets a value indicating whether stats are computed on the tracer side.
+    ///
+    /// NOTE: as of tracer version 3.27.0, this property cannot be used to enable or
+    /// disable stats computation. You must use a static configuration source such
+    /// as environment variables or datadog.json to set the property instead. This
+    /// property will be marked obsolete and removed in a future version of Datadog.Trace.
     /// </summary>
     public bool StatsComputationEnabled
     {
@@ -370,6 +382,8 @@ public sealed class TracerSettings
         [Instrumented]
         [MethodImpl(MethodImplOptions.NoInlining)]
         get => _agentUri.Value;
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         set => _agentUri = _agentUri.Override(value);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.AssemblyReferencesHaveNotChanged.net6.0.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.AssemblyReferencesHaveNotChanged.net6.0.verified.txt
@@ -1,5 +1,6 @@
 System.Collections, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.Concurrent, Version=4.0.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+System.ComponentModel.Primitives, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Diagnostics.Debug, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Linq, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Runtime, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
@@ -1,5 +1,6 @@
 System.Collections, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.Concurrent, Version=4.0.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+System.ComponentModel.Primitives, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Diagnostics.Debug, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Linq, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Runtime, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.PublicApiHasNotChanged.verified.txt
@@ -469,6 +469,7 @@ namespace Datadog.Trace.Configuration
         public string? ServiceName { get; set; }
         public string? ServiceVersion { get; set; }
         public bool StartupDiagnosticLogEnabled { get; set; }
+        [set: System.ComponentModel.Browsable(false)]
         public bool StatsComputationEnabled { get; set; }
         public bool TraceEnabled { get; set; }
         public bool TracerMetricsEnabled { get; set; }

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.PublicApiHasNotChanged.verified.txt
@@ -374,6 +374,7 @@ namespace Datadog.Trace.Configuration
     {
         [System.Obsolete("This property is obsolete and will be removed in a future version. To set the Age" +
             "ntUri, use the TracerSettings.AgentUri property")]
+        [set: System.ComponentModel.Browsable(false)]
         public System.Uri AgentUri { get; set; }
     }
     public sealed class GlobalSettings
@@ -438,13 +439,17 @@ namespace Datadog.Trace.Configuration
     }
     public sealed class TracerSettings
     {
+        [System.ComponentModel.Browsable(false)]
         public TracerSettings() { }
+        [System.ComponentModel.Browsable(false)]
         public TracerSettings(bool useDefaultSources) { }
+        [set: System.ComponentModel.Browsable(false)]
         public System.Uri AgentUri { get; set; }
         [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
             "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
         public bool AnalyticsEnabled { get; set; }
         public string? CustomSamplingRules { get; set; }
+        [set: System.ComponentModel.Browsable(false)]
         [set: System.Obsolete("This value cannot be set in code. Instead, set it using the DD_DIAGNOSTIC_SOURCE_" +
             "ENABLED environment variable, or in configuration files")]
         public bool DiagnosticSourceEnabled { get; set; }


### PR DESCRIPTION
## Summary of changes

Hides some of the public APIs exposed in Datadog.Trace that we don't think customer should be using.

## Reason for change

There are several configuration APIs that customers can call using configuration in code which are problematic:

- `new TracerSettings()` - ignores all env vars and default sources. Customers should generally be calling `TracerSettings.FromDefaultSources()`, it's unlikely that they really _want_ this behavior. It also makes our code much more complex.
- `new TracerSettings(bool useDefaultSources)` - as above
- `TracerSettings.set_StatsComputationEnabled` - changing this at runtime is problematic, particularly with the move to libdatadog data pipeline, and at some point soon we'll basically be ignoring it 
- `TracerSettings.set_AgentUri` - changing this at runtime means everything has to reinitialialize, and customers likely end up with incorrect values for some period of time, as well as increased startup times
- `TracerSettings.Exporter.set_AgentUri` - as above

We would _like_ to obsolete and remove these properties, but that takes two major versions to do (one to obsolete them, one to remove them). This at least ensures that _new_ customers shouldn't use these APIs.

## Implementation details

Add `[Browsable(false)]` and `[EditorBrowsable(EditorBrowsableState.Never)]` to the APIs.

## Test coverage

There's no change in functionality, so nothing really to test. Updated the public APIs. This requires an additional in-box reference for .NET Core 3.1 + .NET 6, but I think that's fine.

## Other details

https://datadoghq.atlassian.net/browse/LANGPLAT-819

