### PR TITLE
Fix (and extend) `AgentWriter` benchmark

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -72,7 +72,6 @@ namespace Benchmarks.Trace
         /// Write realistic traces, but don't flush, to isolate overhead from serialization only
         /// </summary>
         [Benchmark]
-        [BenchmarkCategory(Constants.TracerCategory, Constants.RunOnPrs, Constants.RunOnMaster)]
         public Task WriteEnrichedTraces()
         {
             _agentWriterNoOpFlush.WriteTrace(_enrichedSpans);


### PR DESCRIPTION
## Summary of changes

- Fix `null` reference exception in `AgentWriter` benchmark (introduced in #7724)
- Add a (local only) benchmark that tests serialization without flushing
- use a custom tag object in the benchmarks

## Reason for change

The `AgentWriter` benchmark has been broken since #7724 was merged, as it's passing a null ref to a non-null field. This fixes that issue.

Also, this adds a benchmark (which _doesn't_ run in CI currently) which tests the serialization of spans _without_ flushing, so we can distinguish the source of allocation more easily.

Finally, I made some changes to the spans used in the existing `AgentWriter` benchmark. This is due to discrepancies I noticed in the results from the benchmark vs other testing.

## Implementation details

- Pass a `StatsdManager` into the `AgentWriter` instead of `null`
- Create a "noop" `Api` which doesn't do anything, and use that in a different `AgentWriter` instance, this effectively isolates the overhead in the benchmark to being the serialization _only_, instead of including "flush" related overhead (which _is_ included in the existing benchmark). To avoid bloating our benchmarking runs, don't bother to run this one in CI (it's just useful for inestigation).
- Pass a `SqlTags` object into the spans, with a couple of fields set.
- Set a tag _other_ than `env` on the spans. `env` is a "special" trace-level tag, so it doesn't _really_ do what you think it does here and IMO is less revealing.

## Test coverage

Tested locally - running the benchmarks _without_ the sql tags change:

|                      Method |              Runtime |     Mean |   Error |   StdDev |   Median | Ratio | RatioSD | Allocated | Alloc Ratio |
|---------------------------- |--------------------- |---------:|--------:|---------:|---------:|------:|--------:|----------:|------------:|
|         WriteEnrichedTraces |             .NET 6.0 | 391.0 us | 7.54 us |  9.54 us | 389.2 us |  0.79 |    0.02 |     105 B |        0.50 |
|         WriteEnrichedTraces | .NET Framework 4.7.2 | 499.2 us | 3.95 us |  3.69 us | 499.0 us |  1.00 |    0.00 |     208 B |        1.00 |
|                             |                      |          |         |          |          |       |         |           |             |
| WriteAndFlushEnrichedTraces |             .NET 6.0 | 391.9 us | 8.65 us | 24.82 us | 384.9 us |  0.81 |    0.05 |    2697 B |        0.81 |
| WriteAndFlushEnrichedTraces | .NET Framework 4.7.2 | 511.3 us | 5.30 us |  4.43 us | 511.0 us |  1.00 |    0.00 |    3312 B |        1.00 |

I then made the `SqlTags` change, and ran again:

|                      Method |              Runtime |     Mean |    Error |   StdDev | Ratio | RatioSD |    Gen0 | Allocated | Alloc Ratio |
|---------------------------- |--------------------- |---------:|---------:|---------:|------:|--------:|--------:|----------:|------------:|
|         WriteEnrichedTraces |             .NET 6.0 | 488.9 us |  7.55 us | 11.29 us |  0.70 |    0.02 |       - |     110 B |       0.001 |
|         WriteEnrichedTraces | .NET Framework 4.7.2 | 703.3 us |  5.56 us |  4.93 us |  1.00 |    0.00 | 17.5781 |  112537 B |       1.000 |
|                             |                      |          |          |          |       |         |         |           |             |
| WriteAndFlushEnrichedTraces |             .NET 6.0 | 481.2 us |  9.39 us | 10.43 us |  0.64 |    0.02 |       - |    2701 B |        0.02 |
| WriteAndFlushEnrichedTraces | .NET Framework 4.7.2 | 725.2 us | 14.49 us | 27.21 us |  1.00 |    0.00 | 17.5781 |  115641 B |        1.00 |

Yikes, we have some rogue allocation there on .NET FX!

## Other details

