### PR TITLE
[Dynamic Instrumentation] DEBUG-4089 Support file-based debugger probes

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -665,7 +665,7 @@ supportedConfigurations:
       Configuration key for enabling or disabling Dynamic Instrumentation.
       Default value is false (disabled).
   DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE:
-  - implementation: A
+  - implementation: B
     type: string
     default: null
     product: Debugger

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -664,6 +664,13 @@ supportedConfigurations:
     documentation: |-
       Configuration key for enabling or disabling Dynamic Instrumentation.
       Default value is false (disabled).
+  DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE:
+  - implementation: A
+    type: string
+    default: null
+    product: Debugger
+    const_name: DynamicInstrumentationProbeFile
+    documentation: Configuration key for loading Dynamic Instrumentation probe definitions from a local JSON file.
   DD_DYNAMIC_INSTRUMENTATION_MAX_DEPTH_TO_SERIALIZE:
   - implementation: A
     type: int

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Debugger.Configurations
         private readonly string? _env;
         private readonly string? _version;
         private readonly int _maxProbesPerType;
-        private readonly HashSet<string> _removedRcmProbeIds = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _removedRcmProbeIds = new();
         private Func<IReadOnlyList<ProbeDefinition>, List<UpdateResult>>? _handleAddedProbesChanges;
         private Action<string[]>? _handleRemovedProbesChanges;
 

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
@@ -40,7 +40,13 @@ namespace Datadog.Trace.Debugger.Configurations
         {
             var result = new List<UpdateResult>();
             var filteredConfiguration = ApplyConfigurationFilters(configuration);
-            var comparer = new ProbeConfigurationComparer(_currentConfiguration, filteredConfiguration);
+
+            // Merge the new filtered configuration with the existing one so that
+            // _currentConfiguration always represents the union of all accepted
+            // configurations from both file and RCM
+            var mergedConfiguration = MergeConfigurations(_currentConfiguration, filteredConfiguration);
+
+            var comparer = new ProbeConfigurationComparer(_currentConfiguration, mergedConfiguration);
 
             if (comparer.HasProbeRelatedChanges)
             {
@@ -52,7 +58,7 @@ namespace Datadog.Trace.Debugger.Configurations
                 HandleRateLimitChanged(comparer);
             }
 
-            _currentConfiguration = configuration;
+            _currentConfiguration = mergedConfiguration;
 
             return result;
         }
@@ -67,6 +73,30 @@ namespace Datadog.Trace.Debugger.Configurations
             {
                 Log.Error(ex, "Failed to remove configurations");
             }
+        }
+
+        private static ProbeConfiguration MergeConfigurations(ProbeConfiguration current, ProbeConfiguration incoming)
+        {
+            return new ProbeConfiguration
+            {
+                LogProbes = current.LogProbes
+                                   .Concat(incoming.LogProbes)
+                                   .Distinct()
+                                   .ToArray(),
+                MetricProbes = current.MetricProbes
+                                      .Concat(incoming.MetricProbes)
+                                      .Distinct()
+                                      .ToArray(),
+                SpanProbes = current.SpanProbes
+                                    .Concat(incoming.SpanProbes)
+                                    .Distinct()
+                                    .ToArray(),
+                SpanDecorationProbes = current.SpanDecorationProbes
+                                              .Concat(incoming.SpanDecorationProbes)
+                                              .Distinct()
+                                              .ToArray(),
+                ServiceConfiguration = incoming.ServiceConfiguration ?? current.ServiceConfiguration
+            };
         }
 
         private ProbeConfiguration ApplyConfigurationFilters(ProbeConfiguration configuration)

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
@@ -20,8 +20,11 @@ namespace Datadog.Trace.Debugger.Configurations
         private readonly string? _env;
         private readonly string? _version;
         private readonly int _maxProbesPerType;
+        private readonly HashSet<string> _removedRcmProbeIds = new(StringComparer.Ordinal);
 
         private ProbeConfiguration _currentConfiguration;
+        private ProbeConfiguration? _fileConfiguration;
+        private ProbeConfiguration _rcmConfiguration;
 
         private ConfigurationUpdater(string? env, string? version, int maxProbesPerType)
         {
@@ -29,6 +32,7 @@ namespace Datadog.Trace.Debugger.Configurations
             _version = version;
             _maxProbesPerType = maxProbesPerType;
             _currentConfiguration = new ProbeConfiguration();
+            _rcmConfiguration = new ProbeConfiguration();
         }
 
         public static ConfigurationUpdater Create(string? environment, string? serviceVersion, int maxProbesPerType)
@@ -38,15 +42,47 @@ namespace Datadog.Trace.Debugger.Configurations
 
         public List<UpdateResult> AcceptAdded(ProbeConfiguration configuration)
         {
+            foreach (var probeId in ProbeConfigurationUtils.GetProbeIds(configuration))
+            {
+                _removedRcmProbeIds.Remove(probeId);
+            }
+
+            _rcmConfiguration = ProbeConfigurationUtils.Merge(_rcmConfiguration, configuration);
+            return ApplyEffectiveConfiguration();
+        }
+
+        public List<UpdateResult> AcceptFile(ProbeConfiguration configuration)
+        {
+            _fileConfiguration = configuration;
+            return ApplyEffectiveConfiguration();
+        }
+
+        public void AcceptRemoved(List<RemoteConfigurationPath> paths)
+        {
+            try
+            {
+                var removedProbeIds = paths.Where(ProbeConfigurationUtils.IsProbePath).Select(ProbeConfigurationUtils.GetProbeIdFromPath).ToArray();
+                var isServiceConfigurationRemoved = paths.Any(path => path.Id.StartsWith(DefinitionPaths.ServiceConfiguration, StringComparison.Ordinal));
+                foreach (var probeId in removedProbeIds)
+                {
+                    _removedRcmProbeIds.Add(probeId);
+                }
+
+                _rcmConfiguration = ProbeConfigurationUtils.RemoveItems(_rcmConfiguration, removedProbeIds, isServiceConfigurationRemoved);
+                HandleRemovedProbesChanges(removedProbeIds);
+                _ = ApplyEffectiveConfiguration();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to remove configurations");
+            }
+        }
+
+        private List<UpdateResult> ApplyEffectiveConfiguration()
+        {
             var result = new List<UpdateResult>();
-            var filteredConfiguration = ApplyConfigurationFilters(configuration);
-
-            // Merge the new filtered configuration with the existing one so that
-            // _currentConfiguration always represents the union of all accepted
-            // configurations from both file and RCM
-            var mergedConfiguration = MergeConfigurations(_currentConfiguration, filteredConfiguration);
-
-            var comparer = new ProbeConfigurationComparer(_currentConfiguration, mergedConfiguration);
+            var filteredConfiguration = ApplyConfigurationFilters(GetEffectiveConfiguration());
+            var comparer = new ProbeConfigurationComparer(_currentConfiguration, filteredConfiguration);
 
             if (comparer.HasProbeRelatedChanges)
             {
@@ -58,45 +94,20 @@ namespace Datadog.Trace.Debugger.Configurations
                 HandleRateLimitChanged(comparer);
             }
 
-            _currentConfiguration = mergedConfiguration;
+            _currentConfiguration = filteredConfiguration;
 
             return result;
         }
 
-        public void AcceptRemoved(List<RemoteConfigurationPath> paths)
+        private ProbeConfiguration GetEffectiveConfiguration()
         {
-            try
+            var fileConfiguration = _fileConfiguration;
+            if (fileConfiguration != null && _removedRcmProbeIds.Count != 0)
             {
-                HandleRemovedProbesChanges(paths);
+                fileConfiguration = ProbeConfigurationUtils.RemoveItems(fileConfiguration, _removedRcmProbeIds, removeServiceConfiguration: false);
             }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to remove configurations");
-            }
-        }
 
-        private static ProbeConfiguration MergeConfigurations(ProbeConfiguration current, ProbeConfiguration incoming)
-        {
-            return new ProbeConfiguration
-            {
-                LogProbes = current.LogProbes
-                                   .Concat(incoming.LogProbes)
-                                   .Distinct()
-                                   .ToArray(),
-                MetricProbes = current.MetricProbes
-                                      .Concat(incoming.MetricProbes)
-                                      .Distinct()
-                                      .ToArray(),
-                SpanProbes = current.SpanProbes
-                                    .Concat(incoming.SpanProbes)
-                                    .Distinct()
-                                    .ToArray(),
-                SpanDecorationProbes = current.SpanDecorationProbes
-                                              .Concat(incoming.SpanDecorationProbes)
-                                              .Distinct()
-                                              .ToArray(),
-                ServiceConfiguration = incoming.ServiceConfiguration ?? current.ServiceConfiguration
-            };
+            return ProbeConfigurationUtils.Merge(fileConfiguration, _rcmConfiguration);
         }
 
         private ProbeConfiguration ApplyConfigurationFilters(ProbeConfiguration configuration)
@@ -152,9 +163,9 @@ namespace Datadog.Trace.Debugger.Configurations
             return DebuggerManager.Instance.DynamicInstrumentation?.UpdateAddedProbeInstrumentations(comparer.AddedDefinitions) ?? [];
         }
 
-        private void HandleRemovedProbesChanges(List<RemoteConfigurationPath> paths)
+        private void HandleRemovedProbesChanges(string[] probeIds)
         {
-            DebuggerManager.Instance.DynamicInstrumentation?.UpdateRemovedProbeInstrumentations(paths);
+            DebuggerManager.Instance.DynamicInstrumentation?.UpdateRemovedProbeInstrumentations(probeIds);
         }
 
         private void HandleRateLimitChanged(ProbeConfigurationComparer comparer)

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
@@ -21,6 +21,8 @@ namespace Datadog.Trace.Debugger.Configurations
         private readonly string? _version;
         private readonly int _maxProbesPerType;
         private readonly HashSet<string> _removedRcmProbeIds = new(StringComparer.Ordinal);
+        private Func<IReadOnlyList<ProbeDefinition>, List<UpdateResult>>? _handleAddedProbesChanges;
+        private Action<string[]>? _handleRemovedProbesChanges;
 
         private ProbeConfiguration _currentConfiguration;
         private ProbeConfiguration? _fileConfiguration;
@@ -40,6 +42,12 @@ namespace Datadog.Trace.Debugger.Configurations
             return new ConfigurationUpdater(environment, serviceVersion, maxProbesPerType);
         }
 
+        public void SetProbeInstrumentationHandlers(Func<IReadOnlyList<ProbeDefinition>, List<UpdateResult>> handleAddedProbesChanges, Action<string[]> handleRemovedProbesChanges)
+        {
+            _handleAddedProbesChanges = handleAddedProbesChanges;
+            _handleRemovedProbesChanges = handleRemovedProbesChanges;
+        }
+
         public List<UpdateResult> AcceptAdded(ProbeConfiguration configuration)
         {
             foreach (var probeId in ProbeConfigurationUtils.GetProbeIds(configuration))
@@ -55,6 +63,15 @@ namespace Datadog.Trace.Debugger.Configurations
         {
             _fileConfiguration = configuration;
             return ApplyEffectiveConfiguration();
+        }
+
+        public bool HasAnyEffectiveProbeForFile(ProbeConfiguration configuration)
+        {
+            var effectiveConfiguration = GetEffectiveConfiguration(configuration);
+            return HasAnyEffectiveProbe(effectiveConfiguration.LogProbes)
+                || HasAnyEffectiveProbe(effectiveConfiguration.MetricProbes)
+                || HasAnyEffectiveProbe(effectiveConfiguration.SpanProbes)
+                || HasAnyEffectiveProbe(effectiveConfiguration.SpanDecorationProbes);
         }
 
         public void AcceptRemoved(List<RemoteConfigurationPath> paths)
@@ -99,9 +116,9 @@ namespace Datadog.Trace.Debugger.Configurations
             return result;
         }
 
