### PR TITLE
Revert "Revert "[Profiler] Make `timer_create`-based CPU profiler default (#7322)""

### DIFF
--- a/profiler/build/CpuWallTime.linux.json
+++ b/profiler/build/CpuWallTime.linux.json
@@ -26,6 +26,7 @@
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
         "DD_INTERNAL_USE_BACKTRACE2": "1",
+        "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
         "DD_TRACE_ENABLED" : "0"
       }
     },
@@ -35,17 +36,19 @@
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
+        "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
         "DD_INTERNAL_USE_BACKTRACE2": "0",
         "DD_TRACE_ENABLED" : "0"
       }
     },
     {
-      "name": "Profiler_cpu_walltime_timer_create",
+      "name": "Profiler_cpu_walltime_manual",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
-        "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
+        "DD_INTERNAL_USE_BACKTRACE2": "1",
+        "DD_INTERNAL_CPU_PROFILER_TYPE": "ManualCpuTime",
         "DD_TRACE_ENABLED" : "0"
       }
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuSampleProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuSampleProvider.cpp
@@ -11,10 +11,10 @@
 CpuSampleProvider::CpuSampleProvider(
     SampleValueTypeProvider& valueTypeProvider,
     RawSampleTransformer* rawSampleTransformer,
-    std::unique_ptr<RingBuffer> ringBuffer,
+    RingBuffer* ringBuffer,
     MetricsRegistry& metricsRegistry
     )
     :
-    RawSampleCollectorBase<RawCpuSample>("CpuSampleProvider", valueTypeProvider.GetOrRegister(CpuTimeProvider::SampleTypeDefinitions), rawSampleTransformer, std::move(ringBuffer), metricsRegistry)
+    RawSampleCollectorBase<RawCpuSample>("CpuSampleProvider", valueTypeProvider.GetOrRegister(CpuTimeProvider::SampleTypeDefinitions), rawSampleTransformer, ringBuffer, metricsRegistry)
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuSampleProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuSampleProvider.h
@@ -23,6 +23,6 @@ public:
     CpuSampleProvider(
         SampleValueTypeProvider& valueTypeProvider,
         RawSampleTransformer* rawSampleTransformer,
-        std::unique_ptr<RingBuffer> ringBuffer,
+        RingBuffer* ringBuffer,
         MetricsRegistry& metricsRegistry);
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -93,6 +93,22 @@ bool ProfilerSignalManager::UnRegisterHandler()
     return true;
 }
 
+bool ProfilerSignalManager::IgnoreSignal() {
+    struct sigaction sampleAction;
+    sampleAction.sa_handler = SIG_IGN;
+    sigemptyset(&sampleAction.sa_mask);
+    sampleAction.sa_flags = 0;
+
+    int32_t result = sigaction(_signalToSend, &sampleAction, nullptr);
+    if (result != 0)
+    {
+        Log::Error("ProfilerSignalManager::IgnoreSignal: Failed mark ", strsignal(_signalToSend), " as ignored. Reason: ",
+                   strerror(errno), ".");
+        return false;
+    }
+    return true;
+}
+
 void ProfilerSignalManager::SetSignal(int32_t signal)
 {
     _signalToSend = signal;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -18,6 +18,7 @@ public:
 
     bool RegisterHandler(HandlerFn_t handler);
     bool UnRegisterHandler();
+    bool IgnoreSignal();
     int32_t SendSignal(pid_t threadId);
     bool CheckSignalHandler();
     bool IsHandlerInPlace() const;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RawSampleCollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/RawSampleCollectorBase.h
@@ -96,12 +96,12 @@ public:
         const char* name,
         std::vector<SampleValueTypeProvider::Offset> valueOffsets,
         RawSampleTransformer* rawSampleTransformer,
-        std::unique_ptr<RingBuffer> ringBuffer,
+        RingBuffer* ringBuffer,
         MetricsRegistry& metricsRegistry) :
         ProviderBase(name),
         _valueOffsets{std::move(valueOffsets)},
         _rawSampleTransformer{rawSampleTransformer},
-        _collectedSamples{std::move(ringBuffer)},
+        _collectedSamples{ringBuffer},
         _failedReservationMetric{metricsRegistry.GetOrRegister<DiscardMetrics>("dotnet_raw_sample_failed_allocation")}
     {
     }
@@ -110,7 +110,7 @@ public:
 
     SampleHolder GetRawSample()
     {
-        return SampleHolder(_collectedSamples.get(), _failedReservationMetric.get());
+        return SampleHolder(_collectedSamples, _failedReservationMetric.get());
     }
     
     const char* GetName() override
