### PR TITLE
Nit: cache is ready state for profiler in ProfilerStatus

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ContinuousProfiler
         private readonly object _lockObj;
         private bool _isInitialized;
         private IntPtr _engineStatusPtr;
-        private bool? _isProfilerReadyCache;
+        private bool _isProfilerReadyCache;
 
         public ProfilerStatus(ProfilerSettings settings)
         {
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ContinuousProfiler
                 }
 
                 // once _isProfilerReadyCache is true, it's never false anymore
-                if (_isProfilerReadyCache.HasValue && _isProfilerReadyCache.Value)
+                if (_isProfilerReadyCache)
                 {
                     return true;
                 }


### PR DESCRIPTION
## Summary of changes

We don't need to read and marshall a byte every time

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
