### PR TITLE
Fix null character termination in CString abstraction.

### DIFF
--- a/tracer/src/Datadog.Trace/LibDatadog/CString.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/CString.cs
@@ -28,19 +28,22 @@ internal struct CString : IDisposable
         {
             var encoding = StringEncoding.UTF8;
             var maxBytesCount = encoding.GetMaxByteCount(str.Length);
-            Ptr = Marshal.AllocHGlobal(maxBytesCount);
+            Ptr = Marshal.AllocHGlobal(maxBytesCount + 1); // Make space for null character.
             unsafe
             {
                 fixed (char* strPtr = str)
                 {
                     try
                     {
-                        Length = (nuint)encoding.GetBytes(strPtr, str.Length, (byte*)Ptr, maxBytesCount);
+                        int byteCount = encoding.GetBytes(strPtr, str.Length, (byte*)Ptr, maxBytesCount);
+                        ((byte*)Ptr)[byteCount] = 0;
+                        Length = (nuint)byteCount;
                     }
                     catch
                     {
                         Marshal.FreeHGlobal(Ptr);
                         Ptr = IntPtr.Zero;
+                        Length = UIntPtr.Zero;
                     }
                 }
             }


### PR DESCRIPTION
## Summary of changes
Add null termination byte for CString abstraction.

## Reason for change
Testing the new libdatadog release I noticed some errors when Cstrings were passed to the process discovery native API.

## Implementation details

Make extra space for null character and add the termination character at the end of the buffer.

## Test coverage

🙈 

## Other details
