### PR TITLE
[TestOptimization] Catch IOException on the Git folder discovery

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GitInfo.cs
@@ -192,6 +192,11 @@ internal class GitInfo : IGitInfo
                 Log.Warning(ex, "Get directories failed with DirectoryNotFoundException");
                 return null;
             }
+            catch (IOException ex)
+            {
+                Log.Warning(ex, "Get directories failed with IOException");
+                return null;
+            }
             catch (UnauthorizedAccessException ex)
             {
                 Log.Warning(ex, "Get directories failed with UnauthorizedAccessException");


### PR DESCRIPTION
## Summary of changes

This PR adds another exception catch but for the IOException.

## Reason for change

This exception appears on a customer:
```
System.IO.IOException
     at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
     at System.IO.FileSystemEnumerableIterator`1.CommonInit()
     at System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost)
     at System.IO.DirectoryInfo.InternalGetDirectories(String searchPattern, SearchOption searchOption)
     at Datadog.Trace.Ci.CIEnvironment.GitInfo.GetParentGitFolder(String innerFolder)
     at Datadog.Trace.Ci.CIEnvironment.GitInfo.GetCurrent()
     at Datadog.Trace.Ci.CIEnvironment.CIEnvironmentValues.ReloadEnvironmentData()
     at Datadog.Trace.Ci.CIEnvironment.CIEnvironmentValues.Create()
     at System.Lazy`1.CreateValue()
     at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
     at System.Lazy`1.get_Value()
     at Datadog.Trace.Ci.TestOptimization.<>c.<get_Instance>b__16_0()
     at System.Threading.LazyInitializer.EnsureInitializedCore[T](T& target, Func`1 valueFactory)
     at Datadog.Trace.SpanContext..ctor(TraceId traceId, String serviceName)
     at Datadog.Trace.SpanContext..ctor(ISpanContext parent, TraceContext traceContext, String serviceName, TraceId traceId, UInt64 spanId, String rawTraceId, String rawSpanId, Boolean isRemote)
     at Datadog.Trace.Tracer.CreateSpanContext(ISpanContext parent, String serviceName, TraceId traceId, UInt64 spanId, String rawTraceId, String rawSpanId, Boolean addToTraceContext, IEnumerable`1 links)
     at Datadog.Trace.Tracer.StartSpan(String operationName, ITags tags, ISpanContext parent, String serviceName, Nullable`1 startTime, TraceId traceId, UInt64 spanId, String rawTraceId, String rawSpanId, Boolean
  addToTraceContext, IEnumerable`1 links)
     at Datadog.Trace.ClrProfiler.ScopeFactory.CreateInactiveOutboundHttpSpan(Tracer tracer, String httpMethod, Uri requestUri, IntegrationId integrationId, HttpTags& tags, TraceId traceId, UInt64 spanId, Nullable`1
  startTime, Boolean addToTraceContext)
```

## Implementation details

a single new catch of the existing try/catch blocks

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
