### PR TITLE
[Docs] Small developer docs clean-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ tracer/src/Datadog.Trace
 - **`docs/development/AzureFunctions.md`** — Setup, testing, instrumentation specifics, and debugging guide
 
 📖 **Load when**: Need detailed architectural understanding of Azure Functions internals
-- **`docs/development/AzureFunctions-Architecture.md`** — Deep dive into Azure Functions Host and .NET Worker architecture, gRPC protocol, and instrumentation hook points
+- **`docs/development/for-ai/AzureFunctions-Architecture.md`** — Deep dive into Azure Functions Host and .NET Worker architecture, gRPC protocol, and instrumentation hook points
 
 📖 **Load when**: Working on AWS Lambda or general serverless instrumentation
 - **`docs/development/Serverless.md`** — Serverless instrumentation patterns across cloud providers
@@ -314,7 +314,7 @@ The tracer runs in-process with customer applications and must have minimal perf
 - `docs/development/AutomaticInstrumentation.md` — Creating integrations
 - `docs/development/DuckTyping.md` — Duck typing guide
 - `docs/development/AzureFunctions.md` — Azure Functions integration
-- `docs/development/AzureFunctions-Architecture.md` — Azure Functions architecture deep dive
+- `docs/development/for-ai/AzureFunctions-Architecture.md` — Azure Functions architecture deep dive
 - `docs/development/Serverless.md` — Serverless instrumentation
 - `docs/development/UpdatingTheSdk.md` — SDK updates
 - `docs/development/QueryingDatadogAPIs.md` — Querying Datadog APIs for debugging (spans, logs)

--- a/docs/development/AzureFunctions.md
+++ b/docs/development/AzureFunctions.md
@@ -3,7 +3,7 @@
 This document describes how dd-trace-dotnet integrates with Azure Functions for distributed tracing.
 
 **Related Documentation:**
-- [Azure Functions Architecture Deep Dive](AzureFunctions-Architecture.md) - Detailed architectural information about Azure Functions Host and .NET Worker
+- [Azure Functions Architecture Deep Dive](for-ai/AzureFunctions-Architecture.md) - Detailed architectural information about Azure Functions Host and .NET Worker
 
 Azure functions operates in one of two ways:
 
@@ -47,7 +47,7 @@ We also instrument the `FunctionExecutor`. This provides all the details about t
 
 Isolated functions are the only supported model for Azure Functions going forward. In this model, instead of the customer's app being a class library, its a real ASP.NET Core application. The host `func.exe` starts the customer app as a sub process, and sets up a GRPC channel between the two apps. The `func.exe` host acts as a proxy for requests to the customer's app.
 
-For detailed information about the isolated worker architecture, gRPC protocol, and middleware model, see [Azure Functions Architecture Deep Dive](AzureFunctions-Architecture.md).
+For detailed information about the isolated worker architecture, gRPC protocol, and middleware model, see [Azure Functions Architecture Deep Dive](for-ai/AzureFunctions-Architecture.md).
 
 `func.exe` sets up an in-process Azure Function for every function in the customer's app. Each of the functions in `func.exe` are simple calls that proxy the request to the customer app, and then return the response.
 
@@ -115,7 +115,7 @@ gantt
 
 Isolated Azure Functions also supports an [ASP.NET Core Integration](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?tabs=hostbuilder%2Cwindows#aspnet-core-integration) mode where the host uses HTTP proxying instead of sending all request details over gRPC.
 
-**For architectural details** about HTTP proxying, YARP, and detection, see [Azure Functions Architecture Deep Dive](AzureFunctions-Architecture.md).
+**For architectural details** about HTTP proxying, YARP, and detection, see [Azure Functions Architecture Deep Dive](for-ai/AzureFunctions-Architecture.md).
 
 When ASP.NET Core integration is enabled, the `func.exe` host uses **HTTP proxying** instead of sending all request details over gRPC:
 

--- a/docs/development/for-ai/AzureFunctions-Architecture.md
+++ b/docs/development/for-ai/AzureFunctions-Architecture.md
@@ -3,8 +3,8 @@
 This document provides detailed architectural information about Azure Functions Host and .NET Worker, focusing on aspects relevant to dd-trace-dotnet instrumentation and distributed tracing.
 
 **Related Documentation:**
-- [Azure Functions Integration Guide](AzureFunctions.md) - Setup, testing, and instrumentation specifics for dd-trace-dotnet
-- [AGENTS.md](../../AGENTS.md) - Repository structure and development guidelines
+- [Azure Functions Integration Guide](../AzureFunctions.md) - Setup, testing, and instrumentation specifics for dd-trace-dotnet
+- [AGENTS.md](../../../AGENTS.md) - Repository structure and development guidelines
 
 **External Resources:**
 - [Azure Functions Host Repository](https://github.com/Azure/azure-functions-host)
@@ -910,10 +910,10 @@ Capture exceptions from:
 
 ### Related dd-trace-dotnet Documentation
 
-- [AzureFunctions.md](AzureFunctions.md) - Integration guide for dd-trace-dotnet
-- [AutomaticInstrumentation.md](AutomaticInstrumentation.md) - Creating integrations
-- [DuckTyping.md](DuckTyping.md) - Duck typing patterns for third-party types
-- [AGENTS.md](../../AGENTS.md) - Repository structure
+- [AzureFunctions.md](../AzureFunctions.md) - Integration guide for dd-trace-dotnet
+- [AutomaticInstrumentation.md](../AutomaticInstrumentation.md) - Creating integrations
+- [DuckTyping.md](../DuckTyping.md) - Duck typing patterns for third-party types
+- [AGENTS.md](../../../AGENTS.md) - Repository structure
 
 ---
 


### PR DESCRIPTION
## Summary of changes

Small docs clean-up to resolve pending comments from #7639.

## Reason for change

Improve documentation clarity and structure.

## Implementation details

- `AGENTS.md` 🤖
  - Removed reference to old `Datadog.Monitoring.Distribution`
  - Added `Datadog.Trace.Bundle`
- `docs/development/AzureFunctions.md`
  - Clarified package usage patterns for `Datadog.AzureFunctions` vs `Datadog.Trace`
- `docs/development/for-ai/AzureFunctions-Architecture.md` 🤖
  - moved to `docs/development/for-ai/` subdirectory to indicate AI agent-focused content
- Updated cross-references to reflect new Azure Functions Architecture doc location
- Small formatting tweaks

## Test coverage

Documentation changes only - no functional code changes.