### PR TITLE
Protect against `claimsPrincipal` being `null`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/HttpContextSetUser.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/HttpContextSetUser.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
 
         private const string HttpContextExtensionsTypeName = "Microsoft.AspNetCore.Http.DefaultHttpContext";
 
-        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, ref ClaimsPrincipal claimsPrincipal)
+        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, ref ClaimsPrincipal? claimsPrincipal)
         {
             if (Security.Instance is { IsTrackUserEventsEnabled: true } security)
             {


### PR DESCRIPTION
## Summary of changes

We are getting `NullReferenceException` in `HttpContextSetUser`, guessing the `claimsPrincipal` can be `null`.

## Reason for change

```
Error : Exception occurred when calling the CallTarget integration continuation.
System.NullReferenceException
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents.HttpContextSetUser.OnMethodBegin[TTarget](TTarget instance, ClaimsPrincipal& claimsPrincipal)
   at Microsoft.AspNetCore.Http.DefaultHttpContext.set_User(ClaimsPrincipal value)
```

## Implementation details

Added `claimsPrincipal is not null`

## Test coverage

None 🤷 

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
