### PR TITLE
Fix W3c null reference exception

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -696,6 +696,14 @@ namespace Datadog.Trace.Propagators
 
             using var enumerator = values.GetEnumerator();
 
+            if (enumerator is null)
+            {
+                // GetEnumerator() returned null, which violates the IEnumerable contract
+                // but we handle it gracefully
+                value = string.Empty;
+                return false;
+            }
+
             if (!enumerator.MoveNext())
             {
                 // there were no items

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -1119,6 +1119,15 @@ namespace Datadog.Trace.Tests.Propagators
         }
 
         [Fact]
+        public void TryGetSingleRare_ShouldReturnFalse_ForNullEnumerator()
+        {
+            // Test case for IEnumerable that returns null from GetEnumerator()
+            var badEnumerable = new BadEnumerable();
+            W3CTraceContextPropagator.TryGetSingleRare(badEnumerable, out var value).Should().BeFalse();
+            value.Should().Be(string.Empty);
+        }
+
+        [Fact]
         public void TryGetSingle_ShouldReturnFalse_ForEmptyValeus()
         {
             W3CTraceContextPropagator.TryGetSingle(Array.Empty<string>(), out _).Should().BeFalse();
@@ -1163,6 +1172,13 @@ namespace Datadog.Trace.Tests.Propagators
             {
                 result.SpanContext.Should().BeNull();
             }
+        }
+
+        private class BadEnumerable : IEnumerable<string>
+        {
+            public IEnumerator<string> GetEnumerator() => null;
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Fixed a [NullReferenceException in W3CTraceContextPropagator.TryGetSingleRare](https://app.datadoghq.com/error-tracking?query=service%3Ainstrumentation-telemetry-data%20%40lib_language%3Adotnet&et-side=activity&et-viz=events&fromUser=false&order=total_count&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22ec0e79e6-3ae6-11f0-9153-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1764066866319&to_ts=1764671666319&live=true) that occurred when extracting trace
  context from carriers with custom IEnumerable implementations that violate the interface contract by returning
  null from GetEnumerator().

## Reason for change

There are around 26k exceptions thrown in the last week.

The stack shows:
   
```
System.NullReferenceException
at Datadog.Trace.Propagators.W3CTraceContextPropagator.TryGetSingleRare(IEnumerable`1 values, String& value)
at Datadog.Trace.Propagators.W3CTraceContextPropagator.TryExtract[TCarrier,TCarrierGetter](TCarrier carrier, TCarrierGetter carrierGetter, PropagationContext& context)   
at Datadog.Trace.Propagators.SpanContextPropagator.Extract[TCarrier,TCarrierGetter](TCarrier carrier, TCarrierGetter carrierGetter)   
at Datadog.Trace.SpanContextExtractor.ExtractInternal[TCarrier](TCarrier carrier, Func`3 getter, String messageType, String source)   
at Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Propagators.SpanContextExtractorExtractIntegration.OnMethodBegin[TTarget,TCarrier,TAction](TTarget instance, TCarrier& carrier, TAction& getter)
```

## Implementation details

- Added a null check for the enumerator in W3CTraceContextPropagator.TryGetSingleRare (line 699-705)
- Added a test case TryGetSingleRare_ShouldReturnFalse_ForNullEnumerator to verify graceful handling of this edge
  case

The error occurred when manual instrumentation's SpanContextExtractor.Extract was called with a custom carrier
 getter that returned an IEnumerable<string?> with a broken GetEnumerator() implementation. While this violates the
   IEnumerable contract, the tracer should handle such cases gracefully.

This defensive programming approach prevents the tracer from throwing exceptions due to customer code errors,
  improving resilience.

## Test coverage

  - Added unit test with a BadEnumerable class that returns null from GetEnumerator()
  - Verified the method returns false and outputs an empty string when encountering a null enumerator
  - Existing tests continue to pass, ensuring no regression

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
