### PR TITLE
exclude api keys from sample app logs

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -374,9 +374,9 @@ namespace Samples
 
             var envVars = from envVar in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
                           from prefix in prefixes
-                          let key = envVar.Key as string
+                          let key = (envVar.Key as string)?.ToUpperInvariant() // use ToUpperInvariant() because in .NET Framework string.Contains() doesn't have StringComparison overload
                           let value = envVar.Value as string
-                          where key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && !key.Contains("API_KEY", StringComparison.OrdinalIgnoreCase)
+                          where key.StartsWith(prefix, StringComparison.Ordinal) && !key.Contains("API_KEY")
                           orderby key
                           select new KeyValuePair<string, string>(key, value);
 


### PR DESCRIPTION
## Summary of changes

Exclude environment variables named `*API_KEY*` in `SampleHelpers.GetDatadogEnvironmentVariables()`.

## Reason for change

Prevent logging API keys in test outputs.

## Implementation details

- In `GetDatadogEnvironmentVariables()`, filter out any environment variable whose key contains "API_KEY" (case-insensitive)

Bonus changes:
- Changed the return type from `IEnumerable<T>` to `List<T>` since we already materialize the list (potential tiny perf improvement when iterating)
- Removed unnecessary `ToUpperInvariant()` call on the key and replaced `StartsWith()` with a case-insensitive comparison

## Test coverage

None, it's a helper method used in tests.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
