### PR TITLE
Run dsm-throughput macrobenchmarks on master push & schedule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -227,6 +227,8 @@ dsm_throughput:
     include: .gitlab/benchmarks/dsm-throughput.yml
   allow_failure: true
   rules:
-    - if: '$CI_COMMIT_BRANCH'
-      when: on_success
-    - when: never
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"'
+      when: always
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $BENCHMARK_RUN == "true"'
+      when: always
+    - when: manual


### PR DESCRIPTION
## Summary of changes
One of our pipeline scripts started failing because we are failing to check out a tag. We should run dsm-throughput in the same manner as existing macrobenchmarks.

## Reason for change
Set up scripts was failing to check out a tag, because we ran this on a tag pipeline in the release.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
