### PR TITLE
Add fix for not re-reporting telemetry when there are "empty" dynamic config changes

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
@@ -1074,10 +1074,10 @@ internal sealed class MutableSettings : IEquatable<MutableSettings>
     /// by excluding all the default sources. Effectively gives all the settings their default
     /// values. Should only be used with the manual instrumentation source
     /// </summary>
-    public static MutableSettings CreateWithoutDefaultSources(TracerSettings tracerSettings)
+    public static MutableSettings CreateWithoutDefaultSources(TracerSettings tracerSettings, ConfigurationTelemetry telemetry)
         => CreateInitialMutableSettings(
             NullConfigurationSource.Instance,
-            new ConfigurationTelemetry(),
+            telemetry,
             new OverrideErrorLog(),
             tracerSettings);
 

--- a/tracer/src/Datadog.Trace/Configuration/SettingsManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/SettingsManager.cs
@@ -7,41 +7,56 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Datadog.Trace.Configuration.ConfigurationSources;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
-using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Configuration;
 
 public partial record TracerSettings
 {
-    internal class SettingsManager(
-        TracerSettings tracerSettings,
-        MutableSettings initialMutable,
-        ExporterSettings initialExporter)
+    internal class SettingsManager
     {
-        private readonly TracerSettings _tracerSettings = tracerSettings;
+        private readonly TracerSettings _tracerSettings;
+        private readonly ConfigurationTelemetry _initialTelemetry;
         private readonly List<SettingChangeSubscription> _subscribers = [];
 
         private IConfigurationSource _dynamicConfigurationSource = NullConfigurationSource.Instance;
         private ManualInstrumentationConfigurationSourceBase _manualConfigurationSource =
             new ManualInstrumentationConfigurationSource(new Dictionary<string, object?>(), useDefaultSources: true);
 
+        // We delay creating these, as we likely won't need them
+        private ConfigurationTelemetry? _noDefaultSettingsTelemetry;
+        private MutableSettings? _noDefaultSourcesSettings;
+
         private SettingChanges? _latest;
+
+        public SettingsManager(IConfigurationSource source, TracerSettings tracerSettings, IConfigurationTelemetry telemetry, OverrideErrorLog errorLog)
+        {
+            // We record the telemetry for the initial settings in a dedicated ConfigurationTelemetry,
+            // because we need to be able to reapply this configuration on dynamic config updates
+            // We don't re-record error logs, so we just use the built-in for that
+            var initialTelemetry = new ConfigurationTelemetry();
+            InitialMutableSettings = MutableSettings.CreateInitialMutableSettings(source, initialTelemetry, errorLog, tracerSettings);
+            InitialExporterSettings = new ExporterSettings(source, initialTelemetry);
+            _tracerSettings = tracerSettings;
+            _initialTelemetry = initialTelemetry;
+            initialTelemetry.CopyTo(telemetry);
+        }
 
         /// <summary>
         /// Gets the initial <see cref="MutableSettings"/>. On app startup, these will be the values read from
         /// static sources. To subscribe to updates to these settings, from code or remote config, call <see cref="SubscribeToChanges"/>.
         /// </summary>
-        public MutableSettings InitialMutableSettings { get; } = initialMutable;
+        public MutableSettings InitialMutableSettings { get; }
 
         /// <summary>
         /// Gets the initial <see cref="ExporterSettings"/>. On app startup, these will be the values read from
         /// static sources. To subscribe to updates to these settings, from code or remote config, call <see cref="SubscribeToChanges"/>.
         /// </summary>
-        public ExporterSettings InitialExporterSettings { get; } = initialExporter;
+        public ExporterSettings InitialExporterSettings { get; }
 
         /// <summary>
         /// Subscribe to changes in <see cref="MutableSettings"/> and/or <see cref="ExporterSettings"/>.
@@ -133,13 +148,37 @@ public partial record TracerSettings
             ManualInstrumentationConfigurationSourceBase manualSource,
             IConfigurationTelemetry telemetry)
         {
-            var initialSettings = manualSource.UseDefaultSources
-                                      ? InitialMutableSettings
-                                      : MutableSettings.CreateWithoutDefaultSources(_tracerSettings);
+            // Set the correct default telemetry and initial settings depending
+            // on whether the manual config source explicitly disables using the default sources
+            ConfigurationTelemetry defaultTelemetry;
+            MutableSettings initialSettings;
+            if (manualSource.UseDefaultSources)
+            {
+                defaultTelemetry = _initialTelemetry;
+                initialSettings = InitialMutableSettings;
+            }
+            else
+            {
+                // We only need to initialize the "no default sources" settings once
+                // and we don't want to initialize them if we don't _need_ to
+                // so lazy-initialize here
+                if (_noDefaultSourcesSettings is null || _noDefaultSettingsTelemetry is null)
+                {
+                    InitialiseNoDefaultSourceSettings();
+                }
+
+                defaultTelemetry = _noDefaultSettingsTelemetry;
+                initialSettings = _noDefaultSourcesSettings;
+            }
 
             var current = _latest;
             var currentMutable = current?.UpdatedMutable ?? current?.PreviousMutable ?? InitialMutableSettings;
             var currentExporter = current?.UpdatedExporter ?? current?.PreviousExporter ?? InitialExporterSettings;
+
+            // we create a temporary ConfigurationTelemetry object to hold the changes to settings
+            // if nothing is actually written, and nothing changes compared to the default, then we
+            // don't need to report it to the provided telemetry
+            var tempTelemetry = new ConfigurationTelemetry();
 
             var overrideErrorLog = new OverrideErrorLog();
             var newMutableSettings = MutableSettings.CreateUpdatedMutableSettings(
@@ -147,7 +186,7 @@ public partial record TracerSettings
                 manualSource,
                 initialSettings,
                 _tracerSettings,
-                telemetry,
+                tempTelemetry,
                 overrideErrorLog); // TODO: We'll later report these
 
             // The only exporter setting we currently _allow_ to change is the AgentUri, but if that does change,
@@ -159,7 +198,7 @@ public partial record TracerSettings
             var newRawExporterSettings = ExporterSettings.Raw.CreateUpdatedFromManualConfig(
                 currentExporter.RawSettings,
                 manualSource,
-                telemetry,
+                tempTelemetry,
                 manualSource.UseDefaultSources);
 
             var isSameMutableSettings = currentMutable.Equals(newMutableSettings);
@@ -171,11 +210,31 @@ public partial record TracerSettings
                 return null;
             }
 
+            // we have changes, so we need to report them
+            // First record the "default"/fallback values, then record the "new" values
+            defaultTelemetry.CopyTo(telemetry);
+            tempTelemetry.CopyTo(telemetry);
+
             Log.Information("Notifying consumers of new settings");
             var updatedMutableSettings = isSameMutableSettings ? null : newMutableSettings;
             var updatedExporterSettings = isSameExporterSettings ? null : new ExporterSettings(newRawExporterSettings, telemetry);
 
             return new SettingChanges(updatedMutableSettings, updatedExporterSettings, currentMutable, currentExporter);
+        }
+
+        [MemberNotNull(nameof(_noDefaultSettingsTelemetry))]
+        [MemberNotNull(nameof(_noDefaultSourcesSettings))]
+        private void InitialiseNoDefaultSourceSettings()
+        {
+            if (_noDefaultSourcesSettings is not null
+             && _noDefaultSettingsTelemetry is not null)
+            {
+                return;
+            }
+
+            var telemetry = new ConfigurationTelemetry();
+            _noDefaultSettingsTelemetry = telemetry;
+            _noDefaultSourcesSettings = MutableSettings.CreateWithoutDefaultSources(_tracerSettings, telemetry);
         }
 
         private void NotifySubscribers(SettingChanges settings)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
