### PR TITLE
Add configuration option to disable agent discovery service

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManagerFactory.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.Ci
             return new ApmAgentWriter(settings, updateSampleRates, discoveryService, traceBufferSize);
         }
 
-        protected override IDiscoveryService GetDiscoveryService(TracerSettings settings)
+        internal override IDiscoveryService GetDiscoveryService(TracerSettings settings)
             => _testOptimizationTracerManagement.DiscoveryService;
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -586,6 +586,14 @@ namespace Datadog.Trace.Configuration
         public const string ApplicationMonitoringConfigFileEnabled = "DD_APPLICATION_MONITORING_CONFIG_FILE_ENABLED";
 
         /// <summary>
+        /// Configuration key to disable the agent discovery service.
+        /// When disabled, the tracer will not query the agent for available endpoints.
+        /// This is useful in environments where the discovery endpoint is not available (e.g., Azure Functions with Rust agent).
+        /// Default value is true (discovery service enabled).
+        /// </summary>
+        public const string DiscoveryServiceEnabled = "DD_TRACE_DISCOVERY_ENABLED";
+
+        /// <summary>
         /// String constants for CI Visibility configuration keys.
         /// </summary>
         public static class CIVisibility

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -372,6 +372,10 @@ namespace Datadog.Trace.Configuration
                                              .WithKeys(ConfigurationKeys.AzureServiceBusBatchLinksEnabled)
                                              .AsBool(defaultValue: true);
 
+            DiscoveryServiceEnabled = config
+                                     .WithKeys(ConfigurationKeys.DiscoveryServiceEnabled)
+                                     .AsBool(defaultValue: true);
+
             DelayWcfInstrumentationEnabled = config
                                             .WithKeys(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
                                             .AsBool(defaultValue: true);
@@ -843,6 +847,15 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.AzureServiceBusBatchLinksEnabled"/>
         public bool AzureServiceBusBatchLinksEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the agent discovery service is enabled.
+        /// When disabled, the tracer will not query the agent for available endpoints.
+        /// This is useful in environments where the discovery endpoint is not available (e.g., Azure Functions with Rust agent).
+        /// Default value is true (discovery service enabled).
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DiscoveryServiceEnabled"/>
+        public bool DiscoveryServiceEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether to enable the updated WCF instrumentation that delays execution

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -462,9 +462,6 @@ namespace Datadog.Trace
             }
         }
 
-        protected virtual IDiscoveryService GetDiscoveryService(TracerSettings settings)
-            => DiscoveryService.Create(settings.Exporter);
-
         internal static IDogStatsd CreateDogStatsdClient(TracerSettings settings, string serviceName, List<string> constantTags, string prefix = null)
         {
             try
@@ -537,6 +534,11 @@ namespace Datadog.Trace
 
             return CreateDogStatsdClient(settings, serviceName, constantTags);
         }
+
+        internal virtual IDiscoveryService GetDiscoveryService(TracerSettings settings)
+            => settings.DiscoveryServiceEnabled
+                   ? DiscoveryService.Create(settings.Exporter)
+                   : NullDiscoveryService.Instance;
 
         /// <summary>
         /// Gets an "application name" for the executing application by looking at

--- a/tracer/test/Datadog.Trace.Tests/TracerManagerFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerManagerFactoryTests.cs
@@ -103,6 +103,29 @@ public class TracerManagerFactoryTests : IAsyncLifetime
         _manager.TracerFlareManager.Should().BeOfType<NullTracerFlareManager>();
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DiscoveryServiceCanBeDisabled(bool enabled)
+    {
+        var source = CreateConfigurationSource((ConfigurationKeys.DiscoveryServiceEnabled, enabled.ToString()));
+        var settings = new TracerSettings(source);
+
+        settings.DiscoveryServiceEnabled.Should().Be(enabled);
+
+        var factory = new TracerManagerFactory();
+        var discoveryService = factory.GetDiscoveryService(settings);
+
+        if (enabled)
+        {
+            discoveryService.Should().BeOfType<DiscoveryService>();
+        }
+        else
+        {
+            discoveryService.Should().BeSameAs(NullDiscoveryService.Instance);
+        }
+    }
+
     private static TracerManager CreateTracerManager(TracerSettings settings)
     {
         return new TracerManagerFactory().CreateTracerManager(


### PR DESCRIPTION
## Summary

Adds `DD_TRACE_DISCOVERY_ENABLED` environment variable (default: `true`) to allow disabling the agent discovery service. When disabled, the tracer uses `NullDiscoveryService` instead of querying the agent for available endpoints.

## Motivation

In certain environments, such as Azure Functions with the Rust agent, the discovery endpoint is not available. Currently, the tracer always attempts to query the discovery service, which results in unnecessary network calls and potential errors in these scenarios.

## Changes

- Added `DD_TRACE_DISCOVERY_ENABLED` configuration key to `ConfigurationKeys.cs`
- Added `DiscoveryServiceEnabled` property to `TracerSettings` (defaults to `true`)
- Updated `TracerManagerFactory.GetDiscoveryService()` to return `NullDiscoveryService.Instance` when disabled
- Changed `GetDiscoveryService()` visibility from `protected` to `internal virtual` for consistency with override in `TestOptimizationTracerManagerFactory`
- Added unit test `DiscoveryServiceCanBeDisabled` to verify both enabled and disabled states

## Test Plan

- [x] Unit test verifies setting is read correctly
- [x] Unit test verifies `DiscoveryService` is returned when enabled
- [x] Unit test verifies `NullDiscoveryService.Instance` is returned when disabled
- [ ] Manual testing in Azure Functions environment with Rust agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)