### PR TITLE
[AAP] Enable by default API Security Endpoints collection

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -132,7 +132,7 @@ namespace Datadog.Trace.AppSec
                                            .Value;
 
             ApiSecurityEndpointCollectionEnabled = config.WithKeys(ConfigurationKeys.AppSec.ApiSecurityEndpointCollectionEnabled)
-                                           .AsBool(false);
+                                           .AsBool(true);
 
             ApiSecurityEndpointCollectionMessageLimit = config.WithKeys(ConfigurationKeys.AppSec.ApiSecurityEndpointCollectionMessageLimit)
                                            .AsInt32(300, val => val >= 0)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Configuration
             internal const string ApiSecuritySampleDelay = "DD_API_SECURITY_SAMPLE_DELAY";
 
             /// <summary>
-            /// with a default value of false, it allows a customer to disable the collection of endpoints for API Security.
+            /// with a default value of true, it allows a customer to disable the collection of endpoints for API Security.
             /// </summary>
             internal const string ApiSecurityEndpointCollectionEnabled = "DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED";
 


### PR DESCRIPTION
## Summary of changes

This PR enable by default the feature to collect all endpoints at startup.
See #6733 #7317 for implementation.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
