### PR TITLE
Increase debugger serialize timeout for unit tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotHelper.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotHelper.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.IO;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Snapshots;
@@ -14,6 +16,21 @@ namespace Datadog.Trace.Tests.Debugger;
 
 internal static class SnapshotHelper
 {
+    static SnapshotHelper()
+    {
+        // Configure the serializer with a high timeout for tests to prevent rare timeout failures on slow CI machines
+        var testSettings = new DebuggerSettings(
+            new NameValueConfigurationSource(new()
+            {
+                {
+                    ConfigurationKeys.Debugger.MaxTimeToSerialize, "1000"
+                }
+            }),
+            NullConfigurationTelemetry.Instance);
+
+        DebuggerSnapshotSerializer.SetConfig(testSettings);
+    }
+
     internal static string GenerateSnapshot(object instance, bool prettify = true)
     {
         return GenerateSnapshot(null, new object[] { }, new object[] { instance }, prettify);


### PR DESCRIPTION
## Summary of changes

We have detected [the following error in the CI](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/190390/logs/5425) in some debugger unit tests:

```
2025-11-04T09:35:52.6197579Z 09:35:52 [DBG]   Failed Datadog.Trace.Tests.Debugger.DebuggerSnapshotCreatorTests.ObjectStructure_EmptyArray [2 s]
2025-11-04T09:35:52.6199535Z 09:35:52 [DBG]   Error Message:
2025-11-04T09:35:52.6199996Z 09:35:52 [DBG]    VerifyException : Results do not match.
2025-11-04T09:35:52.6200382Z 09:35:52 [DBG] Differences:
2025-11-04T09:35:52.6200868Z 09:35:52 [DBG] Received: DebuggerSnapshotCreatorTests.ObjectStructure_EmptyArray.received.txt
2025-11-04T09:35:52.6201403Z 09:35:52 [DBG] Verified: DebuggerSnapshotCreatorTests.ObjectStructure_EmptyArray.verified.txt
2025-11-04T09:35:52.6202014Z 09:35:52 [DBG] Received Content:
2025-11-04T09:35:52.6202362Z 09:35:52 [DBG] {
2025-11-04T09:35:52.6202703Z 09:35:52 [DBG]   local0: {
2025-11-04T09:35:52.6203061Z 09:35:52 [DBG]     elements: [],
2025-11-04T09:35:52.6203435Z 09:35:52 [DBG]     notCapturedReason: timeout,
2025-11-04T09:35:52.6203982Z 09:35:52 [DBG]     size: 0,
2025-11-04T09:35:52.6204341Z 09:35:52 [DBG]     type: Int32[]
2025-11-04T09:35:52.6204689Z 09:35:52 [DBG]   }
2025-11-04T09:35:52.6205018Z 09:35:52 [DBG] }
2025-11-04T09:35:52.6205359Z 09:35:52 [DBG] Verified Content:
2025-11-04T09:35:52.6205718Z 09:35:52 [DBG] {
2025-11-04T09:35:52.6206057Z 09:35:52 [DBG]   local0: {
2025-11-04T09:35:52.6206398Z 09:35:52 [DBG]     elements: [],
2025-11-04T09:35:52.6206754Z 09:35:52 [DBG]     size: 0,
2025-11-04T09:35:52.6207116Z 09:35:52 [DBG]     type: Int32[]
2025-11-04T09:35:52.6207459Z 09:35:52 [DBG]   }
2025-11-04T09:35:52.6207780Z 09:35:52 [DBG] }
```
The proposed solution is to increase the timeout:
ConfigurationKeys.Debugger.MaxTimeToSerialize, "1000"

The error could be reproduced locally by setting this config value to 1, which confirms that this solution should work.

In other tests (debugger integration tests), [we are already setting this value to 1000.](https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs#L856)

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
