### PR TITLE
Handle null HttpRequest in AspNetCore naming

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -43,14 +43,30 @@ namespace Datadog.Trace.PlatformHelpers
 
         public string GetDefaultResourceName(HttpRequest request)
         {
+            // Be defensive: in some edge cases the HttpRequest object may be null (e.g.,
+            // framework- or host-specific error paths). Avoid throwing and return a safe default.
+            if (request is null)
+            {
+                return "UNKNOWN /";
+            }
+
             string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
 
-            string absolutePath = request.PathBase.HasValue
-                                      ? request.PathBase.ToUriComponent() + request.Path.ToUriComponent()
-                                      : request.Path.ToUriComponent();
+            string absolutePath;
+            try
+            {
+                absolutePath = request.PathBase.HasValue
+                                   ? request.PathBase.ToUriComponent() + request.Path.ToUriComponent()
+                                   : request.Path.ToUriComponent();
+            }
+            catch
+            {
+                // If anything goes wrong building the path, fall back to root
+                absolutePath = "/";
+            }
 
-            string resourceUrl = UriHelpers.GetCleanUriPath(absolutePath)
-                                           .ToLowerInvariant();
+            var cleanedPath = UriHelpers.GetCleanUriPath(absolutePath);
+            string resourceUrl = (cleanedPath ?? "/").ToLowerInvariant();
 
             return $"{httpMethod} {resourceUrl}";
         }

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AspNetCoreHttpRequestHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AspNetCoreHttpRequestHandlerTests.cs
@@ -5,6 +5,8 @@
 
 #if !NETFRAMEWORK
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -15,6 +17,19 @@ namespace Datadog.Trace.Tests.PlatformHelpers
     public class AspNetCoreHttpRequestHandlerTests
     {
         public const string OriginalPath = "/somepath/Home/Index";
+
+        [Fact]
+        public void GetDefaultResourceName_ReturnsUnknownSlash_WhenRequestIsNull()
+        {
+            var handler = new AspNetCoreHttpRequestHandler(
+                DatadogLogging.GetLoggerFor<AspNetCoreHttpRequestHandlerTests>(),
+                "aspnet_core.request",
+                IntegrationId.AspNetCore);
+
+            var result = handler.GetDefaultResourceName(null);
+
+            result.Should().Be("UNKNOWN /");
+        }
 
         [Theory]
         [InlineData(null, "/somepath/Home/Index")]


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8195e97d-e28f-41f9-9242-b6293cd98085","source":"issue","resourceId":"5f298210-3db0-11f0-abc8-da7ad0900002","workflowId":"4d34968a-c759-4a77-aeb6-e10ea74494e4","codeChangeId":"abd8fce4-d811-4fbb-8893-62bed06cadd4","sourceType":""} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=8195e97d-e28f-41f9-9242-b6293cd98085) to fix issue [5f298210-3db0-11f0-abc8-da7ad0900002](https://app.datadoghq.com/error-tracking/issue/5f298210-3db0-11f0-abc8-da7ad0900002?from_ts=1761072622569&to_ts=1761079822569#code)

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Summary of changes

Added null safety checks and defensive exception handling to `AspNetCoreHttpRequestHandler.GetDefaultResourceName()` to prevent `NullReferenceException` when the `HttpRequest` is null. The method now returns a safe default resource name ("UNKNOWN /") instead of crashing. Added a new unit test to verify the null case is handled correctly.

## Reason for change

A `NullReferenceException` occurred in the instrumentation-telemetry-data service when the ASP.NET Core diagnostic observer attempted to compute a resource name for a null `HttpRequest` during request completion. This happened in edge cases such as framework error paths or host-specific failures where the request object was not available during the stop event.

<details>
	<summary>More details</summary>

The exception occurred in the Hosting.HttpRequestIn.Stop event handler. When `StopAspNetCorePipelineScope()` calls `GetDefaultResourceName(HttpRequest)` to set a default span resource name, it did not account for scenarios where the `HttpRequest` could be null. The method previously dereferenced `request.Method` and `request.Path*` without null validation, causing an immediate crash before the span could be properly finalized.

In rare stop-phase error paths (aborted/failed requests or late shutdown scenarios), the `HttpRequest` parameter can legitimately be null, and the code must gracefully handle this case.
</details>

## Implementation details

- Added a null check at the start of `GetDefaultResourceName()` to return "UNKNOWN /" if the request is null
- Wrapped path construction in a try-catch block to handle any exceptions that may occur when accessing `PathBase` or `Path` properties
- Added null coalescing to handle cases where `UriHelpers.GetCleanUriPath()` returns null
- These defensive measures ensure the method always returns a valid resource name without throwing exceptions

## Test coverage

Added a new unit test `GetDefaultResourceName_ReturnsUnknownSlash_WhenRequestIsNull()` that verifies the handler correctly returns "UNKNOWN /" when passed a null `HttpRequest`.

## Other details

This fix makes the request handler more resilient to edge cases and prevents telemetry collection from crashing during request completion, even in error scenarios.