### PR TITLE
[SINT-4157] sanitise ultimate-pipeline.yml

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4238,6 +4238,10 @@ stages:
               echo "Label 'docker_image_artifacts' not found in PR — skipping Docker image build"
               exit 0
             fi
+            if ! [[ $BRANCH_NAME =~ ^[A-Za-z0-9._/-]+$ ]]; then
+              echo "Exiting - Manages branches only if they contain letters, numbers and the following special characters: . - _ /"
+              exit 1
+            fi
           fi
 
           echo "Creating dispatch event for https://github.com/DataDog/dd-trace-dotnet/actions/workflows/create-system-test-docker-base-images.yml with ref=$REF and azdo_build_id=$(Build.BuildId) and is_release_version=False"


### PR DESCRIPTION
## Summary of changes

## Reason for change

Follow-up of https://github.com/DataDog/dd-trace-dotnet/pull/7582, that got reverted in https://github.com/DataDog/dd-trace-dotnet/pull/7627.
The present PR updates the regular expression: the hyphen should be at the end or escaped to avoid being interpreted as a range operator. 

## Implementation details

From [source](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html):

> The <hyphen-minus> character shall be treated as itself if it occurs first (after an initial '^', if any) or last in the list, or as an ending range point in a range expression.

## Test coverage

Tested locally with this script [test-branch-name.sh](https://github.com/user-attachments/files/22740574/test-branch-name.sh) and got the following result, which reproduces the error in the PR and validates the fix from this PR. In particular:
`maximo/otel-metrics-api-exporter` and `maximo/otel-metrics-api-exporter.` are authorized patterns, while `maximo/otel-metrics-api-exporter\;` is not. Test results confirm that the corrected regex now implements this behavior correctly

```
$ bash ./test-branch-name.sh maximo/otel-metrics-api-exporter
Handling maximo/otel-metrics-api-exporter
reverted regex NOT matched (branch name deemed UNSAFE, will exit)
corrected regex matched (branch name deemed safe)

$ bash ./test-branch-name.sh maximo/otel-metrics-api-exporter.
Handling maximo/otel-metrics-api-exporter.
reverted regex NOT matched (branch name deemed UNSAFE, will exit)
corrected regex matched (branch name deemed safe)

$ bash ./test-branch-name.sh maximo/otel-metrics-api-exporter\;
Handling maximo/otel-metrics-api-exporter;
reverted regex NOT matched (branch name deemed UNSAFE, will exit)
corrected regex NOT matched (branch name deemed UNSAFE, will exit)
```


## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
