### PR TITLE
Use RuntimeHelpers.GetHashCode in IndexObject

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/DefaultTaintedMap.cs
+++ b/tracer/src/Datadog.Trace/Iast/DefaultTaintedMap.cs
@@ -228,7 +228,7 @@ internal class DefaultTaintedMap : ITaintedMap
 
     private int IndexObject(object objectStored)
     {
-        return Index(PositiveHashCode(objectStored.GetHashCode()));
+        return Index(PositiveHashCode(IastUtils.IdentityHashCode(objectStored)));
     }
 
     private int PositiveHashCode(int hash)

--- a/tracer/src/Datadog.Trace/Iast/IastUtils.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastUtils.cs
@@ -71,7 +71,20 @@ internal static class IastUtils
 
     public static int IdentityHashCode(object item)
     {
-        return (item?.GetHashCode() ?? 0);
+        if (item == null)
+        {
+            return 0;
+        }
+
+        try
+        {
+            return item.GetHashCode();
+        }
+        catch
+        {
+            // Seen this that it appears some customer objects have overrode GetHashCode and throw
+            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(item);
+        }
     }
 
     public static Range[] GetRangesForString(string stringValue, Source source)


### PR DESCRIPTION
## Summary of changes

This changes to use a means to get the hash code of an object to handle `null`, `object.GetHashCode` and a fallback to use RuntimeHelpers `GetHashCode` for when `object.GetHashCode` fails.

## Reason for change

My guess is that `GetHashCode` is overridden for the given object and we probably should avoid that?

Spotted the following in Error Tracking:

```
Error : PropagationModuleImpl.PropagateWholeResultWhenInputTainted exception
System.NullReferenceException
   at REDACTED
   at Datadog.Trace.Iast.DefaultTaintedMap.IndexObject(Object objectStored)
   at Datadog.Trace.Iast.DefaultTaintedMap.Get(Object objectToFind)
   at Datadog.Trace.Iast.Propagation.PropagationModuleImpl.PropagateWholeResultWhenInputTainted(String result, Object input1, Object input2, Object input3)
```

## Implementation details

Swapped from one to the other.

## Test coverage

🤷 Didn't try to reproduce

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
