### PR TITLE
Mark FlakyRetriesWithExceptionReplay as flaky

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
@@ -45,7 +45,7 @@ public class MsTestV2RetriesTests : TestingFrameworkRetriesTests
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "TestIntegrations")]
     [Trait("Category", "FlakyRetries")]
-    [Flaky("Under investigation", 3)]
+    [Flaky("Under investigation", 5)]
     public override Task FlakyRetriesWithExceptionReplay(string packageVersion)
     {
         return base.FlakyRetriesWithExceptionReplay(packageVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
@@ -45,7 +45,7 @@ public class NUnitRetriesTests : TestingFrameworkRetriesTests
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "TestIntegrations")]
     [Trait("Category", "FlakyRetries")]
-    [Flaky("Under investigation", 3)]
+    [Flaky("Under investigation", 5)]
     public override Task FlakyRetriesWithExceptionReplay(string packageVersion)
     {
         return base.FlakyRetriesWithExceptionReplay(packageVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
@@ -45,7 +45,7 @@ public class XUnitRetriesTests : TestingFrameworkRetriesTests
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "TestIntegrations")]
     [Trait("Category", "FlakyRetries")]
-    [Flaky("Under investigation", 3)]
+    [Flaky("Under investigation", 5)]
     public override Task FlakyRetriesWithExceptionReplay(string packageVersion)
     {
         return base.FlakyRetriesWithExceptionReplay(packageVersion);


### PR DESCRIPTION
## Summary of changes

FlakyRetriesWithExceptionReplay [are failing recently in master](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.status%3Afail%20%40git.branch%3Amaster%20%40test.full_name%3A%2AWithExceptionReplay%2A&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A437%2C%40test.name%3A163%2C%40duration%3A60%2C%40test.service%2C%40git.branch&fromUser=false&index=citest&start=1756808890617&end=1759400890617&paused=false). The reason is under investigation. In the meantime, we will marke these tests as flaky.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
