### PR TITLE
Fix broken CI when running tests against a specific sample

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2249,7 +2249,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter '$(IntegrationTestFilter)' --SampleName '$(IntegrationTestSampleName)'"
+        command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
         apikey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
@@ -2333,7 +2333,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter '$(IntegrationTestFilter)' --SampleName '$(IntegrationTestSampleName)'"
+        command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
@@ -3079,7 +3079,7 @@ stages:
           parameters:
             build: true
             baseImage: $(baseImage)
-            command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter '$(IntegrationTestFilter)' --SampleName '$(IntegrationTestSampleName)'"
+            command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
 
@@ -3149,7 +3149,7 @@ stages:
           parameters:
             build: true
             baseImage: $(baseImage)
-            command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter '$(IntegrationTestFilter)' --SampleName '$(IntegrationTestSampleName)'"
+            command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
 


### PR DESCRIPTION
## Summary of changes

Fixes the ability to filter to a specific sample/test

## Reason for change

When we're doing comprehensive testing for a single integration against all supported versions, we have to filter to building a single sample (to avoid hitting OOM issues) and only running a single test (seeing as the required other samples aren't available).

We recently broke the ability to do that, first by overwriting the Filter using the group ID, and then by introducing an unescaped `&`, which is interpreted by the shell

## Implementation details

Add quotes around the `&` filter values so we don't produce invalid commands

## Test coverage

Did a [basic test here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=191032&view=logs&j=f9026553-c92c-5e80-784f-89f6825c6525&t=c1b0dd6a-7540-5a8e-0b4b-ce38b6d23432) - it failed as expected, but for an unrelated reason, the important thing is that the _command_ ran without errors ([like it was here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=191018&view=results)) :D 