@@ -182,6 +182,6 @@ private:
 
     std::vector<SampleValueTypeProvider::Offset> _valueOffsets;
     RawSampleTransformer* _rawSampleTransformer;
-    std::unique_ptr<RingBuffer> _collectedSamples;
+    RingBuffer* _collectedSamples;
     std::shared_ptr<DiscardMetrics> _failedReservationMetric;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -84,7 +84,13 @@ bool TimerCreateCpuProfiler::StartImpl()
         Instance = this;
 
         // Create and start timer for all threads.
-        _pManagedThreadsList->ForEach([this](ManagedThreadInfo* thread) { RegisterThreadImpl(thread); });
+        _pManagedThreadsList->ForEach([this](ManagedThreadInfo* thread) {
+            // only register threads that have an OS thread id
+            if (thread->GetOsThreadId() != 0)
+            {
+                RegisterThreadImpl(thread);
+            }
+        });
     }
 
     return registered;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -42,7 +42,7 @@ public:
 
 private:
     static bool CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext);
-    static TimerCreateCpuProfiler* Instance;
+    static std::atomic<TimerCreateCpuProfiler*> Instance;
 
     bool CanCollect(void* context);
     bool Collect(void* ucontext);
@@ -59,4 +59,5 @@ private:
     std::shared_mutex _registerLock;
     std::shared_ptr<CounterMetric> _totalSampling;
     std::shared_ptr<DiscardMetrics> _discardMetrics;
+    std::atomic<std::uint64_t> _nbThreadsInSignalHandler;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -26,6 +26,12 @@ std::string const Configuration::DefaultEmptyString = "";
 std::chrono::seconds const Configuration::DefaultDevUploadInterval = 20s;
 std::chrono::seconds const Configuration::DefaultProdUploadInterval = 60s;
 std::chrono::milliseconds const Configuration::DefaultCpuProfilingInterval = 9ms;
+CpuProfilerType const Configuration::DefaultCpuProfilerType =
+#ifdef _WINDOWS
+    CpuProfilerType::ManualCpuTime;
+#else
+    CpuProfilerType::TimerCreate;
+#endif
 
 Configuration::Configuration()
 {
@@ -110,7 +116,7 @@ Configuration::Configuration()
         );
     _httpRequestDurationThreshold = ExtractHttpRequestDurationThreshold();
     _forceHttpSampling = GetEnvironmentValue(EnvironmentVariables::ForceHttpSampling, false);
-    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, CpuProfilerType::ManualCpuTime);
+    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
     _isWaitHandleProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::WaitHandleProfilingEnabled, false);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -122,6 +122,7 @@ private:
     static std::chrono::seconds const DefaultDevUploadInterval;
     static std::chrono::seconds const DefaultProdUploadInterval;
     static std::chrono::milliseconds const DefaultCpuProfilingInterval;
+    static CpuProfilerType const DefaultCpuProfilerType;
 
     bool _isProfilingEnabled;
     bool _isCpuProfilingEnabled;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -71,6 +71,30 @@
 
 #include <cmath>
 
