### PR TITLE
Fix microbenchmark artifacts

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -85,7 +85,7 @@ run-benchmarks:
     when: always
     paths:
       - platform/artifacts
-      - artifacts/
+      - artifacts
     expire_in: 3 months
   variables:
     # Allows ephemeral instances to read content from benchmarking-platform


### PR DESCRIPTION
## Summary of changes

Fixes empty artifacts in the run-benchmarks job for microbenchmarks by adding the artifacts/ path to the artifact collection configuration.

The run-benchmarks job from microbenchmarks was only collecting artifacts from platform/artifacts/, which only contains the .debug.env file. The actual benchmark results (.converted.json files) downloaded by [upload-to-bp-ui.sh](https://github.com/DataDog/benchmarking-platform/blob/dd-trace-dotnet/micro/steps/upload-to-bp-ui.sh#L25) from the BP repository were being saved to ./artifacts/ but weren't included in the job artifacts, resulting in empty/incomplete artifacts.

This PR fixes the artifact collection, effectivelly adding the tests results to the artifact.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
