### PR TITLE
Fix `InvalidOperationException` in Baggage handling in Azure Functions

### DIFF
--- a/tracer/src/Datadog.Trace/Baggage.cs
+++ b/tracer/src/Datadog.Trace/Baggage.cs
@@ -378,6 +378,12 @@ internal sealed class Baggage : IDictionary<string, string?>
             ThrowHelper.ThrowArgumentNullException(nameof(destination));
         }
 
+        if (ReferenceEquals(this, destination))
+        {
+            // We're trying to merge with ourselves
+            return;
+        }
+
         var sourceItems = _items;
 
         if (sourceItems is null || sourceItems.Count == 0)

--- a/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/BaggageTests.cs
@@ -168,4 +168,14 @@ public class BaggageTests
         baggage1.GetValueOrDefault("key1").Should().Be("new value");
         baggage1.GetValueOrDefault("key2").Should().Be("value2");
     }
+
+    [Fact]
+    public void MergeInto_SameInstance()
+    {
+        var baggage = new Baggage { { "key1", "value1" } };
+
+        baggage.MergeInto(baggage);
+        baggage.Count.Should().Be(1);
+        baggage.GetValueOrDefault("key1").Should().Be("value1");
+    }
 }


### PR DESCRIPTION
## Summary of changes

Fixes `InvalidOperationException` in baggage handling

## Reason for change

#7620 added support for event hubs to Azure Functions, but [we've subsequently seen errors related to baggage](https://app.datadoghq.com/error-tracking/issue/a0cbfac8-b924-11f0-a50e-da7ad0900002?query=source%3Adotnet%20%40tracer_version%3A3.30.0.0%20service%3Ainstrumentation-telemetry-data%20-%40error.is_crash%3Atrue&index=&tb=org_id%2C%40rc-client.tracer_version%2C%40org_id&from_ts=1761842690105&to_ts=1763052290105&live=true):

```
Error : Error creating or populating scope.
System.InvalidOperationException
   at Datadog.Trace.Baggage.MergeInto(Baggage destination)
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions.AzureFunctionsCommon.CreateIsolatedFunctionScope[T](Tracer tracer, T context)
```

We can reproduce this if you pass the same baggage instance to itself in `MergeInto`, so we guard against that here.

> _Why_ are we merging baggage into ourself, you may well ask. Good question... I haven't investigated... that's a problem for @pablomartinezbernardo and @lucaspimentel 😄 

## Implementation details

Check that you're not merging into yourself

## Test coverage

Added a unit test, confirmed it repros, then fixed it
