### PR TITLE
[AAP] Rugerize waf encoder disposal

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -487,7 +487,7 @@ namespace Datadog.Trace.AppSec
         public void Dispose()
         {
             _waf?.Dispose();
-            Encoder.Pool.Dispose();
+            Encoder.Dispose();
             _activeAddressesLocker.Dispose();
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -47,6 +47,22 @@ namespace Datadog.Trace.AppSec.WafEncoding
             }
         }
 
+        internal static void Dispose()
+        {
+            try
+            {
+                if (_pool is { IsDisposed: false })
+                {
+                    _pool.Dispose();
+                    _pool = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "WafEncoder Crashed on shutdown.");
+            }
+        }
+
         /// <summary>
         /// For testing purposes
         /// </summary>


### PR DESCRIPTION
## Summary of changes
Added error handling to Waf Encoder dispose and omitted a call to GetPool on disposal

## Reason for change
A [crash](https://app.datadoghq.com/error-tracking?query=source%3Adotnet%20service%3Ainstrumentation-telemetry-data%20%40tags.crash_datadog%3Atrue%20%40library_version.major%3A3%20-%40tags.crash_profiler%3Atrue%20-%40tags.crash_appsec%3Atrue%20-%40tags.crash_runtime_metrics%3Atrue%20%40library_version.minor%3A%3E%3D31&link_source=monitor_notif&monitor_id=236533719&monitor_sub_type=.new%28%29&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%2220f1908a-bfa8-11f0-9ff3-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1763996319000&to_ts=1764082719000&live=false) happened here on shutdown

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
