### PR TITLE
Comment out new test agent on Windows

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
 #if NET6_0_OR_GREATER
-        [SkippableTheory(Skip = "Temporarily disabled due to Docker Hub rate limits on test-agent.windows image")]
+        [SkippableTheory]
         [Flaky("New test agent seems to not always be ready", maxRetries: 3)]
         [Trait("Category", "EndToEnd")]
         [Trait("RequiresDockerDependency", "true")]


### PR DESCRIPTION
## Summary of changes

Comments out the start / stop test agent as we are hitting unauthenticated Docker rate limits as it pulls in a later version that the VM doesn't yet have generalized on it.

The tests do not yet run on Windows due to flake we were seeing, so should be no harm.

## Reason for change

This is to get CI green again sooner rather than later

```
Mode                 LastWriteTime         Length Name                                                                 
----                 -------------         ------ ----                                                                 
d-----        10/21/2025   6:15 PM                snapshots                                                            
 test-agent.windows Pulling 
 test-agent.windows Warning 
Sending build context to Docker daemon  9.166kB

Step 1/5 : FROM python:3.10.5-windowsservercore-ltsc2022
toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```

## Implementation details

Commented out the docker steps in the pipeline.

## Test coverage

The tests run on Linux only at the moment, so we should have the same level of testing.
Have not tested this, will see if this resolves it hopefully.

## Other details
<!-- Fixes #{issue} -->

I thought that https://github.com/DataDog/dd-trace-dotnet/pull/7656 would just cause the tests to be a bit slower as they'd need to pull from Docker for a bit as we worked on updating the VMs, but didn't realize we'd hit an unauthenticated rate limit.

Will prioritize updating the VMs with this image to get this working again.

**EDIT** I forgot that we skipped running on Windows for the above reason and for other flake we were attempting to address as well, so we don't have as much of a push
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