+void LogServiceStart(bool success, const char* name )
+{
+    if (success)
+    {
+        Log::Info(name, " started successfully.");
+    }
+    else
+    {
+        Log::Info(name, " failed to start. This service might have been started earlier.");
+    }
+}
+
+void LogServiceStop(bool success, const char* name )
+{
+    if (success)
+    {
+        Log::Info(name, " stopped successfully.");
+    }
+    else
+    {
+        Log::Info(name, " failed to stopped. This service might have been stopped earlier.");
+    }
+}
+
 IClrLifetime* CorProfilerCallback::GetClrLifetime() const
 {
     return _pClrLifetime.get();
@@ -519,7 +543,9 @@ void CorProfilerCallback::InitializeServices()
 #ifdef LINUX
     if (_pConfiguration->IsCpuProfilingEnabled() && _pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
     {
-        _pCpuProfiler = RegisterService<TimerCreateCpuProfiler>(
+        // Other alternative in case of crash-at-shutdown, do not register it as a service
+        // we will have to start it by hand (already stopped by hand)
+        _pCpuProfiler = std::make_unique<TimerCreateCpuProfiler>(
             _pConfiguration.get(),
             ProfilerSignalManager::Get(SIGPROF),
             _pManagedThreadList,
@@ -794,16 +820,21 @@ bool CorProfilerCallback::StartServices()
         }
 
         success = service->Start();
-        if (success)
-        {
-            Log::Info(name, " started successfully.");
-        }
-        else
-        {
-            Log::Info(name, " failed to start. This service might have been started earlier.");
-        }
+        LogServiceStart(success, name);
         result &= success;
     }
+
+#ifdef LINUX
+    // We cannot add the timer_create-based CPU profiler to the _services list
+    // we have to control the Stop
+    // If we fail to stop, we mustn't release the memory associated to it
+    // otherwise we might crash.
+    if (_pCpuProfiler != nullptr)
+    {
+        auto success = _pCpuProfiler->Start();
+        LogServiceStart(success, _pCpuProfiler->GetName());
+    }
+#endif
 
     return result;
 }
@@ -839,14 +870,7 @@ bool CorProfilerCallback::StopServices()
         const auto& service = _services[i - 1];
         const auto* name = service->GetName();
         success = service->Stop();
-        if (success)
-        {
-            Log::Info(name, " stopped successfully.");
-        }
-        else
-        {
-            Log::Info(name, " failed to stop. This service might have been stopped earlier.");
-        }
+        LogServiceStop(success, name);
         result &= success;
     }
 
@@ -1599,7 +1623,16 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown()
 #ifdef LINUX
     if (_pCpuProfiler != nullptr)
     {
-        _pCpuProfiler->Stop();
+        // if we failed at stopping the time_create-based CPU profiler,
+        // it's safer to not release the memory.
+        // Otherwise, we might crash the application.
+        // Reason: one thread could be executing the signal handler and accessing some field
+        auto stopped = _pCpuProfiler->Stop();
+        LogServiceStop(stopped, _pCpuProfiler->GetName());
+        if (stopped)
+        {
+            _pCpuProfiler = nullptr;
+        }
     }
 #endif
 
@@ -1871,7 +1904,7 @@ void CorProfilerCallback::OnThreadRoutineFinished()
         return;
     }
 
-    auto* cpuProfiler = myThis->_pCpuProfiler;
+    auto* cpuProfiler = myThis->_pCpuProfiler.get();
     if (cpuProfiler == nullptr)
     {
         return;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -60,7 +60,6 @@
 #include "SystemCallsShield.h"
 #include "TimerCreateCpuProfiler.h"
 #include "LibrariesInfoCache.h"
-#include "RingBuffer.h"
 #include "CpuSampleProvider.h"
 #endif
 
@@ -246,8 +245,8 @@ void CorProfilerCallback::InitializeServices()
             // So, cpuAllocated will have to be over 37 trillion to have a value that cannot be represented by a std::size_t
             std::size_t rbSize = std::ceil(nbSamplesCollectorTick * cpuAllocated * RawSampleCollectorBase<RawCpuSample>::SampleSize);
             Log::Info("RingBuffer size estimate (bytes): ", rbSize);
-            auto ringBuffer = std::make_unique<RingBuffer>(rbSize, CpuSampleProvider::SampleSize);
-            _pCpuSampleProvider = RegisterService<CpuSampleProvider>(valueTypeProvider, _rawSampleTransformer.get(), std::move(ringBuffer), _metricsRegistry);
+            _pCpuProfilerRb = std::make_unique<RingBuffer>(rbSize, CpuSampleProvider::SampleSize);
+            _pCpuSampleProvider = RegisterService<CpuSampleProvider>(valueTypeProvider, _rawSampleTransformer.get(), _pCpuProfilerRb.get(), _metricsRegistry);
         }
 #else // WINDOWS
         _pCpuTimeProvider = RegisterService<CpuTimeProvider>(

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -34,8 +34,11 @@
 #include "ProxyMetric.h"
 #include "IAllocationsRecorder.h"
 #include "IMetadataProvider.h"
-#include "ThreadLifetimeProvider.h"
 #include "shared/src/native-src/string.h"
+#include "ThreadLifetimeProvider.h"
+#ifdef LINUX
+#include "TimerCreateCpuProfiler.h"
+#endif
 #include "IEtwEventsManager.h"
 #include "ISsiLifetime.h"
 #include "PInvoke.h"
@@ -55,7 +58,6 @@ class IConfiguration;
 class IExporter;
 class RawSampleTransformer;
 class RuntimeIdStore;
-class TimerCreateCpuProfiler;
 class CpuSampleProvider;
 class NetworkProvider;
 
@@ -258,7 +260,7 @@ private :
     RuntimeIdStore* _pRuntimeIdStore = nullptr;
 #ifdef LINUX
     SystemCallsShield* _systemCallsShield = nullptr;
-    TimerCreateCpuProfiler* _pCpuProfiler = nullptr;
+    std::unique_ptr<TimerCreateCpuProfiler> _pCpuProfiler = nullptr;
     CpuSampleProvider* _pCpuSampleProvider = nullptr;
 #endif
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -37,6 +37,7 @@
 #include "shared/src/native-src/string.h"
 #include "ThreadLifetimeProvider.h"
 #ifdef LINUX
+#include "RingBuffer.h"
 #include "TimerCreateCpuProfiler.h"
 #endif
 #include "IEtwEventsManager.h"
@@ -262,6 +263,7 @@ private :
     SystemCallsShield* _systemCallsShield = nullptr;
     std::unique_ptr<TimerCreateCpuProfiler> _pCpuProfiler = nullptr;
     CpuSampleProvider* _pCpuSampleProvider = nullptr;
+    std::unique_ptr<RingBuffer> _pCpuProfilerRb = nullptr;
 #endif
 
     std::vector<std::unique_ptr<IService>> _services;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
@@ -47,10 +47,14 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var logFile = Directory.GetFiles(runner.Environment.LogDir)
                 .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
 
-            var nbSignalHandlerInstallation = File.ReadLines(logFile)
-                .Count(l => l.Contains("Successfully setup signal handler for"));
+            
+            File.ReadLines(logFile)
+                .Count(l => l.Contains("Successfully setup signal handler for User defined signal 1 signal"))
+                .Should().Be(1);
 
-            nbSignalHandlerInstallation.Should().Be(1);
+            File.ReadLines(logFile)
+                .Count(l => l.Contains("Successfully setup signal handler for Profiling timer expired signal"))
+                .Should().Be(1);
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
@@ -25,7 +25,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         }
 
         [TestAppFact("Samples.Computer01")]
