### PR TITLE
Fix download artifacts link in logs. Improve logging.

### DIFF
--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -98,7 +98,7 @@ if [ -z "${downloadUrl}" ]; then
   exit 1
 fi
 
-echo "Downloading artifacts from '$downloadUrl'..."
+echo "Downloading artifacts from ${downloadUrl}"
 curl -o $target_dir/artifacts.zip "$downloadUrl"
 unzip $target_dir/artifacts.zip -d $target_dir
 mv $target_dir/$artifactName/* $target_dir


### PR DESCRIPTION
## Summary of changes

In jobs dd-gitlab/download-serverless-artifacts and dd-gitlab/download-single-step-artifacts
, when Azure DevOps artifacts couldn't be found, the log output wrapped the artifacts URL in single quotes for display:
`  echo "Checking for artifacts at '$artifactsUrl'..." `

When users clicked or copied the URL from logs to debug issues, they inadvertently included the trailing ' character, which became %27 in the URL. This caused the Azure DevOps API to search for an artifact named ssi-artifacts' instead of ssi-artifacts, resulting in a 404 error.

Changes made in download-single-step-artifacts.sh and download-serverless-artifacts.sh:

  - Removed quotes around ${artifactsUrl} in echo statement
  - Added proper quoting to curl command for safety
  - Added status reporting during polling to show elapsed time and API error messages
  - Enhanced error output to display full API response and direct build link when timeout occurs

After the changes: 

<img width="2488" height="476" alt="image" src="https://github.com/user-attachments/assets/2ca12529-230e-446f-a7ad-22e80c34d6b2" />

## Reason for change

The urls and links shown in the logs were not correct. Added more log info to debug failures.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
