### PR TITLE
Protect against `FileLoadException` for NLog

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LogsInjectionHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LogsInjectionHelper.cs
@@ -27,15 +27,20 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjecti
 
         static LogsInjectionHelper()
         {
+            // Use typeof(TTarget).Assembly to get the NLog assembly safely, avoiding Type.GetType()
+            // which can throw FileLoadException even with throwOnError: false when there are
+            // assembly loading issues (version mismatches, binding redirects, etc.)
+            var nlogAssembly = typeof(TTarget).Assembly;
+
             // this is not available in older versions of NLog (e.g., v2.1 doesn't have JSON support)
-            _jsonAttributeType = Type.GetType("NLog.Layouts.JsonAttribute, NLog", throwOnError: false);
+            _jsonAttributeType = nlogAssembly.GetType("NLog.Layouts.JsonAttribute", throwOnError: false);
             if (_jsonAttributeType is null)
             {
                 return;
             }
 
             // this simple layout should exist for all versions
-            _simpleLayoutType = Type.GetType("NLog.Layouts.SimpleLayout, NLog", throwOnError: false);
+            _simpleLayoutType = nlogAssembly.GetType("NLog.Layouts.SimpleLayout", throwOnError: false);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes

Try to protect against a `TypeInitializationException` and `FileLoadException` being seen in NLog

## Reason for change

Thought process is that the previous method was resolving the incorrect NLog assembly? This way may get the exact one?
🤷 

https://learn.microsoft.com/en-us/dotnet/fundamentals/reflection/viewing-type-information

> Use [Assembly.GetType](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.gettype) or [Assembly.GetTypes](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.gettypes) to obtain Type objects from assemblies that have not been loaded, passing in the name of the type or types you want. Use [Type.GetType](https://learn.microsoft.com/en-us/dotnet/api/system.type.gettype) to get the Type objects from an assembly that is already loaded. Use [Module.GetType](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.module.gettype) and [Module.GetTypes](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.module.gettypes) to obtain module Type objects.

## Implementation details

Swaps from using GetType() to Assembly to bypass the assembly resolution logic.

## Test coverage

None, unsure how it actually emerges

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
