### PR TITLE
[SymbDB] Ignore canceled exception

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -228,6 +228,10 @@ namespace Datadog.Trace.Debugger.Symbols
 
                 await UploadAssemblySymbols(assembly).ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                // ignore
+            }
             catch (Exception e)
             {
                 Log.Error(e, "Error while trying to extract assembly symbol {Assembly}", assembly);


### PR DESCRIPTION
## Summary of changes
We don't want to trigger error in case symbol upload has canceled
