### PR TITLE
Add a Continuous Profiler availability check

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerAvailabilityHelper.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerAvailabilityHelper.cs
@@ -18,7 +18,18 @@ internal static class ProfilerAvailabilityHelper
     // We should add or remove conditions from here as our deployment requirements change.
     // Longer term, we'd like to be able to pass this information from the native side to the managed side, but
     // today that only works on Windows (hence the early short-circuit).
-    private static readonly Lazy<bool> ProfilerIsAvailable = new(() =>
+    private static readonly Lazy<bool> ProfilerIsAvailable = new(() => GetIsContinuousProfilerAvailable(EnvironmentHelpersNoLogging.IsClrProfilerAttachedSafe));
+
+    /// <summary>
+    /// Gets a value indicating whether returns true if the continuous profiler _should_ be available
+    /// </summary>
+    public static bool IsContinuousProfilerAvailable => ProfilerIsAvailable.Value;
+
+    // Internal for testing
+    internal static bool IsContinuousProfilerAvailable_TestingOnly(Func<bool> isClrProfilerAttached)
+        => GetIsContinuousProfilerAvailable(isClrProfilerAttached);
+
+    private static bool GetIsContinuousProfilerAvailable(Func<bool> isClrProfilerAttached)
     {
         // Profiler is not available on ARM(64)
         var fd = FrameworkDescription.Instance;
@@ -39,11 +50,11 @@ internal static class ProfilerAvailabilityHelper
         // - AWS Lambda
         // - Azure Functions where the site extension is _not_ used
         var isUnsupported = EnvironmentHelpers.IsAwsLambda()
-                         || (EnvironmentHelpers.IsAzureFunctions() && !EnvironmentHelpers.IsUsingAzureAppServicesSiteExtension());
+                            || (EnvironmentHelpers.IsAzureFunctions() && !EnvironmentHelpers.IsUsingAzureAppServicesSiteExtension());
 
         // As a final check, we check whether the ClrProfiler is attached - if it's not, then the P/Invokes won't
         // have been re-written, and native calls won't work.
-        return !isUnsupported && EnvironmentHelpersNoLogging.IsClrProfilerAttachedSafe();
+        return !isUnsupported && isClrProfilerAttached();
 
         static bool IsSupportedArch(FrameworkDescription fd)
         {
@@ -54,10 +65,5 @@ internal static class ProfilerAvailabilityHelper
                 _ => false,
             };
         }
-    });
-
-    /// <summary>
-    /// Gets a value indicating whether returns true if the continuous profiler _should_ be available
-    /// </summary>
-    public static bool IsContinuousProfilerAvailable => ProfilerIsAvailable.Value;
+    }
 }

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerAvailabilityHelper.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerAvailabilityHelper.cs
@@ -1,0 +1,63 @@
+// <copyright file="ProfilerAvailabilityHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.ContinuousProfiler;
+
+internal static class ProfilerAvailabilityHelper
+{
+    // This will never change, so we use a lazy to cache the result.
+    // This confirms that we are in an automatic instrumentation environment (and so P/Invokes have been re-written)
+    // and that the profiling library has been deployed (which is not the case in some serverless environments).
+    // We should add or remove conditions from here as our deployment requirements change.
+    // Longer term, we'd like to be able to pass this information from the native side to the managed side, but
+    // today that only works on Windows (hence the early short-circuit).
+    private static readonly Lazy<bool> ProfilerIsAvailable = new(() =>
+    {
+        // Profiler is not available on ARM(64)
+        var fd = FrameworkDescription.Instance;
+        if (!IsSupportedArch(fd))
+        {
+            return false;
+        }
+
+        // This variable is set by the native loader after trying to load the profiler
+        // it means the profiler is _there_ though it may not be _loaded_. This only works
+        // on Windows at the moment. We assume that the CLR profiler must be attached in this scenario
+        if (fd.IsWindows() && !string.IsNullOrEmpty(EnvironmentHelpers.GetEnvironmentVariable("DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH")))
+        {
+            return true;
+        }
+
+        // Now we're into fuzzy territory. The CP is not available in some environments
+        // - AWS Lambda
+        // - Azure Functions where the site extension is _not_ used
+        var isUnsupported = EnvironmentHelpers.IsAwsLambda()
+                         || (EnvironmentHelpers.IsAzureFunctions() && !EnvironmentHelpers.IsUsingAzureAppServicesSiteExtension());
+
+        // As a final check, we check whether the ClrProfiler is attached - if it's not, then the P/Invokes won't
+        // have been re-written, and native calls won't work.
+        return !isUnsupported && EnvironmentHelpersNoLogging.IsClrProfilerAttachedSafe();
+
+        static bool IsSupportedArch(FrameworkDescription fd)
+        {
+            return fd.OSPlatform switch
+            {
+                OSPlatformName.Windows when fd.ProcessArchitecture is ProcessArchitecture.X64 or ProcessArchitecture.X86 => true,
+                OSPlatformName.Linux when fd.ProcessArchitecture is ProcessArchitecture.X64 => true,
+                _ => false,
+            };
+        }
+    });
+
+    /// <summary>
+    /// Gets a value indicating whether returns true if the continuous profiler _should_ be available
+    /// </summary>
+    public static bool IsContinuousProfilerAvailable => ProfilerIsAvailable.Value;
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ContinuousProfiler
 
                 if (!ProfilerAvailabilityHelper.IsContinuousProfilerAvailable)
                 {
-                    Log.Debug("The continuous profiler is not available in this environment.");
+                    Log.Information("The continuous profiler is not available in this environment.");
                     return;
                 }
 

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -63,6 +63,12 @@ namespace Datadog.Trace.ContinuousProfiler
 
                 _isInitialized = true;
 
+                if (!ProfilerAvailabilityHelper.IsContinuousProfilerAvailable)
+                {
+                    Log.Debug("The continuous profiler is not available in this environment.");
+                    return;
+                }
+
                 try
                 {
                     _engineStatusPtr = NativeInterop.GetProfilerStatusPointer();

--- a/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ProfilerAvailabilityHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ProfilerAvailabilityHelperTests.cs
@@ -1,0 +1,100 @@
+// <copyright file="ProfilerAvailabilityHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using ProfilerAvailabilityHelper =  Datadog.Trace.ContinuousProfiler.ProfilerAvailabilityHelper;
+
+namespace Datadog.Trace.Tests.ContinuousProfiler;
+
+[Collection(nameof(EnvironmentVariablesTestCollection))]
+[EnvironmentRestorer(
+    "DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH",
+    LambdaMetadata.FunctionNameEnvVar,
+    ConfigurationKeys.AzureAppService.SiteNameKey,
+    ConfigurationKeys.AzureFunctions.FunctionsWorkerRuntime,
+    ConfigurationKeys.AzureFunctions.FunctionsExtensionVersion,
+    ConfigurationKeys.AzureAppService.AzureAppServicesContextKey)]
+public class ProfilerAvailabilityHelperTests
+{
+    private static readonly Func<bool> ClrProfilerIsAttached = () => true;
+    private static readonly Func<bool> ClrProfilerNotAttached = () => false;
+
+    [SkippableFact]
+    public void IsContinuousProfilerAvailable_OnUnsupportedPlatforms_ReturnsFalse()
+    {
+        // Skip on platforms that it's available
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Windows, SkipOn.ArchitectureValue.X64);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Windows, SkipOn.ArchitectureValue.X86);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.X64);
+
+        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(ClrProfilerIsAttached).Should().BeFalse();
+    }
+
+    [SkippableTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsContinuousProfilerAvailable_OnSupportedPlatforms_WithNoEnvVars_ReturnsClrAttached(bool clrAttached)
+    {
+        SkipUnsupported();
+        var attachedCheck = clrAttached ? ClrProfilerIsAttached : ClrProfilerNotAttached;
+        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(attachedCheck).Should().Be(clrAttached);
+    }
+
+    [SkippableTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsContinuousProfilerAvailable_OnWindows_WithEnvVar_IgnoresAttachment_ReturnsTrue(bool clrAttached)
+    {
+        SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
+        var attachedCheck = clrAttached ? ClrProfilerIsAttached : ClrProfilerNotAttached;
+        Environment.SetEnvironmentVariable("DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH", @"c:\some\path");
+        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(attachedCheck).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public void IsContinuousProfilerAvailable_InLambda_IgnoresAttachment_ReturnsFalse()
+    {
+        SkipUnsupported();
+        Environment.SetEnvironmentVariable(LambdaMetadata.FunctionNameEnvVar, @"SomeFunction");
+        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(ClrProfilerIsAttached).Should().BeFalse();
+    }
+
+    [SkippableFact]
+    public void IsContinuousProfilerAvailable_InAzureFunctionsWithoutExtension_IgnoresAttachment_ReturnsFalse()
+    {
+        SkipUnsupported();
+        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureAppService.SiteNameKey, "MyApp");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsWorkerRuntime, "dotnet");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsExtensionVersion, "v6.0");
+        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(ClrProfilerIsAttached).Should().BeFalse();
+    }
+
+    [SkippableTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsContinuousProfilerAvailable_InAzureFunctionsWithExtension_ReturnsClrAttached(bool clrAttached)
+    {
+        SkipUnsupported();
+        var attachedCheck = clrAttached ? ClrProfilerIsAttached : ClrProfilerNotAttached;
+        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureAppService.SiteNameKey, "MyApp");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsWorkerRuntime, "dotnet");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsExtensionVersion, "v6.0");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1");
+        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(attachedCheck).Should().Be(clrAttached);
+    }
+
+    private static void SkipUnsupported()
+    {
+        SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.X86);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Windows, SkipOn.ArchitectureValue.ARM64);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
@@ -51,6 +51,7 @@ public class ConfigurationTests
         "DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER",
         // Internal env vars that we only ever read from environment
         "DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH",
+        "DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH",
         "DD_DOTNET_TRACER_HOME",
         "DD_INSTRUMENTATION_INSTALL_ID",
         "DD_INSTRUMENTATION_INSTALL_TYPE",


### PR DESCRIPTION
## Summary of changes

Add a checker to decide whether the profiler is available

## Reason for change

We are going to be (and are currently) making P/Invoke calls on startup to call the profiler. If the ClrProfiler is not attached, or the CP file is not available (and so P/Invokes are not re-written) then this can cause additional delays.

## Implementation details

Add explicit checks for
- Unsupported environments
- Has the profiler set the "profiler available" env var (only works on Windows right now)
- Are we in known unsupported environments (lambda and Azure functions outside of AAS extension)
- Is the ClrProfiler attached

## Test coverage

If everything still works, this _should_ work

## Other details

A blocker for #7287