### PR TITLE
Revert BenchmarkDotNet version

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.OpenTelemetry.Api/Benchmarks.OpenTelemetry.Api.csproj
+++ b/tracer/test/benchmarks/Benchmarks.OpenTelemetry.Api/Benchmarks.OpenTelemetry.Api.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="OpenTelemetry" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
   </ItemGroup>

--- a/tracer/test/benchmarks/Benchmarks.OpenTelemetry.InstrumentedApi/Benchmarks.OpenTelemetry.InstrumentedApi.csproj
+++ b/tracer/test/benchmarks/Benchmarks.OpenTelemetry.InstrumentedApi/Benchmarks.OpenTelemetry.InstrumentedApi.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
   </ItemGroup>
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.5.14" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="NLog" Version="5.2.0" />


### PR DESCRIPTION
## Summary of changes

Revert the version of BenchmarkDotNet we use

## Reason for change

We updated it in #7865, but we stopped getting data exported to Datadog. Reverting temporarily while we investigate

## Implementation details

Revert the version

## Test coverage

This is the test
