### PR TITLE
[Code Origin] Disable code origin for exit spans

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -36,9 +36,14 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
         internal void SetCodeOriginForExitSpan(Span? span)
         {
+            if (ShouldSkipExitSpan())
+            {
+                return;
+            }
+
             if (span == null)
             {
-                Log.Debug("Can not add code origin when span is null");
+                Log.Debug("Can not add code origin for exit span when span is null");
                 return;
             }
 
@@ -56,6 +61,13 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             }
 
             AddExitSpanTags(span);
+        }
+
+        private bool ShouldSkipExitSpan()
+        {
+            // Exit span code origin has been disabled since tracer version 3.2.8.
+            // when it will be enabled, update SpanCodeOriginTests.ExitSpanTests
+            return true;
         }
 
         internal void SetCodeOriginForEntrySpan(Span? span, Type? type, MethodInfo? method)

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
         private bool ShouldSkipExitSpan()
         {
-            // Exit span code origin has been disabled since tracer version 3.2.8.
+            // Exit span code origin has been disabled since tracer version 3.28.0.
             // when it will be enabled, update SpanCodeOriginTests.ExitSpanTests
             return true;
         }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.Spans.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.Spans.verified.txt
@@ -17,8 +17,7 @@ at Samples.Probes.TestRuns.SmokeTests.AsyncSpanOnMethodWithExceptionProbeTest.Ca
       error.type: System.InvalidOperationException,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.Spans.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.dynamic.span.verified.txt
@@ -13,7 +13,6 @@
       runtime-id: Guid_2,
       SpanDecorationArgsAndLocals: Run,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationArgsAndLocals.probe_id: Guid_3
     },
     Metrics: {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.trace.annotation.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -34,7 +33,6 @@
       language: dotnet,
       SpanDecorationArgsAndLocals: Run,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationArgsAndLocals.probe_id: Guid_3
     }
   }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.dynamic.span.verified.txt
@@ -13,7 +13,6 @@
       runtime-id: Guid_2,
       SpanDecorationError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationError.evaluation_error: EvaluationError { Expression = this.error },
       _dd.di.SpanDecorationError.probe_id: Guid_3
     },

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.trace.annotation.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -34,7 +33,6 @@
       language: dotnet,
       SpanDecorationError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationError.evaluation_error: EvaluationError { Expression = this.error },
       _dd.di.SpanDecorationError.probe_id: Guid_3
     }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationErrorInWhen.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationErrorInWhen.with.dynamic.span.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.dynamic.span.verified.txt
@@ -13,7 +13,6 @@
       runtime-id: Guid_2,
       SpanDecorationSameTags: 3,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationSameTags.probe_id: Guid_3
     },
     Metrics: {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.trace.annotation.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -34,7 +33,6 @@
       language: dotnet,
       SpanDecorationSameTags: 3,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationSameTags.probe_id: Guid_3
     }
   }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.dynamic.span.verified.txt
@@ -13,7 +13,6 @@
       runtime-id: Guid_2,
       SpanDecorationSameTagsFirstError: Run,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationSameTagsFirstError.probe_id: Guid_3
     },
     Metrics: {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.trace.annotation.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -34,7 +33,6 @@
       language: dotnet,
       SpanDecorationSameTagsFirstError: Run,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationSameTagsFirstError.probe_id: Guid_3
     }
   }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.dynamic.span.verified.txt
@@ -13,7 +13,6 @@
       runtime-id: Guid_2,
       SpanDecorationSameTagsSecondError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationSameTagsSecondError.evaluation_error: EvaluationError { Expression = this.error },
       _dd.di.SpanDecorationSameTagsSecondError.probe_id: Guid_3
     },

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.trace.annotation.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -34,7 +33,6 @@
       language: dotnet,
       SpanDecorationSameTagsSecondError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationSameTagsSecondError.evaluation_error: EvaluationError { Expression = this.error },
       _dd.di.SpanDecorationSameTagsSecondError.probe_id: Guid_3
     }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoSegmentsWithError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoSegmentsWithError.with.dynamic.span.verified.txt
