### PR TITLE
Publish native symbols in all DCs

### DIFF
--- a/.github/actions/publish-debug-symbols/action.yml
+++ b/.github/actions/publish-debug-symbols/action.yml
@@ -5,14 +5,27 @@ inputs:
   artifacts_path:
     description: "Path to the build artifacts"
     required: true
-  preprod_key:
-    description: "Preprod API key"
-    default: ""
-    required: false
-  public_symbols_key:
-    description: "Public symbols API key"
-    default: ""
-    required: false
+  preprod_api_key:
+    description: "Pre-production API key"
+    required: true
+  us1_api_key:
+    description: "US1 API key"
+    required: true
+  us3_api_key:
+    description: "US3 API key"
+    required: true
+  us5_api_key:
+    description: "US5 API key"
+    required: true
+  eu1_api_key:
+    description: "EU1 API key"
+    required: true
+  ap1_api_key:
+    description: "AP1 API key"
+    required: true
+  ap2_api_key:
+    description: "AP2 API key"
+    required: true
 
 runs:
   using: "composite"
@@ -84,17 +97,14 @@ runs:
 
     - name: Push debug symbols
       shell: bash
+      env:
+        BOLD_GREEN: "\e[1;32m"
+        RESET: "\e[0m"
       run: |
-        if [ -n "${{ inputs.public_symbols_key }}" ]; then
-          echo "Push symbols to prod env"
-          DATADOG_API_KEY="${{ inputs.public_symbols_key }}" DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload "$DEBUG_SYMBOLS_DIR/linux"
-          DATADOG_API_KEY="${{ inputs.public_symbols_key }}" DD_BETA_COMMANDS_ENABLED=1 datadog-ci pe-symbols upload "$DEBUG_SYMBOLS_DIR/windows"
-        fi
-
-        if [ -n "${{ inputs.preprod_key }}" ]; then
-          echo "Push symbols to staging env"
-          DATADOG_API_KEY="${{ inputs.preprod_key }}" DATADOG_SITE="datad0g.com" DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload "$DEBUG_SYMBOLS_DIR/linux"
-          DATADOG_API_KEY="${{ inputs.preprod_key }}" DATADOG_SITE="datad0g.com" DD_BETA_COMMANDS_ENABLED=1 datadog-ci pe-symbols upload "$DEBUG_SYMBOLS_DIR/windows"
-        fi
-
-    
+        for i in "datad0g.com ${{ inputs.preprod_api_key }}" "datadoghq.com ${{ inputs.us1_api_key }}" "us3.datadoghq.com ${{ inputs.us3_api_key }}" "us5.datadoghq.com ${{ inputs.us5_api_key }}" "datadoghq.eu ${{ inputs.eu1_api_key }}" "ap1.datadoghq.com ${{ inputs.ap1_api_key }}" "ap2.datadoghq.com ${{ inputs.ap2_api_key }}"; do
+          site=$(echo $i | cut -d' ' -f1)
+          api_key=$(echo $i | cut -d' ' -f2)
+          echo -e "${BOLD_GREEN}Pushing symbols to $site${RESET}"
+          DATADOG_API_KEY="$api_key" DATADOG_SITE="$site" DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload "$DEBUG_SYMBOLS_DIR/linux"
+          DATADOG_API_KEY="$api_key" DATADOG_SITE="$site" DD_BETA_COMMANDS_ENABLED=1 datadog-ci pe-symbols upload "$DEBUG_SYMBOLS_DIR/windows"
+        done

--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -25,14 +25,11 @@ on:
         required: true
       GH_APP_PRIVATE_KEY:
         required: true
-      DD_PREPROD_API_KEY:
-        required: true
-      DD_PUBLIC_SYMBOL_API_KEY:
-        required: true
 
 jobs:
   create_draft_release:
     runs-on: ubuntu-latest
+    environment: publish-debug-symbols-env
     permissions:
       contents: write # create release
       actions: read # read secrets
@@ -163,5 +160,10 @@ jobs:
         uses: ./.github/actions/publish-debug-symbols
         with:
           artifacts_path: ${{steps.assets.outputs.artifacts_path}}
-          preprod_key: "${{ secrets.DD_PREPROD_API_KEY }}"
-          public_symbols_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"
+          preprod_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_PREPROD_API_KEY }}
+          us1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US1 }}
+          us3_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US3 }}
+          us5_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US5 }}
+          eu1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_EU1 }}
+          ap1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_AP1 }}
+          ap2_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_AP2 }}

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   create_draft_release:
     runs-on: ubuntu-latest
+    environment: publish-debug-symbols-env
     permissions:
       contents: write # create release
       actions: read # read secrets
@@ -143,5 +144,10 @@ jobs:
         uses: ./.github/actions/publish-debug-symbols
         with:
           artifacts_path: ${{steps.assets.outputs.artifacts_path}}
-          preprod_key: "${{ secrets.DD_PREPROD_API_KEY }}"
-          public_symbols_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"
+          preprod_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_PREPROD_API_KEY }}
+          us1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US1 }}
+          us3_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US3 }}
+          us5_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US5 }}
+          eu1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_EU1 }}
+          ap1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_AP1 }}
+          ap2_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_AP2 }}

--- a/.github/workflows/publish_debug_symbols.yml
+++ b/.github/workflows/publish_debug_symbols.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish_native_debug_symbols:
     runs-on: ubuntu-latest
+    environment: publish-debug-symbols-env
     env:
       ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
 
@@ -33,5 +34,10 @@ jobs:
         uses: ./.github/actions/publish-debug-symbols
         with:
           artifacts_path: ${{ env.ARTIFACTS_PATH }}
-          preprod_key: "${{ secrets.DD_PREPROD_API_KEY }}"
-          public_symbols_key: "${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}"
+          preprod_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_PREPROD_API_KEY }}
+          us1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US1 }}
+          us3_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US3 }}
+          us5_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US5 }}
+          eu1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_EU1 }}
+          ap1_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_AP1 }}
+          ap2_api_key: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_AP2 }}


### PR DESCRIPTION
## Summary of changes

Publishing .NET APM native symbols to alls DCs.

## Reason for change

When resolving symbols for crash reports in a DC different from us1, the deobfuscation API is unable to get the symbol for a specific frame.

## Implementation details

- Create a github environment and create secrets with all the API keys we need.
- update the action to take as parameter all the API keys
- Use the github environment on the different jobs we need to upload the symbol files

## Test coverage
https://github.com/DataDog/dd-trace-dotnet/actions/runs/19435230104/job/55604220909
-> Upload to preprod is failing (same with the current state of the job)

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
