### PR TITLE
Minor fix in DynamicConfigurationManager update process

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -191,7 +191,6 @@ namespace Datadog.Trace.Configuration
                     if (activeConfigurations.Remove(removedConfig.Id))
                     {
                         Log.Debug("Explicitly removed APM_TRACING configuration {ConfigId}", removedConfig.Id);
-                        applyDetailsResult.Add(ApplyDetails.FromOk(removedConfig.Path));
                     }
                 }
             }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationManagerTests.cs
@@ -216,16 +216,12 @@ public class DynamicConfigurationManagerTests
         Dictionary<string, List<RemoteConfiguration>> configByProduct,
         Dictionary<string, List<RemoteConfigurationPath>> removedConfigByProduct)
     {
-        var removed = removedConfigByProduct
-                     .Where(x => x.Key == ProductName)
-                     .SelectMany(x => x.Value)
-                     .Where(x => originalConfig.ContainsKey(x.Id)) // Only acknowledge the configs that we actually have
-                     .Select(x => ApplyDetails.FromOk(x.Path));
+        // Only acknowledge added configs, not removed ones
         var added = configByProduct
                    .Where(x => x.Key == ProductName)
                    .SelectMany(x => x.Value)
                    .Select(x => ApplyDetails.FromOk(x.Path.Path));
-        List<ApplyDetails> expected = [..removed, ..added];
+        List<ApplyDetails> expected = [..added];
 
         applyDetails.Should().BeEquivalentTo(expected);
     }


### PR DESCRIPTION
## Reason for change

I accidentally acknowledge removed configs. This OR remove that.

## Test coverage

Updated existing DynamicConfigurationManagerTests


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
