### PR TITLE
Add missing assembly for <.NET Core 3.1

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netstandard2.0.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netstandard2.0.verified.txt
@@ -10,3 +10,4 @@ System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKey
 System.Reflection.Emit, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Emit.ILGeneration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Emit.Lightweight, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+System.Runtime.CompilerServices.Unsafe, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a


### PR DESCRIPTION
## Summary of changes

Add additional assembly to public API for unsafe to .NET Standard 2.0

## Reason for change

#7874 reduced the allocation in `TraceContext` and used `unsafe` code. Apparently this is a new assembly reference for < .NET Core 3.1, and because we don't run tests on .NET Core 2.1 (ever) or .NET Core 3.0 tests (on PRs), we missed it.

## Implementation details

Added the assembly reference, and confirmed it passes for both .NET Core 2.1 and 3.0 now.

## Test coverage

Covered by existing

## Other details

Raises the question of whether we _should_ be testing one of those on PRs again, given there's whole code paths that go untouched otherwise 😅 