### PR TITLE
Capture Exception when sending metrics

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -10,6 +10,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers.AutoInstrumentation;
 using Newtonsoft.Json.Linq;
@@ -101,12 +102,20 @@ public static class ErrorHelpers
                         """;
 
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
-        var response = await client.PostAsync("https://api.datadoghq.com/api/v2/series", content);
-        var responseContent = await response.Content.ReadAsStringAsync();
 
-        if (response.StatusCode != HttpStatusCode.Accepted)
+        try
         {
-            outputHelper.WriteLine($"Failed to submit metric {metricName}. Response was: Code: {response.StatusCode}. Response: {responseContent}. Payload sent was: \"{payload}\"");
+            var response = await client.PostAsync("https://api.datadoghq.com/api/v2/series", content);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode != HttpStatusCode.Accepted)
+            {
+                outputHelper.WriteLine($"Failed to submit metric {metricName}. Response was: Code: {response.StatusCode}. Response: {responseContent}. Payload sent was: \"{payload}\"");
+            }
+        }
+        catch (Exception ex)
+        {
+            outputHelper.WriteLine($"Failed to submit metric {metricName}. Exception: {ex.ToString()} Payload: \"{payload}\"");
         }
     }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -10,7 +10,6 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers.AutoInstrumentation;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
## Summary of changes

We are getting some [test errors](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.status%3Afail%20%40git.branch%3Amaster%20%40test.full_name%3A%2ACouch%2A&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZmlUDfVUlPy2QAAABhBWm1sWG5pQUFBQkRidXJUT3YtMjlsbEgAAAAkZjE5OWE1NTEtYjcxYi00ZTNjLWE4MjQtMzk3OWJkMWZmNWFlAAHSfw&fromUser=false&index=citest&testId=AwAAAZmlUDfVUlPy2QAAABhBWm1sWG5pQUFBQkRidXJUT3YtMjlsbEgAAAAkZjE5OWE1NTEtYjcxYi00ZTNjLWE4MjQtMzk3OWJkMWZmNWFlAAHSfw&trace=AwAAAZmlUDfVUlPy2QAAABhBWm1sWG5pQUFBQkRidXJUT3YtMjlsbEgAAAAkZjE5OWE1NTEtYjcxYi00ZTNjLWE4MjQtMzk3OWJkMWZmNWFlAAHSfw&start=1758882011475&end=1759486811475&paused=false) because the flaky attributte sends some telemetry reporting the flaky test failures and, when the telemetry call fails, en exception is thrown and the test itself fails as well.

```
System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
---- System.IO.IOException : Received an unexpected EOF or 0 bytes from the transport stream.
```

This error can make any test using telemetry fail if the telemetry endpoint does not respond, for instance, so it can potentially affect many tests.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
