### PR TITLE
Revert "[SINT-4157] sanitise ultimate-pipeline.yml"

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4238,10 +4238,6 @@ stages:
               echo "Label 'docker_image_artifacts' not found in PR — skipping Docker image build"
               exit 0
             fi
-            if ! [[ $BRANCH_NAME =~ ^[A-Za-z0-9._-/]+$ ]]; then
-              echo "Exiting - Manages branches only if they contain letters, numbers and the following special characters: . - _ /"
-              exit 1
-            fi
           fi
 
           echo "Creating dispatch event for https://github.com/DataDog/dd-trace-dotnet/actions/workflows/create-system-test-docker-base-images.yml with ref=$REF and azdo_build_id=$(Build.BuildId) and is_release_version=False"


### PR DESCRIPTION
Reverts DataDog/dd-trace-dotnet#7582

This is preventing us to run the action as expected as the regex appears to be incorrect.
Since we must trigger this ourselves there really isn't a risk here at the moment, will let the SINT team follow up to resolve.

This is blocking the testing of https://github.com/DataDog/dd-trace-dotnet/pull/7514

https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=188595&view=logs&j=8299a7f3-61e2-5626-a12e-85b7b20deab1&t=e26f8d61-df24-5d93-564c-322f7221200d 