-        private ProbeConfiguration GetEffectiveConfiguration()
+        private ProbeConfiguration GetEffectiveConfiguration(ProbeConfiguration? fileConfigurationOverride = null)
         {
-            var fileConfiguration = _fileConfiguration;
+            var fileConfiguration = fileConfigurationOverride ?? _fileConfiguration;
             if (fileConfiguration != null && _removedRcmProbeIds.Count != 0)
             {
                 fileConfiguration = ProbeConfigurationUtils.RemoveItems(fileConfiguration, _removedRcmProbeIds, removeServiceConfiguration: false);
@@ -126,8 +143,7 @@ namespace Datadog.Trace.Debugger.Configurations
             {
                 var filtered =
                     probes
-                       .Where(probe => probe.Language == TracerConstants.Language)
-                       .Where(IsEnvAndVersionMatch);
+                       .Where(IsProbeIncluded);
 
                 if (_maxProbesPerType > 0)
                 {
@@ -135,37 +151,48 @@ namespace Datadog.Trace.Debugger.Configurations
                 }
 
                 return filtered.ToArray();
-
-                bool IsEnvAndVersionMatch(ProbeDefinition probe)
-                {
-                    if (probe.Tags == null || probe.Tags.Length == 0)
-                    {
-                        return true;
-                    }
-
-                    var tagMap =
-                            probe.Tags
-                                 .Distinct()
-                                 .Select(Tag.FromString)
-                                 .ToDictionary(tag => tag.Key, tag => tag.Value)
-                        ;
-
-                    var envNotExistsOrMatch = !tagMap.TryGetValue("env", out var probeEnv) || probeEnv == _env;
-                    var versionNotExistsOrMatch = !tagMap.TryGetValue("version", out var probeVersion) || probeVersion == _version;
-
-                    return envNotExistsOrMatch && versionNotExistsOrMatch;
-                }
             }
+        }
+
+        private bool HasAnyEffectiveProbe<T>(T[] probes)
+            where T : ProbeDefinition
+        {
+            return probes.Any(IsProbeIncluded);
+        }
+
+        private bool IsProbeIncluded(ProbeDefinition probe)
+        {
+            return probe.Language == TracerConstants.Language && IsEnvAndVersionMatch(probe);
+        }
+
+        private bool IsEnvAndVersionMatch(ProbeDefinition probe)
+        {
+            if (probe.Tags == null || probe.Tags.Length == 0)
+            {
+                return true;
+            }
+
+            var tagMap =
+                    probe.Tags
+                         .Distinct()
+                         .Select(Tag.FromString)
+                         .ToDictionary(tag => tag.Key, tag => tag.Value)
+                ;
+
+            var envNotExistsOrMatch = !tagMap.TryGetValue("env", out var probeEnv) || probeEnv == _env;
+            var versionNotExistsOrMatch = !tagMap.TryGetValue("version", out var probeVersion) || probeVersion == _version;
+
+            return envNotExistsOrMatch && versionNotExistsOrMatch;
         }
 
         private List<UpdateResult> HandleAddedProbesChanges(ProbeConfigurationComparer comparer)
         {
-            return DebuggerManager.Instance.DynamicInstrumentation?.UpdateAddedProbeInstrumentations(comparer.AddedDefinitions) ?? [];
+            return _handleAddedProbesChanges?.Invoke(comparer.AddedDefinitions) ?? [];
         }
 
         private void HandleRemovedProbesChanges(string[] probeIds)
         {
-            DebuggerManager.Instance.DynamicInstrumentation?.UpdateRemovedProbeInstrumentations(probeIds);
+            _handleRemovedProbesChanges?.Invoke(probeIds);
         }
 
         private void HandleRateLimitChanged(ProbeConfigurationComparer comparer)

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationFileLoader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationFileLoader.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Util.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
 namespace Datadog.Trace.Debugger.Configurations;
@@ -37,23 +38,26 @@ internal static class ProbeConfigurationFileLoader
 
             Log.Information("Loading probes from file: {ProbeFile}", probeFile);
 
-            string fileContent;
-            using (var reader = new StreamReader(probeFile))
-            {
-                fileContent = await reader.ReadToEndAsync().ConfigureAwait(false);
-            }
-
-            if (string.IsNullOrWhiteSpace(fileContent))
+            using var reader = new StreamReader(probeFile);
+            using var jsonReader = new JsonTextReader(reader) { ArrayPool = JsonArrayPool.Shared };
+            if (!await jsonReader.ReadAsync().ConfigureAwait(false))
             {
                 Log.Debug("Probe file is empty: {ProbeFile}", probeFile);
                 return null;
             }
 
-            var jArray = JsonHelper.ParseJArray(fileContent);
-            var logs = new List<LogProbe>();
-            var metrics = new List<MetricProbe>();
-            var spans = new List<SpanProbe>();
-            var spanDecorations = new List<SpanDecorationProbe>();
+            var jArray = await JArray.LoadAsync(jsonReader).ConfigureAwait(false);
+            while (await jsonReader.ReadAsync().ConfigureAwait(false))
+            {
+                // Validate no trailing content after the array.
+            }
+
+            List<LogProbe>? logs = null;
+            List<MetricProbe>? metrics = null;
+            List<SpanProbe>? spans = null;
+            List<SpanDecorationProbe>? spanDecorations = null;
+            var serializer = JsonSerializer.CreateDefault();
+            var duplicateProbes = 0;
 
             foreach (var jToken in jArray)
             {
@@ -77,34 +81,46 @@ internal static class ProbeConfigurationFileLoader
                     switch (type)
                     {
                         case "LOG_PROBE":
-                            var logProbe = jObject.ToObject<LogProbe>();
+                            var logProbe = jObject.ToObject<LogProbe>(serializer);
                             if (logProbe is not null && IsValidProbe(logProbe))
                             {
-                                logs.Add(logProbe);
+                                if (!AddProbe(ref logs, logProbe))
+                                {
+                                    duplicateProbes++;
+                                }
                             }
 
                             break;
                         case "METRIC_PROBE":
-                            var metricProbe = jObject.ToObject<MetricProbe>();
+                            var metricProbe = jObject.ToObject<MetricProbe>(serializer);
                             if (metricProbe is not null && IsValidProbe(metricProbe))
                             {
-                                metrics.Add(metricProbe);
+                                if (!AddProbe(ref metrics, metricProbe))
+                                {
+                                    duplicateProbes++;
+                                }
                             }
 
                             break;
                         case "SPAN_PROBE":
-                            var spanProbe = jObject.ToObject<SpanProbe>();
+                            var spanProbe = jObject.ToObject<SpanProbe>(serializer);
                             if (spanProbe is not null && IsValidProbe(spanProbe))
                             {
-                                spans.Add(spanProbe);
+                                if (!AddProbe(ref spans, spanProbe))
+                                {
+                                    duplicateProbes++;
+                                }
                             }
 
                             break;
                         case "SPAN_DECORATION_PROBE":
-                            var spanDecorationProbe = jObject.ToObject<SpanDecorationProbe>();
+                            var spanDecorationProbe = jObject.ToObject<SpanDecorationProbe>(serializer);
                             if (spanDecorationProbe is not null && IsValidProbe(spanDecorationProbe))
                             {
-                                spanDecorations.Add(spanDecorationProbe);
+                                if (!AddProbe(ref spanDecorations, spanDecorationProbe))
+                                {
+                                    duplicateProbes++;
+                                }
                             }
 
                             break;
@@ -119,32 +135,26 @@ internal static class ProbeConfigurationFileLoader
                 }
             }
 
-            var totalProbes = logs.Count + metrics.Count + spans.Count + spanDecorations.Count;
-            if (totalProbes == 0)
+            var uniqueCount = (logs?.Count ?? 0) + (metrics?.Count ?? 0) + (spans?.Count ?? 0) + (spanDecorations?.Count ?? 0);
+            if (uniqueCount == 0)
             {
                 Log.Warning("No valid probes found in file: {ProbeFile}", probeFile);
                 return null;
             }
 
-            var uniqueLogs = DeduplicateProbes(logs);
-            var uniqueMetrics = DeduplicateProbes(metrics);
-            var uniqueSpans = DeduplicateProbes(spans);
-            var uniqueSpanDecorations = DeduplicateProbes(spanDecorations);
-
-            var uniqueCount = uniqueLogs.Length + uniqueMetrics.Length + uniqueSpans.Length + uniqueSpanDecorations.Length;
-            if (uniqueCount < totalProbes)
+            if (duplicateProbes != 0)
             {
-                Log.Debug("Removed {Count} duplicate probe(s) from file", property: totalProbes - uniqueCount);
+                Log.Debug("Removed {Count} duplicate probe(s) from file", property: duplicateProbes);
             }
 
             Log.Information("Successfully loaded {Count} probes from file.", property: uniqueCount);
 
             return new ProbeConfiguration
             {
-                LogProbes = uniqueLogs,
-                MetricProbes = uniqueMetrics,
-                SpanProbes = uniqueSpans,
-                SpanDecorationProbes = uniqueSpanDecorations
+                LogProbes = ToArrayOrEmpty(logs),
+                MetricProbes = ToArrayOrEmpty(metrics),
+                SpanProbes = ToArrayOrEmpty(spans),
+                SpanDecorationProbes = ToArrayOrEmpty(spanDecorations)
             };
         }
         catch (Exception ex)
@@ -165,27 +175,27 @@ internal static class ProbeConfigurationFileLoader
         return true;
     }
 
-    private static T[] DeduplicateProbes<T>(List<T> probes)
+    private static bool AddProbe<T>(ref List<T>? probes, T probe)
         where T : ProbeDefinition
     {
-        if (probes.Count == 0)
+        if (probes is not null)
         {
-            return [];
-        }
-
-        var uniqueProbes = new List<T>(probes.Count);
-        var seenIds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var probe in probes)
-        {
-            if (!seenIds.Add(probe.Id))
+            for (var i = 0; i < probes.Count; i++)
             {
-                Log.Warning("Duplicate probe ID '{Id}' found in file, using first occurrence", probe.Id);
-                continue;
+                if (probes[i].Id == probe.Id)
+                {
+                    Log.Warning("Duplicate probe ID '{Id}' found in file, using first occurrence", probe.Id);
+                    return false;
+                }
             }
-
-            uniqueProbes.Add(probe);
         }
 
-        return uniqueProbes.ToArray();
+        (probes ??= new()).Add(probe);
+        return true;
+    }
+
+    private static T[] ToArrayOrEmpty<T>(List<T>? probes)
+    {
+        return probes?.ToArray() ?? [];
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationFileLoader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationFileLoader.cs
@@ -1,0 +1,191 @@
+// <copyright file="ProbeConfigurationFileLoader.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
+using Datadog.Trace.Util.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+
+namespace Datadog.Trace.Debugger.Configurations;
+
+internal static class ProbeConfigurationFileLoader
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProbeConfigurationFileLoader));
+
+    public static async Task<ProbeConfiguration?> LoadAsync(string? probeFile)
+    {
+        if (string.IsNullOrEmpty(probeFile))
+        {
+            return null;
+        }
+
+        try
+        {
+            if (!File.Exists(probeFile))
+            {
+                Log.Warning("Probe file specified but not found: {ProbeFile}", probeFile);
+                return null;
+            }
+
+            Log.Information("Loading probes from file: {ProbeFile}", probeFile);
+
+            string fileContent;
+            using (var reader = new StreamReader(probeFile))
+            {
+                fileContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+            }
+
+            if (string.IsNullOrWhiteSpace(fileContent))
+            {
+                Log.Debug("Probe file is empty: {ProbeFile}", probeFile);
+                return null;
+            }
+
+            var jArray = JsonHelper.ParseJArray(fileContent);
+            var logs = new List<LogProbe>();
+            var metrics = new List<MetricProbe>();
+            var spans = new List<SpanProbe>();
+            var spanDecorations = new List<SpanDecorationProbe>();
+
+            foreach (var jToken in jArray)
+            {
+                var jObject = jToken as JObject;
+                if (jObject == null)
+                {
+                    Log.Warning("Invalid probe entry in file, skipping");
+                    continue;
+                }
+
+                var typeToken = jObject["type"];
+                if (typeToken == null)
+                {
+                    Log.Warning("Probe entry missing 'type' field, skipping");
+                    continue;
+                }
+
+                var type = typeToken.ToString();
+                try
+                {
+                    switch (type)
+                    {
+                        case "LOG_PROBE":
+                            var logProbe = jObject.ToObject<LogProbe>();
+                            if (logProbe is not null && IsValidProbe(logProbe))
+                            {
+                                logs.Add(logProbe);
+                            }
+
+                            break;
+                        case "METRIC_PROBE":
+                            var metricProbe = jObject.ToObject<MetricProbe>();
+                            if (metricProbe is not null && IsValidProbe(metricProbe))
+                            {
+                                metrics.Add(metricProbe);
+                            }
+
+                            break;
+                        case "SPAN_PROBE":
+                            var spanProbe = jObject.ToObject<SpanProbe>();
+                            if (spanProbe is not null && IsValidProbe(spanProbe))
+                            {
+                                spans.Add(spanProbe);
+                            }
+
+                            break;
+                        case "SPAN_DECORATION_PROBE":
+                            var spanDecorationProbe = jObject.ToObject<SpanDecorationProbe>();
+                            if (spanDecorationProbe is not null && IsValidProbe(spanDecorationProbe))
+                            {
+                                spanDecorations.Add(spanDecorationProbe);
+                            }
+
+                            break;
+                        default:
+                            Log.Warning("Unknown probe type '{Type}' in file, skipping", type);
+                            break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to deserialize probe of type '{Type}', skipping", type);
+                }
+            }
+
+            var totalProbes = logs.Count + metrics.Count + spans.Count + spanDecorations.Count;
+            if (totalProbes == 0)
+            {
+                Log.Warning("No valid probes found in file: {ProbeFile}", probeFile);
+                return null;
+            }
+
+            var uniqueLogs = DeduplicateProbes(logs);
+            var uniqueMetrics = DeduplicateProbes(metrics);
+            var uniqueSpans = DeduplicateProbes(spans);
+            var uniqueSpanDecorations = DeduplicateProbes(spanDecorations);
+
+            var uniqueCount = uniqueLogs.Length + uniqueMetrics.Length + uniqueSpans.Length + uniqueSpanDecorations.Length;
+            if (uniqueCount < totalProbes)
+            {
+                Log.Debug("Removed {Count} duplicate probe(s) from file", property: totalProbes - uniqueCount);
+            }
+
+            Log.Information("Successfully loaded {Count} probes from file.", property: uniqueCount);
+
+            return new ProbeConfiguration
+            {
+                LogProbes = uniqueLogs,
+                MetricProbes = uniqueMetrics,
+                SpanProbes = uniqueSpans,
+                SpanDecorationProbes = uniqueSpanDecorations
+            };
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to load probes from file: {ProbeFile}", probeFile);
+            return null;
+        }
+    }
+
+    private static bool IsValidProbe(ProbeDefinition probe)
+    {
+        if (StringUtil.IsNullOrEmpty(probe.Id))
+        {
+            Log.Warning("Probe entry missing 'id' field, skipping");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static T[] DeduplicateProbes<T>(List<T> probes)
+        where T : ProbeDefinition
+    {
+        if (probes.Count == 0)
+        {
+            return [];
+        }
+
+        var uniqueProbes = new List<T>(probes.Count);
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var probe in probes)
+        {
+            if (!seenIds.Add(probe.Id))
+            {
+                Log.Warning("Duplicate probe ID '{Id}' found in file, using first occurrence", probe.Id);
+                continue;
+            }
+
+            uniqueProbes.Add(probe);
+        }
+
+        return uniqueProbes.ToArray();
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationUtils.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationUtils.cs
@@ -36,46 +36,36 @@ internal static class ProbeConfigurationUtils
         return new ProbeConfiguration
         {
             ServiceConfiguration = removeServiceConfiguration ? null : configuration.ServiceConfiguration,
-            LogProbes = configuration.LogProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray(),
-            MetricProbes = configuration.MetricProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray(),
-            SpanProbes = configuration.SpanProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray(),
-            SpanDecorationProbes = configuration.SpanDecorationProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray()
+            LogProbes = RemoveProbes(configuration.LogProbes, removedProbeIds),
+            MetricProbes = RemoveProbes(configuration.MetricProbes, removedProbeIds),
+            SpanProbes = RemoveProbes(configuration.SpanProbes, removedProbeIds),
+            SpanDecorationProbes = RemoveProbes(configuration.SpanDecorationProbes, removedProbeIds)
         };
     }
 
     public static string GetProbeIdFromPath(RemoteConfigurationPath path)
     {
         var id = path.Id;
-        if (id.StartsWith(DefinitionPaths.LogProbe, StringComparison.Ordinal))
+        var prefixLength = GetProbeIdPrefixLength(id);
+        return prefixLength == 0 ? id : id.Substring(prefixLength);
+    }
+
+    public static bool IsProbeId(RemoteConfigurationPath path, string probeId)
+    {
+        var id = path.Id;
+        var prefixLength = GetProbeIdPrefixLength(id);
+        if (prefixLength == 0)
         {
-            return id.Substring(DefinitionPaths.LogProbe.Length);
+            return id == probeId;
         }
 
-        if (id.StartsWith(DefinitionPaths.MetricProbe, StringComparison.Ordinal))
-        {
-            return id.Substring(DefinitionPaths.MetricProbe.Length);
-        }
-
-        if (id.StartsWith(DefinitionPaths.SpanProbe, StringComparison.Ordinal))
-        {
-            return id.Substring(DefinitionPaths.SpanProbe.Length);
-        }
-
-        if (id.StartsWith(DefinitionPaths.SpanDecorationProbe, StringComparison.Ordinal))
-        {
-            return id.Substring(DefinitionPaths.SpanDecorationProbe.Length);
-        }
-
-        return id;
+        return id.Length == prefixLength + probeId.Length
+            && string.Compare(id, prefixLength, probeId, 0, probeId.Length, StringComparison.Ordinal) == 0;
     }
 
     public static bool IsProbePath(RemoteConfigurationPath path)
     {
-        var id = path.Id;
-        return id.StartsWith(DefinitionPaths.LogProbe, StringComparison.Ordinal)
-            || id.StartsWith(DefinitionPaths.MetricProbe, StringComparison.Ordinal)
-            || id.StartsWith(DefinitionPaths.SpanProbe, StringComparison.Ordinal)
-            || id.StartsWith(DefinitionPaths.SpanDecorationProbe, StringComparison.Ordinal);
+        return GetProbeIdPrefixLength(path.Id) != 0;
     }
 
     public static IEnumerable<string> GetProbeIds(ProbeConfiguration configuration)
@@ -114,7 +104,7 @@ internal static class ProbeConfigurationUtils
             return lowerPriority;
         }
 
-        var mergedProbes = new Dictionary<string, T>(StringComparer.Ordinal);
+        var mergedProbes = new Dictionary<string, T>();
         foreach (var probe in lowerPriority)
         {
             mergedProbes[probe.Id] = probe;
@@ -126,5 +116,71 @@ internal static class ProbeConfigurationUtils
         }
 
         return mergedProbes.Values.ToArray();
+    }
+
+    private static T[] RemoveProbes<T>(T[] probes, ICollection<string> removedProbeIds)
+        where T : ProbeDefinition
+    {
+        if (removedProbeIds.Count == 0 || probes.Length == 0)
+        {
+            return probes;
+        }
+
+        var removedCount = 0;
+        for (var i = 0; i < probes.Length; i++)
+        {
+            if (removedProbeIds.Contains(probes[i].Id))
+            {
+                removedCount++;
+            }
+        }
+
+        if (removedCount == 0)
+        {
+            return probes;
+        }
+
+        if (removedCount == probes.Length)
+        {
+            return [];
+        }
+
+        var filteredProbes = new T[probes.Length - removedCount];
+        var index = 0;
+        for (var i = 0; i < probes.Length; i++)
+        {
+            var probe = probes[i];
+            if (!removedProbeIds.Contains(probe.Id))
+            {
+                filteredProbes[index++] = probe;
+            }
+        }
+
+        return filteredProbes;
+    }
+
+    private static int GetProbeIdPrefixLength(string id)
+    {
+        if (id.StartsWith(DefinitionPaths.LogProbe, StringComparison.Ordinal))
+        {
+            return DefinitionPaths.LogProbe.Length;
+        }
+
+        if (id.StartsWith(DefinitionPaths.MetricProbe, StringComparison.Ordinal))
+        {
+            return DefinitionPaths.MetricProbe.Length;
+        }
+
+        if (id.StartsWith(DefinitionPaths.SpanProbe, StringComparison.Ordinal))
+        {
+            return DefinitionPaths.SpanProbe.Length;
+        }
+
+        if (id.StartsWith(DefinitionPaths.SpanDecorationProbe, StringComparison.Ordinal))
+        {
+            return DefinitionPaths.SpanDecorationProbe.Length;
+        }
+
+        return 0;
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationUtils.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationUtils.cs
@@ -1,0 +1,130 @@
+// <copyright file="ProbeConfigurationUtils.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.RemoteConfigurationManagement;
+
+namespace Datadog.Trace.Debugger.Configurations;
+
+internal static class ProbeConfigurationUtils
+{
+    public static ProbeConfiguration Merge(ProbeConfiguration? lowerPriority, ProbeConfiguration? higherPriority)
+    {
+        return new ProbeConfiguration
+        {
+            ServiceConfiguration = higherPriority?.ServiceConfiguration ?? lowerPriority?.ServiceConfiguration,
+            LogProbes = MergeProbes(lowerPriority?.LogProbes, higherPriority?.LogProbes ?? []),
+            MetricProbes = MergeProbes(lowerPriority?.MetricProbes, higherPriority?.MetricProbes ?? []),
+            SpanProbes = MergeProbes(lowerPriority?.SpanProbes, higherPriority?.SpanProbes ?? []),
+            SpanDecorationProbes = MergeProbes(lowerPriority?.SpanDecorationProbes, higherPriority?.SpanDecorationProbes ?? [])
+        };
+    }
+
+    public static ProbeConfiguration RemoveItems(ProbeConfiguration configuration, ICollection<string> removedProbeIds, bool removeServiceConfiguration)
+    {
+        if (removedProbeIds.Count == 0 && !removeServiceConfiguration)
+        {
+            return configuration;
+        }
+
+        return new ProbeConfiguration
+        {
+            ServiceConfiguration = removeServiceConfiguration ? null : configuration.ServiceConfiguration,
+            LogProbes = configuration.LogProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray(),
+            MetricProbes = configuration.MetricProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray(),
+            SpanProbes = configuration.SpanProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray(),
+            SpanDecorationProbes = configuration.SpanDecorationProbes.Where(probe => !removedProbeIds.Contains(probe.Id)).ToArray()
+        };
+    }
+
+    public static string GetProbeIdFromPath(RemoteConfigurationPath path)
+    {
+        var id = path.Id;
+        if (id.StartsWith(DefinitionPaths.LogProbe, StringComparison.Ordinal))
+        {
+            return id.Substring(DefinitionPaths.LogProbe.Length);
+        }
+
+        if (id.StartsWith(DefinitionPaths.MetricProbe, StringComparison.Ordinal))
+        {
+            return id.Substring(DefinitionPaths.MetricProbe.Length);
+        }
+
+        if (id.StartsWith(DefinitionPaths.SpanProbe, StringComparison.Ordinal))
+        {
+            return id.Substring(DefinitionPaths.SpanProbe.Length);
+        }
+
+        if (id.StartsWith(DefinitionPaths.SpanDecorationProbe, StringComparison.Ordinal))
+        {
+            return id.Substring(DefinitionPaths.SpanDecorationProbe.Length);
+        }
+
+        return id;
+    }
+
+    public static bool IsProbePath(RemoteConfigurationPath path)
+    {
+        var id = path.Id;
+        return id.StartsWith(DefinitionPaths.LogProbe, StringComparison.Ordinal)
+            || id.StartsWith(DefinitionPaths.MetricProbe, StringComparison.Ordinal)
+            || id.StartsWith(DefinitionPaths.SpanProbe, StringComparison.Ordinal)
+            || id.StartsWith(DefinitionPaths.SpanDecorationProbe, StringComparison.Ordinal);
+    }
+
+    public static IEnumerable<string> GetProbeIds(ProbeConfiguration configuration)
+    {
+        foreach (var probe in configuration.LogProbes)
+        {
+            yield return probe.Id;
+        }
+
+        foreach (var probe in configuration.MetricProbes)
+        {
+            yield return probe.Id;
+        }
+
+        foreach (var probe in configuration.SpanProbes)
+        {
+            yield return probe.Id;
+        }
+
+        foreach (var probe in configuration.SpanDecorationProbes)
+        {
+            yield return probe.Id;
+        }
+    }
+
+    private static T[] MergeProbes<T>(T[]? lowerPriority, T[] higherPriority)
+        where T : ProbeDefinition
+    {
+        if (lowerPriority == null || lowerPriority.Length == 0)
+        {
+            return higherPriority;
+        }
+
+        if (higherPriority.Length == 0)
+        {
+            return lowerPriority;
+        }
+
+        var mergedProbes = new Dictionary<string, T>(StringComparer.Ordinal);
+        foreach (var probe in lowerPriority)
+        {
+            mergedProbes[probe.Id] = probe;
+        }
+
+        foreach (var probe in higherPriority)
+        {
+            mergedProbes[probe.Id] = probe;
+        }
+
+        return mergedProbes.Values.ToArray();
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
@@ -413,7 +413,10 @@ namespace Datadog.Trace.Debugger
                     Log.Warning("Remote configuration is not available in this environment, so Dynamic Instrumentation cannot be enabled.");
                 }
 
-                return;
+                if (string.IsNullOrEmpty(debuggerSettings.ProbeFile))
+                {
+                    return;
+                }
             }
 
             var requestedDiState = debuggerSettings.DynamicInstrumentationEnabled || debuggerSettings.DynamicSettings.DynamicInstrumentationEnabled == true;

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -152,6 +152,8 @@ namespace Datadog.Trace.Debugger
                                          .Value;
 
             SymbolDatabaseCompressionEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseCompressionEnabled).AsBool(true);
