### PR TITLE
Increase retries in Stack Exchange Submit traces test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsStackExchangeRedis(metadataSchemaVersion);
 
-        [Flaky("The PING_REPLICA sometimes invokes the master server instead. We believe it's infrastructure related")]
+        [Flaky("The PING_REPLICA sometimes invokes the master server instead. We believe it's infrastructure related", maxRetries: 3)]
         [SkippableTheory]
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]


### PR DESCRIPTION
## Summary of changes

Stack Exchange Submit traces test is still flaky with one retry with the same infraestructure error (pinging the host stackexchangeredis instead of the replica one)

Since this is not a tracer error, increasing the retries would be advisable.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
