### PR TITLE
[ER]- Fix ER system tests

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplaySettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplaySettings.cs
@@ -22,7 +22,9 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             source ??= NullConfigurationSource.Instance;
             var config = new ConfigurationBuilder(source, telemetry);
 
-            var erEnabledResult = config.WithKeys(ConfigurationKeys.Debugger.ExceptionReplayEnabled).AsBoolResult();
+#pragma warning disable CS0612 // Type or member is obsolete
+            var erEnabledResult = config.WithKeys(ConfigurationKeys.Debugger.ExceptionReplayEnabled, fallbackKey: ConfigurationKeys.Debugger.ExceptionDebuggingEnabled).AsBoolResult();
+#pragma warning restore CS0612 // Type or member is obsolete
             Enabled = erEnabledResult.WithDefault(false);
             CanBeEnabled = erEnabledResult.ConfigurationResult is not { IsValid: true, Result: false };
 


### PR DESCRIPTION
## Summary of changes
This [PR ](https://github.com/DataDog/dd-trace-dotnet/pull/7366) breaks ER system tests because it ommits an obosolete environment variable key, this PR fix that by returning that key.
