### PR TITLE
[SINT-2273] update workflow steps

### DIFF
--- a/.github/workflows/delete-pr-image.yml
+++ b/.github/workflows/delete-pr-image.yml
@@ -19,6 +19,10 @@ jobs:
         run: |
           BRANCH="${{ github.event.pull_request.head.ref }}"
           TAG="${BRANCH//\//_}"
+          if ! [[ $TAG =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Exiting - Manages branches only if they contain letters, numbers and the following special characters: . - _"
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Delete image by tag from GHCR


### PR DESCRIPTION
## Summary of changes

Update `delete-pr-image` workflow to only run on sanitized inputs.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
