### PR TITLE
Fix profiler_execution_benchmarks flakiness

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4536,6 +4536,7 @@ stages:
         DD_PROFILING_AGENTLESS: 1
         DD_CIVISIBILITY_LOGS_ENABLED: 0
         DD_CIVISIBILITY_ITR_ENABLED: 0
+      retryCountOnTaskFailure: 3
 
     - powershell: |
         mkdir -p $(System.DefaultWorkingDirectory)/profiler/build_data/benchmarks/$(testName)
@@ -4618,6 +4619,7 @@ stages:
         DD_PROFILING_AGENTLESS: 1
         DD_CIVISIBILITY_LOGS_ENABLED: 0
         DD_CIVISIBILITY_ITR_ENABLED: 0
+      retryCountOnTaskFailure: 3
 
     - script: |
         mkdir -p $(System.DefaultWorkingDirectory)/profiler/build_data/benchmarks/$(testName)


### PR DESCRIPTION
## Summary of changes

We are getting the following flaky error when running the profiler_execution_benchmarks:

`Scenario: Profiler_garbagecollections Cmd: Samples.Computer01 --scenario 12 --iterations 4000 --param 2 Warming up .. Duration: 2 sec 426 ms Run .An error occurred while running TimeItSharp: System.IO.EndOfStreamException: Unable to read beyond the end of the stream. at void System.ThrowHelper.ThrowEndOfFileException() at double System.IO.BinaryReader.ReadDouble() at async Task<DataPoint> TimeItSharp.Common.ScenarioProcessor.RunCommandAsync(int index, Scenario scenario, TimeItPhase phase, int executionId, Cancellation*** cancellation***) in /_/src/TimeItSharp.Common/ScenarioProcessor.cs:858 at void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()`

This error comes from TimeItSharp and is a known bug that will be addressed in future versions of the library. In the meantime, retrying the task will prevent it from failing.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
