### PR TITLE
[Azure Functions] Add Nuke targets to build local nuget for testing

### DIFF
--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -494,7 +494,8 @@ partial class Build
                 });
 
        Target DownloadBundleNugetFromBuild => _ => _
-        .Description("Downloads Datadog.Trace.Bundle package from Azure DevOps and extracts it to the local bundle home directory")
+        .Description("Downloads Datadog.Trace.Bundle package from Azure DevOps and extracts it to the local bundle home directory." +
+                     " Useful for building Datadog.Trace.Bundle or Datadog.AzureFunctions nupkg packages locally.")
         .Requires(() => BuildId)
         .Executes(async () =>
         {

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -536,7 +536,7 @@ partial class Build
             }
 
             EnsureCleanDirectory(packageExtractionDirectory);
-            CompressionTasks.UncompressZip(packageFile, packageExtractionDirectory);
+            UncompressZipQuiet(packageFile, packageExtractionDirectory);
 
             var contentDirectory = packageExtractionDirectory / "contentFiles" / "any" / "any" / "datadog";
 

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -493,7 +493,7 @@ partial class Build
                     }
                 });
 
-       Target UpdateAzureFunctionsPackageFromBuild => _ => _
+       Target UpdateAzureFunctionsNugetFromBuild => _ => _
         .Description("Downloads Datadog.AzureFunctions package from Azure DevOps, " +
                      "updates the bundle contents with a local build of Datadog.Trace.dll, " +
                      "and rebuilds the package")

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -260,7 +260,7 @@ partial class Build
            var outputPath = TracerDirectory / "build" / "supported_versions.json";
            await GenerateSupportMatrix.GenerateInstrumentationSupportMatrix(outputPath, distinctIntegrations);
        });
-    
+
     Target GenerateSpanDocumentation => _ => _
         .Description("Regenerate documentation from our code models")
         .Executes(() =>
@@ -585,9 +585,9 @@ partial class Build
             // not in CI
             return false;
         }
-        
+
         return scheduleName == "Daily Debug Run";
-    } 
+    }
 
     private static MSBuildTargetPlatform GetDefaultTargetPlatform()
     {
@@ -603,7 +603,7 @@ partial class Build
 
         return MSBuildTargetPlatform.x64;
     }
-    
+
     private static string GetDefaultRuntimeIdentifier(bool isAlpine)
     {
         // https://learn.microsoft.com/en-us/dotnet/core/rid-catalog
@@ -614,7 +614,7 @@ partial class Build
 
             (PlatformFamily.Linux, "x64") => isAlpine ? "linux-musl-x64" : "linux-x64",
             (PlatformFamily.Linux, "ARM64" or "ARM64EC") => isAlpine ? "linux-musl-arm64" : "linux-arm64",
-            
+
             (PlatformFamily.OSX, "ARM64" or "ARM64EC") => "osx-arm64",
             _ => null
         };

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -498,7 +498,6 @@ partial class Build
                      "updates the bundle contents with a local build of Datadog.Trace.dll, " +
                      "and rebuilds the package")
         .Requires(() => BuildId)
-        .Requires(() => AzureDevopsToken)
         .Triggers(BuildAzureFunctionsNuget)
         .Executes(async () =>
         {

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -551,7 +551,7 @@ partial class Build
 
        Target UpdateAzureFunctionsNugetFromBuild => _ => _
         .Description("Updates the bundle home contents with local builds of Datadog.Trace.dll, and rebuilds the Datadog.AzureFunctions package")
-        .DependsOn(DownloadBundleNugetFromBuild)
+        .After(DownloadBundleNugetFromBuild)
         .Triggers(BuildAzureFunctionsNuget)
         .Executes(() =>
         {


### PR DESCRIPTION
## Summary of changes

Adds a Nuke target to download `Datadog.Trace.Bundle` and extract it into the local bundle home directory.

## Reason for change

This is useful for building `Datadog.Trace.Bundle` or `Datadog.AzureFunctions` nupkg packages locally for testing, and I do it manually too often. Automate all the things?

## Implementation details

Add Nuke target `DownloadBundleNugetFromBuild`:
- download `Datadog.Trace.Bundle` from an Azure DevOps build
- extracts the files into `tracer/src/Datadog.Trace.Bundle/home`

Usage:
```shell
# download a fresh copy of the bundle files from Azure DevOps
.\tracer\build.ps1 DownloadBundleNugetFromBuild --BuildId 187203
```

## Test coverage

Tested locally. Not used in production builds.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
