### PR TITLE
Set timeouts and improved logging in dotnet-tool Nuget smoke tests.

### DIFF
--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Worker.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Worker.cs
@@ -34,8 +34,19 @@ namespace AspNetCoreSmokeTest
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            var timeout = TimeSpan.FromMinutes(2);
+            var startTime = DateTimeOffset.UtcNow;
+
             while (!_appListening && !stoppingToken.IsCancellationRequested)
             {
+                if (DateTimeOffset.UtcNow - startTime > timeout)
+                {
+                    _logger.LogError("Timed out waiting for application to start after {Timeout}", timeout);
+                    Program.ExitCode = 1;
+                    _lifetime.StopApplication();
+                    return;
+                }
+
                 _logger.LogInformation("Waiting for app started handling requests");
                 await Task.Delay(100, stoppingToken);
             }


### PR DESCRIPTION
## Summary of changes

 Summary of changes

  - Add timeout to HttpClient in Worker.cs to prevent indefinite hangs
  - Add CancellationToken support to ReadAsStringAsync for .NET 5.0+
  - Add 2-minute timeout for application startup to prevent indefinite waiting
  
## Reason for change

 The dotnet-tool-nuget-smoke-tests CI job has been experiencing[ flaky timeouts](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/190751/logs/21713), where the test hangs for the full
  15-minute timeout period before failing:

```
  2025-11-10T14:35:33.9771350Z Running: dotnet /app/AspNetCoreSmokeTest.dll
  2025-11-10T14:50:42.1702536Z ##[error]The task has timed out.
```

  The application starts but never completes, causing the entire CI pipeline to hang.

## Implementation details

  Previously, the HttpClient had no timeout configured, which could cause indefinite hangs when making the
  self-request to /api/values. Added a 30-second timeout:

  Added cancellation token support to ReadAsStringAsync() for .NET 5.0+, allowing the operation to be cancelled
  properly:

  Added a 2-minute timeout when waiting for the ApplicationStarted event. If the application fails to start (due to
  tracer/profiler initialization issues), the worker now:
  - Logs an error with diagnostic information
  - Sets the exit code to 1
  - Stops the application cleanly
  - Prevents hanging for the full 15-minute CI timeout

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
