### PR TITLE
[Debugger Default-On] Add debuger dynamic configurations keys

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ApmTracingConfig.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ApmTracingConfig.cs
@@ -104,6 +104,9 @@ namespace Datadog.Trace.Configuration
                 ServiceMapping = higher.ServiceMapping ?? lower.ServiceMapping,
                 DataStreamsEnabled = higher.DataStreamsEnabled ?? lower.DataStreamsEnabled,
                 SpanSamplingRules = higher.SpanSamplingRules ?? lower.SpanSamplingRules,
+                DynamicInstrumentationEnabled = higher.DynamicInstrumentationEnabled ?? lower.DynamicInstrumentationEnabled,
+                ExceptionReplayEnabled = higher.ExceptionReplayEnabled ?? lower.ExceptionReplayEnabled,
+                CodeOriginEnabled = higher.CodeOriginEnabled ?? lower.CodeOriginEnabled
             };
         }
     }
@@ -181,5 +184,14 @@ namespace Datadog.Trace.Configuration
 
         [JsonProperty("span_sampling_rules")]
         public object? SpanSamplingRules { get; set; }
+
+        [JsonProperty("dynamic_instrumentation_enabled")]
+        public bool? DynamicInstrumentationEnabled { get; set; }
+
+        [JsonProperty("exception_replay_enabled")]
+        public bool? ExceptionReplayEnabled { get; set; }
+
+        [JsonProperty("code_origin_enabled")]
+        public bool? CodeOriginEnabled { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ApmTracingConfigMerger.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ApmTracingConfigMerger.cs
@@ -130,7 +130,10 @@ namespace Datadog.Trace.Configuration
                 RuntimeMetricsEnabled: not null,
                 ServiceMapping: not null,
                 DataStreamsEnabled: not null,
-                SpanSamplingRules: not null
+                SpanSamplingRules: not null,
+                DynamicInstrumentationEnabled: not null,
+                ExceptionReplayEnabled: not null,
+                CodeOriginEnabled: not null
             };
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
@@ -27,7 +27,10 @@ namespace Datadog.Trace.Configuration.ConfigurationSources
             { ConfigurationKeys.CustomSamplingRules, "tracing_sampling_rules" },
             // { ConfigurationKeys.SpanSamplingRules, "span_sampling_rules" },
             // { ConfigurationKeys.DataStreamsMonitoring.Enabled, "data_streams_enabled" },
-            { ConfigurationKeys.GlobalTags, "tracing_tags" }
+            { ConfigurationKeys.GlobalTags, "tracing_tags" },
+            { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "dynamic_instrumentation_enabled" },
+            { ConfigurationKeys.Debugger.ExceptionReplayEnabled, "exception_replay_enabled" },
+            { ConfigurationKeys.Debugger.CodeOriginForSpansEnabled, "code_origin_enabled" },
         };
 
         internal DynamicConfigConfigurationSource(string json, ConfigurationOrigins origin)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
@@ -63,7 +63,7 @@ public class DebuggerManagerDynamicTests : TestHelper
                 memoryAssertions.NoObjectsExist<LineProbeResolver>();
                 memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
             },
-            remoteConfig: new { DD_DYNAMIC_INSTRUMENTATION_ENABLED = true },
+            remoteConfig: new { dynamic_instrumentation_enabled = true },
             DynamicInstrumentationEnabledLogEntry,
             finalMemoryAssertions: memoryAssertions =>
             {
@@ -88,7 +88,7 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, no Exception Replay objects should exist
                 memoryAssertions.NoObjectsExist<ExceptionAutoInstrumentation.ExceptionReplay>();
             },
-            remoteConfig: new { DD_EXCEPTION_REPLAY_ENABLED = true },
+            remoteConfig: new { exception_replay_enabled = true },
             ExceptionReplayEnabledLogEntry);
     }
 
@@ -108,7 +108,7 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, no Code Origin object should exist
                 memoryAssertions.NoObjectsExist<SpanCodeOrigin.SpanCodeOrigin>();
             },
-            remoteConfig: new { DD_CODE_ORIGIN_FOR_SPANS_ENABLED = true },
+            remoteConfig: new { code_origin_enabled = true },
             CodeOriginForSpansEnabledLogEntry);
     }
 
