### PR TITLE
Update profiler availability helper to assume Windows always sets the env var

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerAvailabilityHelper.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerAvailabilityHelper.cs
@@ -40,17 +40,16 @@ internal static class ProfilerAvailabilityHelper
 
         // This variable is set by the native loader after trying to load the profiler
         // it means the profiler is _there_ though it may not be _loaded_. This only works
-        // on Windows at the moment. We assume that the CLR profiler must be attached in this scenario
-        if (fd.IsWindows() && !string.IsNullOrEmpty(EnvironmentHelpers.GetEnvironmentVariable("DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH")))
+        // on Windows at the moment. We assume that the CLR profiler must be attached in this scenario.
+        if (fd.IsWindows())
         {
-            return true;
+            return !string.IsNullOrEmpty(EnvironmentHelpers.GetEnvironmentVariable("DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH"));
         }
 
         // Now we're into fuzzy territory. The CP is not available in some environments
         // - AWS Lambda
-        // - Azure Functions where the site extension is _not_ used
-        var isUnsupported = EnvironmentHelpers.IsAwsLambda()
-                            || (EnvironmentHelpers.IsAzureFunctions() && !EnvironmentHelpers.IsUsingAzureAppServicesSiteExtension());
+        // - Azure Functions where the site extension is _not_ used (Site extension is Windows only, so that's already covered)
+        var isUnsupported = EnvironmentHelpers.IsAwsLambda() || EnvironmentHelpers.IsAzureFunctions();
 
         // As a final check, we check whether the ClrProfiler is attached - if it's not, then the P/Invokes won't
         // have been re-written, and native calls won't work.

--- a/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ProfilerAvailabilityHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ProfilerAvailabilityHelperTests.cs
@@ -58,6 +58,16 @@ public class ProfilerAvailabilityHelperTests
         ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(attachedCheck).Should().BeTrue();
     }
 
+    [SkippableTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsContinuousProfilerAvailable_OnWindows_NoEnvVar_IgnoresAttachment_ReturnsFalse(bool clrAttached)
+    {
+        SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
+        var attachedCheck = clrAttached ? ClrProfilerIsAttached : ClrProfilerNotAttached;
+        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(attachedCheck).Should().BeFalse();
+    }
+
     [SkippableFact]
     public void IsContinuousProfilerAvailable_InLambda_IgnoresAttachment_ReturnsFalse()
     {
@@ -96,5 +106,6 @@ public class ProfilerAvailabilityHelperTests
         SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.X86);
         SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
         SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Windows, SkipOn.ArchitectureValue.ARM64);
+        SkipOn.Platform(SkipOn.PlatformValue.Windows); // Windows is controlled by env var only, so doesn't apply to most tests
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ProfilerAvailabilityHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ProfilerAvailabilityHelperTests.cs
@@ -77,27 +77,13 @@ public class ProfilerAvailabilityHelperTests
     }
 
     [SkippableFact]
-    public void IsContinuousProfilerAvailable_InAzureFunctionsWithoutExtension_IgnoresAttachment_ReturnsFalse()
+    public void IsContinuousProfilerAvailable_InAzureFunctions_IgnoresAttachment_ReturnsFalse()
     {
         SkipUnsupported();
         Environment.SetEnvironmentVariable(ConfigurationKeys.AzureAppService.SiteNameKey, "MyApp");
         Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsWorkerRuntime, "dotnet");
         Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsExtensionVersion, "v6.0");
         ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(ClrProfilerIsAttached).Should().BeFalse();
-    }
-
-    [SkippableTheory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void IsContinuousProfilerAvailable_InAzureFunctionsWithExtension_ReturnsClrAttached(bool clrAttached)
-    {
-        SkipUnsupported();
-        var attachedCheck = clrAttached ? ClrProfilerIsAttached : ClrProfilerNotAttached;
-        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureAppService.SiteNameKey, "MyApp");
-        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsWorkerRuntime, "dotnet");
-        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureFunctions.FunctionsExtensionVersion, "v6.0");
-        Environment.SetEnvironmentVariable(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1");
-        ProfilerAvailabilityHelper.IsContinuousProfilerAvailable_TestingOnly(attachedCheck).Should().Be(clrAttached);
     }
 
     private static void SkipUnsupported()


### PR DESCRIPTION
## Summary of changes

Update profiler availability helper algorithm on Windows

## Reason for change

- If the Continuous Profiler isn't available, the native loader does not rewrite P/Invokes and does not set `DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH`
- If it is available, the native loader sets the `DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH` value
- Currently, the `ProfilerAvailabilityHelper` is treating the presence of the variable as indication the profiler is available, but it's not treating the _absence_ as an indication the profiler is _not_ available.
- This PR changes that to treat the `DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH` variable as the deciding factor on Windows

(Note that his variable is _not_ available today on non-Windows as it doesn't propagate from the native side. We hope to fix that in the future, but in the mean time we must rely on heuristics).

## Implementation details

Update the logic of the helper on Windows to only rely on the `DD_INTERNAL_PROFILING_NATIVE_ENGINE_PATH` variable.

Note that I also removed the AAS Extension check, as that only runs on Windows anyway, so would never return `true` (as it's caught in the `IsWindows()` branch).

## Test coverage

Updated the unit tests with new behaviour. Basically we need to skip more tests on Windows, as it's only governed by that flag

## Other details

Related to the following:
- https://github.com/DataDog/dd-trace-dotnet/pull/7554
- https://github.com/DataDog/dd-trace-dotnet/pull/7287
- https://github.com/DataDog/dd-trace-dotnet/pull/7552
