### PR TITLE
[Test Optimization] Add `branch` parameter to test management API request

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.GetTestManagementTests.cs
+++ b/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.GetTestManagementTests.cs
@@ -31,12 +31,13 @@ internal sealed partial class TestOptimizationClient
 
         var commitSha = _testOptimization.CIValues.HeadCommit ?? _commitSha;
         var commitMessage = _testOptimization.CIValues.HeadMessage ?? _testOptimization.CIValues.Message ?? string.Empty;
+        var branch = _testOptimization.CIValues.Branch;
         _testManagementUrl ??= GetUriFromPath(TestManagementUrlPath);
         var query = new DataEnvelope<Data<TestManagementQuery>>(
             new Data<TestManagementQuery>(
                 commitSha,
                 TestManagementType,
-                new TestManagementQuery(_repositoryUrl, commitSha, null, commitMessage)),
+                new TestManagementQuery(_repositoryUrl, commitSha, null, commitMessage, branch)),
             null);
 
         var jsonQuery = JsonConvert.SerializeObject(query, SerializerSettings);
@@ -126,12 +127,16 @@ internal sealed partial class TestOptimizationClient
         [JsonProperty("commit_message")]
         public readonly string CommitMessage;
 
-        public TestManagementQuery(string repositoryUrl, string commitSha, string? module, string commitMessage)
+        [JsonProperty("branch")]
+        public readonly string? Branch;
+
+        public TestManagementQuery(string repositoryUrl, string commitSha, string? module, string commitMessage, string? branch)
         {
             RepositoryUrl = repositoryUrl;
             CommitSha = commitSha;
             Module = module;
             CommitMessage = commitMessage;
+            Branch = branch;
         }
     }
 


### PR DESCRIPTION
## Summary of changes

Include `branch` in the request payload to `/api/v2/test/libraries/test-management/tests`, sourced from `CIEnvironmentValues.Branch`.

## Reason for change

Needed for new flaky PR gates

## Implementation details

## Test coverage
Today's tests should suffice

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
