### PR TITLE
[SymDB] Do not send telemetry on transient http error

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -344,7 +344,15 @@ namespace Datadog.Trace.Debugger.Symbols
             }
 
             Encoding.UTF8.GetBytes(symbol, 0, symbol.Length, _payload, 0);
-            return await _api.SendBatchAsync(new ArraySegment<byte>(_payload)).ConfigureAwait(false);
+            try
+            {
+                return await _api.SendBatchAsync(new ArraySegment<byte>(_payload)).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                Log.ErrorSkipTelemetry(e, "Error uploading symbol database");
+                return false;
+            }
         }
 
         private bool TrySerializeClass(Model.Scope classScope, StringBuilder sb, int currentBytes, out int newTotalBytes)


### PR DESCRIPTION
## Reason for change
In case of a transient network issue, we don't want to send this error to our instrumentation telemetry.

## Other details
Fix: Error while trying to extract assembly symbol {Assembly}