+
+            ProbeFile = config.WithKeys(ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile).AsString() ?? string.Empty;
         }
 
         internal ImmutableDynamicDebuggerSettings DynamicSettings { get; init; } = new();
@@ -197,6 +199,8 @@ namespace Datadog.Trace.Debugger
         public bool CodeOriginForSpansCanBeEnabled { get; }
 
         public int CodeOriginMaxUserFrames { get; }
+
+        public string ProbeFile { get; }
 
         public static DebuggerSettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry)
         {

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -604,7 +604,7 @@ namespace Datadog.Trace.Debugger
                 var updateResults = _configurationUpdater.AcceptAdded(rcmUpdate);
                 foreach (var updateResult in updateResults)
                 {
-                    var config = configs.FirstOrDefault(c => ProbeConfigurationUtils.GetProbeIdFromPath(c.Path) == updateResult.Id);
+                    var config = configs.FirstOrDefault(c => ProbeConfigurationUtils.IsProbeId(c.Path, updateResult.Id));
                     if (config != null)
                     {
                         result.Add(

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -73,6 +73,7 @@ namespace Datadog.Trace.Debugger
             _probeStatusPoller = probeStatusPoller;
             _subscriptionManager = remoteConfigurationManager;
             _configurationUpdater = configurationUpdater;
+            _configurationUpdater.SetProbeInstrumentationHandlers(UpdateAddedProbeInstrumentations, UpdateRemovedProbeInstrumentations);
             _dogStats = dogStats;
             _unboundProbes = new List<ProbeDefinition>();
             _subscription = new Subscription(
@@ -113,23 +114,20 @@ namespace Datadog.Trace.Debugger
                 var probeConfiguration = await fileProbesTask.ConfigureAwait(false);
                 if (probeConfiguration != null)
                 {
-                    _configurationUpdater.AcceptFile(probeConfiguration);
-                    hasFileProbes = (probeConfiguration.LogProbes.Length
-                                   + probeConfiguration.MetricProbes.Length
-                                   + probeConfiguration.SpanProbes.Length
-                                   + probeConfiguration.SpanDecorationProbes.Length) > 0;
-
+                    hasFileProbes = _configurationUpdater.HasAnyEffectiveProbeForFile(probeConfiguration);
                     if (hasFileProbes)
                     {
                         StartRuntimeIfNeeded();
                     }
+
+                    _configurationUpdater.AcceptFile(probeConfiguration);
                 }
 
                 var isRcmAvailable = await rcmAvailabilityTask.ConfigureAwait(false);
                 if (isRcmAvailable)
                 {
-                    _subscriptionManager.SubscribeToChanges(_subscription);
                     StartRuntimeIfNeeded();
+                    _subscriptionManager.SubscribeToChanges(_subscription);
                 }
 
                 // Start background processing and register the assembly load callback if either:

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +24,6 @@ using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Datadog.Trace.Vendors.Serilog.Events;
 using Datadog.Trace.Vendors.StatsdClient;
 using ProbeInfo = Datadog.Trace.Debugger.Expressions.ProbeInfo;
@@ -51,7 +49,6 @@ namespace Datadog.Trace.Debugger
         private readonly DebuggerSettings _settings;
         private readonly object _instanceLock = new();
         private int _disposeState;
-        private volatile ProbeConfiguration? _fileProbes;
 
         internal DynamicInstrumentation(
             DebuggerSettings settings,
@@ -107,7 +104,7 @@ namespace Datadog.Trace.Debugger
             try
             {
                 // Start loading probes from file and checking RCM availability in parallel
-                var fileProbesTask = LoadProbesFromFileAsync();
+                var fileProbesTask = ProbeConfigurationFileLoader.LoadAsync(_settings.ProbeFile);
                 var rcmAvailabilityTask = WaitForRcmAvailabilityAsync();
 
                 var hasFileProbes = false;
@@ -116,28 +113,30 @@ namespace Datadog.Trace.Debugger
                 var probeConfiguration = await fileProbesTask.ConfigureAwait(false);
                 if (probeConfiguration != null)
                 {
-                    _fileProbes = probeConfiguration;
-                    _configurationUpdater.AcceptAdded(probeConfiguration);
+                    _configurationUpdater.AcceptFile(probeConfiguration);
                     hasFileProbes = (probeConfiguration.LogProbes.Length
                                    + probeConfiguration.MetricProbes.Length
                                    + probeConfiguration.SpanProbes.Length
                                    + probeConfiguration.SpanDecorationProbes.Length) > 0;
+
+                    if (hasFileProbes)
+                    {
+                        StartRuntimeIfNeeded();
+                    }
                 }
 
                 var isRcmAvailable = await rcmAvailabilityTask.ConfigureAwait(false);
                 if (isRcmAvailable)
                 {
                     _subscriptionManager.SubscribeToChanges(_subscription);
+                    StartRuntimeIfNeeded();
                 }
 
                 // Start background processing and register the assembly load callback if either:
                 // - RCM is available
                 // - There are probes from file
-                if (isRcmAvailable || hasFileProbes)
+                if (IsInitialized)
                 {
-                    AppDomain.CurrentDomain.AssemblyLoad += CheckUnboundProbes;
-                    StartBackgroundProcess();
-                    IsInitialized = true;
                     Log.Information("Dynamic Instrumentation initialization completed successfully");
                 }
                 else
@@ -153,6 +152,18 @@ namespace Datadog.Trace.Debugger
             {
                 Log.Error(e, "Dynamic Instrumentation initialization failed");
             }
+        }
+
+        private void StartRuntimeIfNeeded()
+        {
+            if (IsInitialized)
+            {
+                return;
+            }
+
+            AppDomain.CurrentDomain.AssemblyLoad += CheckUnboundProbes;
+            StartBackgroundProcess();
+            IsInitialized = true;
         }
 
         private void StartBackgroundProcess()
@@ -278,7 +289,10 @@ namespace Datadog.Trace.Debugger
 
                     using var disposableMethodProbes = new DisposableEnumerable<NativeMethodProbeDefinition>(methodProbes);
                     using var disposableSpanProbes = new DisposableEnumerable<NativeSpanProbeDefinition>(spanProbes);
-                    DebuggerNativeMethods.InstrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
+                    if (methodProbes.Count != 0 || lineProbes.Count != 0 || spanProbes.Count != 0)
+                    {
+                        DebuggerNativeMethods.InstrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
+                    }
 
                     var probeIds = fetchProbeStatus.Select(fp => fp.ProbeId).ToArray();
                     _probeStatusPoller.UpdateProbes(probeIds, fetchProbeStatus.ToArray());
@@ -312,19 +326,11 @@ namespace Datadog.Trace.Debugger
             return values is { Length: > 0 } ? string.Join(" | ", values) : null;
         }
 
-        internal void UpdateRemovedProbeInstrumentations(List<RemoteConfigurationPath> paths)
+        internal void UpdateRemovedProbeInstrumentations(string[] removedProbesIds)
         {
             if (IsDisposed)
             {
                 return;
-            }
-
-            var removedProbesIds = paths
-                                  .Select(TrimProbeTypeFromPath)
-                                  .ToArray();
-            string TrimProbeTypeFromPath(RemoteConfigurationPath path)
-            {
-                return path.Id.Split('_').Last();
             }
 
             if (removedProbesIds.Length == 0)
@@ -586,24 +592,21 @@ namespace Datadog.Trace.Debugger
                 }
             }
 
-            // Merge file probes with RCM probes (RCM takes precedence on ID conflicts)
-            var currentFileProbes = _fileProbes;
-
-            var probeConfiguration = new ProbeConfiguration()
+            var rcmUpdate = new ProbeConfiguration()
             {
                 ServiceConfiguration = serviceConfig,
-                LogProbes = MergeProbes(currentFileProbes?.LogProbes, logs.ToArray()),
-                MetricProbes = MergeProbes(currentFileProbes?.MetricProbes, metrics.ToArray()),
-                SpanProbes = MergeProbes(currentFileProbes?.SpanProbes, spans.ToArray()),
-                SpanDecorationProbes = MergeProbes(currentFileProbes?.SpanDecorationProbes, spanDecoration.ToArray())
+                LogProbes = logs.ToArray(),
+                MetricProbes = metrics.ToArray(),
+                SpanProbes = spans.ToArray(),
+                SpanDecorationProbes = spanDecoration.ToArray()
             };
 
             try
             {
-                var updateResults = _configurationUpdater.AcceptAdded(probeConfiguration);
+                var updateResults = _configurationUpdater.AcceptAdded(rcmUpdate);
                 foreach (var updateResult in updateResults)
                 {
-                    var config = configs.FirstOrDefault(c => c.Path.Id == updateResult.Id);
+                    var config = configs.FirstOrDefault(c => ProbeConfigurationUtils.GetProbeIdFromPath(c.Path) == updateResult.Id);
                     if (config != null)
                     {
                         result.Add(
@@ -749,199 +752,6 @@ namespace Datadog.Trace.Debugger
                     rcmAvailabilityTcs.TrySetResult(true);
                 }
             }
-        }
-
-        private async Task<ProbeConfiguration?> LoadProbesFromFileAsync()
-        {
-            if (string.IsNullOrEmpty(_settings.ProbeFile))
-            {
-                return null;
-            }
-
-            try
-            {
-                if (!File.Exists(_settings.ProbeFile))
-                {
-                    Log.Warning("Probe file specified but not found: {ProbeFile}", _settings.ProbeFile);
-                    return null;
-                }
-
-                Log.Information("Loading probes from file: {ProbeFile}", _settings.ProbeFile);
-
-                string fileContent;
-                using (var reader = new StreamReader(_settings.ProbeFile))
-                {
-                    fileContent = await reader.ReadToEndAsync().ConfigureAwait(false);
-                }
-
-                if (string.IsNullOrWhiteSpace(fileContent))
-                {
-                    Log.Debug("Probe file is empty: {ProbeFile}", _settings.ProbeFile);
-                    return null;
-                }
-
-                var jArray = JArray.Parse(fileContent);
-                var logs = new List<LogProbe>();
-                var metrics = new List<MetricProbe>();
-                var spans = new List<SpanProbe>();
-                var spanDecorations = new List<SpanDecorationProbe>();
-
-                foreach (var jToken in jArray)
-                {
-                    var jObject = jToken as JObject;
-                    if (jObject == null)
-                    {
-                        Log.Warning("Invalid probe entry in file, skipping");
-                        continue;
-                    }
-
-                    var typeToken = jObject["type"];
-                    if (typeToken == null)
-                    {
-                        Log.Warning("Probe entry missing 'type' field, skipping");
-                        continue;
-                    }
-
-                    var type = typeToken.ToString();
-                    try
-                    {
-                        switch (type)
-                        {
-                            case "LOG_PROBE":
-                                var logProbe = jObject.ToObject<LogProbe>();
-                                if (logProbe != null)
-                                {
-                                    logs.Add(logProbe);
-                                }
-
-                                break;
-                            case "METRIC_PROBE":
-                                var metricProbe = jObject.ToObject<MetricProbe>();
-                                if (metricProbe != null)
-                                {
-                                    metrics.Add(metricProbe);
-                                }
-
-                                break;
-                            case "SPAN_PROBE":
-                                var spanProbe = jObject.ToObject<SpanProbe>();
-                                if (spanProbe != null)
-                                {
-                                    spans.Add(spanProbe);
-                                }
-
-                                break;
-                            case "SPAN_DECORATION_PROBE":
-                                var spanDecorationProbe = jObject.ToObject<SpanDecorationProbe>();
-                                if (spanDecorationProbe != null)
-                                {
-                                    spanDecorations.Add(spanDecorationProbe);
-                                }
-
-                                break;
-                            default:
-                                Log.Warning("Unknown probe type '{Type}' in file, skipping", type);
-                                break;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "Failed to deserialize probe of type '{Type}', skipping", type);
-                    }
-                }
-
-                var totalProbes = logs.Count + metrics.Count + spans.Count + spanDecorations.Count;
-                if (totalProbes == 0)
-                {
-                    Log.Warning("No valid probes found in file: {ProbeFile}", _settings.ProbeFile);
-                    return null;
-                }
-
-                // Deduplicate probes within the file by ID
-                var uniqueLogs = DeduplicateProbes(logs);
-                var uniqueMetrics = DeduplicateProbes(metrics);
-                var uniqueSpans = DeduplicateProbes(spans);
-                var uniqueSpanDecorations = DeduplicateProbes(spanDecorations);
-
-                var uniqueCount = uniqueLogs.Length + uniqueMetrics.Length + uniqueSpans.Length + uniqueSpanDecorations.Length;
-                if (uniqueCount < totalProbes)
-                {
-                    Log.Debug("Removed {Count} duplicate probe(s) from file", property: totalProbes - uniqueCount);
-                }
-
-                Log.Information("Successfully loaded {Count} probes from file.", property: uniqueCount);
-
-                return new ProbeConfiguration
-                {
-                    LogProbes = uniqueLogs,
-                    MetricProbes = uniqueMetrics,
-                    SpanProbes = uniqueSpans,
-                    SpanDecorationProbes = uniqueSpanDecorations
-                };
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Failed to load probes from file: {ProbeFile}", _settings.ProbeFile);
-                return null;
-            }
-        }
-
-        private T[] DeduplicateProbes<T>(List<T> probes)
-            where T : ProbeDefinition
-        {
-            if (probes.Count == 0)
-            {
-                return [];
-            }
-
-            return probes
-                  .GroupBy(p => p.Id)
-                  .Select(g =>
-                   {
-                       if (g.Count() > 1)
-                       {
-                           Log.Warning("Duplicate probe ID '{Id}' found in file, using first occurrence", g.Key);
-                       }
-
-                       return g.First();
-                   })
-                  .ToArray();
-        }
-
-        private T[] MergeProbes<T>(T[]? fileProbes, T[] rcmProbes)
-            where T : ProbeDefinition
-        {
-            if (fileProbes == null || fileProbes.Length == 0)
-            {
-                return rcmProbes;
-            }
-
-            if (rcmProbes.Length == 0)
-            {
-                return fileProbes;
-            }
-
-            // Combine and deduplicate by ID (RCM takes precedence over file if conflict)
-            var mergedProbes = new Dictionary<string, T>(StringComparer.Ordinal);
-
-            // Add file probes first
-            foreach (var probe in fileProbes)
-            {
-                mergedProbes[probe.Id] = probe;
-            }
-
-            // Add/overwrite with RCM probes (RCM wins on conflicts)
-            foreach (var probe in rcmProbes)
-            {
-                if (mergedProbes.ContainsKey(probe.Id))
-                {
-                    Log.Debug("Probe ID '{Id}' exists in both file and RCM, using RCM version", probe.Id);
-                }
-
-                mergedProbes[probe.Id] = probe;
-            }
-
-            return mergedProbes.Values.ToArray();
         }
 
         public void Dispose()

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,7 @@ using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Datadog.Trace.Vendors.Serilog.Events;
 using Datadog.Trace.Vendors.StatsdClient;
 using ProbeInfo = Datadog.Trace.Debugger.Expressions.ProbeInfo;
@@ -49,6 +51,7 @@ namespace Datadog.Trace.Debugger
         private readonly DebuggerSettings _settings;
         private readonly object _instanceLock = new();
         private int _disposeState;
+        private volatile ProbeConfiguration? _fileProbes;
 
         internal DynamicInstrumentation(
             DebuggerSettings settings,
@@ -103,17 +106,44 @@ namespace Datadog.Trace.Debugger
         {
             try
             {
-                var isRcmAvailable = await WaitForRcmAvailabilityAsync().ConfigureAwait(false);
-                if (!isRcmAvailable)
+                // Start loading probes from file and checking RCM availability in parallel
+                var fileProbesTask = LoadProbesFromFileAsync();
+                var rcmAvailabilityTask = WaitForRcmAvailabilityAsync();
+
+                var hasFileProbes = false;
+
+                // Always attempt to load probes from file, even if RCM is unavailable
+                var probeConfiguration = await fileProbesTask.ConfigureAwait(false);
+                if (probeConfiguration != null)
                 {
-                    return;
+                    _fileProbes = probeConfiguration;
+                    _configurationUpdater.AcceptAdded(probeConfiguration);
+                    hasFileProbes = (probeConfiguration.LogProbes.Length
+                                   + probeConfiguration.MetricProbes.Length
+                                   + probeConfiguration.SpanProbes.Length
+                                   + probeConfiguration.SpanDecorationProbes.Length) > 0;
                 }
 
-                _subscriptionManager.SubscribeToChanges(_subscription);
-                AppDomain.CurrentDomain.AssemblyLoad += CheckUnboundProbes;
-                StartBackgroundProcess();
-                IsInitialized = true;
-                Log.Information("Dynamic Instrumentation initialization completed successfully");
+                var isRcmAvailable = await rcmAvailabilityTask.ConfigureAwait(false);
+                if (isRcmAvailable)
+                {
+                    _subscriptionManager.SubscribeToChanges(_subscription);
+                }
+
+                // Start background processing and register the assembly load callback if either:
+                // - RCM is available
+                // - There are probes from file
+                if (isRcmAvailable || hasFileProbes)
+                {
+                    AppDomain.CurrentDomain.AssemblyLoad += CheckUnboundProbes;
+                    StartBackgroundProcess();
+                    IsInitialized = true;
+                    Log.Information("Dynamic Instrumentation initialization completed successfully");
+                }
+                else
+                {
+                    Log.Information("Dynamic Instrumentation not initialized because RCM isn't available and no valid probes have loaded from file");
+                }
             }
             catch (OperationCanceledException e)
             {
@@ -556,13 +586,16 @@ namespace Datadog.Trace.Debugger
                 }
             }
 
+            // Merge file probes with RCM probes (RCM takes precedence on ID conflicts)
+            var currentFileProbes = _fileProbes;
+
             var probeConfiguration = new ProbeConfiguration()
             {
                 ServiceConfiguration = serviceConfig,
-                MetricProbes = metrics.ToArray(),
-                SpanDecorationProbes = spanDecoration.ToArray(),
-                LogProbes = logs.ToArray(),
-                SpanProbes = spans.ToArray()
+                LogProbes = MergeProbes(currentFileProbes?.LogProbes, logs.ToArray()),
+                MetricProbes = MergeProbes(currentFileProbes?.MetricProbes, metrics.ToArray()),
+                SpanProbes = MergeProbes(currentFileProbes?.SpanProbes, spans.ToArray()),
+                SpanDecorationProbes = MergeProbes(currentFileProbes?.SpanDecorationProbes, spanDecoration.ToArray())
             };
 
             try
@@ -716,6 +749,199 @@ namespace Datadog.Trace.Debugger
                     rcmAvailabilityTcs.TrySetResult(true);
                 }
             }
+        }
+
+        private async Task<ProbeConfiguration?> LoadProbesFromFileAsync()
+        {
+            if (string.IsNullOrEmpty(_settings.ProbeFile))
+            {
+                return null;
+            }
+
+            try
+            {
+                if (!File.Exists(_settings.ProbeFile))
+                {
+                    Log.Warning("Probe file specified but not found: {ProbeFile}", _settings.ProbeFile);
+                    return null;
+                }
+
+                Log.Information("Loading probes from file: {ProbeFile}", _settings.ProbeFile);
+
+                string fileContent;
+                using (var reader = new StreamReader(_settings.ProbeFile))
+                {
+                    fileContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+                }
+
+                if (string.IsNullOrWhiteSpace(fileContent))
+                {
+                    Log.Debug("Probe file is empty: {ProbeFile}", _settings.ProbeFile);
+                    return null;
+                }
+
+                var jArray = JArray.Parse(fileContent);
+                var logs = new List<LogProbe>();
+                var metrics = new List<MetricProbe>();
+                var spans = new List<SpanProbe>();
+                var spanDecorations = new List<SpanDecorationProbe>();
+
+                foreach (var jToken in jArray)
+                {
+                    var jObject = jToken as JObject;
+                    if (jObject == null)
+                    {
+                        Log.Warning("Invalid probe entry in file, skipping");
+                        continue;
+                    }
+
+                    var typeToken = jObject["type"];
+                    if (typeToken == null)
+                    {
+                        Log.Warning("Probe entry missing 'type' field, skipping");
+                        continue;
+                    }
+
+                    var type = typeToken.ToString();
+                    try
+                    {
+                        switch (type)
+                        {
+                            case "LOG_PROBE":
+                                var logProbe = jObject.ToObject<LogProbe>();
+                                if (logProbe != null)
+                                {
+                                    logs.Add(logProbe);
+                                }
+
+                                break;
+                            case "METRIC_PROBE":
+                                var metricProbe = jObject.ToObject<MetricProbe>();
+                                if (metricProbe != null)
+                                {
+                                    metrics.Add(metricProbe);
+                                }
+
+                                break;
+                            case "SPAN_PROBE":
+                                var spanProbe = jObject.ToObject<SpanProbe>();
+                                if (spanProbe != null)
+                                {
+                                    spans.Add(spanProbe);
+                                }
+
+                                break;
+                            case "SPAN_DECORATION_PROBE":
+                                var spanDecorationProbe = jObject.ToObject<SpanDecorationProbe>();
+                                if (spanDecorationProbe != null)
+                                {
+                                    spanDecorations.Add(spanDecorationProbe);
+                                }
+
+                                break;
+                            default:
+                                Log.Warning("Unknown probe type '{Type}' in file, skipping", type);
+                                break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Failed to deserialize probe of type '{Type}', skipping", type);
+                    }
+                }
+
+                var totalProbes = logs.Count + metrics.Count + spans.Count + spanDecorations.Count;
+                if (totalProbes == 0)
+                {
+                    Log.Warning("No valid probes found in file: {ProbeFile}", _settings.ProbeFile);
+                    return null;
+                }
+
+                // Deduplicate probes within the file by ID
+                var uniqueLogs = DeduplicateProbes(logs);
+                var uniqueMetrics = DeduplicateProbes(metrics);
+                var uniqueSpans = DeduplicateProbes(spans);
+                var uniqueSpanDecorations = DeduplicateProbes(spanDecorations);
+
+                var uniqueCount = uniqueLogs.Length + uniqueMetrics.Length + uniqueSpans.Length + uniqueSpanDecorations.Length;
+                if (uniqueCount < totalProbes)
+                {
+                    Log.Debug("Removed {Count} duplicate probe(s) from file", property: totalProbes - uniqueCount);
+                }
+
+                Log.Information("Successfully loaded {Count} probes from file.", property: uniqueCount);
+
+                return new ProbeConfiguration
+                {
+                    LogProbes = uniqueLogs,
+                    MetricProbes = uniqueMetrics,
+                    SpanProbes = uniqueSpans,
+                    SpanDecorationProbes = uniqueSpanDecorations
+                };
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load probes from file: {ProbeFile}", _settings.ProbeFile);
+                return null;
+            }
+        }
+
+        private T[] DeduplicateProbes<T>(List<T> probes)
+            where T : ProbeDefinition
+        {
+            if (probes.Count == 0)
+            {
+                return [];
+            }
+
+            return probes
+                  .GroupBy(p => p.Id)
+                  .Select(g =>
+                   {
+                       if (g.Count() > 1)
+                       {
+                           Log.Warning("Duplicate probe ID '{Id}' found in file, using first occurrence", g.Key);
+                       }
+
+                       return g.First();
+                   })
+                  .ToArray();
+        }
+
+        private T[] MergeProbes<T>(T[]? fileProbes, T[] rcmProbes)
+            where T : ProbeDefinition
+        {
+            if (fileProbes == null || fileProbes.Length == 0)
+            {
+                return rcmProbes;
+            }
+
+            if (rcmProbes.Length == 0)
+            {
+                return fileProbes;
+            }
+
+            // Combine and deduplicate by ID (RCM takes precedence over file if conflict)
+            var mergedProbes = new Dictionary<string, T>(StringComparer.Ordinal);
+
+            // Add file probes first
+            foreach (var probe in fileProbes)
+            {
+                mergedProbes[probe.Id] = probe;
+            }
+
+            // Add/overwrite with RCM probes (RCM wins on conflicts)
+            foreach (var probe in rcmProbes)
+            {
+                if (mergedProbes.ContainsKey(probe.Id))
+                {
+                    Log.Debug("Probe ID '{Id}' exists in both file and RCM, using RCM version", probe.Id);
+                }
+
+                mergedProbes[probe.Id] = probe;
+            }
+
+            return mergedProbes.Values.ToArray();
         }
 
         public void Dispose()

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -54,6 +54,11 @@ internal static partial class ConfigurationKeys
         public const string MaxTimeToSerialize = "DD_DYNAMIC_INSTRUMENTATION_MAX_TIME_TO_SERIALIZE";
 
         /// <summary>
+        /// Configuration key for loading Dynamic Instrumentation probe definitions from a local JSON file.
+        /// </summary>
+        public const string DynamicInstrumentationProbeFile = "DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE";
+
+        /// <summary>
         /// Configuration key for set of identifiers that are excluded from redaction decisions.
         /// </summary>
         public const string RedactedExcludedIdentifiers = "DD_DYNAMIC_INSTRUMENTATION_REDACTED_EXCLUDED_IDENTIFIERS";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -54,6 +54,11 @@ internal static partial class ConfigurationKeys
         public const string MaxTimeToSerialize = "DD_DYNAMIC_INSTRUMENTATION_MAX_TIME_TO_SERIALIZE";
 
         /// <summary>
+        /// Configuration key for loading Dynamic Instrumentation probe definitions from a local JSON file.
+        /// </summary>
+        public const string DynamicInstrumentationProbeFile = "DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE";
+
+        /// <summary>
         /// Configuration key for set of identifiers that are excluded from redaction decisions.
         /// </summary>
         public const string RedactedExcludedIdentifiers = "DD_DYNAMIC_INSTRUMENTATION_REDACTED_EXCLUDED_IDENTIFIERS";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -54,6 +54,11 @@ internal static partial class ConfigurationKeys
         public const string MaxTimeToSerialize = "DD_DYNAMIC_INSTRUMENTATION_MAX_TIME_TO_SERIALIZE";
 
         /// <summary>
+        /// Configuration key for loading Dynamic Instrumentation probe definitions from a local JSON file.
+        /// </summary>
+        public const string DynamicInstrumentationProbeFile = "DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE";
+
+        /// <summary>
         /// Configuration key for set of identifiers that are excluded from redaction decisions.
         /// </summary>
         public const string RedactedExcludedIdentifiers = "DD_DYNAMIC_INSTRUMENTATION_REDACTED_EXCLUDED_IDENTIFIERS";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -54,6 +54,11 @@ internal static partial class ConfigurationKeys
         public const string MaxTimeToSerialize = "DD_DYNAMIC_INSTRUMENTATION_MAX_TIME_TO_SERIALIZE";
 
         /// <summary>
+        /// Configuration key for loading Dynamic Instrumentation probe definitions from a local JSON file.
+        /// </summary>
+        public const string DynamicInstrumentationProbeFile = "DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE";
+
+        /// <summary>
         /// Configuration key for set of identifiers that are excluded from redaction decisions.
         /// </summary>
         public const string RedactedExcludedIdentifiers = "DD_DYNAMIC_INSTRUMENTATION_REDACTED_EXCLUDED_IDENTIFIERS";

--- a/tracer/src/Datadog.Trace/Util/Json/JsonHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/Json/JsonHelper.cs
@@ -83,6 +83,20 @@ internal static class JsonHelper
         return o;
     }
 
+    public static JArray ParseJArray(string json)
+    {
+        // equivalent to Datadog.Trace.Vendors.Newtonsoft.Json.Linq.JArray.Parse()
+        // differs from the vendored version, in that we use an array pool
+        using var reader = new JsonTextReader(new StringReader(json)) { ArrayPool = JsonArrayPool.Shared };
+        var a = JArray.Load(reader);
+        while (reader.Read())
+        {
+            // validate no trailing content
+        }
+
+        return a;
+    }
+
     public static string TokenToString(JToken token, Formatting formatting = Formatting.Indented, params JsonConverter[] converters)
     {
         // equivalent to Datadog.Trace.Vendors.Newtonsoft.Json.Linq.JToken.ToString()

--- a/tracer/src/Datadog.Trace/Util/Json/JsonHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/Json/JsonHelper.cs
@@ -83,20 +83,6 @@ internal static class JsonHelper
         return o;
     }
 
-    public static JArray ParseJArray(string json)
-    {
-        // equivalent to Datadog.Trace.Vendors.Newtonsoft.Json.Linq.JArray.Parse()
-        // differs from the vendored version, in that we use an array pool
-        using var reader = new JsonTextReader(new StringReader(json)) { ArrayPool = JsonArrayPool.Shared };
-        var a = JArray.Load(reader);
-        while (reader.Read())
-        {
-            // validate no trailing content
-        }
-
-        return a;
-    }
-
     public static string TokenToString(JToken token, Formatting formatting = Formatting.Indented, params JsonConverter[] converters)
     {
         // equivalent to Datadog.Trace.Vendors.Newtonsoft.Json.Linq.JToken.ToString()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
@@ -1,0 +1,208 @@
+// <copyright file="ConfigurationUpdaterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Datadog.Trace.Debugger.Configurations;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.RemoteConfigurationManagement.Protocol;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ConfigurationUpdaterTests
+{
+    [Fact]
+    public void MergeProbes_FileAndRcm_UnionOfIds()
+    {
+        var fileProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("file-probe-1")]
+        };
+
+        var rcmProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("rcm-probe-1")]
+        };
+
+        var merged = ProbeConfigurationUtils.Merge(fileProbes, rcmProbes);
+
+        merged.LogProbes.Select(p => p.Id).Should().BeEquivalentTo("file-probe-1", "rcm-probe-1");
+    }
+
+    [Fact]
+    public void MergeProbes_DuplicateIds_RcmWins()
+    {
+        var fileProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("shared-id", "From file", sourceFile: "file.cs")]
+        };
+
+        var rcmProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("shared-id", "From RCM", sourceFile: "rcm.cs")]
+        };
+
+        var merged = ProbeConfigurationUtils.Merge(fileProbes, rcmProbes);
+
+        merged.LogProbes.Should().ContainSingle();
+        merged.LogProbes[0].Template.Should().Be("From RCM");
+        merged.LogProbes[0].Where.SourceFile.Should().Be("rcm.cs");
+    }
+
+    [Fact]
+    public void AcceptFile_FiltersByLanguageAndMaxProbeCount()
+    {
+        var updater = CreateUpdater(maxProbesPerType: 1, out var addedProbes, out _);
+
+        var result = updater.AcceptFile(
+            new ProbeConfiguration
+            {
+                LogProbes =
+                [
+                    CreateLogProbe("dotnet-probe-1"),
+                    CreateLogProbe("dotnet-probe-2"),
+                    CreateLogProbe("java-probe", language: "java"),
+                ]
+            });
+
+        result.Select(r => r.Id).Should().Equal("dotnet-probe-1");
+        addedProbes.Should().ContainSingle();
+        addedProbes[0].Select(p => p.Id).Should().Equal("dotnet-probe-1");
+        GetCurrentConfiguration(updater).LogProbes.Select(p => p.Id).Should().Equal("dotnet-probe-1");
+    }
+
+    [Fact]
+    public void AcceptAdded_RcmProbeOverridesFileProbeWithSameId()
+    {
+        var updater = CreateUpdater(out var addedProbes, out _);
+        updater.AcceptFile(
+            new ProbeConfiguration
+            {
+                LogProbes = [CreateLogProbe("shared-id", "From file", sourceFile: "file.cs")]
+            });
+        addedProbes.Clear();
+
+        var result = updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                LogProbes = [CreateLogProbe("shared-id", "From RCM", sourceFile: "rcm.cs")]
+            });
+
+        result.Select(r => r.Id).Should().Equal("shared-id");
+        addedProbes.Should().ContainSingle();
+        var addedProbe = addedProbes[0].Should().ContainSingle().Which.Should().BeOfType<LogProbe>().Which;
+        addedProbe.Template.Should().Be("From RCM");
+        addedProbe.Where.SourceFile.Should().Be("rcm.cs");
+        GetCurrentConfiguration(updater).LogProbes.Should().ContainSingle().Which.Template.Should().Be("From RCM");
+    }
+
+    [Fact]
+    public void AcceptRemoved_RemovesRcmProbeAndSuppressesFileProbeWithSameId()
+    {
+        var updater = CreateUpdater(out _, out var removedProbeIds);
+        var fileConfiguration = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("shared-id", "From file", sourceFile: "file.cs")]
+        };
+
+        updater.AcceptFile(fileConfiguration);
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                LogProbes = [CreateLogProbe("shared-id", "From RCM", sourceFile: "rcm.cs")]
+            });
+
+        updater.AcceptRemoved([CreateRcmPath(DefinitionPaths.LogProbe, "shared-id")]);
+
+        removedProbeIds.Should().Equal("shared-id");
+        GetCurrentConfiguration(updater).LogProbes.Should().BeEmpty();
+        updater.HasAnyEffectiveProbeForFile(fileConfiguration).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AcceptAdded_AfterRemovalClearsFileProbeSuppression()
+    {
+        var updater = CreateUpdater(out _, out _);
+        var fileConfiguration = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("shared-id", "From file", sourceFile: "file.cs")]
+        };
+
+        updater.AcceptFile(fileConfiguration);
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                LogProbes = [CreateLogProbe("shared-id", "From RCM", sourceFile: "rcm.cs")]
+            });
+        updater.AcceptRemoved([CreateRcmPath(DefinitionPaths.LogProbe, "shared-id")]);
+
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                LogProbes = [CreateLogProbe("shared-id", "From RCM again", sourceFile: "rcm.cs")]
+            });
+
+        updater.HasAnyEffectiveProbeForFile(fileConfiguration).Should().BeTrue();
+        GetCurrentConfiguration(updater).LogProbes.Should().ContainSingle().Which.Template.Should().Be("From RCM again");
+    }
+
+    private static ConfigurationUpdater CreateUpdater(
+        out List<IReadOnlyList<ProbeDefinition>> addedProbes,
+        out List<string> removedProbeIds)
+    {
+        return CreateUpdater(maxProbesPerType: 0, out addedProbes, out removedProbeIds);
+    }
+
+    private static ConfigurationUpdater CreateUpdater(
+        int maxProbesPerType,
+        out List<IReadOnlyList<ProbeDefinition>> addedProbes,
+        out List<string> removedProbeIds)
+    {
+        addedProbes = [];
+        removedProbeIds = [];
+
+        var addedProbesCapture = addedProbes;
+        var removedProbeIdsCapture = removedProbeIds;
+        var updater = ConfigurationUpdater.Create("env", "version", maxProbesPerType);
+        updater.SetProbeInstrumentationHandlers(
+            probes =>
+            {
+                addedProbesCapture.Add(probes);
+                return probes.Select(probe => new ConfigurationUpdater.UpdateResult(probe.Id, null)).ToList();
+            },
+            probeIds => removedProbeIdsCapture.AddRange(probeIds));
+
+        return updater;
+    }
+
+    private static LogProbe CreateLogProbe(string id, string? template = null, string sourceFile = "file.cs", string language = "dotnet")
+    {
+        return new LogProbe
+        {
+            Id = id,
+            Language = language,
+            Template = template ?? id,
+            Where = new Where { SourceFile = sourceFile, Lines = ["10"] },
+        };
+    }
+
+    private static RemoteConfigurationPath CreateRcmPath(string probePrefix, string probeId)
+    {
+        return RemoteConfigurationPath.FromPath($"employee/{RcmProducts.LiveDebugging}/{probePrefix}{probeId}/config");
+    }
+
+    private static ProbeConfiguration GetCurrentConfiguration(ConfigurationUpdater updater)
+    {
+        var field = typeof(ConfigurationUpdater).GetField("_currentConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull();
+        return (ProbeConfiguration)field!.GetValue(updater)!;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -210,6 +210,37 @@ namespace Datadog.Trace.Tests.Debugger
 
             settings.MaxProbesPerType.Should().Be(0);
         }
+		
+		[Theory]
+        	[InlineData("/path/to/probes.json")]
+	        [InlineData("C:\\probes\\config.json")]
+        	[InlineData("probes.json")]
+        	public void ProbeFile_ParsesCorrectly(string probeFilePath)
+        	{
+            	var settings = new DebuggerSettings(
+                	new NameValueConfigurationSource(new()
+                	{
+                    	{ ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, probeFilePath }
+                	}),
+                	NullConfigurationTelemetry.Instance);
+
+            	settings.ProbeFile.Should().Be(probeFilePath);
+        	}
+
+        	[Theory]
+        	[InlineData("")]
+        	[InlineData(null)]
+        	public void ProbeFile_EmptyOrNull(string probeFilePath)
+        	{
+            	var settings = new DebuggerSettings(
+                	new NameValueConfigurationSource(new()
+                	{
+                    	{ ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, probeFilePath }
+                	}),
+                	NullConfigurationTelemetry.Instance);
+
+            	settings.ProbeFile.Should().BeEmpty();
+        	}
 
         public class DebuggerSettingsCodeOriginTests
         {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -210,37 +210,37 @@ namespace Datadog.Trace.Tests.Debugger
 
             settings.MaxProbesPerType.Should().Be(0);
         }
-		
-		[Theory]
-        	[InlineData("/path/to/probes.json")]
-	        [InlineData("C:\\probes\\config.json")]
-        	[InlineData("probes.json")]
-        	public void ProbeFile_ParsesCorrectly(string probeFilePath)
-        	{
-            	var settings = new DebuggerSettings(
-                	new NameValueConfigurationSource(new()
-                	{
-                    	{ ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, probeFilePath }
-                	}),
-                	NullConfigurationTelemetry.Instance);
 
-            	settings.ProbeFile.Should().Be(probeFilePath);
-        	}
+        [Theory]
+        [InlineData("/path/to/probes.json")]
+        [InlineData("C:\\probes\\config.json")]
+        [InlineData("probes.json")]
+        public void ProbeFile_ParsesCorrectly(string probeFilePath)
+        {
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, probeFilePath }
+                }),
+                NullConfigurationTelemetry.Instance);
 
