### PR TITLE
[Tracer] Fix EventHubs flaky batch test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventHubsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventHubsTests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = await agent.WaitForSpansAsync(5, timeoutInMilliseconds: 30000);
+                var spans = await agent.WaitForSpansAsync(5, timeoutInMilliseconds: 30000, assertExpectedCount: false);
 
                 using var s = new AssertionScope();
 
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
 
                 createSpans.Should().HaveCount(3, "Expected 3 TryAdd spans with azure_eventhubs.create operation");
                 sendSpans.Should().HaveCount(1, "Expected 1 SendAsync span with azure_eventhubs.send operation");
-                receiveSpans.Should().HaveCount(1, "Expected 1 receive span");
+                receiveSpans.Should().HaveCountGreaterOrEqualTo(1, "Expected at least 1 receive span");
 
                 var individualMessageSpans = createSpans.Where(s => s.Resource == "samples-eventhubs-hub").ToList();
                 individualMessageSpans.Should().HaveCount(3, "Expected 3 individual message spans from TryAdd operations");
@@ -136,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = await agent.WaitForSpansAsync(2, timeoutInMilliseconds: 30000);
+                var spans = await agent.WaitForSpansAsync(2, timeoutInMilliseconds: 30000, assertExpectedCount: false);
 
                 using var s = new AssertionScope();
 
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
                 var receiveSpans = spans.Where(span => span.Name == "azure_eventhubs.receive").ToList();
 
                 sendSpans.Should().HaveCount(1, "Expected 1 SendAsync span (no individual TryAdd spans when batch links disabled)");
-                receiveSpans.Should().HaveCount(1, "Expected 1 receive span");
+                receiveSpans.Should().HaveCountGreaterOrEqualTo(1, "Expected at least 1 receive span");
 
                 foreach (var span in spans)
                 {


### PR DESCRIPTION
## Summary of changes

Expect at least 1 receive span instead of exactly one.

## Reason for change

The test expectations were incorrect, as `ReadEventsFromPartitionAsync` may call `ReceiveAsync` [several times depending on timing](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs#L520).