### PR TITLE
Only pull docker images if we need to

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6401,8 +6401,14 @@ stages:
             targetShaId: $(targetShaId)
             targetBranch: $(targetBranch)
 
-        - script: docker pull $(runtimeImage)
-          displayName: Pull dockerfile
+        - script: |
+            if docker image inspect "$(runtimeImage)" > /dev/null 2>&1; then
+              echo "Image already exists locally, skipping pull"
+            else
+              echo "Image not found — pulling"
+              docker pull "$(runtimeImage)"
+            fi
+          displayName: Pull missing images
           retryCountOnTaskFailure: 3
 
         - script: |
@@ -6455,8 +6461,14 @@ stages:
             targetShaId: $(targetShaId)
             targetBranch: $(targetBranch)
 
-        - script: docker pull $(runtimeImage)
-          displayName: Pull dockerfile
+        - script: |
+            if docker image inspect "$(runtimeImage)" > /dev/null 2>&1; then
+              echo "Image already exists locally, skipping pull"
+            else
+              echo "Image not found — pulling"
+              docker pull "$(runtimeImage)"
+            fi
+          displayName: Pull missing images
           retryCountOnTaskFailure: 3
 
         - script: |


### PR DESCRIPTION
## Summary of changes

Only pulls docker images if we need to

## Reason for change

Docker hub appears to be throwing `500` errors, and even though the images are pre-pulled, we're calling `docker pull` which then fails. Instead, we can only pull if we _need_ to, as we only pre-pull unchanging images anyway.

## Implementation details

Use docker manifest to check if it exists, then docker pull if not

## Test coverage

This is the test

## Other details

Through this to AI, so if it doesn't work, don't blame me