### PR TITLE
Split `create_draft_release` worfklow into hotfix / normal

### DIFF
--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -1,0 +1,167 @@
+name: Create reusable draft release
+
+on:
+  workflow_call:
+    inputs:
+      forced_commit_id:
+        description: 'Force using artifacts from specific commit? If provided, this will try and use the artifacts from the given commit, regardless of build status'
+        required: false
+        type: string
+      ignore_gitlab_failures:
+        description: "DANGER Force ignoring any issues with the GitLab artifacts or SSI. Don't use this unless you _really_ know what you're doing"
+        required: false
+        type: boolean
+        default: false
+      is_hotfix:
+        description: 'Is this a hotfix release? If true, skips vNext milestone renaming'
+        required: true
+        type: boolean
+    secrets:
+      AZURE_DEVOPS_TOKEN:
+        required: true
+      NUGET_API_KEY:
+        required: true
+      GH_APP_ID:
+        required: true
+      GH_APP_PRIVATE_KEY:
+        required: true
+      DD_PREPROD_API_KEY:
+        required: true
+      DD_PUBLIC_SYMBOL_API_KEY:
+        required: true
+
+jobs:
+  create_draft_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create release
+      actions: read # read secrets
+      issues: write # change milestones 
+    env:
+      # Have to use external token with explicit workflow permissions because we are creating
+      # a release from an arbitrary SHA. For "reasons", the built-in token does not _always_
+      # work in that scenario, so using an external token is required. See issue
+      # https://github.com/cli/cli/issues/9514 for more details.
+      AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set SHA
+        id: set_sha
+        run: |
+          if [ -z "${{ inputs.forced_commit_id }}" ]; then
+              commitsha="${GITHUB_SHA}"
+          else
+              commitsha="${{ inputs.forced_commit_id }}"
+          fi
+          echo "Using sha $commitsha"
+          echo "sha=${commitsha}" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        with:
+          global-json-file: global.json
+
+      - name: "Configure Git Credentials"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: "Check NuGet token validity"
+        run: |
+          echo "Downloading test package"
+          if ! curl -fL -o Datadog.Trace.Annotations.1.0.0.nupkg https://www.nuget.org/api/v2/package/Datadog.Trace.Annotations/1.0.0; then
+            echo "Download failed!" >&2
+            exit 1
+          fi
+
+          echo "Pushing package to test NuGet API key validity"
+          if ! dotnet nuget push "Datadog.Trace.Annotations.1.0.0.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json; then
+            echo "Push failed - the API key is likely not valid" >&2
+            echo "Create a new NuGet api key at nuget.org, with glob permissions * to push to the Datadog org and" >&2
+            echo "replace the NUGET_API_KEY GitHub secret with the new key at https://github.com/DataDog/dd-trace-dotnet/settings/secrets/actions " >&2
+            echo "and then try running this release again" >&2
+            exit 1
+          fi
+          
+          echo "Push succeeded, cleaning up"
+          rm Datadog.Trace.Annotations.1.0.0.nupkg
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: "Check GitLab status"
+        if: ${{ !inputs.ignore_gitlab_failures }}
+        run: ./tracer/build.sh VerifyReleaseReadiness
+        env:
+          CommitSha: "${{ steps.set_sha.outputs.sha }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
+
+      - name: "Get current version"
+        id: versions
+        run: ./tracer/build.sh OutputCurrentVersionToGitHub
+
+      - name: "Download build assets from Azure Pipelines"
+        id: assets
+        run: ./tracer/build.sh DownloadReleaseArtifacts
+        env:
+          TargetBranch: ${{ github.ref }}
+          CommitSha: "${{ steps.set_sha.outputs.sha }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
+
+      - name: "Generate release notes"
+        id: release_notes
+        run: ./tracer/build.sh GenerateReleaseNotes
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
+
+      - name: "Rename vNext milestone"
+        id: rename
+        # We don't rename vNext/vNext-v1 for hotfix releases
+        if: ${{ !inputs.is_hotfix && !contains(github.ref, 'hotfix') }}
+        run: ./tracer/build.sh RenameVNextMilestone
+        env:
+          Version: ${{steps.versions.outputs.full_version}}
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v1.0.0
+        with:
+          token: "${{ steps.generate-token.outputs.token }}"
+          draft: true
+          name: "${{steps.versions.outputs.full_version}}"
+          tag_name: "v${{steps.versions.outputs.full_version}}"
+          target_commitish: "${{steps.set_sha.outputs.sha}}"
+          prerelease: ${{steps.versions.outputs.isprerelease}}
+          body: ${{steps.release_notes.outputs.release_notes}}
+          fail_on_unmatched_files: true
+          files: |
+            ${{steps.assets.outputs.artifacts_path}}/*.deb
+            ${{steps.assets.outputs.artifacts_path}}/*.rpm
+            ${{steps.assets.outputs.artifacts_path}}/*.tar.gz
+            ${{steps.assets.outputs.artifacts_path}}/*.zip
+            ${{steps.assets.outputs.gitlab_artifacts_path}}/*.msi
+            ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip
+            ${{steps.assets.outputs.sha_path}}
+
+      - name: "Publish nuget packages to nuget.org"
+        working-directory: ${{steps.assets.outputs.artifacts_path}}
+        run: |
+          dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+      - name: "Copy gitlab artifacts to artifacts_path"
+        run: cp "${{steps.assets.outputs.gitlab_artifacts_path}}/"*.zip "${{steps.assets.outputs.artifacts_path}}/"
+
+      - name: 'Push debug symbols to datadog'
+        uses: ./.github/actions/publish-debug-symbols
+        with:
+          artifacts_path: ${{steps.assets.outputs.artifacts_path}}
+          preprod_key: "${{ secrets.DD_PREPROD_API_KEY }}"
+          public_symbols_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"

--- a/.github/workflows/create_hotfix_draft_release.yml
+++ b/.github/workflows/create_hotfix_draft_release.yml
@@ -1,0 +1,41 @@
+name: Create hotfix draft release
+
+on:
+  workflow_dispatch:
+    inputs:
+      forced_commit_id:
+        description: 'Force using artifacts from specific commit? If provided, this will try and use the artifacts from the given commit, regardless of build status'
+        required: false
+        type: string
+      ignore_gitlab_failures:
+        description: "DANGER Force ignoring any issues with the GitLab artifacts or SSI. Don't use this unless you _really_ know what you're doing"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+    check_branch:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify running on hotfix branch
+              run: |
+                if [[ "${{  github.ref }}" != refs/head/hotfix* ]]; then
+                  echo "Error: This workflow can only be run from a hotfix/* branch"
+                  echo "Current branch: ${{ github.ref }}"
+                  exit 1
+                fi
+
+    create_hotfix_draft_release:
+        needs: check_branch
+        uses: ./.github/workflows/_create_draft_release.yml
+        with:
+            forced_commit_id: ${{ inputs.forced_commit_id }}
+            ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}
+            is_hotfix: true
+        secrets:
+            AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+            NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+            GH_APP_ID: ${{ secrets.GH_APP_ID }}
+            GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+            DD_PREPROD_API_KEY: ${{ secrets.DD_PREPROD_API_KEY }}
+            DD_PUBLIC_SYMBOL_API_KEY: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}

--- a/.github/workflows/create_normal_draft_release.yml
+++ b/.github/workflows/create_normal_draft_release.yml
@@ -1,0 +1,41 @@
+name: Create normal draft release
+
+on:
+  workflow_dispatch:
+    inputs:
+      forced_commit_id:
+        description: 'Force using artifacts from specific commit? If provided, this will try and use the artifacts from the given commit, regardless of build status'
+        required: false
+        type: string
+      ignore_gitlab_failures:
+        description: "DANGER Force ignoring any issues with the GitLab artifacts or SSI. Don't use this unless you _really_ know what you're doing"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+    check_branch:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify running on main release branch
+              run: |
+                if [[ "${{  github.ref }}" != "refs/head/master" ]]; then
+                  echo "Error: This workflow can only be run from the following: master"
+                  echo "Current branch: ${{ github.ref }}"
+                  exit 1
+                fi
+
+    create_normal_draft_release:
+        needs: check_branch
+        uses: ./.github/workflows/_create_draft_release.yml
+        with:
+            forced_commit_id: ${{ inputs.forced_commit_id }}
+            ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}
+            is_hotfix: false
+        secrets:
+            AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+            NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+            GH_APP_ID: ${{ secrets.GH_APP_ID }}
+            GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+            DD_PREPROD_API_KEY: ${{ secrets.DD_PREPROD_API_KEY }}
+            DD_PUBLIC_SYMBOL_API_KEY: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}


### PR DESCRIPTION
## Summary of changes

This creates two new GitHub workflows: one to create a draft hotfix release and another to create a normal draft release.

## Reason for change

During the recent hotfixes I accidentally ran the current `create_draft_release` workflow on the `master` branch (but it failed). If this would have succeed we would have pushed the 3.27.0 artifacts to NuGet too soon when we just wanted to push `3.26.3` artifacts from that hotfix branch.

Splitting this helps prevent that from happening in the future.

## Implementation details

- `.github/workflows/_create_draft_release.yml`
  - This is a re-usable form of `create_draft_release.yml` - I copy/pasted that one. I'll paste below in "Other details" the diff between the files
- `.github/workflows/create_hotfix_draft_release.yml`
  - Can only be run on `hotfix/*` branches
  - Skips doing anything with the `vNext` milestone (main difference)
  - Does everything that `create_draft_release.yml` would do if ran against a `hotfix/` branch
- `.github/workflows/create_normal_draft_release.yml`
  - Can only be run on `master` <- we can consider allowing others at a later point, but we don't have any other release lines that we currently support
  -  Does everything that `create_draft_release.yml` would do if ran on `master`

## Test coverage

None!

## Other details
<!-- Fixes #{issue} -->

Note that I have **NOT** removed the current `create_draft_release` workflow. This is to ensure that when it comes time to release if these new workflows do not work that we won't be blocked. Testing workflows is always a bit challenging 🤷 
I can try to see if this works in a fork though if that is desired :)

https://datadoghq.atlassian.net/browse/LANGPLAT-833

```diff
$ git diff --no-index .github/workflows/create_draft_release.yml .github/workflows/_create_draft_release.yml
diff --git a/.github/workflows/create_draft_release.yml b/.github/workflows/_create_draft_release.yml
index 4b17dab58..ba5280dbf 100644
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -1,14 +1,34 @@
-name: Create draft release
+name: Create reusable draft release

 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       forced_commit_id:
         description: 'Force using artifacts from specific commit? If provided, this will try and use the artifacts from the given commit, regardless of build status'
         required: false
+        type: string
       ignore_gitlab_failures:
         description: "DANGER Force ignoring any issues with the GitLab artifacts or SSI. Don't use this unless you _really_ know what you're doing"
         required: false
+        type: boolean
+        default: false
+      is_hotfix:
+        description: 'Is this a hotfix release? If true, skips vNext milestone renaming'
+        required: true
+        type: boolean
+    secrets:
+      AZURE_DEVOPS_TOKEN:
+        required: true
+      NUGET_API_KEY:
+        required: true
+      GH_APP_ID:
+        required: true
+      GH_APP_PRIVATE_KEY:
+        required: true
+      DD_PREPROD_API_KEY:
+        required: true
+      DD_PUBLIC_SYMBOL_API_KEY:
+        required: true

 jobs:
   create_draft_release:
@@ -33,10 +53,10 @@ jobs:
       - name: Set SHA
         id: set_sha
         run: |
-          if [ -z "${{ github.event.inputs.forced_commit_id }}" ]; then
+          if [ -z "${{ inputs.forced_commit_id }}" ]; then
               commitsha="${GITHUB_SHA}"
           else
-              commitsha="${{ github.event.inputs.forced_commit_id }}"
+              commitsha="${{ inputs.forced_commit_id }}"
           fi
           echo "Using sha $commitsha"
           echo "sha=${commitsha}" >> $GITHUB_OUTPUT
@@ -78,7 +98,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

       - name: "Check GitLab status"
-        if: ${{ !github.event.inputs.ignore_gitlab_failures }}
+        if: ${{ !inputs.ignore_gitlab_failures }}
         run: ./tracer/build.sh VerifyReleaseReadiness
         env:
           CommitSha: "${{ steps.set_sha.outputs.sha }}"
@@ -92,7 +112,7 @@ jobs:
         id: assets
         run: ./tracer/build.sh DownloadReleaseArtifacts
         env:
-          TargetBranch: ${{ github.event.ref }}
+          TargetBranch: ${{ github.ref }}
           CommitSha: "${{ steps.set_sha.outputs.sha }}"
           GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"

@@ -105,7 +125,7 @@ jobs:
       - name: "Rename vNext milestone"
         id: rename
         # We don't rename vNext/vNext-v1 for hotfix releases
-        if: ${{ !contains(github.event.ref, 'hotfix') }}
+        if: ${{ !inputs.is_hotfix && !contains(github.ref, 'hotfix') }}
         run: ./tracer/build.sh RenameVNextMilestone
         env:
           Version: ${{steps.versions.outputs.full_version}}
```

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
