### PR TITLE
Protect against UriFormatException

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -348,8 +348,6 @@ src/Datadog.Trace/Telemetry/DTOs/IPayload.cs
 src/Datadog.Trace/Telemetry/Metrics/IntegrationIdExtensions.cs
 src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
 src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
-src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
-src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
 src/Datadog.Trace/Util/Http/QueryStringManager.cs
 src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
 src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafConfigStruct.cs

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -8,6 +8,8 @@
 using System.Web;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet;
 
+#nullable enable
+
 namespace Datadog.Trace.Util.Http
 {
     internal static partial class HttpRequestExtensions
@@ -36,13 +38,15 @@ namespace Datadog.Trace.Util.Http
         /// <seealso cref="Configuration.ConfigurationKeys.FeatureFlags.BypassHttpRequestUrlCachingEnabled"/>
         internal static string GetUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager, bool bypassHttpRequestUrl)
         {
-            if (bypassHttpRequestUrl)
+            var url = bypassHttpRequestUrl ? RequestDataHelper.BuildUrl(request) : RequestDataHelper.GetUrl(request);
+
+            if (url is not null)
             {
-                return HttpRequestUtils.GetUrl(RequestDataHelper.BuildUrl(request), queryStringManager);
+                return HttpRequestUtils.GetUrl(url, queryStringManager);
             }
             else
             {
-                return HttpRequestUtils.GetUrl(RequestDataHelper.GetUrl(request), queryStringManager);
+                return string.Empty;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Util.Http
         /// <param name="bypassHttpRequestUrl">Whether or not to call access HttpRequest.Url (which caches the URL in HttpRequest).</param>
         /// <returns>The retrieved Url.</returns>
         /// <seealso cref="Configuration.ConfigurationKeys.FeatureFlags.BypassHttpRequestUrlCachingEnabled"/>
-        internal static string GetUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager, bool bypassHttpRequestUrl)
+        internal static string? GetUrlForSpan(this HttpRequest request, QueryStringManager queryStringManager, bool bypassHttpRequestUrl)
         {
             var url = bypassHttpRequestUrl ? RequestDataHelper.BuildUrl(request) : RequestDataHelper.GetUrl(request);
 
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Util.Http
             }
             else
             {
-                return string.Empty;
+                return null;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
@@ -36,6 +36,6 @@ namespace Datadog.Trace.Util.Http
             return $"{scheme}://{GetNormalizedHost(host)}{(port.HasValue ? $":{port}" : string.Empty)}{pathBase}{path}";
         }
 
-        internal static string GetNormalizedHost(string? host) => host is null || host.Equals(string.Empty) ? NoHostSpecified : host;
+        internal static string GetNormalizedHost(string? host) => host is null || host.Length == 0 ? NoHostSpecified : host;
     }
 }

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
@@ -7,13 +7,15 @@ using System;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Util.Http.QueryStringObfuscation;
 
+#nullable enable
+
 namespace Datadog.Trace.Util.Http
 {
     internal class HttpRequestUtils
     {
         private const string NoHostSpecified = "UNKNOWN_HOST";
 
-        internal static string GetUrl(Uri uri, QueryStringManager queryStringManager = null)
+        internal static string GetUrl(Uri uri, QueryStringManager? queryStringManager = null)
             => GetUrl(
                 uri.Scheme,
                 uri.Host,
@@ -23,7 +25,7 @@ namespace Datadog.Trace.Util.Http
                 uri.Query,
                 queryStringManager);
 
-        internal static string GetUrl(string scheme, string host, int? port, string pathBase, string path, string queryString, QueryStringManager queryStringManager = null)
+        internal static string GetUrl(string scheme, string host, int? port, string pathBase, string path, string queryString, QueryStringManager? queryStringManager = null)
         {
             if (queryStringManager != null)
             {
@@ -34,6 +36,6 @@ namespace Datadog.Trace.Util.Http
             return $"{scheme}://{GetNormalizedHost(host)}{(port.HasValue ? $":{port}" : string.Empty)}{pathBase}{path}";
         }
 
-        internal static string GetNormalizedHost(string host) => string.IsNullOrEmpty(host) ? NoHostSpecified : host;
+        internal static string GetNormalizedHost(string? host) => host is null || host.Equals(string.Empty) ? NoHostSpecified : host;
     }
 }

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
@@ -36,6 +36,6 @@ namespace Datadog.Trace.Util.Http
             return $"{scheme}://{GetNormalizedHost(host)}{(port.HasValue ? $":{port}" : string.Empty)}{pathBase}{path}";
         }
 
