### PR TITLE
Check if `httpContext.Response` is not `null`

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -44,7 +44,7 @@ internal static class SecurityCoordinatorHelpers
             if (security.AppsecEnabled && CoreHttpContextStore.Instance.Get() is { } httpContext)
             {
                 var transport = new SecurityCoordinator.HttpTransport(httpContext);
-                if (!transport.IsBlocked)
+                if (!transport.IsBlocked && httpContext.Response is not null)
                 {
                     var securityCoordinator = SecurityCoordinator.Get(security, span, transport);
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -713,8 +713,9 @@ namespace Datadog.Trace.DiagnosticListeners
                 return;
             }
 
-            if (arg.DuckCast<HttpRequestInStopStruct>().HttpContext is { } httpContext
-             && httpContext.Items[AspNetCoreHttpRequestHandler.HttpContextTrackingKey] is AspNetCoreHttpRequestHandler.RequestTrackingFeature { RootScope: { } rootScope })
+            if (arg.TryDuckCast<HttpRequestInStopStruct>(out var stopStruct)
+             && stopStruct.HttpContext is { } httpContext
+             && httpContext.Features.Get<AspNetCoreHttpRequestHandler.RequestTrackingFeature>() is { RootScope: { } rootScope })
             {
                 AspNetCoreRequestHandler.StopAspNetCorePipelineScope(_tracer, _security, rootScope, httpContext);
             }

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -199,18 +199,21 @@ namespace Datadog.Trace.PlatformHelpers
                         span.ResourceName = GetDefaultResourceName(httpContext.Request);
                     }
 
-                    if (isMissingHttpStatusCode)
+                    if (isMissingHttpStatusCode && httpContext.Response != null)
                     {
                         span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, settings);
                     }
                 }
 
-                span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-
-                if (proxyScope?.Span != null)
+                if (httpContext.Response != null)
                 {
-                    proxyScope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, settings);
-                    proxyScope.Span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+
+                    if (proxyScope?.Span != null)
+                    {
+                        proxyScope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, settings);
+                        proxyScope.Span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    }
                 }
 
                 if (security.AppsecEnabled)


### PR DESCRIPTION
## Summary of changes

Saw a couple of of `NullReferenceException` from calling things in ` HttpContext.Response.` so checking if `Response` is not `null`

## Reason for change

```
Error : Event Exception: {EventName}
System.NullReferenceException
   at Microsoft.AspNetCore.Http.DefaultHttpResponse.get_StatusCode()
   at Datadog.Trace.PlatformHelpers.AspNetCoreHttpRequestHandler.StopAspNetCorePipelineScope(Tracer tracer, Security security, Scope rootScope, HttpContext httpContext)
   at Datadog.Trace.DiagnosticListeners.AspNetCoreDiagnosticObserver.OnHostingHttpRequestInStop(Object arg)
   at Datadog.Trace.DiagnosticListeners.AspNetCoreDiagnosticObserver.OnNext(String eventName, Object arg)
   at Datadog.Trace.DiagnosticListeners.DiagnosticObserver.System.IObserver<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.OnNext(KeyValuePair`2 value)
```

```
Error : Event Exception: {EventName}
System.NullReferenceException
   at Datadog.Trace.PlatformHelpers.AspNetCoreHttpRequestHandler.StopAspNetCorePipelineScope(Tracer tracer, Security security, Scope rootScope, HttpContext httpContext)
   at Datadog.Trace.DiagnosticListeners.AspNetCoreDiagnosticObserver.OnHostingHttpRequestInStop(Object arg)
   at Datadog.Trace.DiagnosticListeners.DiagnosticObserver.System.IObserver<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.OnNext(KeyValuePair`2 value)
```

```
Error : Event Exception: {EventName}
System.NullReferenceException
   at Datadog.Trace.DiagnosticListeners.AspNetCoreDiagnosticObserver.OnHostingHttpRequestInStop(Object arg)
   at Datadog.Trace.DiagnosticListeners.DiagnosticObserver.System.IObserver<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.OnNext(KeyValuePair`2 value)
```

## Implementation details

Added some null checks / protections

## Test coverage

Looked at https://github.com/DataDog/dd-trace-dotnet/blob/5f33ec08a4789ebf123c5ea1b5430ccadd38b7ce/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AspNetCoreHttpRequestHandlerTests.cs#L15, but it doesn't look to be super straightforward to test.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
