### PR TITLE
Try to fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,10 @@ updates:
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace"
+    # These cause dependabot to blow up for some unknown reason
+    exclude-paths:
+      - "../Datadog.Trace.Tools.Analyzers/**"
+      - "../Datadog.Trace.Tools.Analyzers.CodeFixes/**"
     registries: "*"
     schedule:
       interval: "daily"
@@ -82,6 +86,10 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.OpenTracing"
+    # These cause dependabot to blow up for some unknown reason
+    exclude-paths:
+      - "../Datadog.Trace.Tools.Analyzers/**"
+      - "../Datadog.Trace.Tools.Analyzers.CodeFixes/**"
     registries: "*"
     schedule:
       interval: "daily"
@@ -105,6 +113,10 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
+    # These cause dependabot to blow up for some unknown reason
+    exclude-paths:
+      - "../Datadog.Trace.Tools.Analyzers/**"
+      - "../Datadog.Trace.Tools.Analyzers.CodeFixes/**"
     registries: "*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary of changes

Try to exclude the analyzer projects from dependabot, seeing as it causes it to blow up

## Reason for change

Dependabot has been broken for a while

## Implementation details

Try to exclude the projects. I have little faith this will work, but also no way of testing it.

## Test coverage

Nope