-        internal static string GetNormalizedHost(string? host) => host is null || host.Length == 0 ? NoHostSpecified : host;
+        internal static string GetNormalizedHost(string? host) => StringUtil.IsNullOrEmpty(host) ? NoHostSpecified : host;
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
@@ -52,7 +52,7 @@ public class RequestDataHelperTests
     [Fact]
     public void GivenAIncorrectHost_WhenGetUrl_HelperAvoidsException()
     {
-        var workerRequest = new MySimpleWorker("/test", "/test", "test.aspx", null, new StringWriter());
+        var workerRequest = new SimpleWorkerInvalidHost("/test", "/test", "test.aspx", null, new StringWriter());
         var context = new HttpContext(workerRequest);
         var request = context.Request;
 
@@ -370,9 +370,9 @@ public class RequestDataHelperTests
         }
     }
 
-    public class MySimpleWorker : SimpleWorkerRequest
+    public class SimpleWorkerInvalidHost : SimpleWorkerRequest
     {
-        public MySimpleWorker(string appVirtualDir, string appPhysicalDir, string page, string query, TextWriter output)
+        public SimpleWorkerInvalidHost(string appVirtualDir, string appPhysicalDir, string page, string query, TextWriter output)
             : base(appVirtualDir, appPhysicalDir, page, query, output)
         {
         }


### PR DESCRIPTION
## Summary of changes

We are getting the [following error](https://app.datadoghq.com/error-tracking?query=source%3Adotnet%20-%2AAppSec%2A%20-%2Adebugger%2A&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22ca471d9c-3adf-11f0-9488-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&view=spans&from_ts=1758274900427&to_ts=1758289300427&live=true) in error tracking:

```
Error : Datadog ASP.NET HttpModule instrumentation error
System.UriFormatException
at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind)
at System.Web.Util.UriUtil.BuildUriImpl(String scheme, String serverName, String port, String path, String queryString, Boolean useLegacyRequestUrlGeneration)
at System.Web.HttpRequest.BuildUrl(Func`1 pathAccessor)
at System.Web.HttpRequest.get_Url()
at Datadog.Trace.AspNet.TracingHttpModule.OnBeginRequest(Object sender, EventArgs eventArgs)
```

The error was not easy to reproduce since the request has to be initially correct so it actually reaches the server.

After some tests, the error could be reproduced by adding a new module in our sample page. This module modifies the request by adding a new server name, which ends up modifying the host name of the url.

```
public class ForwardedHostBreakModule : IHttpModule
{
    public void Init(HttpApplication app)
    {
        app.BeginRequest += (s, e) =>
        {
            var ctx = ((HttpApplication)s).Context;

            // Customer-likely path: If a proxy sent X-Forwarded-Host, copy it to SERVER_NAME
            var fwd = ctx.Request.Headers["X-Forwarded-Host"];
            if (!string.IsNullOrEmpty(fwd))
            {
                // This mutates what System.Web uses to assemble Request.Url
                ctx.Request.ServerVariables.Set("SERVER_NAME", fwd);
            }
        };
    }
    public void Dispose() { }
}
```

And in web.config:

```
  <system.webServer>
    <modules runAllManagedModulesForAllRequests="true">
      <add name="ForwardedHostBreakModule" type="ForwardedHostBreakModule" />
      </modules>
  </system.webServer>
</configuration>
```

If we send this request containing this header and value to a sample page containing the previous module, we will get the same exception that is shown in error tracking:

X-Forwarded-Host: localhost:4444ide

## Reason for change

## Implementation details

## Test coverage

A new integration tests could be added by replicating the previous method. Not really fond of adding this overhead to our CI and sample apps in this case, since it's a corner case not so easy to reproduce.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
