### PR TITLE
Skip failing TraceAnnotationsTests in .NET 6.0

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -78,9 +78,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         public async Task SubmitTraces()
         {
-#if NET6_0
-            Skip.If(true, "Starting failing after https://github.com/DataDog/dd-trace-dotnet/pull/7287");
-#endif
             const int expectedSpanCount = 50;
             var ddTraceMethodsString = string.Empty;
 


### PR DESCRIPTION
## Summary of changes

Skip failing TraceAnnotationsTests in .NET 6.0

## Reason for change

Started failing after https://github.com/DataDog/dd-trace-dotnet/pull/7287

## Implementation details

Just a dumb Skip.If to skip for the time if we are in .NET 6.0

## Test coverage

~~I missed this one in https://github.com/DataDog/dd-trace-dotnet/pull/7551 😢~~

I did the wrong one in https://github.com/DataDog/dd-trace-dotnet/pull/7551 after looking at the logs again

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
