### PR TITLE
Skip sending unactionable performance counters log to telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -147,7 +147,7 @@ namespace Datadog.Trace.RuntimeMetrics
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "An error occured while initializing the performance counters");
+                Log.ErrorSkipTelemetry(ex, "An error occured while initializing the performance counters");
                 throw;
             }
         }


### PR DESCRIPTION
## Summary of changes

Skip sending unactionable log to telemetry

## Reason for change

Perf counters could fail to initialize for a bunch of environment reasons, there's nothing we can do about it without a lot more info

## Implementation details

Just skip telemetry for the log

## Test coverage

Meh

## Other details

[Seen in telemetry](https://app.datadoghq.com/error-tracking/issue/2ebd3614-3ae3-11f0-b4e5-da7ad0900002?link_source=bits_et_notification)