### PR TITLE
Add standard output and error when a test fails and does not display it

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -235,9 +235,16 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 throw new XunitException("An error occured during the test. See the error output above.");
             }
 
-            Assert.True(
-                0 == process.ExitCode,
-                $"Exit code of \"{Path.GetFileName(process.StartInfo?.FileName ?? string.Empty)}\" should be 0 instead of {process.ExitCode} (= 0x{process.ExitCode.ToString("X")})");
+            if (process.ExitCode != 0)
+            {
+                _output.WriteLine($"[TestRunner] Process exited with code {process.ExitCode} (0x{process.ExitCode:X})");
+                _output.WriteLine($"[TestRunner] Standard output:\n{standardOutput}");
+                _output.WriteLine($"[TestRunner] Error output:\n{errorOutput}");
+
+                Assert.True(
+                    false,
+                    $"Exit code of \"{Path.GetFileName(process.StartInfo?.FileName ?? string.Empty)}\" should be 0 instead of {process.ExitCode} (= 0x{process.ExitCode:X})");
+            }
         }
 
         private void SetEnvironmentVariables(StringDictionary environmentVariables, MockDatadogAgent agent)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
@@ -68,7 +68,7 @@ internal static class DebuggerTestHelper
         var listenUrl = $"{localHost}:{listenPort}/";
 
         var process = await helper.StartSample(agent, $"--test-name {testName} --listen-url {listenUrl}", string.Empty, aspNetCorePort: 5000);
-        var processHelper = new DebuggerSampleProcessHelper(listenUrl, process);
+        var processHelper = new DebuggerSampleProcessHelper(listenUrl, process, helper.GetOutput());
 
         return processHelper;
     }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -71,6 +71,8 @@ namespace Datadog.Trace.TestHelpers
 
         protected ITestOutputHelper Output { get; }
 
+        public ITestOutputHelper GetOutput() => Output;
+
         public virtual void Dispose()
         {
         }


### PR DESCRIPTION
## Summary of changes

We get [some CI errors ](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=191248&view=logs&j=5635f724-ec42-5e82-7816-fb263b6cfcc0&t=e80b9b00-921f-539a-741c-f91926c040ef)in tests caused by a non 0 exit code from a sample but we get no output from the sample itself.

This PR improves error reporting when tests fail due to non-zero exit codes by ensuring that process stdout and stderr are logged to the test output before assertions fail. This makes debugging CI failures significantly easier, especially for signal-related crashes (SIGABRT, SIGSEGV, etc.).

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
