### PR TITLE
[Azure Functions] Fix Azure Functions NuGet script for Linux and macOS

### DIFF
--- a/tracer/tools/Build-AzureFunctionsNuget.ps1
+++ b/tracer/tools/Build-AzureFunctionsNuget.ps1
@@ -42,14 +42,22 @@ param(
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
+# Detect OS and determine build script
+if ($PSVersionTable.PSVersion.Major -ge 6) {
+    $buildScript = if ($IsWindows) { 'build.ps1' } else { 'build.sh' }
+} else {
+    # PowerShell 5.x is Windows-only
+    $buildScript = 'build.ps1'
+}
+
 # Resolve paths relative to script location
 $scriptDir = Split-Path -Parent $PSCommandPath
 $tracerDir = Split-Path -Parent $scriptDir
 Write-Verbose "Tracer directory: $tracerDir"
 
 # Clean up previous builds
-Write-Verbose "Cleaning up previous builds from: $tracerDir\bin\artifacts\nuget\azure-functions\"
-Remove-Item -Path "$tracerDir\bin\artifacts\nuget\azure-functions\*" -Force -ErrorAction SilentlyContinue
+Write-Verbose "Cleaning up previous builds from: $tracerDir/bin/artifacts/nuget/azure-functions/"
+Remove-Item -Path "$tracerDir/bin/artifacts/nuget/azure-functions/*" -Force -ErrorAction SilentlyContinue
 
 # Remove package Datadog.AzureFunctions from NuGet cache
 Write-Verbose "Removing $packageId from NuGet cache..."
@@ -82,7 +90,7 @@ else
 if ($BuildId)
 {
     Write-Verbose "Downloading Datadog.Trace.Bundle from build: $BuildId"
-    & "$tracerDir\build.ps1" DownloadBundleNugetFromBuild --build-id $BuildId
+    & "$tracerDir/$buildScript" DownloadBundleNugetFromBuild --build-id $BuildId
 }
 else
 {
@@ -91,20 +99,20 @@ else
 
 # Build Datadog.Trace and publish to bundle folder, replacing the files from the NuGet package
 Write-Verbose "Publishing Datadog.Trace (net6.0) to bundle folder..."
-dotnet publish "$tracerDir\src\Datadog.Trace" -c Release -o "$tracerDir\src\Datadog.Trace.Bundle\home\net6.0" -f 'net6.0'
+dotnet publish "$tracerDir/src/Datadog.Trace" -c Release -o "$tracerDir/src/Datadog.Trace.Bundle/home/net6.0" -f 'net6.0'
 
 Write-Verbose "Publishing Datadog.Trace (net461) to bundle folder..."
-dotnet publish "$tracerDir\src\Datadog.Trace" -c Release -o "$tracerDir\src\Datadog.Trace.Bundle\home\net461" -f 'net461'
+dotnet publish "$tracerDir/src/Datadog.Trace" -c Release -o "$tracerDir/src/Datadog.Trace.Bundle/home/net461" -f 'net461'
 
 # Build Azure Functions NuGet package
 Write-Verbose "Building Datadog.AzureFunctions NuGet package..."
-& "$tracerDir\build.ps1" BuildAzureFunctionsNuget
+& "$tracerDir/$buildScript" BuildAzureFunctionsNuget
 
 # Copy package to destination if specified
 if ($CopyTo)
 {
     Write-Verbose "Copying package to: $CopyTo"
-    Copy-Item "$tracerDir\bin\artifacts\nuget\azure-functions\Datadog.AzureFunctions.*.nupkg" $CopyTo -Force
+    Copy-Item "$tracerDir/bin/artifacts/nuget/azure-functions/Datadog.AzureFunctions.*.nupkg" $CopyTo -Force
 }
 
 Write-Verbose "Build complete!"


### PR DESCRIPTION
## Summary of changes

Fixed the `Build-AzureFunctionsNuget.ps1` script to work on Linux and macOS in addition to Windows.

## Reason for change

The script only worked on only Windows.

## Implementation details

- Added OS detection logic to select the appropriate Nuke build script (`build.ps1` for Windows, `build.sh` for Linux/macOS)
- Changed all hardcoded backslash paths to forward slashes which work in all platforms
- Updated paths in verbose output messages for consistency

## Test coverage

Tested manually on Windows and Linux. This script is only used to build local dev versions of the nuget package, not production code.

## Other details

n/a