@@ -135,9 +135,9 @@ public class DebuggerManagerDynamicTests : TestHelper
             },
             remoteConfig: new
             {
-                DD_DYNAMIC_INSTRUMENTATION_ENABLED = true,
-                DD_EXCEPTION_REPLAY_ENABLED = true,
-                DD_CODE_ORIGIN_FOR_SPANS_ENABLED = true
+                dynamic_instrumentation_enabled = true,
+                exception_replay_enabled = true,
+                code_origin_enabled = true
             },
             ExceptionReplayEnabledLogEntry,
             finalMemoryAssertions: memoryAssertions =>
@@ -173,7 +173,7 @@ public class DebuggerManagerDynamicTests : TestHelper
                 memoryAssertions.ObjectsExist<LineProbeResolver>();
                 memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
             },
-            remoteConfig: new { DD_DYNAMIC_INSTRUMENTATION_ENABLED = false },
+            remoteConfig: new { dynamic_instrumentation_enabled = false },
             $"Dynamic Instrumentation {DisabledByRemoteConfiguration}",
             finalMemoryAssertions: memoryAssertions =>
             {
@@ -201,7 +201,7 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, Exception Replay objects should exist
                 memoryAssertions.ObjectsExist<ExceptionAutoInstrumentation.ExceptionReplay>();
             },
-            remoteConfig: new { DD_EXCEPTION_REPLAY_ENABLED = false },
+            remoteConfig: new { exception_replay_enabled = false },
             $"Exception Replay {DisabledByRemoteConfiguration}");
     }
 
@@ -222,7 +222,7 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, Code Origin object should exist
                 memoryAssertions.ObjectsExist<SpanCodeOrigin.SpanCodeOrigin>();
             },
-            remoteConfig: new { DD_CODE_ORIGIN_FOR_SPANS_ENABLED = false },
+            remoteConfig: new { code_origin_enabled = false },
             $"Code Origin for Spans {DisabledByRemoteConfiguration}");
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -217,7 +217,10 @@ namespace Datadog.Trace.Tests.Configuration
                     tracing_enabled = true,
                     log_injection_enabled = false,
                     tracing_sampling_rate = 0.75,
-                    tracing_tags = new[] { "key1:value1", "key2:value2" }
+                    tracing_tags = new[] { "key1:value1", "key2:value2" },
+                    dynamic_instrumentation_enabled = true,
+                    exception_replay_enabled = true,
+                    code_origin_enabled = true,
                 }
             };
 
@@ -244,6 +247,15 @@ namespace Datadog.Trace.Tests.Configuration
             var stringTags = stringBuilder.WithKeys(ConfigurationKeys.GlobalTags).AsDictionary();
             var jTokenTags = jTokenBuilder.WithKeys(ConfigurationKeys.GlobalTags).AsDictionary();
             stringTags.Should().BeEquivalentTo(jTokenTags);
+
+            stringBuilder.WithKeys(ConfigurationKeys.Debugger.DynamicInstrumentationEnabled).AsBool().Should()
+                .Be(jTokenBuilder.WithKeys(ConfigurationKeys.Debugger.DynamicInstrumentationEnabled).AsBool());
+
+            stringBuilder.WithKeys(ConfigurationKeys.Debugger.ExceptionReplayEnabled).AsBool().Should()
+                .Be(jTokenBuilder.WithKeys(ConfigurationKeys.Debugger.ExceptionReplayEnabled).AsBool());
+
+            stringBuilder.WithKeys(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled).AsBool().Should()
+                .Be(jTokenBuilder.WithKeys(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled).AsBool());
         }
 
         private static ConfigurationBuilder CreateConfig(params (string Key, object Value)[] settings)


### PR DESCRIPTION
## Summary of changes
This PR finalizes the work introduced in [Debugger In-Product Enablement](https://github.com/DataDog/dd-trace-dotnet/pull/7366) and [RC Multi-Config Support](https://github.com/DataDog/dd-trace-dotnet/pull/7536) by integrating the new debugger dynamic configuration keys into both the dynamic configuration source and the APM tracing merger.

## Test coverage
DebuggerManagerDynamicTests