-        	[Theory]
-        	[InlineData("")]
-        	[InlineData(null)]
-        	public void ProbeFile_EmptyOrNull(string probeFilePath)
-        	{
-            	var settings = new DebuggerSettings(
-                	new NameValueConfigurationSource(new()
-                	{
-                    	{ ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, probeFilePath }
-                	}),
-                	NullConfigurationTelemetry.Instance);
+            settings.ProbeFile.Should().Be(probeFilePath);
+        }
 
-            	settings.ProbeFile.Should().BeEmpty();
-        	}
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ProbeFile_EmptyOrNull(string probeFilePath)
+        {
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, probeFilePath }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            settings.ProbeFile.Should().BeEmpty();
+        }
 
         public class DebuggerSettingsCodeOriginTests
         {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -97,6 +97,17 @@ public class DynamicInstrumentationTests
         }
     }
 
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutSeconds = 5)
+    {
+        var timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        var startTime = DateTime.UtcNow;
+
+        while (!condition() && DateTime.UtcNow - startTime < timeout)
+        {
+            await Task.Delay(50);
+        }
+    }
+
     public class ProbeFileLoadingTests : IDisposable
     {
         private readonly List<string> _tempFiles = new();
@@ -178,6 +189,84 @@ public class DynamicInstrumentationTests
             fileProbes!.LogProbes.Should().HaveCount(1);
             fileProbes.MetricProbes.Should().HaveCount(1);
             fileProbes.SpanProbes.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task ProbeFile_ValidProbe_AppliesInstrumentation()
+        {
+            var probeJson = @"[
+                {
+                    ""id"": ""applied-file-probe"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""MyClass.cs"", ""lines"": [""25""] },
+                    ""captureSnapshot"": true
+                }
+            ]";
+
+            var tempFile = CreateTempProbeFile(probeJson);
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, tempFile }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var lineProbeResolver = new LineProbeResolverMock();
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            debugger.Initialize();
+
+            await WaitUntilAsync(() => GetCurrentConfiguration(debugger).LogProbes.Any(probe => probe.Id == "applied-file-probe"));
+
+            lineProbeResolver.Called.Should().BeTrue("file probes should be applied to the owning DynamicInstrumentation instance");
+            probeStatusPoller.Called.Should().BeTrue("applying a file probe should update probe statuses");
+            GetCurrentConfiguration(debugger).LogProbes.Should().ContainSingle(probe => probe.Id == "applied-file-probe");
+        }
+
+        [Fact]
+        public async Task ProbeFile_FilteredOutProbe_DoesNotStartRuntimeWithoutRcm()
+        {
+            var probeJson = @"[
+                {
+                    ""id"": ""filtered-file-probe"",
+                    ""language"": ""java"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""MyClass.cs"", ""lines"": [""25""] },
+                    ""captureSnapshot"": true
+                }
+            ]";
+
+            var tempFile = CreateTempProbeFile(probeJson);
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, tempFile }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var lineProbeResolver = new LineProbeResolverMock();
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, new DiscoveryServiceWithoutRcmMock(), lineProbeResolver, probeStatusPoller);
+            try
+            {
+                debugger.Initialize();
+
+                await WaitUntilAsync(() => GetFileProbes(debugger) is not null);
+
+                GetCurrentConfiguration(debugger).LogProbes.Should().BeEmpty("non-dotnet file probes should be filtered out before starting the runtime");
+                debugger.IsInitialized.Should().BeFalse("a file with no effective probes should not start DI without RCM");
+                lineProbeResolver.Called.Should().BeFalse();
+                probeStatusPoller.Called.Should().BeFalse();
+            }
+            finally
+            {
+                debugger.Dispose();
+            }
         }
 
         [Theory]
