### PR TITLE
Capture timeout exceptions in IAST tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
@@ -422,16 +422,10 @@ public class InstrumentationTestsBase : IDisposable
             {
                 return expression.Invoke();
             }
-            catch (System.Data.SqlClient.SqlException ex) // System.Data.SqlClient.SqlException : Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.
+            catch (System.Data.SqlClient.SqlException ex) when (ex.Message.StartsWith("Timeout expired", StringComparison.OrdinalIgnoreCase))
             {
-                if (ex.Message.StartsWith("Timeout expired", StringComparison.OrdinalIgnoreCase))
-                {
-                    return default(T);
-                }
-                else
-                {
-                    throw;
-                }
+                // System.Data.SqlClient.SqlException : Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.
+                return default(T);
             }
         }
     }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
@@ -422,9 +422,16 @@ public class InstrumentationTestsBase : IDisposable
             {
                 return expression.Invoke();
             }
-            catch (System.Data.SqlClient.SqlException) // System.Data.SqlClient.SqlException : Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.
+            catch (System.Data.SqlClient.SqlException ex) // System.Data.SqlClient.SqlException : Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.
             {
-                return default(T);
+                if (ex.Message.StartsWith("Timeout expired", StringComparison.OrdinalIgnoreCase))
+                {
+                    return default(T);
+                }
+                else
+                {
+                    throw;
+                }
             }
         }
     }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
@@ -418,7 +418,14 @@ public class InstrumentationTestsBase : IDisposable
         }
         else
         {
-            return expression.Invoke();
+            try
+            {
+                return expression.Invoke();
+            }
+            catch (System.Data.SqlClient.SqlException) // System.Data.SqlClient.SqlException : Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.
+            {
+                return default(T);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary of changes

We have started to get some[ flaky errors](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.status%3Afail%20%40git.branch%3Amaster%20%40test.full_name%3ADatadog.Trace.Security.IntegrationTests.Datadog.Trace.Security.IntegrationTests.Iast.IastInstrumentationUnitTests.TestInstrumentedUnitTests&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1755608623079&end=1758200623079&paused=false) in IAST unit instrumentation tests lately.

All the errors are related to local DDBB SQL queries under Windows with the same exception:

```
Failed Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.SqlCommandTests.GivenASqlCommand_WhenCallingExecuteNonQueryWithTainted_VulnerabilityIsReported [34 s]
09:55:03 [DBG]    Error Message:
09:55:03 [DBG]     System.Data.SqlClient.SqlException : Timeout expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.
09:55:03 [DBG]  ---- System.ComponentModel.Win32Exception : The wait operation timed out.
09:55:03 [DBG]    Stack Trace:
09:55:03 [DBG]       at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
09:55:03 [DBG]     at System.Data.SqlClient.SqlInternalConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
09:55:03 [DBG]     at System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)
09:55:03 [DBG]     at System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
09:55:03 [DBG]     at System.Data.SqlClient.SqlCommand.RunExecuteNonQueryTds(String methodName, Boolean async, Int32 timeout, Boolean asyncWrite)
09:55:03 [DBG]     at System.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1 completion, Boolean sendToPipe, Int32 timeout, Boolean asyncWrite, String methodName)
09:55:03 [DBG]     at System.Data.SqlClient.SqlCommand.ExecuteNonQuery()
09:55:03 [DBG]     at Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.SqlCommandTests.<GivenASqlCommand_WhenCallingExecuteNonQueryWithTainted_VulnerabilityIsReported>b__7_0() in D:\a\_work\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SqlInjection\SqlCommandTests.cs:line 41
09:55:03 [DBG]     at Samples.InstrumentedTests.Iast.InstrumentationTestsBase.TestRealDDBBLocalCall[T](Func`1 expression) in D:\a\_work\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\InstrumentationTestsBase.cs:line 421
09:55:03 [DBG]     at Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection.SqlCommandTests.GivenASqlCommand_WhenCallingExecuteNonQueryWithTainted_VulnerabilityIsReported() in D:\a\_work\1\s\tracer\test\test-applications\integrations\Samples.InstrumentedTests\Vulnerabilities\SqlInjection\SqlCommandTests.cs:line 41
```

The stack shows that the error is not related to our instrumentations but to a timeout inside the library. The connection string for these Windows tests is this one:

`var connectionString = @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60;MultipleActiveResultSets=true";`

When using it, we should not get timeouts since we are executing small queries over a local DDBB. Still, this behavior is not related to the tracer or ASM.

This error has also started to happen in the last week while while there are no commits that seem to affect these tests, so why this has started to happen is a question that remains open.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