@@ -13,7 +13,6 @@
       runtime-id: Guid_2,
       SpanDecorationTwoSegments: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValueRun,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationTwoSegments.evaluation_error: EvaluationError { Expression = this.Arg =  },
       _dd.di.SpanDecorationTwoSegments.probe_id: Guid_3
     },

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.dynamic.span.verified.txt
@@ -14,7 +14,6 @@
       SpanDecorationTwoTags: Run,
       SpanDecorationTwoTags2: 3,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationTwoTags.probe_id: Guid_3,
       _dd.di.SpanDecorationTwoTags2.probe_id: Guid_3
     },

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.trace.annotation.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -35,7 +34,6 @@
       SpanDecorationTwoTags: Run,
       SpanDecorationTwoTags2: 3,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationTwoTags.probe_id: Guid_3,
       _dd.di.SpanDecorationTwoTags2.probe_id: Guid_3
     }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWitLiteralWhen.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWitLiteralWhen.with.dynamic.span.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWithoutWhen.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWithoutWhen.with.dynamic.span.verified.txt
@@ -13,7 +13,6 @@
       runtime-id: Guid_2,
       SpanDecorationWithoutWhen: Run,
       version: 1.0.0,
-      _dd.code_origin.type: exit,
       _dd.di.SpanDecorationWithoutWhen.probe_id: Guid_3
     },
     Metrics: {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.Spans.verified.txt
@@ -11,8 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.Spans.verified.txt
@@ -17,8 +17,7 @@ at Samples.Probes.TestRuns.SmokeTests.SpanOnMethodWithExceptionProbeTest.Calcula
       error.type: System.InvalidOperationException,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.code_origin.type: exit
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
@@ -241,6 +241,10 @@ namespace Datadog.Trace.Tests.Debugger
                 TestMethod(spanCodeOrigin, span);
 
                 // Assert
+                // Exit span code origin has been disabled since tracer version 3.2.8.
+                span.Tags.GetTag($"{CodeOriginTag}.type").Should().BeNull();
+
+                /* Uncomment when exit span will be enabled again
                 var codeOriginType = span.Tags.GetTag($"{CodeOriginTag}.type");
                 codeOriginType.Should().Be("exit");
                 var frame0Method = span.Tags.GetTag($"{CodeOriginTag}.frames.0.method");
@@ -253,6 +257,7 @@ namespace Datadog.Trace.Tests.Debugger
                 line.Should().NotBeNullOrEmpty();
                 var column = span.Tags.GetTag($"{CodeOriginTag}.frames.0.column");
                 column.Should().NotBeNullOrEmpty();
+                */
             }
 
             [Fact]
@@ -267,10 +272,15 @@ namespace Datadog.Trace.Tests.Debugger
                 DeepTestMethod1(span, spanCodeOrigin);
 
                 // Assert
+                // Exit span code origin has been disabled since tracer version 3.2.8.
+                span.Tags.GetTag($"{CodeOriginTag}.type").Should().BeNull();
+
+                /* Uncomment when exit span will be enabled again
                 var tags = ((List<KeyValuePair<string, string>>)(typeof(Datadog.Trace.Tagging.TagsList).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(span.Tags))).Select(i => i.Key).ToList();
                 tags.Should().Contain(s => s.StartsWith($"{CodeOriginTag}.frames.0"));
                 tags.Should().Contain(s => s.StartsWith($"{CodeOriginTag}.frames.1"));
                 tags.Should().NotContain(s => s.StartsWith($"{CodeOriginTag}.frames.2"));
+                */
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
@@ -272,7 +272,7 @@ namespace Datadog.Trace.Tests.Debugger
                 DeepTestMethod1(span, spanCodeOrigin);
 
                 // Assert
-                // Exit span code origin has been disabled since tracer version 3.2.8.
+                // Exit span code origin has been disabled since tracer version 3.28.0.
                 span.Tags.GetTag($"{CodeOriginTag}.type").Should().BeNull();
 
                 /* Uncomment when exit span will be enabled again

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
@@ -241,7 +241,7 @@ namespace Datadog.Trace.Tests.Debugger
                 TestMethod(spanCodeOrigin, span);
 
                 // Assert
-                // Exit span code origin has been disabled since tracer version 3.2.8.
+                // Exit span code origin has been disabled since tracer version 3.28.0.
                 span.Tags.GetTag($"{CodeOriginTag}.type").Should().BeNull();
 
                 /* Uncomment when exit span will be enabled again


### PR DESCRIPTION
## Summary of changes
Disabled code origin for exit spans while preserving the functionality for entry spans.

## Test coverage
SetCodeOrigin_WhenEnabled_SetsCorrectTags
SetCodeOrigin_WithMaxFramesLimit_RespectsLimit

