### PR TITLE
[Logs] Fix OTLP Logs timestamp during serialization

### DIFF
--- a/tracer/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
@@ -12,16 +12,6 @@ namespace Datadog.Trace.ExtensionMethods
         /// <summary>
         /// Returns the number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.
         /// </summary>
-        /// <param name="dateTime">The value to get the number of elapsed nanoseconds for.</param>
-        /// <returns>The number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.</returns>
-        public static long ToUnixTimeNanoseconds(this DateTime dateTime)
-        {
-            return (dateTime.Ticks - TimeConstants.UnixEpochInTicks) * TimeConstants.NanoSecondsPerTick;
-        }
-
-        /// <summary>
-        /// Returns the number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.
-        /// </summary>
         /// <param name="dateTimeOffset">The value to get the number of elapsed nanoseconds for.</param>
         /// <returns>The number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.</returns>
         public static long ToUnixTimeNanoseconds(this DateTimeOffset dateTimeOffset)

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/LogPoint.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/LogPoint.cs
@@ -23,7 +23,7 @@ internal class LogPoint
 
     public int LogLevel { get; set; }
 
-    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
 
     public string? LoggerName { get; set; }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -338,12 +338,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("OTEL_LOG_EXPORT_INTERVAL", "1000");
             SetEnvironmentVariable("DD_LOGS_DIRECT_SUBMISSION_MINIMUM_LEVEL", "Verbose");
 
-            var startTimeNanoseconds = DateTime.UtcNow.ToUnixTimeNanoseconds();
+            var startTimeNanoseconds = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
 
             using var agent = EnvironmentHelper.GetMockAgent();
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion ?? "1.13.1"))
             {
-                var endTimeNanoseconds = DateTime.UtcNow.ToUnixTimeNanoseconds();
+                var endTimeNanoseconds = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
 
                 using var httpClient = new System.Net.Http.HttpClient();
                 var logsResponse = await httpClient.GetAsync($"http://{testAgentHost}:4318/test/session/logs");


### PR DESCRIPTION
## Summary of changes
Fixes the serialization of the OTLP Logs timestamps fields.

## Reason for change
Before this change, we would start with a UTC DateTime for the LogRecord object and then when we would encode it as a Unix epoch time we applied a "local->UTC time" conversion by using DateTime.ToUniversalTime(), which shifted the time. This resulted in OTLP logs from the PST timezone being reported as having a local time 7 hours in the future.

## Implementation details
- Change the `Timestamp` property of `Datadog.Trace.OpenTelemetry.Logs.LogPoint` to have type `DateTimeOffset` instead of `DateTime` so we're always dealing with a UTC time, and initialize the value to `DateTimeOffset.UtcNow`
- Remove the previous encoding of DateTime->Unix nanoseconds and replace it with a call to the existing extension method `TimeExtensions.ToUnixTimeNanoseconds`, which is already used for serializing timestamps for Metrics and Traces

## Test coverage
Add a regression test in `OpenTelemetrySdkTests.SubmitsOtlpLogs` by asserting that the timestamp in the OTLP log payload is in the expected range (application lifetime) before scrubbing the data and running the snapshot test.

## Other details
N/A
