### PR TITLE
Handle disposed Cosmos clients gracefully

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/CosmosDb/CosmosCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/CosmosDb/CosmosCommonTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Datadog
+// Licensed under the Apache 2 License.
+
+using System;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.CosmosDb;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ClrProfiler.AutoInstrumentation.CosmosDb
+{
+public class CosmosCommonTests
+{
+    [Fact]
+    public void CreateContainerCallState_DoesNotThrow_WhenDatabaseNewClientDisposed()
+    {
+        var container = new ContainerStub
+        {
+            Id = "container",
+            Database = new DatabaseNewStub { Id = "db" }
+        };
+
+        Action act = () =>
+        {
+            CallTargetState state = CosmosCommon.CreateContainerCallStateExt(container, "SELECT 1");
+            state.Scope?.Dispose();
+        };
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CreateContainerCallState_DoesNotThrow_WhenDatabaseOldClientDisposed()
+    {
+        var container = new ContainerStub
+        {
+            Id = "container",
+            Database = new DatabaseOldStub { Id = "db" }
+        };
+
+        Action act = () =>
+        {
+            CallTargetState state = CosmosCommon.CreateContainerCallStateExt(container, "SELECT 1");
+            state.Scope?.Dispose();
+        };
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CreateDatabaseCallState_DoesNotThrow_WhenClientDisposed_New()
+    {
+        var database = new DatabaseNewStub { Id = "db" };
+
+        Action act = () =>
+        {
+            CallTargetState state = CosmosCommon.CreateDatabaseCallStateExt(database, "SELECT 1");
+            state.Scope?.Dispose();
+        };
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CreateDatabaseCallState_DoesNotThrow_WhenClientDisposed_Old()
+    {
+        var database = new DatabaseOldStub { Id = "db" };
+
+        Action act = () =>
+        {
+            CallTargetState state = CosmosCommon.CreateDatabaseCallStateExt(database, "SELECT 1");
+            state.Scope?.Dispose();
+        };
+
+        act.Should().NotThrow();
+    }
+
+    private class ContainerStub
+    {
+        public string Id
+        {
+            get;
+            set;
+        }
+
+        // Must be object to match ContainerStruct.Database
+        public object Database
+        {
+            get;
+            set;
+        }
+    }
+
+    private class DatabaseNewStub
+    {
+        public string Id
+        {
+            get;
+            set;
+        }
+
+        // Simulate disposed client by throwing on getter access
+        public ThrowingCosmosClient Client => throw new ObjectDisposedException("CosmosClient");
+    }
+
+    private class DatabaseOldStub
+    {
+        public string Id
+        {
+            get;
+            set;
+        }
+
+        public CosmosClientContextStub ClientContext
+        {
+            get;
+        } = new CosmosClientContextStub();
+    }
+
+    private class CosmosClientContextStub
+    {
+        // Simulate disposed client by throwing on getter access
+        public ThrowingCosmosClient Client => throw new ObjectDisposedException("CosmosClient");
+    }
+
+    private class ThrowingCosmosClient
+    {
+        // Not expected to be reached in these tests, but provided for completeness
+        public Uri Endpoint => new Uri("http://localhost");
+    }
+}
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8511c222-047d-472d-948b-fa52d9edb08c","source":"issue","resourceId":"1f756508-3b0d-11f0-86d3-da7ad0900002","workflowId":"f47d8cfc-7202-4b29-892c-08c5b6dbbe36","codeChangeId":"055c442c-575d-442d-b091-40fc1f51ec42","sourceType":""} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=8511c222-047d-472d-948b-fa52d9edb08c) to fix issue [1f756508-3b0d-11f0-86d3-da7ad0900002](https://app.datadoghq.com/error-tracking/issue/1f756508-3b0d-11f0-86d3-da7ad0900002?from_ts=1761153391050&to_ts=1761160591050#code)

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Summary of changes

Wrapped all Cosmos client endpoint access in try/catch blocks to handle `ObjectDisposedException` when the client or container is disposed. Added comprehensive unit tests to verify the instrumentation gracefully handles disposed clients without throwing.

## Reason for change

The Cosmos DB instrumentation was throwing `ObjectDisposedException` when attempting to access the client endpoint during span creation if the underlying Cosmos client had been disposed. This caused the CallTarget integration continuation to fail before the scope could be created, breaking instrumentation for disposed clients.

<details>
	<summary>More details</summary>
	
The Cosmos DB CallTarget integration eagerly dereferences the Cosmos client while creating span metadata without guarding for disposed instances. In `CosmosCommon.CreateContainerCallStateExt` and `CreateDatabaseCallStateExt`, the code accessed `DatabaseNewStruct.Client.Endpoint` or `DatabaseOldStruct.ClientContext.Client.Endpoint` outside of a try/catch. When the underlying `Microsoft.Azure.Cosmos` client was disposed, `Microsoft.Azure.Cosmos.ClientContextCore.get_Client()` invoked `ThrowIfDisposed()`, throwing `ObjectDisposedException` and causing the integration continuation to fail before scope creation.

The fix wraps all endpoint retrieval calls in try/catch blocks to gracefully handle disposal by simply omitting the endpoint when the client is unavailable, allowing instrumentation to continue.
</details>

## Implementation details

- Added try/catch blocks in `CreateContainerCallStateExt` to handle `ObjectDisposedException` when accessing `DatabaseNewStruct.Client.Endpoint` and `DatabaseOldStruct.ClientContext.Client.Endpoint`
- Added try/catch blocks in `CreateDatabaseCallStateExt` for the same client endpoint accesses
- Added try/catch block in `CreateCosmosClientCallStateExt` to handle `ObjectDisposedException` when accessing `CosmosClientStruct.Endpoint`
- Gracefully handles disposal by leaving endpoint as `null` when `ObjectDisposedException` is caught
- Logs warnings for any other unexpected exceptions during endpoint retrieval

## Test coverage

Added comprehensive unit tests in `CosmosCommonTests.cs`:
- `CreateContainerCallState_DoesNotThrow_WhenDatabaseNewClientDisposed`: Verifies no exception when DatabaseNewStruct client is disposed
- `CreateContainerCallState_DoesNotThrow_WhenDatabaseOldClientDisposed`: Verifies no exception when DatabaseOldStruct client is disposed
- `CreateDatabaseCallState_DoesNotThrow_WhenClientDisposed_New`: Verifies no exception for DatabaseNewStruct disposal
- `CreateDatabaseCallState_DoesNotThrow_WhenClientDisposed_Old`: Verifies no exception for DatabaseOldStruct disposal

Tests use stub classes that simulate disposed clients by throwing `ObjectDisposedException` on property access.

## Other details

<!-- Fixes #{issue} -->