@@ -390,6 +479,14 @@ public class DynamicInstrumentationTests
             return (ConfigurationUpdater)field!.GetValue(debugger)!;
         }
 
+        private static ProbeConfiguration GetCurrentConfiguration(DynamicInstrumentation debugger)
+        {
+            var updater = GetConfigurationUpdater(debugger);
+            var field = typeof(ConfigurationUpdater).GetField("_currentConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
+            field.Should().NotBeNull();
+            return (ProbeConfiguration)field!.GetValue(updater)!;
+        }
+
         private string CreateTempProbeFile(string content)
         {
             var tempFile = Path.GetTempFileName();
@@ -398,14 +495,18 @@ public class DynamicInstrumentationTests
             return tempFile;
         }
 
-        private DynamicInstrumentation CreateDebugger(DebuggerSettings settings, IDiscoveryService? discoveryService = null)
+        private DynamicInstrumentation CreateDebugger(
+            DebuggerSettings settings,
+            IDiscoveryService? discoveryService = null,
+            LineProbeResolverMock? lineProbeResolver = null,
+            ProbeStatusPollerMock? probeStatusPoller = null)
         {
             var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();
-            var lineProbeResolver = new LineProbeResolverMock();
+            lineProbeResolver ??= new LineProbeResolverMock();
             var snapshotUploader = new SnapshotUploaderMock();
             var logUploader = new LogUploaderMock();
             var diagnosticsUploader = new UploaderMock();
-            var probeStatusPoller = new ProbeStatusPollerMock();
+            probeStatusPoller ??= new ProbeStatusPollerMock();
 
             return new DynamicInstrumentation(
                 settings,

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -5,7 +5,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
@@ -46,15 +49,7 @@ public class DynamicInstrumentationTests
 
         var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance);
         debugger.Initialize();
-
-        // Wait for async initialization to complete
-        var timeout = TimeSpan.FromSeconds(5);
-        var startTime = DateTime.UtcNow;
-
-        while (!debugger.IsInitialized && DateTime.UtcNow - startTime < timeout)
-        {
-            await Task.Delay(50);
-        }
+        await WaitForInitializationAsync(debugger);
 
         discoveryService.Called.Should().BeTrue();
         debugger.IsInitialized.Should().BeTrue("Dynamic instrumentation should be initialized");
@@ -89,6 +84,397 @@ public class DynamicInstrumentationTests
         diagnosticsUploader.Called.Should().BeFalse();
         probeStatusPoller.Called.Should().BeFalse();
         rcmSubscriptionManagerMock.ProductKeys.Contains(RcmProducts.LiveDebugging).Should().BeFalse();
+    }
+
+    private static async Task WaitForInitializationAsync(DynamicInstrumentation debugger, int timeoutSeconds = 5)
+    {
+        var timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        var startTime = DateTime.UtcNow;
+
+        while (!debugger.IsInitialized && DateTime.UtcNow - startTime < timeout)
+        {
+            await Task.Delay(50);
+        }
+    }
+
+    public class ProbeFileLoadingTests : IDisposable
+    {
+        private readonly List<string> _tempFiles = new();
+
+        public void Dispose()
+        {
+            // Clean up temp files
+            foreach (var file in _tempFiles)
+            {
+                try
+                {
+                    if (File.Exists(file))
+                    {
+                        File.Delete(file);
+                    }
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ProbeFile_MultipleProbeTypes_LoadsAll()
+        {
+            var probeJson = @"[
+                {
+                    ""id"": ""100c9a5c-45ad-49dc-818b-c570d31e11d1"",
+                    ""version"": 0,
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""MyClass.cs"", ""lines"": [""25""] },
+                    ""template"": ""Hello World"",
+                    ""segments"": [{ ""str"": ""Hello World"" }],
+                    ""captureSnapshot"": true,
+                    ""capture"": { ""maxReferenceDepth"": 3 },
+                    ""sampling"": { ""snapshotsPerSecond"": 100 }
+                },
+                {
+                    ""id"": ""metric-1"",
+                    ""type"": ""METRIC_PROBE"",
+                    ""where"": { ""typeName"": ""MyClass"", ""methodName"": ""MyMethod"" },
+                    ""kind"": ""COUNT"",
+                    ""metricName"": ""my.metric""
+                },
+                {
+                    ""id"": ""span-1"",
+                    ""type"": ""SPAN_PROBE"",
+                    ""where"": { ""typeName"": ""MyClass"", ""methodName"": ""MyMethod"" }
+                }
+            ]";
+
+            var tempFile = CreateTempProbeFile(probeJson);
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, tempFile }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var debugger = CreateDebugger(settings);
+            debugger.Initialize();
+
+            var timeout = TimeSpan.FromSeconds(5);
+            var startTime = DateTime.UtcNow;
+
+            while (GetFileProbes(debugger) is null && DateTime.UtcNow - startTime < timeout)
+            {
+                await Task.Delay(50);
+            }
+
+            var fileProbes = GetFileProbes(debugger);
+            fileProbes.Should().NotBeNull("Probe file should be loaded and applied");
+            fileProbes!.LogProbes.Should().HaveCount(1);
+            fileProbes.MetricProbes.Should().HaveCount(1);
+            fileProbes.SpanProbes.Should().HaveCount(1);
+        }
+
+        [Theory]
+        [InlineData(null, false, "non-existent file")]
+        [InlineData("{ invalid json }", true, "invalid json")]
+        [InlineData("", true, "empty file")]
+        [InlineData("[]", true, "empty array")]
+        public async Task ProbeFile_InvalidOrMissingProbeFile_InitializationContinues(string fileContent, bool createFile, string scenario)
+        {
+            string probeFilePath;
+
+            if (createFile)
+            {
+                probeFilePath = CreateTempProbeFile(fileContent ?? string.Empty);
+            }
+            else
+            {
+                probeFilePath = "/nonexistent/path/probes.json";
+            }
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, probeFilePath }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var debugger = CreateDebugger(settings);
+            debugger.Initialize();
+            await WaitForInitializationAsync(debugger);
+
+            debugger.IsInitialized.Should().BeTrue($"Initialization should complete for scenario '{scenario}'");
+            GetFileProbes(debugger).Should().BeNull($"No probes should be loaded for scenario '{scenario}'");
+        }
+
+        [Fact]
+        public async Task ProbeFile_NoProbeFileConfigured_SkipsLoading()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var debugger = CreateDebugger(settings);
+            debugger.Initialize();
+            await WaitForInitializationAsync(debugger);
+
+            debugger.IsInitialized.Should().BeTrue("Initialization should complete normally");
+            GetFileProbes(debugger).Should().BeNull("No probes should be loaded when no file is configured");
+        }
+
+        [Fact]
+        public async Task ProbeFile_PartiallyValidProbes_LoadsValidOnes()
+        {
+            var probeJson = @"[
+                {
+                    ""id"": ""valid-1"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""test.js"", ""lines"": [""10""] },
+                    ""captureSnapshot"": true
+                },
+                {
+                    ""id"": ""invalid-no-type"",
+                    ""where"": { ""sourceFile"": ""test.js"", ""lines"": [""20""] }
+                },
+                {
+                    ""id"": ""valid-2"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""test.js"", ""lines"": [""30""] },
+                    ""captureSnapshot"": false
+                }
+            ]";
+
+            var tempFile = CreateTempProbeFile(probeJson);
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, tempFile }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var debugger = CreateDebugger(settings);
+            debugger.Initialize();
+
+            var timeout = TimeSpan.FromSeconds(5);
+            var startTime = DateTime.UtcNow;
+
+            while (GetFileProbes(debugger) is null && DateTime.UtcNow - startTime < timeout)
+            {
+                await Task.Delay(50);
+            }
+
+            var fileProbes = GetFileProbes(debugger);
+            fileProbes.Should().NotBeNull("Valid probes should be loaded");
+            fileProbes!.LogProbes.Should().HaveCount(2, "Only valid probes should be loaded");
+        }
+
+        [Fact]
+        public async Task ProbeFile_DuplicateIdsWithinFile_KeepsFirstOccurrence()
+        {
+            var probeJson = @"[
+                {
+                    ""id"": ""duplicate-id"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""first.js"", ""lines"": [""10""] },
+                    ""template"": ""First occurrence"",
+                    ""captureSnapshot"": true
+                },
+                {
+                    ""id"": ""unique-id"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""unique.js"", ""lines"": [""20""] },
+                    ""captureSnapshot"": true
+                },
+                {
+                    ""id"": ""duplicate-id"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""second.js"", ""lines"": [""30""] },
+                    ""template"": ""Second occurrence"",
+                    ""captureSnapshot"": false
+                }
+            ]";
+
+            var tempFile = CreateTempProbeFile(probeJson);
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, tempFile }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var debugger = CreateDebugger(settings);
+            debugger.Initialize();
+
+            var timeout = TimeSpan.FromSeconds(5);
+            var startTime = DateTime.UtcNow;
+
+            while (GetFileProbes(debugger) is null && DateTime.UtcNow - startTime < timeout)
+            {
+                await Task.Delay(50);
+            }
+
+            var fileProbes = GetFileProbes(debugger);
+            fileProbes.Should().NotBeNull("Probes should be loaded");
+            fileProbes!.LogProbes.Should().HaveCount(2, "Duplicate should be removed");
+
+            // Verify the first occurrence is kept
+            var duplicateProbe = fileProbes.LogProbes.FirstOrDefault(p => p.Id == "duplicate-id");
+            duplicateProbe.Should().NotBeNull();
+            duplicateProbe!.Where.SourceFile.Should().Be("first.js", "First occurrence should be kept");
+            duplicateProbe.Template.Should().Be("First occurrence");
+        }
+
+        private static ProbeConfiguration GetFileProbes(DynamicInstrumentation debugger)
+        {
+            var field = typeof(DynamicInstrumentation).GetField("_fileProbes", BindingFlags.Instance | BindingFlags.NonPublic);
+            field.Should().NotBeNull();
+            return (ProbeConfiguration)field.GetValue(debugger);
+        }
+
+        private string CreateTempProbeFile(string content)
+        {
+            var tempFile = Path.GetTempFileName();
+            _tempFiles.Add(tempFile);
+            File.WriteAllText(tempFile, content);
+            return tempFile;
+        }
+
+        private DynamicInstrumentation CreateDebugger(DebuggerSettings settings)
+        {
+            var discoveryService = new DiscoveryServiceMock();
+            var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();
+            var lineProbeResolver = new LineProbeResolverMock();
+            var snapshotUploader = new SnapshotUploaderMock();
+            var logUploader = new LogUploaderMock();
+            var diagnosticsUploader = new UploaderMock();
+            var probeStatusPoller = new ProbeStatusPollerMock();
+
+            return new DynamicInstrumentation(
+                settings,
+                discoveryService,
+                rcmSubscriptionManagerMock,
+                lineProbeResolver,
+                snapshotUploader,
+                logUploader,
+                diagnosticsUploader,
+                probeStatusPoller,
+                ConfigurationUpdater.Create("env", "version"),
+                new DogStatsd.NoOpStatsd());
+        }
+    }
+
+    public class ProbeMergeUnitTests
+    {
+        [Fact]
+        public void MergeProbes_FileAndRcm_UnionOfIds()
+        {
+            var debugger = CreateDebugger();
+
+            var fileProbes = new[]
+            {
+                new LogProbe { Id = "file-probe-1" },
+            };
+
+            var rcmProbes = new[]
+            {
+                new LogProbe { Id = "rcm-probe-1" },
+            };
+
+            var merged = InvokeMergeProbes(debugger, fileProbes, rcmProbes);
+
+            merged.Select(p => p.Id).Should().BeEquivalentTo("file-probe-1", "rcm-probe-1");
+        }
+
+        [Fact]
+        public void MergeProbes_DuplicateIds_RcmWins()
+        {
+            var debugger = CreateDebugger();
+
+            var fileProbes = new[]
+            {
+                new LogProbe
+                {
+                    Id = "shared-id",
+                    Where = new Where { SourceFile = "file.js", Lines = new[] { "10" } },
+                    Template = "From file",
+                    CaptureSnapshot = true,
+                },
+            };
+
+            var rcmProbes = new[]
+            {
+                new LogProbe
+                {
+                    Id = "shared-id",
+                    Where = new Where { SourceFile = "rcm.js", Lines = new[] { "99" } },
+                    Template = "From RCM",
+                    CaptureSnapshot = false,
+                },
+            };
+
+            var merged = InvokeMergeProbes(debugger, fileProbes, rcmProbes);
+
+            merged.Should().HaveCount(1);
+
+            var probe = merged[0];
+            probe.Id.Should().Be("shared-id");
+            probe.Where.SourceFile.Should().Be("rcm.js");
+            probe.Template.Should().Be("From RCM");
+            probe.CaptureSnapshot.Should().BeFalse();
+        }
+
+        private static DynamicInstrumentation CreateDebugger()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var discoveryService = new DiscoveryServiceMock();
+            var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();
+            var lineProbeResolver = new LineProbeResolverMock();
+            var snapshotUploader = new SnapshotUploaderMock();
+            var logUploader = new LogUploaderMock();
+            var diagnosticsUploader = new UploaderMock();
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var updater = ConfigurationUpdater.Create("env", "version");
+
+            return new DynamicInstrumentation(
+                settings,
+                discoveryService,
+                rcmSubscriptionManagerMock,
+                lineProbeResolver,
+                snapshotUploader,
+                logUploader,
+                diagnosticsUploader,
+                probeStatusPoller,
+                updater,
+                new DogStatsd.NoOpStatsd());
+        }
+
+        private static T[] InvokeMergeProbes<T>(DynamicInstrumentation debugger, T[] fileProbes, T[] rcmProbes)
+            where T : ProbeDefinition
+        {
+            var method = typeof(DynamicInstrumentation).GetMethod("MergeProbes", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+
+            return (T[])method!
+                       .MakeGenericMethod(typeof(T))
+                       .Invoke(debugger, [fileProbes, rcmProbes])!;
+        }
     }
 
     private class DiscoveryServiceMock : IDiscoveryService
