### PR TITLE
Fail the gitlab job if we fail to upload the artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,11 @@ build:
     - artifacts-out
 
 publish:
+  only:
+    - master
+    - main
+    - /^hotfix.*$/
+    - /^release.*$/
   except:
     variables:
       - $DEPLOY_TO_REL_ENV == "true"


### PR DESCRIPTION
## Summary of changes

Fails the gitlab `publish` job if we fail to upload

## Reason for change

We have been silently failing, and it's blocking the release

## Implementation details

`exit 1` if we fail to upload

## Test coverage

This is the test. ~We're still broken, so this should fail.~


https://datadoghq.atlassian.net/browse/APMLP-722