### PR TITLE
Remove CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,8 @@ jobs:
   profiler:
     name: Analyze Profiler
     runs-on: ubuntu-latest
+    # Temporarily disabled
+    if: false
     permissions:
       actions: read
       contents: read
@@ -90,6 +92,8 @@ jobs:
   tracer:
     name: Analyze Tracer
     runs-on: ubuntu-latest
+    # Temporarily disabled
+    if: false
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary of changes

The job CodeQL is failing in .Net 10 RC2 branches, probably related to [this](https://github.com/github/codeql-action/issues/3207).

We will temporarly disable it until .Net 10 GA.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
