### PR TITLE
[Dynamic Instrumentation] Ensure DI metric probe does not send automatic telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
@@ -64,7 +64,7 @@ internal class DebuggerFactory
         }
         else
         {
-            statsd = TracerManagerFactory.CreateDogStatsdClient(tracerSettings, serviceName, constantTags: null, DebuggerSettings.DebuggerMetricPrefix);
+            statsd = TracerManagerFactory.CreateDogStatsdClient(tracerSettings, serviceName, constantTags: null, prefix: DebuggerSettings.DebuggerMetricPrefix, telemtryFlushInterval: null);
         }
 
         return statsd;

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -465,7 +465,7 @@ namespace Datadog.Trace
         protected virtual IDiscoveryService GetDiscoveryService(TracerSettings settings)
             => DiscoveryService.Create(settings.Exporter);
 
-        internal static IDogStatsd CreateDogStatsdClient(TracerSettings settings, string serviceName, List<string> constantTags, string prefix = null)
+        internal static IDogStatsd CreateDogStatsdClient(TracerSettings settings, string serviceName, List<string> constantTags, string prefix = null, TimeSpan? telemtryFlushInterval = null)
         {
             try
             {
@@ -478,7 +478,7 @@ namespace Datadog.Trace
                     ServiceName = NormalizerTraceProcessor.NormalizeService(serviceName),
                     Environment = settings.Environment,
                     ServiceVersion = settings.ServiceVersion,
-                    Advanced = { TelemetryFlushInterval = null }
+                    Advanced = { TelemetryFlushInterval = telemtryFlushInterval }
                 };
 
                 switch (settings.Exporter.MetricsTransport)


### PR DESCRIPTION
## Summary of changes
Ensure that we do not send automatic telemetry with the DogStatsd metric probe.

## Reason for change
Since version [2.38.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.38.0), DogStatsd is created without telemetry, which is also beneficial for DI. ([PR](https://github.com/DataDog/dd-trace-dotnet/pull/4580))
This PR ensures that the behavior from versions prior to 2.38.0 will not return in the future if the DogStatsd creation logic changes.