### PR TITLE
Fix Asm benchmark and stop-reinitializing tracer

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -73,7 +73,7 @@ namespace Benchmarks.Trace.Asm
 
         private void ExecuteCycle(object body)
         {
-            var traceContext = new Datadog.Trace.TraceContext(new EmptyDatadogTracer(), null);
+            var traceContext = new Datadog.Trace.TraceContext(EmptyDatadogTracer.Instance, null);
             var spanContext = new SpanContext(parent: null, traceContext, serviceName: "My Service Name", traceId: (TraceId)100, spanId: 200);
             var span = new Span(spanContext, DateTimeOffset.Now);
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/EmptyDatadogTracer.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/EmptyDatadogTracer.cs
@@ -17,13 +17,25 @@ namespace Benchmarks.Trace.Asm
 {
     public class EmptyDatadogTracer : IDatadogTracer
     {
+        public static readonly EmptyDatadogTracer Instance = new();
+
+        private readonly IGitMetadataTagsProvider _gitMetadata;
+        private readonly PerTraceSettings _perTraceSettings;
+
+        public EmptyDatadogTracer()
+        {
+            Settings = new(new NullConfigurationSource());
+            _gitMetadata = new NullGitMetadataProvider();
+            _perTraceSettings = new PerTraceSettings(null, null, null, Settings.InitialMutableSettings);
+        }
+
         public string DefaultServiceName => "My Service Name";
 
-        public TracerSettings Settings => new(new NullConfigurationSource());
+        public TracerSettings Settings { get; }
 
-        IGitMetadataTagsProvider IDatadogTracer.GitMetadataTagsProvider => new NullGitMetadataProvider();
+        IGitMetadataTagsProvider IDatadogTracer.GitMetadataTagsProvider => _gitMetadata;
 
-        PerTraceSettings IDatadogTracer.PerTraceSettings => null;
+        PerTraceSettings IDatadogTracer.PerTraceSettings => _perTraceSettings;
 
         void IDatadogTracer.Write(ArraySegment<Span> span)
         {


### PR DESCRIPTION
## Summary of changes

- Fix ASM benchmarks by not returning `null` from `EmptyDatadogTracer.PerTraceSettings`
- Stop re-initializing `TracerSettings` for every execution of the ASM benchmark

## Reason for change

The ASM benchmarks have been broken since https://github.com/DataDog/dd-trace-dotnet/pull/7543 (I think). This is because the `EmptyDatadogTracer` stub used in the benchmark returns `null` from `PerTraceSettings` (which can't happen in practice). 

Additionally, noticed that the benchmark is repeatedly creating a new `TracerSettings` object with every execution, which will add noise and be much more expensive than real life.

## Implementation details

- Ensure `EmptyDatadogTracer.PerTraceSettings` returns a "real" value
- Stop rebuilding `TracerSettings` with every execution

## Test coverage

This is the test
