### PR TITLE
[crashtracking] Change Crashtracking filtering default value

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -687,7 +687,8 @@ internal class CreatedumpCommand : Command
 
         if (!isSuspicious)
         {
-            var filteringEnabled = Environment.GetEnvironmentVariable(EnvironmentFilteringEnabled) ?? string.Empty;
+            // Disable filtering by default.
+            var filteringEnabled = Environment.GetEnvironmentVariable(EnvironmentFilteringEnabled) ?? "0";
 
             if (filteringEnabled == "0"
                 || filteringEnabled.Equals("false", StringComparison.OrdinalIgnoreCase)

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -714,7 +714,7 @@ internal class CreatedumpCommand : Command
         }
 
         DebugPrint("Setting crash report metadata");
-        _ = SetMetadata(crashReport, _runtime, exception);
+        _ = SetMetadata(crashReport, _runtime, exception, isSuspicious);
 
         try
         {
@@ -810,7 +810,7 @@ internal class CreatedumpCommand : Command
         return true;
     }
 
-    private unsafe bool SetMetadata(ICrashReport crashReport, ClrRuntime runtime, ClrException? exception)
+    private unsafe bool SetMetadata(ICrashReport crashReport, ClrRuntime runtime, ClrException? exception, bool isSuspicious)
     {
         var flavor = runtime.ClrInfo.Flavor switch
         {
@@ -854,6 +854,11 @@ internal class CreatedumpCommand : Command
         if (exception != null)
         {
             tags = [.. tags, ("exception", exception.ToString())];
+        }
+
+        if (isSuspicious)
+        {
+            tags = [.. tags, ("crash_datadog", "true")];
         }
 
         var bag = new List<IntPtr>();


### PR DESCRIPTION
## Summary of changes

Disable crash report filtering by default.

## Reason for change

Crashtracker is going to be used by customer. It would be great if they could see crashes caused by their code in the UI.

## Implementation details

- Set default value to "0"
- Add the `datadog_crash:true` tag if the callstack is suspicious.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