@@ -134,8 +520,11 @@ public class DynamicInstrumentationTests
 
         public ICollection<string> ProductKeys { get; } = new List<string>();
 
+        public ISubscription LastSubscription { get; private set; }
+
         public void SubscribeToChanges(ISubscription subscription)
         {
+            LastSubscription = subscription;
             foreach (var productKey in subscription.ProductKeys)
             {
                 ProductKeys.Add(productKey);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -127,6 +127,7 @@ public class DynamicInstrumentationTests
                 {
                     ""id"": ""100c9a5c-45ad-49dc-818b-c570d31e11d1"",
                     ""version"": 0,
+                    ""language"": ""dotnet"",
                     ""type"": ""LOG_PROBE"",
                     ""where"": { ""sourceFile"": ""MyClass.cs"", ""lines"": [""25""] },
                     ""template"": ""Hello World"",
@@ -137,6 +138,7 @@ public class DynamicInstrumentationTests
                 },
                 {
                     ""id"": ""metric-1"",
+                    ""language"": ""dotnet"",
                     ""type"": ""METRIC_PROBE"",
                     ""where"": { ""typeName"": ""MyClass"", ""methodName"": ""MyMethod"" },
                     ""kind"": ""COUNT"",
@@ -144,6 +146,7 @@ public class DynamicInstrumentationTests
                 },
                 {
                     ""id"": ""span-1"",
+                    ""language"": ""dotnet"",
                     ""type"": ""SPAN_PROBE"",
                     ""where"": { ""typeName"": ""MyClass"", ""methodName"": ""MyMethod"" }
                 }
@@ -182,7 +185,7 @@ public class DynamicInstrumentationTests
         [InlineData("{ invalid json }", true, "invalid json")]
         [InlineData("", true, "empty file")]
         [InlineData("[]", true, "empty array")]
-        public async Task ProbeFile_InvalidOrMissingProbeFile_InitializationContinues(string fileContent, bool createFile, string scenario)
+        public async Task ProbeFile_InvalidOrMissingProbeFile_InitializationContinues(string? fileContent, bool createFile, string scenario)
         {
             string probeFilePath;
 
@@ -235,18 +238,20 @@ public class DynamicInstrumentationTests
             var probeJson = @"[
                 {
                     ""id"": ""valid-1"",
+                    ""language"": ""dotnet"",
                     ""type"": ""LOG_PROBE"",
-                    ""where"": { ""sourceFile"": ""test.js"", ""lines"": [""10""] },
+                    ""where"": { ""sourceFile"": ""test.cs"", ""lines"": [""10""] },
                     ""captureSnapshot"": true
                 },
                 {
                     ""id"": ""invalid-no-type"",
-                    ""where"": { ""sourceFile"": ""test.js"", ""lines"": [""20""] }
+                    ""where"": { ""sourceFile"": ""test.cs"", ""lines"": [""20""] }
                 },
                 {
                     ""id"": ""valid-2"",
+                    ""language"": ""dotnet"",
                     ""type"": ""LOG_PROBE"",
-                    ""where"": { ""sourceFile"": ""test.js"", ""lines"": [""30""] },
+                    ""where"": { ""sourceFile"": ""test.cs"", ""lines"": [""30""] },
                     ""captureSnapshot"": false
                 }
             ]";
@@ -283,21 +288,24 @@ public class DynamicInstrumentationTests
             var probeJson = @"[
                 {
                     ""id"": ""duplicate-id"",
+                    ""language"": ""dotnet"",
                     ""type"": ""LOG_PROBE"",
-                    ""where"": { ""sourceFile"": ""first.js"", ""lines"": [""10""] },
+                    ""where"": { ""sourceFile"": ""first.cs"", ""lines"": [""10""] },
                     ""template"": ""First occurrence"",
                     ""captureSnapshot"": true
                 },
                 {
                     ""id"": ""unique-id"",
+                    ""language"": ""dotnet"",
                     ""type"": ""LOG_PROBE"",
-                    ""where"": { ""sourceFile"": ""unique.js"", ""lines"": [""20""] },
+                    ""where"": { ""sourceFile"": ""unique.cs"", ""lines"": [""20""] },
                     ""captureSnapshot"": true
                 },
                 {
                     ""id"": ""duplicate-id"",
+                    ""language"": ""dotnet"",
                     ""type"": ""LOG_PROBE"",
-                    ""where"": { ""sourceFile"": ""second.js"", ""lines"": [""30""] },
+                    ""where"": { ""sourceFile"": ""second.cs"", ""lines"": [""30""] },
                     ""template"": ""Second occurrence"",
                     ""captureSnapshot"": false
                 }
@@ -331,15 +339,55 @@ public class DynamicInstrumentationTests
             // Verify the first occurrence is kept
             var duplicateProbe = fileProbes.LogProbes.FirstOrDefault(p => p.Id == "duplicate-id");
             duplicateProbe.Should().NotBeNull();
-            duplicateProbe!.Where.SourceFile.Should().Be("first.js", "First occurrence should be kept");
+            duplicateProbe!.Where.SourceFile.Should().Be("first.cs", "First occurrence should be kept");
             duplicateProbe.Template.Should().Be("First occurrence");
         }
 
-        private static ProbeConfiguration GetFileProbes(DynamicInstrumentation debugger)
+        [Fact]
+        public async Task ProbeFile_ValidFileWithoutRcm_InitializesWithoutWaitingForRcmTimeout()
         {
-            var field = typeof(DynamicInstrumentation).GetField("_fileProbes", BindingFlags.Instance | BindingFlags.NonPublic);
+            var probeJson = @"[
+                {
+                    ""id"": ""file-only-id"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""file-only.cs"", ""lines"": [""10""] },
+                    ""captureSnapshot"": true
+                }
+            ]";
+
+            var tempFile = CreateTempProbeFile(probeJson);
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, tempFile }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var debugger = CreateDebugger(settings, new DiscoveryServiceWithoutRcmMock());
+            debugger.Initialize();
+            await WaitForInitializationAsync(debugger);
+
+            debugger.IsInitialized.Should().BeTrue("file probes should not wait for the RCM availability timeout");
+            GetFileProbes(debugger).Should().NotBeNull();
+            debugger.Dispose();
+        }
+
+        private static ProbeConfiguration? GetFileProbes(DynamicInstrumentation debugger)
+        {
+            var updater = GetConfigurationUpdater(debugger);
+            var field = typeof(ConfigurationUpdater).GetField("_fileConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
             field.Should().NotBeNull();
-            return (ProbeConfiguration)field.GetValue(debugger);
+            return (ProbeConfiguration?)field!.GetValue(updater);
+        }
+
+        private static ConfigurationUpdater GetConfigurationUpdater(DynamicInstrumentation debugger)
+        {
+            var field = typeof(DynamicInstrumentation).GetField("_configurationUpdater", BindingFlags.Instance | BindingFlags.NonPublic);
+            field.Should().NotBeNull();
+            return (ConfigurationUpdater)field!.GetValue(debugger)!;
         }
 
         private string CreateTempProbeFile(string content)
@@ -350,9 +398,8 @@ public class DynamicInstrumentationTests
             return tempFile;
         }
 
