### PR TITLE
Fix flakiness in the `TraceAnnotation` tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         public async Task SubmitTraces()
         {
-            const int expectedSpanCount = 50;
+            const int expectedSpanCount = 51;
             var ddTraceMethodsString = string.Empty;
 
             foreach (var type in TestTypes)
@@ -98,7 +98,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
-                var orderedSpans = spans.OrderBy(s => s.Start).ToList();
+                // Exclude the http span
+                var orderedSpans = spans
+                                  .Where(s => !s.Tags.ContainsKey("http-client-handler-type"))
+                                  .OrderBy(s => s.Start)
+                                  .ToList();
                 var rootSpan = orderedSpans.First();
                 var remainingSpans = orderedSpans.Skip(1).ToList();
 
@@ -181,12 +185,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task IntegrationDisabled()
         {
-#if NET6_0
-            Skip.If(true, "Starting failing after https://github.com/DataDog/dd-trace-dotnet/pull/7287");
-#endif
             // Don't bother with telemetry in version mismatch scenarios because older versions may only support V1 telemetry
             // which we no longer support in our mock telemetry agent
             // FIXME: Could be fixed with an upgrade to the NuGet package (after .NET 8?)
+            EnvironmentHelper.DebugModeEnabled = true;
             MockTelemetryAgent telemetry = _enableTelemetry ? this.ConfigureTelemetry() : null;
             SetEnvironmentVariable("DD_TRACE_METHODS", string.Empty);
             SetEnvironmentVariable("DD_TRACE_ANNOTATIONS_ENABLED", "false");
@@ -195,7 +197,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.Spans;
 
-            Assert.Empty(spans);
+            // Only the http client spans should be there
+            spans.Should().OnlyContain(s => s.Tags.ContainsKey("http-client-handler-type"));
             if (telemetry != null)
             {
                 await telemetry.AssertIntegrationAsync(IntegrationId.TraceAnnotations, enabled: false, autoEnabled: false);

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
@@ -112,6 +112,12 @@ namespace Samples.TraceAnnotations
             HttpRequestMessage message = new HttpRequestMessage();
             message.Method = HttpMethod.Get;
 
+            // trigger a "standard" instrumented integration to ensure that integration telemetry is always sent,
+            // even when trace annotations are disabled
+            message.RequestUri = new Uri("http://www.google.com");
+            var httpClient = new HttpClient();
+            using var response = await httpClient.SendAsync(message);
+
             // Delay
             await Task.Delay(500);
 


### PR DESCRIPTION
## Summary of changes

Fixes flakiness in the `TraceAnnotation` tests

## Reason for change

https://github.com/DataDog/dd-trace-dotnet/pull/7287 incidentally introduced flakiness in the test when the profiler is not available (i.e. only on Windows). We temporarily disabled the test in `#7551` and `#7552`. This reinstates the test, and removes the flake.

## Implementation details

The important thing is that we do a "real" instrumentation in the app, to insure that we send instrumentation telemetry. Without this, there's a race condition between us instrumenting our "own" `HttpClient` usages and the app ending. 

In more detail, we see this flake because:

- The integration telemetry is only sent when something is instrumented (or subsequently errors)
- The delay in profiling introduced in #7287 causes a delay in sending the calltarget definitions
  - We will address that delay in a separate PR
- The telemetry thread runs in the background, and is already started before we P/Invoke into the profiler
- The delay causes us to not instrument the HttpClient calls that the background telemetry thread makes initially - if we skip the P/Invoke, then they are instrumented at this point
- The app shuts down, which causes another telemetry flush
- At this point the `HttpClient` calls are instrumented, and the instrumentation details are collected, but now we're shutting down, so this data is never sent.

By forcing an instrumentation in the app, we bypass the race condition entirely.

## Test coverage

Excluded the span from the tests so it's effectively the same. We don't care about the contents of that span (or whether the request passes or fails) - we just want to make sure we have instrumentation.

## Other details