### PR TITLE
Add benchmark for two scopes

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -93,5 +93,17 @@ namespace Benchmarks.Trace
                 scope.Span.SetTraceSamplingPriority(SamplingPriority.UserReject);
             }
         }
+
+        /// <summary>
+        /// Starts and finishes two scopes in the same trace benchmark
+        /// </summary>
+        [Benchmark]
+        public void StartFinishTwoScopes()
+        {
+            using var scope1 = _tracer.StartActiveInternal("operation1");
+            scope1.Span.SetTraceSamplingPriority(SamplingPriority.UserReject);
+
+            using var scope2 = _tracer.StartActiveInternal("operation2");
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Adds a new micro benchmark

## Reason for change

We have a benchmark for creating a span, and a scope, but I'm working on some perf improvements, and I want to be able to see the improvements specifically when there are two scopes in a trace.

## Implementation details

Add a new simple benchmark

## Test coverage

Not really, this is so that there's something to compare against in my update!

