### PR TITLE
Improve aerospike sample to avoid timeouts

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
@@ -71,7 +71,6 @@ namespace Samples.Aerospike
             // Asynchronous methods
             await client.Put(null, CancellationToken.None, key1, bin1, bin2);
             await client.Add(null, CancellationToken.None, key1, bin3);
-
             await client.Prepend(null, CancellationToken.None, key1, bin4);
             await client.Append(null, CancellationToken.None, key1, bin5);
 
@@ -91,9 +90,7 @@ namespace Samples.Aerospike
         {
             var clientPolicy = new AsyncClientPolicy
             {
-                // This is the cluster-level connect timeout; keep it if you want.
                 timeout = 10_000,
-                // Optional but recommended when running in CI:
                 failIfNotConnected = true
             };
 
@@ -109,7 +106,6 @@ namespace Samples.Aerospike
                 maxRetries = 2
             };
 
-            // Batches & existence checks use base Policy too:
             clientPolicy.batchPolicyDefault = new BatchPolicy
             {
                 totalTimeout = 10_000,


### PR DESCRIPTION
## Summary of changes

We are getting the following flaky error in our integration tests:

```
2025-10-27T13:32:43.7186618Z 13:32:43 [DBG] [xUnit.net 00:09:13.41] Datadog.Trace.ClrProfiler.IntegrationTests: STARTED: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(4.0.3, v1)
2025-10-27T13:32:56.8742298Z 13:32:56 [DBG] [xUnit.net 00:09:26.57] Datadog.Trace.ClrProfiler.IntegrationTests: SUCCESS: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(4.0.3, v1) (13.1545012s)
2025-10-27T13:32:56.8743768Z 13:32:56 [DBG] [xUnit.net 00:09:26.57] Datadog.Trace.ClrProfiler.IntegrationTests: STARTED: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(4.0.3, v0)
2025-10-27T13:33:10.3154276Z 13:33:10 [DBG] [xUnit.net 00:09:40.01] Datadog.Trace.ClrProfiler.IntegrationTests: SUCCESS: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(4.0.3, v0) (13.4408747s)
2025-10-27T13:33:10.3155380Z 13:33:10 [DBG] [xUnit.net 00:09:40.01] Datadog.Trace.ClrProfiler.IntegrationTests: STARTED: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(5.4.1, v1)
2025-10-27T13:33:23.5189430Z 13:33:23 [DBG] [xUnit.net 00:09:53.21] Datadog.Trace.ClrProfiler.IntegrationTests: SUCCESS: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(5.4.1, v1) (13.2027726s)
2025-10-27T13:33:23.5190606Z 13:33:23 [DBG] [xUnit.net 00:09:53.21] Datadog.Trace.ClrProfiler.IntegrationTests: STARTED: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(5.4.1, v0)
2025-10-27T13:33:41.1650334Z 13:33:41 [DBG] [xUnit.net 00:10:10.86] Datadog.Trace.ClrProfiler.IntegrationTests: FAILURE: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(5.4.1, v0) (17.6434209s)
2025-10-27T13:33:41.1651175Z 13:33:41 [DBG] [xUnit.net 00:10:10.86] Datadog.Trace.ClrProfiler.IntegrationTests: STARTED: Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(4.3.1, v1)
2025-10-27T13:33:41.1732740Z 13:33:41 [ERR] [xUnit.net 00:10:10.86]     Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(packageVersion: "5.4.1", metadataSchemaVersion: "v0") [FAIL]
2025-10-27T13:33:42.6667078Z 13:33:42 [DBG]   Failed Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(packageVersion: "5.4.1", metadataSchemaVersion: "v0") [17 s]
2025-10-27T13:33:42.6667493Z 13:33:42 [DBG]   Error Message:
2025-10-27T13:33:42.6667956Z 13:33:42 [DBG]    Datadog.Trace.TestHelpers.ExitCodeException+SIGABRTExitCodeException : Expected exit code: 0, actual exit code: 134.
2025-10-27T13:33:42.6668207Z 13:33:42 [DBG]   Stack Trace:
2025-10-27T13:33:42.6668512Z 13:33:42 [DBG]      at Datadog.Trace.TestHelpers.ExitCodeException.Throw(Int32 actualExitCode, Int32 expectedExitCode, String message) in /project/tracer/test/Datadog.Trace.TestHelpers/ExitCodeException.cs:line 44
2025-10-27T13:33:42.6668925Z 13:33:42 [DBG]    at Datadog.Trace.TestHelpers.TestHelper.WaitForProcessResult(ProcessHelper helper, Int32 expectedExitCode, Boolean dumpChildProcesses) in /project/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs:line 202
2025-10-27T13:33:42.6669423Z 13:33:42 [DBG]    at Datadog.Trace.TestHelpers.TestHelper.RunSampleAndWaitForExit(MockTracerAgent agent, String arguments, String packageVersion, String framework, Int32 aspNetCorePort, Boolean usePublishWithRID, String dotnetRuntimeArgs) in /project/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs:line 173
2025-10-27T13:33:42.6670002Z 13:33:42 [DBG]    at Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(String packageVersion, String metadataSchemaVersion) in /project/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs:line 51
2025-10-27T13:33:42.6670343Z 13:33:42 [DBG] --- End of stack trace from previous location where exception was thrown ---
2025-10-27T13:33:42.6670570Z 13:33:42 [DBG]   Standard Output Messages:
2025-10-27T13:33:42.6670764Z 13:33:42 [DBG]  Platform: X64
2025-10-27T13:33:42.6670997Z 13:33:42 [DBG]  TargetPlatform: X64
2025-10-27T13:33:42.6671199Z 13:33:42 [DBG]  Configuration: Release
2025-10-27T13:33:42.6671421Z 13:33:42 [DBG]  TargetFramework: netcoreapp3.1
2025-10-27T13:33:42.6671617Z 13:33:42 [DBG]  .NET Core: True
2025-10-27T13:33:42.6671852Z 13:33:42 [DBG]  Native Loader DLL: /project/shared/bin/monitoring-home/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so
2025-10-27T13:33:42.6672106Z 13:33:42 [DBG]  Agent listener info: Traces at port 41929
2025-10-27T13:33:42.6672376Z 13:33:42 [DBG]  Starting Application: /project/artifacts/publish/Samples.Aerospike/release_netcoreapp3.1_5.4.1/Samples.Aerospike.dll
2025-10-27T13:33:42.6672618Z 13:33:42 [DBG]  ProcessId: 6808
2025-10-27T13:33:42.6672804Z 13:33:42 [DBG]  StandardOutput:
2025-10-27T13:33:42.6673001Z 13:33:42 [DBG]  Writing full dump to file /tmp/coredump.6808
2025-10-27T13:33:42.6673223Z 13:33:42 [DBG]  Written 194633728 bytes (47518 pages) to core file
2025-10-27T13:33:42.6673420Z 13:33:42 [DBG]  
2025-10-27T13:33:42.6673682Z 13:33:42 [DBG]  StandardError:
2025-10-27T13:33:42.6673964Z 13:33:42 [DBG]  Unhandled exception. Aerospike.Client.AerospikeException+Timeout: Client timeout: iteration=1 socket=30000 total=1000 maxRetries=0 node=BB95FC0D312DF0A 172.17.0.1 32769 inDoubt=True
2025-10-27T13:33:42.6674338Z 13:33:42 [DBG]     at Samples.Aerospike.Program.Main(String[] args) in D:\a\_work\1\s\tracer\test\test-applications\integrations\Samples.Aerospike\Program.cs:line 70
2025-10-27T13:33:42.6674633Z 13:33:42 [DBG]     at Samples.Aerospike.Program.<Main>(String[] args)
2025-10-27T13:33:42.6674891Z 13:33:42 [DBG]  
2025-10-27T13:33:42.6675512Z 13:33:42 [DBG]  ProcessId: 6808
2025-10-27T13:33:42.6675876Z 13:33:42 [DBG]  Exit Code: 134
2025-10-27T13:33:42.6676207Z 13:33:42 [DBG] 
```

Even though we were setting a timeout in the sample, the timeout was not correctly applied.

* new AsyncClientPolicy { timeout = 10_000 } is a client-level knob. It does not override the per-operation timeouts.
* Each Aerospike operation we call with a null policy uses the client’s default op policies (readPolicyDefault, writePolicyDefault, batchPolicyDefault, queryPolicyDefault, …).
* Those defaults ship with totalTimeout = 1000 ms and maxRetries = 0. That’s what our exception shows: total=1000, iteration=1, maxRetries=0.

New default policies have been defined to apply timeouts.

A small fix was done to fix the Add operation. We were using strings for the add operation instead of numbers. While this did not trigger an error in our code, it was causing a server error. the Add method in the Aerospike C# client is fire-and-forget in style unless you actually inspect the Task or catch exceptions from it.

A using statement was added to close the results.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
