### PR TITLE
Stop testing .NET 8 on PRs

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -188,14 +188,14 @@ partial class Build
     {
         // we only support linux-arm64 on .NET 5+, so we run a different subset of the TFMs for ARM64
         (PlatformFamily.Linux, true, true) => new[] { TargetFramework.NET5_0, TargetFramework.NET6_0, TargetFramework.NET7_0, TargetFramework.NET8_0, TargetFramework.NET9_0, TargetFramework.NET10_0, },
-        (PlatformFamily.Linux, true, false) => new[] { TargetFramework.NET5_0, TargetFramework.NET6_0, TargetFramework.NET8_0, TargetFramework.NET9_0, TargetFramework.NET10_0, },
+        (PlatformFamily.Linux, true, false) => new[] { TargetFramework.NET5_0, TargetFramework.NET6_0, TargetFramework.NET9_0, TargetFramework.NET10_0, },
         // Don't test 2.1 for now, as the build is broken on master. If/when that's resolved, re-enable
         (PlatformFamily.Windows, _, true) => new[] { TargetFramework.NET48, TargetFramework.NETCOREAPP3_0, TargetFramework.NETCOREAPP3_1, TargetFramework.NET5_0, TargetFramework.NET6_0, TargetFramework.NET7_0, TargetFramework.NET8_0, TargetFramework.NET9_0, TargetFramework.NET10_0, },
-        (PlatformFamily.Windows, _, false) => new[] { TargetFramework.NET48, TargetFramework.NETCOREAPP3_1, TargetFramework.NET8_0, TargetFramework.NET9_0, TargetFramework.NET10_0, },
+        (PlatformFamily.Windows, _, false) => new[] { TargetFramework.NET48, TargetFramework.NETCOREAPP3_1, TargetFramework.NET9_0, TargetFramework.NET10_0, },
         // Everything else e.g. MaxOS, linux-x64 etc
         // Same as Windows just without the .NET FX
         (_, _, true) => new[] { TargetFramework.NETCOREAPP3_0, TargetFramework.NETCOREAPP3_1, TargetFramework.NET5_0, TargetFramework.NET6_0, TargetFramework.NET7_0, TargetFramework.NET8_0, TargetFramework.NET9_0, TargetFramework.NET10_0, },
-        (_, _, false) => new[] { TargetFramework.NETCOREAPP3_1, TargetFramework.NET8_0, TargetFramework.NET9_0, TargetFramework.NET10_0, },
+        (_, _, false) => new[] { TargetFramework.NETCOREAPP3_1, TargetFramework.NET9_0, TargetFramework.NET10_0, },
     };
 
     string ReleaseBranchForCurrentVersion() => new Version(Version).Major switch


### PR DESCRIPTION
## Summary of changes

Removes .NET 8 from the standard test matrix for PRs

## Reason for change

We recently added .NET 10 to the standard test matrix for PRs. As running more tests means more chance of flake, we agreed that removing .NET 8 to bring us back to the same level of testing makes sense. 

- We chose to remove .NET 8 vs .NET 9, as there are CLR fixes in .NET 9 that aren't in .NET 8
- Both .NET 8 and .NET 9 have the same amount of official support remaining
- Both .NET 8 and .NET 9 hit the same code paths in our code (which is all .NET 6+)

Also, to be clear, we still run the full suite of TFMs (.NET Core 3.0+) on `master`. We also run the full suite of TFMs on PRs if there are "risky" modifications (modifications to integrations), or if the `run_all_test_frameworks` variable is set.

## Implementation details

Removed .NET 8 from the "on PRs" frameworks

## Test coverage

Technically the _same_ coverage, but a bit less comprehensive on PRs
