### PR TITLE
[Dynamix Instrumentation] Fix DebuggerUploader adaptive flush interval

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerUploaderBase.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerUploaderBase.cs
@@ -45,9 +45,9 @@ internal abstract class DebuggerUploaderBase : IDebuggerUploader
 
     public async Task StartFlushingAsync()
     {
+        var currentInterval = _initialFlushInterval;
         while (!_processExit.Task.IsCompleted)
         {
-            var currentInterval = _initialFlushInterval;
             try
             {
                 await Upload().ConfigureAwait(false);


### PR DESCRIPTION
## Summary of changes
Fixes a bug where the adaptive flush interval in DebuggerUploaderBase never actually adapted because the interval was reinitialized on every loop iteration. 

## Reason for change
This bug caused our debug log to be very noisy with irrelevant messages on every timer interval, regardless of whether the interval changed or not.