-        private DynamicInstrumentation CreateDebugger(DebuggerSettings settings)
+        private DynamicInstrumentation CreateDebugger(DebuggerSettings settings, IDiscoveryService? discoveryService = null)
         {
-            var discoveryService = new DiscoveryServiceMock();
             var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();
             var lineProbeResolver = new LineProbeResolverMock();
             var snapshotUploader = new SnapshotUploaderMock();
@@ -362,15 +409,15 @@ public class DynamicInstrumentationTests
 
             return new DynamicInstrumentation(
                 settings,
-                discoveryService,
+                discoveryService ?? new DiscoveryServiceMock(),
                 rcmSubscriptionManagerMock,
                 lineProbeResolver,
                 snapshotUploader,
                 logUploader,
                 diagnosticsUploader,
                 probeStatusPoller,
-                ConfigurationUpdater.Create("env", "version"),
-                new DogStatsd.NoOpStatsd());
+                ConfigurationUpdater.Create("env", "version", 0),
+                global::Datadog.Trace.DogStatsd.NoOpStatsd.Instance);
         }
     }
 
@@ -379,101 +426,108 @@ public class DynamicInstrumentationTests
         [Fact]
         public void MergeProbes_FileAndRcm_UnionOfIds()
         {
-            var debugger = CreateDebugger();
-
-            var fileProbes = new[]
+            var fileProbes = new ProbeConfiguration
             {
-                new LogProbe { Id = "file-probe-1" },
+                LogProbes = [new LogProbe { Id = "file-probe-1" }]
             };
 
-            var rcmProbes = new[]
+            var rcmProbes = new ProbeConfiguration
             {
-                new LogProbe { Id = "rcm-probe-1" },
+                LogProbes = [new LogProbe { Id = "rcm-probe-1" }]
             };
 
-            var merged = InvokeMergeProbes(debugger, fileProbes, rcmProbes);
+            var merged = ProbeConfigurationUtils.Merge(fileProbes, rcmProbes);
 
-            merged.Select(p => p.Id).Should().BeEquivalentTo("file-probe-1", "rcm-probe-1");
+            merged.LogProbes.Select(p => p.Id).Should().BeEquivalentTo("file-probe-1", "rcm-probe-1");
         }
 
         [Fact]
         public void MergeProbes_DuplicateIds_RcmWins()
         {
-            var debugger = CreateDebugger();
-
-            var fileProbes = new[]
+            var fileProbes = new ProbeConfiguration
             {
-                new LogProbe
-                {
-                    Id = "shared-id",
-                    Where = new Where { SourceFile = "file.js", Lines = new[] { "10" } },
-                    Template = "From file",
-                    CaptureSnapshot = true,
-                },
+                LogProbes =
+                [
+                    new LogProbe
+                    {
+                        Id = "shared-id",
+                        Where = new Where { SourceFile = "file.cs", Lines = new[] { "10" } },
+                        Template = "From file",
+                        CaptureSnapshot = true,
+                    }
+                ]
             };
 
-            var rcmProbes = new[]
+            var rcmProbes = new ProbeConfiguration
             {
-                new LogProbe
-                {
-                    Id = "shared-id",
-                    Where = new Where { SourceFile = "rcm.js", Lines = new[] { "99" } },
-                    Template = "From RCM",
-                    CaptureSnapshot = false,
-                },
+                LogProbes =
+                [
+                    new LogProbe
+                    {
+                        Id = "shared-id",
+                        Where = new Where { SourceFile = "rcm.cs", Lines = new[] { "99" } },
+                        Template = "From RCM",
+                        CaptureSnapshot = false,
+                    }
+                ]
             };
 
-            var merged = InvokeMergeProbes(debugger, fileProbes, rcmProbes);
+            var merged = ProbeConfigurationUtils.Merge(fileProbes, rcmProbes);
 
-            merged.Should().HaveCount(1);
+            merged.LogProbes.Should().HaveCount(1);
 
-            var probe = merged[0];
+            var probe = merged.LogProbes[0];
             probe.Id.Should().Be("shared-id");
-            probe.Where.SourceFile.Should().Be("rcm.js");
+            probe.Where.SourceFile.Should().Be("rcm.cs");
             probe.Template.Should().Be("From RCM");
             probe.CaptureSnapshot.Should().BeFalse();
         }
 
-        private static DynamicInstrumentation CreateDebugger()
+        [Fact]
+        public void RcmRemovalSuppressesFileProbeWithSameId()
         {
-            var settings = DebuggerSettings.FromSource(
-                new NameValueConfigurationSource(new()
+            var updater = ConfigurationUpdater.Create("env", "version", 0);
+
+            updater.AcceptFile(
+                new ProbeConfiguration
                 {
-                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
-                }),
-                NullConfigurationTelemetry.Instance);
+                    LogProbes =
+                    [
+                        new LogProbe
+                        {
+                            Id = "shared-id",
+                            Language = "dotnet",
+                            Where = new Where { SourceFile = "file.cs", Lines = new[] { "10" } },
+                            Template = "From file",
+                        }
+                    ]
+                });
 
-            var discoveryService = new DiscoveryServiceMock();
-            var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();
-            var lineProbeResolver = new LineProbeResolverMock();
-            var snapshotUploader = new SnapshotUploaderMock();
-            var logUploader = new LogUploaderMock();
-            var diagnosticsUploader = new UploaderMock();
-            var probeStatusPoller = new ProbeStatusPollerMock();
-            var updater = ConfigurationUpdater.Create("env", "version");
+            updater.AcceptAdded(
+                new ProbeConfiguration
+                {
+                    LogProbes =
+                    [
+                        new LogProbe
+                        {
+                            Id = "shared-id",
+                            Language = "dotnet",
+                            Where = new Where { SourceFile = "rcm.cs", Lines = new[] { "99" } },
+                            Template = "From RCM",
+                        }
+                    ]
+                });
 
-            return new DynamicInstrumentation(
-                settings,
-                discoveryService,
-                rcmSubscriptionManagerMock,
-                lineProbeResolver,
-                snapshotUploader,
-                logUploader,
-                diagnosticsUploader,
-                probeStatusPoller,
-                updater,
-                new DogStatsd.NoOpStatsd());
+            updater.AcceptRemoved([RemoteConfigurationPath.FromPath($"employee/{RcmProducts.LiveDebugging}/logProbe_shared-id/config")]);
+
+            GetCurrentConfiguration(updater).LogProbes.Should().BeEmpty("an RCM removal for a probe ID should suppress the file probe with the same ID");
         }
 
-        private static T[] InvokeMergeProbes<T>(DynamicInstrumentation debugger, T[] fileProbes, T[] rcmProbes)
-            where T : ProbeDefinition
+        private static ProbeConfiguration GetCurrentConfiguration(ConfigurationUpdater updater)
         {
-            var method = typeof(DynamicInstrumentation).GetMethod("MergeProbes", BindingFlags.Instance | BindingFlags.NonPublic);
-            method.Should().NotBeNull();
-
-            return (T[])method!
-                       .MakeGenericMethod(typeof(T))
-                       .Invoke(debugger, [fileProbes, rcmProbes])!;
+            var field = typeof(ConfigurationUpdater).GetField("_currentConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
+            field.Should().NotBeNull();
+            return (ProbeConfiguration)field!.GetValue(updater)!;
         }
     }
 
@@ -514,13 +568,50 @@ public class DynamicInstrumentationTests
         public Task DisposeAsync() => Task.CompletedTask;
     }
 