-        public void CheckTimerCreateIsNotDefault(string appName, string framework, string appAssembly)
+        public void CheckTimerCreateIsDefault(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
             // disable default profilers except CPU
@@ -41,8 +41,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             var logLines = File.ReadLines(logFile);
 
-            logLines.Should().NotContainMatch("*timer_create Cpu profiler is enabled*");
-            logLines.Should().ContainMatch("*Manual Cpu profiler is enabled*");
+            logLines.Should().ContainMatch("*timer_create Cpu profiler is enabled*");
+            logLines.Should().NotContainMatch("*Manual Cpu profiler is enabled*");
 
             SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotBeEmpty("No samples were found");
         }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1184,20 +1184,38 @@ TEST_F(ConfigurationTest, CheckDefaultCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr(""));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+    auto expected =
+#ifdef _WINDOWS
+        CpuProfilerType::ManualCpuTime;
+#else
+        CpuProfilerType::TimerCreate;
+#endif
+    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
 }
 
 TEST_F(ConfigurationTest, CheckDefaultCpuProfilerTypeWhenEnvVarNotSet)
 {
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+    auto expected =
+#ifdef _WINDOWS
+        CpuProfilerType::ManualCpuTime;
+#else
+        CpuProfilerType::TimerCreate;
+#endif
+    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
 }
 
 TEST_F(ConfigurationTest, CheckUnknownCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("UnknownCpuProfilerType"));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+    auto expected =
+#ifdef _WINDOWS
+        CpuProfilerType::ManualCpuTime;
+#else
+        CpuProfilerType::TimerCreate;
+#endif
+    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
 }
 
 TEST_F(ConfigurationTest, CheckManualCpuProfilerType)

--- a/profiler/test/Datadog.Profiler.Native.Tests/CpuSampleProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CpuSampleProviderTest.cpp
@@ -32,7 +32,7 @@ TEST(CpuSampleProviderTest, WriteAndReadSample)
     auto const nbSamples = 11;
     auto metricRegistry = MetricsRegistry();
     auto rb = std::make_unique<RingBuffer>(CpuSampleProvider::SampleSize * nbSamples, CpuSampleProvider::SampleSize);
-    auto provider = CpuSampleProvider(valueTypes, &rawSampleTransformer, std::move(rb), metricRegistry);
+    auto provider = CpuSampleProvider(valueTypes, &rawSampleTransformer, rb.get(), metricRegistry);
 
     provider.Start();
 


### PR DESCRIPTION
## Summary of changes

Reverts DataDog/dd-trace-dotnet#7427 and supersedes DataDog/dd-trace-dotnet#7444

## Reason for change

Another try to make `timer_create`-based CPU profiler the default. What's the difference between this PR and the last one(s): 
- The RingBuffer is now long-lived and does not have its lifecycle tied to the provider.

## Implementation details
- Only register managed threads that are assigned to native threads.
- Have the ring buffer as a field of the CorProfilerCallback class so it can outlive the customer(s).

## Test coverage

## Other details
<!-- Fixes #{issue} -->
https://datadoghq.atlassian.net/browse/PROF-11986

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
