### PR TITLE
Add fix for whitespace in exporter settings and metrics URL

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/ExporterSettings.cs
@@ -89,7 +89,7 @@ public partial class ExporterSettings
     {
         foreach (var key in keys)
         {
-            var value = configuration?.GetString(key);
+            var value = configuration?.GetString(key)?.Trim();
 
             if (value != null)
             {

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.Shared.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.Shared.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Configuration
             // Check the parameters in order of precedence
             // For some cases, we allow falling back on another configuration (eg invalid url as the application will need to be restarted to fix it anyway).
             // For other cases (eg a configured unix domain socket path not found), we don't fallback as the problem could be fixed outside the application.
-            if (!string.IsNullOrWhiteSpace(agentUri))
+            if (!string.IsNullOrEmpty(agentUri))
             {
                 if (TryGetAgentUriAndTransport(agentUri!, origin, out var settings))
                 {
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Configuration
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(tracesPipeName))
+            if (!string.IsNullOrEmpty(tracesPipeName))
             {
                 RecordTraceTransport(nameof(TracesTransportType.WindowsNamedPipe), origin);
 
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Configuration
 
             // This property shouldn't have been introduced. We need to remove it as part of 3.0
             // But while it's here, we need to handle it properly
-            if (!string.IsNullOrWhiteSpace(tracesUnixDomainSocketPath))
+            if (!string.IsNullOrEmpty(tracesUnixDomainSocketPath))
             {
 #if NETCOREAPP3_1_OR_GREATER
                 if (TryGetAgentUriAndTransport(UnixDomainSocketPrefix + tracesUnixDomainSocketPath, origin, out var settings))

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -234,7 +234,7 @@ namespace Datadog.Trace.Configuration
 
         private MetricsTransportSettings ConfigureMetricsTransport(string? metricsUrl, string? traceAgentUrl, string? agentHost, int dogStatsdPort, string? metricsPipeName, string? metricsUnixDomainSocketPath)
         {
-            if (!string.IsNullOrWhiteSpace(metricsUrl) && TryGetMetricsUriAndTransport(metricsUrl!, out var settingsFromUri))
+            if (!string.IsNullOrEmpty(metricsUrl) && TryGetMetricsUriAndTransport(metricsUrl!, out var settingsFromUri))
             {
                 return settingsFromUri;
             }
@@ -252,7 +252,7 @@ namespace Datadog.Trace.Configuration
 
             MetricsTransportSettings settings;
 
-            if (!string.IsNullOrWhiteSpace(traceAgentUrl)
+            if (!string.IsNullOrEmpty(traceAgentUrl)
              && !traceAgentUrl!.StartsWith(UnixDomainSocketPrefix)
              && Uri.TryCreate(traceAgentUrl, UriKind.Absolute, out var tcpUri))
             {
@@ -273,11 +273,11 @@ namespace Datadog.Trace.Configuration
                     portSource: dogStatsDPortSource,
                     out settings);
             }
-            else if (!string.IsNullOrWhiteSpace(metricsPipeName))
+            else if (!string.IsNullOrEmpty(metricsPipeName))
             {
                 settings = new MetricsTransportSettings(TransportType.NamedPipe, PipeName: metricsPipeName);
             }
-            else if (metricsUnixDomainSocketPath != null)
+            else if (!string.IsNullOrEmpty(metricsUnixDomainSocketPath))
             {
 #if NETCOREAPP3_1_OR_GREATER
                 SetUds(metricsUnixDomainSocketPath, metricsUnixDomainSocketPath, metricsUnixDomainSocketPath, ConfigurationKeys.MetricsUnixDomainSocketPath, out settings);
@@ -447,22 +447,22 @@ namespace Datadog.Trace.Configuration
                 // Get values from the config
                 var config = new ConfigurationBuilder(source, telemetry);
                 // NOTE: Keep this in sync with CreateUpdatedFromManualConfig below
-                TraceAgentUri = config.WithKeys(ConfigurationKeys.AgentUri).AsString();
-                TracesPipeName = config.WithKeys(ConfigurationKeys.TracesPipeName).AsString();
-                TracesUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.TracesUnixDomainSocketPath).AsString();
+                TraceAgentUri = config.WithKeys(ConfigurationKeys.AgentUri).AsString()?.Trim();
+                TracesPipeName = config.WithKeys(ConfigurationKeys.TracesPipeName).AsString()?.Trim();
+                TracesUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.TracesUnixDomainSocketPath).AsString()?.Trim();
 
                 TraceAgentHost = config
                                .WithKeys(ConfigurationKeys.AgentHost, "DD_TRACE_AGENT_HOSTNAME", "DATADOG_TRACE_AGENT_HOSTNAME")
-                               .AsString();
+                               .AsString()?.Trim();
 
                 TraceAgentPort = config
                                .WithKeys(ConfigurationKeys.AgentPort, "DATADOG_TRACE_AGENT_PORT")
                                .AsInt32();
 
-                MetricsUrl = config.WithKeys(ConfigurationKeys.MetricsUri).AsString();
+                MetricsUrl = config.WithKeys(ConfigurationKeys.MetricsUri).AsString()?.Trim();
                 DogStatsdPort = config.WithKeys(ConfigurationKeys.DogStatsdPort).AsInt32(0);
-                MetricsPipeName = config.WithKeys(ConfigurationKeys.MetricsPipeName).AsString();
-                MetricsUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.MetricsUnixDomainSocketPath).AsString();
+                MetricsPipeName = config.WithKeys(ConfigurationKeys.MetricsPipeName).AsString()?.Trim();
+                MetricsUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.MetricsUnixDomainSocketPath).AsString()?.Trim();
 
                 TracesPipeTimeoutMs = config
                                      .WithKeys(ConfigurationKeys.TracesPipeTimeoutMs)


### PR DESCRIPTION
## Summary of changes

- Trim whitespace in the exporter settings values before trying to use them
- Fix a bug where having a whitespace in the `DD_DOGSTATSD_SOCKET` variable would cause incorrect (and invalid) UDS config

## Reason for change

This manifested in a different test in a branch, where an empty string passed in `DD_DOGSTATSD_SOCKET` was causing us to use UDS for metrics even through it's not available and not _really_ set.

## Implementation details

- `Trim()` the string variables (I don't think there's a good reason not to?)
- As we're trimming, we can switch to `IsNullOrEmpty` instead of `IsWhitespace`
- Treat empty `DD_DOGSTATSD_SOCKET` as not set

Alternatively, we could not trim, stick to using `IsWhitespace`, and just update the check I fixed to use `IsWhitespace` 🤷‍♂️ 

## Test coverage

Added a couple of unit tests. Only one test is for this specific issue, the others were just part of my investigation, and seemed reasonable.

## Other details

Discovered as part of https://github.com/DataDog/dd-trace-dotnet/pull/7724 and https://datadoghq.atlassian.net/browse/LANGPLAT-819