### PR TITLE
[Dynamic Instrumentation] Skip some debugger tests on .NET 8 or greater

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
@@ -20,7 +20,8 @@ using Xunit.Abstractions;
 #nullable enable
 namespace Datadog.Trace.Debugger.IntegrationTests;
 
-#if !NETCOREAPP2_1
+// These tests crashed on NETCOREAPP2_1 and often hang on .NET 8 or greater (mostly on x86 but sometimes also on x64).
+#if !NETCOREAPP2_1 && !NET8_0_OR_GREATER
 [CollectionDefinition(nameof(DebuggerManagerDynamicTests), DisableParallelization = true)]
 [Collection(nameof(DebuggerManagerDynamicTests))]
 [UsesVerify]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerTests.cs
@@ -20,8 +20,8 @@ using Xunit.Abstractions;
 #nullable enable
 namespace Datadog.Trace.Debugger.IntegrationTests;
 
-// These tests crashed on NETCOREAPP2_1 and often hang on .NET 8 (mostly on x86 but sometimes also on x64).
-#if !NETCOREAPP2_1 && !NET8_0
+// These tests crashed on NETCOREAPP2_1 and often hang on .NET 8 or greater (mostly on x86 but sometimes also on x64).
+#if !NETCOREAPP2_1 && !NET8_0_OR_GREATER
 [CollectionDefinition(nameof(DebuggerManagerTests), DisableParallelization = true)]
 [Collection(nameof(DebuggerManagerTests))]
 [UsesVerify]


### PR DESCRIPTION
## Summary of changes
Skip debugger configuration tests on .NET 8 or greater until we investigate and understand the issue that sometimes causes the tests to hang (DEBUG-4572).
