### PR TITLE
Add VBCSCompiler to exclude list

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/constants.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/constants.h
@@ -42,6 +42,7 @@ const shared::WSTRING default_exclude_processes[]{
     WStr("sqlagent.exe"),
     WStr("sqlbrowser.exe"),
     WStr("sqlservr.exe"),
+    WStr("VBCSCompiler"),
     WStr("VBCSCompiler.exe"),
     WStr("vsdbg"),
     WStr("vsdbg.exe"),


### PR DESCRIPTION
## Summary of changes

Add `VBCSCompiler` to "don't instrument" list

## Reason for change

We saw it being instrumented in CI in the RC2 update #7659

## Implementation details

Add `VBCSCompiler` to the list

## Test coverage

Will be covered indirectly by #7659
