### PR TITLE
Ignore the test filter for `RunWindowsAzureFunctionsTests`

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1900,7 +1900,7 @@ partial class Build
                     //.WithMemoryDumpAfter(timeoutInMinutes: 30)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&(Category=AzureFunctions)&(SkipInCI!=True)" : Filter)
+                    .SetFilter("(RunOnWindows=True)&(Category=AzureFunctions)&(SkipInCI!=True)") // FIXME: ignoring the global Filter as when set it may cause issues
                     .SetTestTargetPlatform(TargetPlatform)
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)


### PR DESCRIPTION
## Summary of changes

This removes the ability to change the test filter that is used when running the Azure Functions Tests and it will just fallback on the default values.

## Reason for change

When someone sets the test filter for a CI build to something that requires a sample project that is **not** an Azure Functions sample app this stage will fail at it cannot find the sample application as only Azure Function samples are build prior to this stage.
We don't build all of the sample applications when running these as that takes significant time.
We have these in their own stage because they are a pain to build and test.
```
19:09:24 [ERR] Target RunWindowsAzureFunctionsTests has thrown an exception
Nuke.Common.Tooling.ProcessException: Process 'dotnet.exe' exited with code 1.
   > C:\dotnet\dotnet.exe test D:\a\_work\1\s\tracer\test\Datadog.Trace.ClrProfiler.IntegrationTests\Datadog.Trace.ClrProfiler.IntegrationTests.csproj --configuration Release --framework net7.0 --filter QuartzTests --logger trx --no-build --no-restore --results-directory D:\a\_work\1\s\artifacts\build_data\results\Datadog.Trace.ClrProfiler.IntegrationTests --settings D:\a\_work\1\s\tracer\test\test.settings /property:Platform=AnyCPU
   @ D:\a\_work\1\s
Error output:
   [xUnit.net 00:00:04.64]     Datadog.Trace.ClrProfiler.IntegrationTests.QuartzTests.SubmitsTraces(packageVersion: "") [FAIL]
```

## Implementation details

`.SetFilter` just always uses the default.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

Can likely fix this betterer some how, maybe just a new separate test filter, but I actually don't know how often we actually are filtering the Azure Functions tests.

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
