### PR TITLE
Fix RedirectInput test flakyness

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Console/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Console/Program.cs
@@ -117,8 +117,6 @@ namespace Samples.Console_
                 {
                     Console.WriteLine("Ready");
                     Console.WriteLine($"Echo: {Console.ReadLine()}");
-                    // Small delay to ensure the test has time to read the output before the process exits
-                    Thread.Sleep(100);
                     return;
                 }
 


### PR DESCRIPTION
## Summary of changes

We are getting [the following error in master](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=190387&view=logs&j=b3c3fdd8-5f52-57f5-d8dc-ef70b96c816b&t=15258d2a-ebbf-52c3-618d-fdfc97db216a):
```
##[error][xUnit.net 00:00:14.01]     Datadog.Trace.Tools.dd_dotnet.ArtifactTests.RunCommandTests.RedirectInput [FAIL]
04:57:34 [ERR] [xUnit.net 00:00:14.01]     Datadog.Trace.Tools.dd_dotnet.ArtifactTests.RunCommandTests.RedirectInput [FAIL]
04:57:34 [DBG] [xUnit.net 00:00:14.30] Datadog.Trace.Tools.dd_dotnet.ArtifactTests: SUCCESS: Datadog.Trace.Tools.dd_dotnet.ArtifactTests.RunCommandTests.EmptyCommand() (0.3031637s)
04:57:34 [DBG] [xUnit.net 00:00:14.30] Datadog.Trace.Tools.dd_dotnet.ArtifactTests: STARTED: Datadog.Trace.Tools.dd_dotnet.ArtifactTests.RunCommandTests.Run()
04:57:35 [DBG]   Failed Datadog.Trace.Tools.dd_dotnet.ArtifactTests.RunCommandTests.RedirectInput [4 s]
04:57:35 [DBG]   Error Message:
04:57:35 [DBG]    System.InvalidOperationException : Cannot process request because the process (7424) has exited.
04:57:35 [DBG]   Stack Trace:
04:57:35 [DBG]      at System.Diagnostics.Process.GetProcessHandle(Int32 access, Boolean throwIfExited)
04:57:35 [DBG]    at System.Diagnostics.Process.Kill()
04:57:35 [DBG]    at Datadog.Trace.Tools.dd_dotnet.ArtifactTests.RunCommandTests.RedirectInput() in D:\a\_work\1\s\tracer\test\Datadog.Trace.Tools.dd_dotnet.ArtifactTests\RunCommandTests.cs:line 103
04:57:35 [DBG]   Standard Output Messages:
04:57:35 [DBG]  Platform: X64
04:57:35 [DBG]  TargetPlatform: X64
04:57:35 [DBG]  Configuration: Release
04:57:35 [DBG]  TargetFramework: net48
04:57:35 [DBG]  .NET Core: False
04:57:35 [DBG]  Native Loader DLL: D:\a\_work\1\s\shared\bin\monitoring-home\win-x64\Datadog.Trace.ClrProfiler.Native.dll
04:57:35 [DBG]  D:\a\_work\1\s\shared\bin\monitoring-home\dd-dotnet.cmd run -- D:\a\_work\1\s\artifacts\bin\Samples.Console\release_net48\Samples.Console.exe  echo
04:57:35 [DBG] 
```

 The CI failure was a race condition in the test cleanup code:
  - The test sends input and reads the echo response
  - The sample app exits after printing the echo (as designed)
  - The test tried to unconditionally kill the process
  - Sometimes the process had already exited before Kill() was called, causing InvalidOperationException

  Thce fix:
  1. Added a check for !process.HasExited before attempting to kill the process
  2. Catch an InvalidOperationException for race conditions after testing process.HasExited
  3. Added process.Dispose() for proper resource cleanup
  4. Added a small delay after the echo in the sample app to avoid the sample program to finish before reading it's output
  
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