+using Datadog.Trace.Util.Streams;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.RemoteConfigurationManagement.Transport

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/EmptyDatadogTracer.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/EmptyDatadogTracer.cs
@@ -6,6 +6,7 @@
 using System;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Schema;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Sampling;
 using Moq;
 
@@ -23,7 +24,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             DefaultServiceName = "My Service Name";
             Settings = new TracerSettings(NullConfigurationSource.Instance);
             var namingSchema = new NamingSchema(SchemaVersion.V0, false, false, DefaultServiceName, null, null);
-            PerTraceSettings = new PerTraceSettings(null, null, namingSchema, MutableSettings.CreateWithoutDefaultSources(Settings));
+            PerTraceSettings = new PerTraceSettings(null, null, namingSchema, MutableSettings.CreateWithoutDefaultSources(Settings, new ConfigurationTelemetry()));
         }
 
         public string DefaultServiceName { get; }

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
@@ -427,7 +428,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var tracer = new Mock<IDatadogTracer>();
             tracer.Setup(x => x.DefaultServiceName).Returns("Default");
-            tracer.Setup(x => x.PerTraceSettings).Returns(new PerTraceSettings(null, null, null!, MutableSettings.CreateWithoutDefaultSources(new(NullConfigurationSource.Instance))));
+            tracer.Setup(x => x.PerTraceSettings).Returns(new PerTraceSettings(null, null, null!, MutableSettings.CreateWithoutDefaultSources(new(NullConfigurationSource.Instance), new ConfigurationTelemetry())));
             var traceContext = new TraceContext(tracer.Object);
             var rootSpanContext = new SpanContext(null, traceContext, null);
             var rootSpan = new Span(rootSpanContext, DateTimeOffset.UtcNow);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsSettingManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsSettingManagerTests.cs
