### PR TITLE
[DI-EL] Add debug log in case evaluation result is null and it shouldn't be null

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ExpressionEvaluationResult.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ExpressionEvaluationResult.cs
@@ -20,19 +20,19 @@ internal ref struct ExpressionEvaluationResult
 
     internal List<EvaluationError> Errors { get; set; }
 
-    internal bool HasError => Errors is { Count: > 0 };
+    internal readonly bool HasError => Errors is { Count: > 0 };
 
-    internal bool IsNull()
+    internal readonly bool IsNull()
     {
         return Template == null && Condition == null && Metric == null && Decorations?.Length == 0 && Errors == null;
     }
 
     internal struct DecorationResult
     {
-        public string TagName { get; set; }
+        internal string TagName { get; set; }
 
-        public string Value { get; set; }
+        internal string Value { get; set; }
 
-        public EvaluationError[] Errors { get; set; }
+        internal EvaluationError[] Errors { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeInfo.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeInfo.cs
@@ -41,9 +41,9 @@ namespace Datadog.Trace.Debugger.Expressions
 
         internal string[] Tags { get; } = Tags;
 
-        public TargetSpan? TargetSpan { get; } = TargetSpan;
+        internal TargetSpan? TargetSpan { get; } = TargetSpan;
 
-        public CaptureLimitInfo CaptureLimitInfo { get; } = CaptureLimitInfo;
+        internal CaptureLimitInfo CaptureLimitInfo { get; } = CaptureLimitInfo;
     }
 
     internal readonly record struct CaptureLimitInfo(
@@ -52,12 +52,12 @@ namespace Datadog.Trace.Debugger.Expressions
         int MaxLength,
         int MaxFieldCount)
     {
-        public int MaxReferenceDepth { get; } = MaxReferenceDepth;
+        internal int MaxReferenceDepth { get; } = MaxReferenceDepth;
 
-        public int MaxCollectionSize { get; } = MaxCollectionSize;
+        internal int MaxCollectionSize { get; } = MaxCollectionSize;
 
-        public int MaxLength { get; } = MaxLength;
+        internal int MaxLength { get; } = MaxLength;
 
-        public int MaxFieldCount { get; } = MaxFieldCount;
+        internal int MaxFieldCount { get; } = MaxFieldCount;
     }
 }


### PR DESCRIPTION
## Summary of changes
We saw customer's log where evaluation result was null, that usually should not happen so we want more debug log around that to investigate further.
