### PR TITLE
Fix the `verify_app_trimming_changes_are_persisted` job

### DIFF
--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -26,7 +26,7 @@ jobs:
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace.Trimming\build\Datadog.Trace.Trimming.xml" -Recurse -File | Remove-Item
 
       - name: "Regenerating Datadog.Trace.Trimming.xml"
-        run: .\tracer\build.ps1 BuildTracerHome CreateTrimmingFile
+        run: .\tracer\build.ps1 BuildManagedTracerHome CreateTrimmingFile
 
       - name: "Verify no changes in Datadog.Trace.Trimming.xml"
         run: |


### PR DESCRIPTION
## Summary of changes

Fixes the `verify_app_trimming_changes_are_persisted` job

## Reason for change

The trimming job is currently trying to build the native code, but [we're getting this error](https://github.com/DataDog/dd-trace-dotnet/actions/runs/17909695789/job/50921858072?pr=7287):

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.Cpp.WindowsSDK.targets(46,5):
error MSB8036: The Windows SDK version 10.0.19041.0 was not found.
Install the required version of Windows SDK or change the SDK version in the project property
pages or by right-clicking the solution and selecting "Retarget solution".
```

We only need to build the managed code to regenerate the trimming file, so fix that

## Implementation details

`BuildTracerHome` -> `BuildManagedTracerHome`

## Test coverage

If this PR passes, we're good

## Other details

Blocking CI in general