@@ -16,4 +16,80 @@ namespace Datadog.Trace.Tests.Configuration;
 
 public class TracerSettingsSettingManagerTests
 {
+    [Fact]
+    public void UpdateSettings_HandlesDynamicConfigurationChanges()
+    {
+        var tracerSettings = new TracerSettings();
+        SettingChanges settingChanges = null;
+        tracerSettings.Manager.SubscribeToChanges(changes => settingChanges = changes);
+
+        // default is null, but it's recorded as "1.0" in  telemetry
+        tracerSettings.Manager.InitialMutableSettings.GlobalSamplingRate.Should().Be(null);
+        var sampleRateConfig = GetLatestSampleRateTelemetry((ConfigurationTelemetry)tracerSettings.Telemetry);
+
+        sampleRateConfig.Should().NotBeNull();
+        sampleRateConfig.Origin.Should().Be(ConfigurationOrigins.Default);
+        sampleRateConfig.DoubleValue.Should().Be(1.0);
+
+        var rawConfig1 = """{"action": "enable", "revision": 1698167126064, "service_target": {"service": "test_service", "env": "test_env"}, "lib_config": {"tracing_sampling_rate": 0.7, "log_injection_enabled": null, "tracing_header_tags": null, "runtime_metrics_enabled": null, "tracing_debug": null, "tracing_service_mapping": null, "tracing_sampling_rules": null, "data_streams_enabled": null, "dynamic_instrumentation_enabled": null, "exception_replay_enabled": null, "code_origin_enabled": null, "live_debugging_enabled": null}, "id": "-1796479631020605752"}""";
+        var dynamicConfig = new DynamicConfigConfigurationSource(rawConfig1, ConfigurationOrigins.RemoteConfig);
+        var telemetry = new ConfigurationTelemetry();
+
+        var wasUpdated = tracerSettings.Manager.UpdateDynamicConfigurationSettings(
+            dynamicConfig,
+            centralTelemetry: telemetry);
+
+        wasUpdated.Should().BeTrue();
+        settingChanges.Should().NotBeNull();
+        settingChanges!.UpdatedExporter.Should().BeNull();
+        settingChanges!.UpdatedMutable.Should().NotBeNull();
+        settingChanges!.UpdatedMutable.GlobalSamplingRate.Should().Be(0.7);
+
+        sampleRateConfig = GetLatestSampleRateTelemetry(telemetry);
+
+        sampleRateConfig.Should().NotBeNull();
+        sampleRateConfig.Origin.Should().Be(ConfigurationOrigins.RemoteConfig);
+        sampleRateConfig.DoubleValue.Should().Be(0.7);
+        telemetry.Clear();
+
+        // reset to "default"
+        var rawConfig2 = """{"action": "enable", "revision": 1698167126064, "service_target": {"service": "test_service", "env": "test_env"}, "lib_config": {"tracing_sampling_rate": null, "log_injection_enabled": null, "tracing_header_tags": null, "runtime_metrics_enabled": null, "tracing_debug": null, "tracing_service_mapping": null, "tracing_sampling_rules": null, "data_streams_enabled": null, "dynamic_instrumentation_enabled": null, "exception_replay_enabled": null, "code_origin_enabled": null, "live_debugging_enabled": null}, "id": "5931732111467439992"}""";
+        dynamicConfig = new DynamicConfigConfigurationSource(rawConfig2, ConfigurationOrigins.RemoteConfig);
+
+        wasUpdated = tracerSettings.Manager.UpdateDynamicConfigurationSettings(
+            dynamicConfig,
+            centralTelemetry: telemetry);
+
+        wasUpdated.Should().BeTrue();
+        settingChanges.Should().NotBeNull();
+        settingChanges!.UpdatedExporter.Should().BeNull();
+        settingChanges!.UpdatedMutable.Should().NotBeNull();
+        settingChanges!.UpdatedMutable.GlobalSamplingRate.Should().Be(null);
+
+        sampleRateConfig = GetLatestSampleRateTelemetry(telemetry);
+
+        sampleRateConfig.Should().NotBeNull();
+        sampleRateConfig.Origin.Should().Be(ConfigurationOrigins.Default);
+        sampleRateConfig.DoubleValue.Should().Be(1.0);
+        telemetry.Clear();
+
+        // Send the same config again, and make sure we _don't_ record more telemetry, so what we already have is correct
+        var existingChanges = settingChanges;
+        wasUpdated = tracerSettings.Manager.UpdateDynamicConfigurationSettings(
+            dynamicConfig,
+            centralTelemetry: telemetry);
+
+        wasUpdated.Should().BeFalse();
+        existingChanges.Should().Be(settingChanges);
+        telemetry.GetQueueForTesting().Should().BeEmpty();
+    }
+
+    private static ConfigurationTelemetry.ConfigurationTelemetryEntry GetLatestSampleRateTelemetry(ConfigurationTelemetry telemetry)
+    {
+        return telemetry
+              .GetQueueForTesting()
+              .Where(x => x.Key == ConfigurationKeys.GlobalSamplingRate)
+              .OrderByDescending(x => x.SeqId)
+              .FirstOrDefault();
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Util/StubDatadogTracer.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/StubDatadogTracer.cs
@@ -6,6 +6,7 @@
 using System;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Schema;
+using Datadog.Trace.Configuration.Telemetry;
 
 namespace Datadog.Trace.Tests.Util;
 
@@ -16,7 +17,7 @@ internal class StubDatadogTracer : IDatadogTracer
         DefaultServiceName = "stub-service";
         Settings = new TracerSettings(NullConfigurationSource.Instance);
         var namingSchema = new NamingSchema(SchemaVersion.V0, false, false, DefaultServiceName, null, null);
-        PerTraceSettings = new PerTraceSettings(null, null, namingSchema, MutableSettings.CreateWithoutDefaultSources(Settings));
+        PerTraceSettings = new PerTraceSettings(null, null, namingSchema, MutableSettings.CreateWithoutDefaultSources(Settings, new ConfigurationTelemetry()));
     }
 
     public string DefaultServiceName { get; }


### PR DESCRIPTION
## Summary of changes

A fix for #7724 to handle telemetry reporting in dynamic config "reset" scenarios

## Reason for change

The system tests for #7724 were failing in some dynamic configuration scenarios. Specifically, the tests were sending remote config _without_ any configuration values "i.e. 'reset to use defaults'" and were waiting a telemetry update. However, we never sent it, because there was "no telemetry to record". 

Note that we _did_ correctly apply the new configuration, we just didn't report the telemetry correctly, primarily due to limitations in the telemetry protocol. This PR adds a fix for that, and will be merged into #7724.

## Implementation details

The solution is to "remember" the telemetry from the default mutable configuration values, _without_ any dynamic sources, and "replay" this telemetry when we update telemetry. This feels kind of hacky, but it's something I suspected we might need to do, and had been avoiding up to this point because we do a "full reconfigure" anyway.

## Test coverage

Added a specific unit test that mimics the behaviour of the system-test (i.e. an "empty" dynamic config response) and confirms the telemetry is recorded as expected

## Other details

https://datadoghq.atlassian.net/browse/LANGPLAT-819

Part of a config stack

- https://github.com/DataDog/dd-trace-dotnet/pull/7522
- https://github.com/DataDog/dd-trace-dotnet/pull/7525
- https://github.com/DataDog/dd-trace-dotnet/pull/7530
- https://github.com/DataDog/dd-trace-dotnet/pull/7532
- https://github.com/DataDog/dd-trace-dotnet/pull/7543
- https://github.com/DataDog/dd-trace-dotnet/pull/7544
- https://github.com/DataDog/dd-trace-dotnet/pull/7721
- https://github.com/DataDog/dd-trace-dotnet/pull/7722
- https://github.com/DataDog/dd-trace-dotnet/pull/7695
- https://github.com/DataDog/dd-trace-dotnet/pull/7723
- https://github.com/DataDog/dd-trace-dotnet/pull/7724
- https://github.com/DataDog/dd-trace-dotnet/pull/7796 👈

Unlike other PRs in the stack, I'll merge this directly into #7724 to fix the tests there, just thought I'd keep this separate for easier reviewing