### PR TITLE
Avoid exceptions in ProcessBasicChecksTests

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -150,11 +150,18 @@ namespace Datadog.Trace.TestHelpers
                     UseShellExecute = false
                 };
 
-                var executedSuccessfully = Process.Start(opts).WaitForExit(20_000);
-
-                if (!executedSuccessfully)
+                using (var process = Process.Start(opts))
                 {
-                    throw new Exception($"Error setting CorFlags.exe {Path.GetFileName(executable)} {setBit}");
+                    if (process == null)
+                    {
+                        throw new Exception("Failed to start CorFlags process.");
+                    }
+
+                    var exited = process.WaitForExit(20_000);
+                    if (!exited)
+                    {
+                        throw new Exception($"Error setting CorFlags.exe {Path.GetFileName(executable)} {setBit}");
+                    }
                 }
 
                 _corFlagsApplied.TryAdd(executablePath, true);


### PR DESCRIPTION
## Summary of changes

We are getting[ the following error](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=190458&view=logs&j=9ae0d641-16d0-5fe4-2a78-25e7d3a739c7&t=18795609-41b3-5076-f153-54e821578c6a) in master:

```
04:54:49 [DBG] Datadog.Trace.Tools.dd_dotnet.ArtifactTests: STARTED: Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks.ProcessBasicChecksTests.WorkingWithContinuousProfiler(1, True)[0m
04:54:49 [DBG] Datadog.Trace.Tools.dd_dotnet.ArtifactTests: STARTED: Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks.AgentConnectivityCheckTests.DetectVersionNamedPipes()
...
04:54:51 [DBG]   Failed Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks.ProcessBasicChecksTests.WorkingWithContinuousProfiler(enabled: "1", ssiInjectionEnabled: True) [390 ms]
04:54:51 [DBG]   Error Message:
04:54:51 [DBG]    System.ComponentModel.Win32Exception : Access is denied
04:54:51 [DBG]   Stack Trace:
04:54:51 [DBG]      at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
04:54:51 [DBG]    at System.Diagnostics.Process.Start()
04:54:51 [DBG]    at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
04:54:51 [DBG]    at Datadog.Trace.Tools.dd_dotnet.ArtifactTests.ConsoleTestHelper.<StartConsole>d__5.MoveNext()
04:54:51 [DBG] --- End of stack trace from previous location where exception was thrown ---
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
04:54:51 [DBG]    at Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks.ProcessBasicChecksTests.<WorkingWithContinuousProfiler>d__13.MoveNext() in D:\a\_work\1\s\tracer\test\Datadog.Trace.Tools.dd_dotnet.ArtifactTests\Checks\ProcessBasicChecksTests.cs:line 244
04:54:51 [DBG] --- End of stack trace from previous location where exception was thrown ---
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
04:54:51 [DBG] --- End of stack trace from previous location where exception was thrown ---
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
04:54:51 [DBG] --- End of stack trace from previous location where exception was thrown ---
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
04:54:51 [DBG]    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
04:54:51 [DBG]   Standard Output Messages:
04:54:51 [DBG]  Platform: X86
04:54:51 [DBG]  TargetPlatform: X86
04:54:51 [DBG]  Configuration: Release
04:54:51 [DBG]  TargetFramework: net48
04:54:51 [DBG]  .NET Core: False
04:54:51 [DBG]  Native Loader DLL: D:\a\_work\1\s\shared\bin\monitoring-home\win-x86\Datadog.Trace.ClrProfiler.Native.dll
04:54:51 [DBG]  Searching for CorFlags.exe in C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin
04:54:51 [DBG]  CorFlags.exe found at C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\CorFlags.exe
04:54:51 [DBG]  Updating Samples.Console.exe using /32BITREQ+
```

 The "Access is denied" error happens when trying to start the process. This suggests that:

  1. The WorkingWithContinuousProfiler test is running at the same time as AgentConnectivityCheckTests which uses the same console app
  2. Each test case calls StartConsole, which calls PrepareSampleApp, which calls ProfilerHelper.SetCorFlags on line 46
  of ConsoleTestHelper.cs
  3. SetCorFlags modifies the same executable file in-place using CorFlags.exe
  4. One test thread is still running CorFlags.exe to modify the executable
  5. While CorFlags.exe has the file locked for writing
  6. Another test thread completes SetCorFlags() and tries to start that same executable
  7. Windows denies access because the file is still locked by CorFlags.exe from the other thread

  So the lock needs to protect not just the CorFlags modification, but also ensure the CorFlags.exe process has fully
  released the file lock before another thread can use that executable.

This error have been observed under Windows, net4, x86, which makes sense based on the ProfilerHelper.SetCorFlags conditions:

```
    protected (string Executable, string Args) PrepareSampleApp(EnvironmentHelper environmentHelper)
    {
        var sampleAppPath = environmentHelper.GetSampleApplicationPath();
        var executable = EnvironmentHelper.IsCoreClr() ? environmentHelper.GetSampleExecutionSource() : sampleAppPath;
        var args = EnvironmentHelper.IsCoreClr() ? sampleAppPath : string.Empty;

        if (EnvironmentTools.IsWindows()
         && !EnvironmentHelper.IsCoreClr()
         && !EnvironmentTools.IsTestTarget64BitProcess())
        {
            ProfilerHelper.SetCorFlags(executable, Output, !EnvironmentTools.IsTestTarget64BitProcess());
        }

        return (executable, args);
    }
```

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
