### PR TITLE
Limit Dependabot to 1 open PR for our integration bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/tracer/dependabot/integrations"
     registries: "*"
+    open-pull-requests-limit: 1
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
## Summary of changes

This will make it so that Dependabot can only have 1 PR open at any time for the version bumps for tested versions.

## Reason for change

I think having multiple is just noise, as the first one will kick off a new `[Test Package Versions Bump]` and after that gets merged I think all the dependabot ones just get closed.

## Implementation details

Added `open-pull-requests-limit: 1` to just the dependabot stage for these

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-

## Test coverage

Nope

## Other details
<!-- Fixes #{issue} -->

Does this make sense 🤷 

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
