### PR TITLE
Update `CODEOWNERS` for consistent ownership of managed loader files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -223,7 +223,7 @@ missing-nullability-files.csv             @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj @DataDog/apm-dotnet
-/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup*.cs                                     @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj @DataDog/apm-dotnet


### PR DESCRIPTION
## Summary of changes

Updates the `CODEOWNERS` pattern for managed loader files from `Startup.cs` to `Startup*.cs` to include all Startup-related files.

## Reason for change

The `CODEOWNERS` file only had an entry for `Startup.cs`, but there are additional related files in the managed loader:
- `Startup.cs`
- `Startup.NetCore.cs`
- `Startup.NetFramework.cs`
- `StartupLogger.cs`

These files are all part of the managed loader startup logic and should have the same ownership oversight.

## Implementation details

Changed the `CODEOWNERS` pattern from:
```
/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs @DataDog/apm-dotnet
```

To:
```
/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup*.cs @DataDog/apm-dotnet
```

This wildcard pattern now matches all Startup-related files in the managed loader directory.

## Test coverage

N/A - CODEOWNERS configuration change only

## Other details

N/A