+    private class DiscoveryServiceWithoutRcmMock : IDiscoveryService
+    {
+        internal bool Called { get; private set; }
+
+        public void SubscribeToChanges(Action<AgentConfiguration> callback)
+        {
+            Called = true;
+            callback(
+                new AgentConfiguration(
+                    configurationEndpoint: null,
+                    debuggerEndpoint: "debuggerEndpoint",
+                    debuggerV2Endpoint: "debuggerV2Endpoint",
+                    diagnosticsEndpoint: "diagnosticsEndpoint",
+                    symbolDbEndpoint: "symbolDbEndpoint",
+                    agentVersion: "agentVersion",
+                    statsEndpoint: "traceStatsEndpoint",
+                    dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
+                    eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
+                    telemetryProxyEndpoint: "telemetryProxyEndpoint",
+                    tracerFlareEndpoint: "tracerFlareEndpoint",
+                    containerTagsHash: "containerTagsHash",
+                    clientDropP0: false,
+                    spanMetaStructs: true,
+                    spanEvents: true));
+        }
+
+        public void RemoveSubscription(Action<AgentConfiguration> callback)
+        {
+        }
+
+        public void SetCurrentConfigStateHash(string configStateHash)
+        {
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+    }
+
     private class RcmSubscriptionManagerMock : IRcmSubscriptionManager
     {
         public bool HasAnySubscription { get; }
 
         public ICollection<string> ProductKeys { get; } = new List<string>();
 
-        public ISubscription LastSubscription { get; private set; }
+        public ISubscription? LastSubscription { get; private set; }
 
         public void SubscribeToChanges(ISubscription subscription)
         {
@@ -574,7 +665,9 @@ public class DynamicInstrumentationTests
 
         public LineProbeResolveResult TryResolveLineProbe(ProbeDefinition probe, out LineProbeResolver.BoundLineProbeLocation? location, LineProbeDiagnosticLevel diagnosticLevel = LineProbeDiagnosticLevel.Full)
         {
-            throw new NotImplementedException();
+            Called = true;
+            location = null;
+            return new LineProbeResolveResult(LiveProbeResolveStatus.Error, LineProbeResolveReason.MissingPdb, "PDB not available in unit test");
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationFileLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationFileLoaderTests.cs
@@ -1,0 +1,224 @@
+// <copyright file="ProbeConfigurationFileLoaderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Datadog.Trace.Debugger.Configurations;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ProbeConfigurationFileLoaderTests : IDisposable
+{
+    private readonly List<string> _tempFiles = [];
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task LoadAsync_WithoutProbeFile_ReturnsNull(string? probeFile)
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(probeFile);
+
+        configuration.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_MissingFile_ReturnsNull()
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+
+        configuration.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{}")]
+    [InlineData("[")]
+    [InlineData("[]")]
+    public async Task LoadAsync_InvalidOrEmptyFile_ReturnsNull(string content)
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(CreateTempProbeFile(content));
+
+        configuration.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadAsync_MultipleProbeTypes_LoadsAllTypes()
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(
+            CreateTempProbeFile(
+                """
+                [
+                  {
+                    "id": "log-1",
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "sourceFile": "log.cs", "lines": ["10"] },
+                    "template": "Hello",
+                    "captureSnapshot": true
+                  },
+                  {
+                    "id": "metric-1",
+                    "language": "dotnet",
+                    "type": "METRIC_PROBE",
+                    "where": { "typeName": "MyClass", "methodName": "MyMethod" },
+                    "kind": "COUNT",
+                    "metricName": "my.metric"
+                  },
+                  {
+                    "id": "span-1",
+                    "language": "dotnet",
+                    "type": "SPAN_PROBE",
+                    "where": { "typeName": "MyClass", "methodName": "MyMethod" }
+                  },
+                  {
+                    "id": "span-decoration-1",
+                    "language": "dotnet",
+                    "type": "SPAN_DECORATION_PROBE",
+                    "where": { "typeName": "MyClass", "methodName": "MyMethod" },
+                    "targetSpan": "ACTIVE",
+                    "decorations": []
+                  }
+                ]
+                """));
+
+        configuration.Should().NotBeNull();
+        configuration!.LogProbes.Should().ContainSingle().Which.Id.Should().Be("log-1");
+        configuration.MetricProbes.Should().ContainSingle().Which.Id.Should().Be("metric-1");
+        configuration.SpanProbes.Should().ContainSingle().Which.Id.Should().Be("span-1");
+        configuration.SpanDecorationProbes.Should().ContainSingle().Which.Id.Should().Be("span-decoration-1");
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvalidEntries_AreSkipped()
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(
+            CreateTempProbeFile(
+                """
+                [
+                  1,
+                  { "id": "missing-type", "language": "dotnet" },
+                  { "id": "unknown-type", "language": "dotnet", "type": "UNKNOWN_PROBE" },
+                  {
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "sourceFile": "missing-id.cs", "lines": ["10"] }
+                  },
+                  {
+                    "id": "valid-log",
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "sourceFile": "valid.cs", "lines": ["10"] }
+                  }
+                ]
+                """));
+
+        configuration.Should().NotBeNull();
+        configuration!.LogProbes.Should().ContainSingle().Which.Id.Should().Be("valid-log");
+        configuration.MetricProbes.Should().BeEmpty();
+        configuration.SpanProbes.Should().BeEmpty();
+        configuration.SpanDecorationProbes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_DuplicateProbeIds_KeepFirstOccurrence()
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(
+            CreateTempProbeFile(
+                """
+                [
+                  {
+                    "id": "duplicate-id",
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "sourceFile": "first.cs", "lines": ["10"] },
+                    "template": "First"
+                  },
+                  {
+                    "id": "duplicate-id",
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "sourceFile": "second.cs", "lines": ["20"] },
+                    "template": "Second"
+                  },
+                  {
+                    "id": "unique-id",
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "sourceFile": "unique.cs", "lines": ["30"] },
+                    "template": "Unique"
+                  }
+                ]
+                """));
+
+        configuration.Should().NotBeNull();
+        configuration!.LogProbes.Should().HaveCount(2);
+        configuration.LogProbes[0].Id.Should().Be("duplicate-id");
+        configuration.LogProbes[0].Template.Should().Be("First");
+        configuration.LogProbes[0].Where.SourceFile.Should().Be("first.cs");
+        configuration.LogProbes[1].Id.Should().Be("unique-id");
+    }
+
+    [Fact]
+    public async Task LoadAsync_ProbeDeserializationFailure_SkipsOnlyFailedProbe()
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(
+            CreateTempProbeFile(
+                """
+                [
+                  {
+                    "id": "invalid-metric",
+                    "language": "dotnet",
+                    "type": "METRIC_PROBE",
+                    "where": { "typeName": "MyClass", "methodName": "MyMethod" },
+                    "kind": "INVALID_KIND",
+                    "metricName": "my.metric"
+                  },
+                  {
+                    "id": "valid-log",
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "sourceFile": "valid.cs", "lines": ["10"] }
+                  }
+                ]
+                """));
+
+        configuration.Should().NotBeNull();
+        configuration!.MetricProbes.Should().BeEmpty();
+        configuration.LogProbes.Should().ContainSingle().Which.Id.Should().Be("valid-log");
+    }
+
+    public void Dispose()
+    {
+        foreach (var file in _tempFiles)
+        {
+            try
+            {
+                if (File.Exists(file))
+                {
+                    File.Delete(file);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    private string CreateTempProbeFile(string content)
+    {
+        var tempFile = Path.GetTempFileName();
+        _tempFiles.Add(tempFile);
+        File.WriteAllText(tempFile, content);
+        return tempFile;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationUtilsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationUtilsTests.cs
@@ -1,0 +1,257 @@
+// <copyright file="ProbeConfigurationUtilsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Linq;
+using Datadog.Trace.Debugger.Configurations;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.RemoteConfigurationManagement.Protocol;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ProbeConfigurationUtilsTests
+{
+    public static TheoryData<string> ProbePathPrefixes() => new()
+    {
+        DefinitionPaths.LogProbe,
+        DefinitionPaths.MetricProbe,
+        DefinitionPaths.SpanProbe,
+        DefinitionPaths.SpanDecorationProbe,
+    };
+
+    [Theory]
+    [MemberData(nameof(ProbePathPrefixes))]
+    public void GetProbeIdFromPath_ReturnsIdWithoutProbePrefix(string probePrefix)
+    {
+        var path = CreateRcmPath(probePrefix, "probe-id");
+
+        ProbeConfigurationUtils.GetProbeIdFromPath(path).Should().Be("probe-id");
+    }
+
+    [Fact]
+    public void GetProbeIdFromPath_ReturnsWholeIdForNonProbePath()
+    {
+        var path = CreateRcmPath(DefinitionPaths.ServiceConfiguration, "service");
+
+        ProbeConfigurationUtils.GetProbeIdFromPath(path).Should().Be("serviceConfig_service");
+    }
+
+    [Theory]
+    [MemberData(nameof(ProbePathPrefixes))]
+    public void IsProbePath_ReturnsTrueForProbePaths(string probePrefix)
+    {
+        ProbeConfigurationUtils.IsProbePath(CreateRcmPath(probePrefix, "probe-id")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsProbePath_ReturnsFalseForNonProbePath()
+    {
+        ProbeConfigurationUtils.IsProbePath(CreateRcmPath(DefinitionPaths.ServiceConfiguration, "service")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsProbeId_MatchesProbePathWithoutAllocatingExtractedId()
+    {
+        var path = CreateRcmPath(DefinitionPaths.LogProbe, "probe-id");
+
+        ProbeConfigurationUtils.IsProbeId(path, "probe-id").Should().BeTrue();
+        ProbeConfigurationUtils.IsProbeId(path, "probe").Should().BeFalse();
+        ProbeConfigurationUtils.IsProbeId(path, "probe-id-extra").Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetProbeIds_ReturnsAllProbeIdsInConfigurationOrder()
+    {
+        var configuration = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("log-id")],
+            MetricProbes = [CreateMetricProbe("metric-id")],
+            SpanProbes = [CreateSpanProbe("span-id")],
+            SpanDecorationProbes = [CreateSpanDecorationProbe("span-decoration-id")]
+        };
+
+        ProbeConfigurationUtils.GetProbeIds(configuration).Should().Equal("log-id", "metric-id", "span-id", "span-decoration-id");
+    }
+
+    [Fact]
+    public void Merge_WhenLowerPriorityIsNull_ReturnsHigherPriorityProbes()
+    {
+        var higherPriorityLogProbes = new[] { CreateLogProbe("rcm-probe") };
+        var higherPriority = new ProbeConfiguration
+        {
+            LogProbes = higherPriorityLogProbes
+        };
+
+        var merged = ProbeConfigurationUtils.Merge(null, higherPriority);
+
+        merged.LogProbes.Should().BeSameAs(higherPriorityLogProbes);
+    }
+
+    [Fact]
+    public void Merge_WhenHigherPriorityHasNoProbes_ReturnsLowerPriorityProbes()
+    {
+        var lowerPriorityLogProbes = new[] { CreateLogProbe("file-probe") };
+        var lowerPriority = new ProbeConfiguration
+        {
+            LogProbes = lowerPriorityLogProbes
+        };
+
+        var merged = ProbeConfigurationUtils.Merge(lowerPriority, new ProbeConfiguration());
+
+        merged.LogProbes.Should().BeSameAs(lowerPriorityLogProbes);
+    }
+
+    [Fact]
+    public void Merge_FileAndRcm_ReturnsUnionOfProbeIds()
+    {
+        var fileProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("file-probe-1")]
+        };
+
+        var rcmProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("rcm-probe-1")]
+        };
+
+        var merged = ProbeConfigurationUtils.Merge(fileProbes, rcmProbes);
+
+        merged.LogProbes.Select(p => p.Id).Should().BeEquivalentTo("file-probe-1", "rcm-probe-1");
+    }
+
+    [Fact]
+    public void Merge_DuplicateIds_HigherPriorityWins()
+    {
+        var fileProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("shared-id", "From file", sourceFile: "file.cs")]
+        };
+
+        var rcmProbes = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("shared-id", "From RCM", sourceFile: "rcm.cs")]
+        };
+
+        var merged = ProbeConfigurationUtils.Merge(fileProbes, rcmProbes);
+
+        merged.LogProbes.Should().ContainSingle();
+        merged.LogProbes[0].Template.Should().Be("From RCM");
+        merged.LogProbes[0].Where.SourceFile.Should().Be("rcm.cs");
+    }
+
+    [Fact]
+    public void RemoveItems_WhenNothingIsRemoved_ReturnsSameConfiguration()
+    {
+        var configuration = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("log-id")]
+        };
+
+        ProbeConfigurationUtils.RemoveItems(configuration, [], removeServiceConfiguration: false).Should().BeSameAs(configuration);
+    }
+
+    [Fact]
+    public void RemoveItems_WhenRemovedIdsDoNotMatch_ReusesProbeArrays()
+    {
+        var logProbes = new[] { CreateLogProbe("log-id") };
+        var configuration = new ProbeConfiguration
+        {
+            LogProbes = logProbes
+        };
+
+        var result = ProbeConfigurationUtils.RemoveItems(configuration, ["other-id"], removeServiceConfiguration: false);
+
+        result.Should().NotBeSameAs(configuration);
+        result.LogProbes.Should().BeSameAs(logProbes);
+    }
+
+    [Fact]
+    public void RemoveItems_RemovesMatchingProbeIdsAcrossProbeTypes()
+    {
+        var configuration = new ProbeConfiguration
+        {
+            LogProbes = [CreateLogProbe("remove-id"), CreateLogProbe("keep-log")],
+            MetricProbes = [CreateMetricProbe("remove-id"), CreateMetricProbe("keep-metric")],
+            SpanProbes = [CreateSpanProbe("remove-id"), CreateSpanProbe("keep-span")],
+            SpanDecorationProbes = [CreateSpanDecorationProbe("remove-id"), CreateSpanDecorationProbe("keep-span-decoration")]
+        };
+
+        var result = ProbeConfigurationUtils.RemoveItems(configuration, ["remove-id"], removeServiceConfiguration: false);
+
+        result.LogProbes.Select(p => p.Id).Should().Equal("keep-log");
+        result.MetricProbes.Select(p => p.Id).Should().Equal("keep-metric");
+        result.SpanProbes.Select(p => p.Id).Should().Equal("keep-span");
+        result.SpanDecorationProbes.Select(p => p.Id).Should().Equal("keep-span-decoration");
+    }
+
+    [Fact]
+    public void RemoveItems_CanRemoveServiceConfigurationWithoutChangingProbes()
+    {
+        var logProbes = new[] { CreateLogProbe("log-id") };
+        var serviceConfiguration = new ServiceConfiguration();
+        var configuration = new ProbeConfiguration
+        {
+            ServiceConfiguration = serviceConfiguration,
+            LogProbes = logProbes
+        };
+
+        var result = ProbeConfigurationUtils.RemoveItems(configuration, [], removeServiceConfiguration: true);
+
+        result.ServiceConfiguration.Should().BeNull();
+        result.LogProbes.Should().BeSameAs(logProbes);
+    }
+
+    private static LogProbe CreateLogProbe(string id, string? template = null, string sourceFile = "file.cs")
+    {
+        return new LogProbe
+        {
+            Id = id,
+            Language = "dotnet",
+            Template = template ?? id,
+            Where = new Where { SourceFile = sourceFile, Lines = ["10"] },
+        };
+    }
+
+    private static MetricProbe CreateMetricProbe(string id)
+    {
+        return new MetricProbe
+        {
+            Id = id,
+            Language = "dotnet",
+            MetricName = id,
+            Where = new Where { TypeName = "MyClass", MethodName = "MyMethod" },
+        };
+    }
+
+    private static SpanProbe CreateSpanProbe(string id)
+    {
+        return new SpanProbe
+        {
+            Id = id,
+            Language = "dotnet",
+            Where = new Where { TypeName = "MyClass", MethodName = "MyMethod" },
+        };
+    }
+
+    private static SpanDecorationProbe CreateSpanDecorationProbe(string id)
+    {
+        return new SpanDecorationProbe
+        {
+            Id = id,
+            Language = "dotnet",
+            Where = new Where { TypeName = "MyClass", MethodName = "MyMethod" },
+            Decorations = [],
+        };
+    }
+
+    private static RemoteConfigurationPath CreateRcmPath(string probePrefix, string probeId)
+    {
+        return RemoteConfigurationPath.FromPath($"employee/{RcmProducts.LiveDebugging}/{probePrefix}{probeId}/config");
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -516,6 +516,7 @@
   "DD_DYNAMIC_INSTRUMENTATION_UPLOAD_BATCH_SIZE": "dynamic_instrumentation_upload_batch_size",
   "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_INTERVAL": "dynamic_instrumentation_diagnostics_interval",
   "DD_DYNAMIC_INSTRUMENTATION_UPLOAD_FLUSH_INTERVAL": "dynamic_instrumentation_upload_interval",
+  "DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE": "dynamic_instrumentation_probe_file",
   "DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS": "dynamic_instrumentation_redacted_identifiers",
   "DD_DYNAMIC_INSTRUMENTATION_REDACTION_EXCLUDED_IDENTIFIERS": "dynamic_instrumentation_redaction_excluded_identifiers",
   "DD_DYNAMIC_INSTRUMENTATION_REDACTED_EXCLUDED_IDENTIFIERS": "dynamic_instrumentation_redacted_excluded_identifiers",


### PR DESCRIPTION
## Summary of changes
Added support to load log/metric/span/span‑decoration probes from a JSON file (DebuggerSettings.ProbeFile)

## Reason for change
Dynamic Instrumentation only worked with RCM‑delivered probes. There was no support for loading probes from a local file, and the internal configuration state wasn’t designed for combining file and RCM probes or handling file‑only 

## Implementation details

- Added support to load log/metric/span/span‑decoration probes from a JSON file (DebuggerSettings.ProbeFile) during DynamicInstrumentation initialization.
- Ensured Dynamic Instrumentation can operate in three modes: RCM‑only, file‑only, and combined file+RCM.
- Implemented source‑level merge (MergeProbes) where RCM wins on ID conflicts with file probes, and configuration‑level union (MergeConfigurations).
- Updated initialization to start background processing and status/snapshot upload when either RCM is available or file probes exist.

## Test coverage
Updated DynamicInstrumentationTests to cover file probe loading (multiple probe types, invalid/missing/empty files, no file configured, partially valid file entries, and duplicate IDs within a file) and merge semantics between file and RCM probes.
