### PR TITLE
Try to fix dependabot again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,17 +55,26 @@ updates:
 
   # Src libraries
   - package-ecosystem: "nuget"
-    directory: "/tracer/src/Datadog.Trace"
-    # These cause dependabot to blow up for some unknown reason
+    directory: "/tracer/src"
+    # This is a hacky way to get Dependabot to care primarily about
+    # - Datadog.Trace
+    # - Datadog.Trace.OpenTracing
+    # - Datadog.Trace.BenchmarkDotNet
     exclude-paths:
-      - "../Datadog.Trace.Tools.Analyzers/**"
-      - "../Datadog.Trace.Tools.Analyzers.CodeFixes/**"
+      - "Datadog.AutoInstrumentation.Generator/**"
+      - "Datadog.AzureFunctions/**"
+      - "Datadog.InstrumentedAssemblyGenerator/**"
+      - "Datadog.InstrumentedAssemblyVerification/**"
+      - "Datadog.Trace.Bundle/**"
+      - "Datadog.Trace.SourceGenerators/**"
+      - "Datadog.Trace.Tools.Analyzers/**"
+      - "Datadog.Trace.Tools.Analyzers.CodeFixes/**"
+      - "Datadog.Trace.Tools.dd_dotnet.SourceGenerators/**"
     registries: "*"
     schedule:
       interval: "daily"
     labels:
       - "dependencies"
-      - "area:tracer"
     ignore:
       ### Start Datadog.Trace.csproj ignored dependencies
       # DiagnosticSource is kept at the lowest supported version for widest compatibility
@@ -83,60 +92,6 @@ updates:
 
       # Lock Microsoft.Build.Framework for widest compatibility when instrumenting builds
       - dependency-name: "Microsoft.Build.Framework"
-
-  - package-ecosystem: "nuget"
-    directory: "/tracer/src/Datadog.Trace.OpenTracing"
-    # These cause dependabot to blow up for some unknown reason
-    exclude-paths:
-      - "../Datadog.Trace.Tools.Analyzers/**"
-      - "../Datadog.Trace.Tools.Analyzers.CodeFixes/**"
-    registries: "*"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-      - "area:opentracing"
-    ignore:
-      ### Start Datadog.Trace.csproj ignored dependencies
-      # DiagnosticSource is kept at the lowest supported version for widest compatibility
-      - dependency-name: "System.Diagnostics.DiagnosticSource"
-
-      # AspNetCore reference libraries are kept at the lowest supported version for compatibility on netstandard2.0
-      - dependency-name: "Microsoft.AspNetCore.Hosting.Abstractions"
-      - dependency-name: "Microsoft.AspNetCore.Mvc.Abstractions"
-      - dependency-name: "Microsoft.AspNetCore.Routing"
-
-      # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
-      - dependency-name: "System.Reflection.Emit"
-      - dependency-name: "System.Reflection.Emit.Lightweight"
-      ### End Datadog.Trace.csproj ignored dependencies
-
-  - package-ecosystem: "nuget"
-    directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
-    # These cause dependabot to blow up for some unknown reason
-    exclude-paths:
-      - "../Datadog.Trace.Tools.Analyzers/**"
-      - "../Datadog.Trace.Tools.Analyzers.CodeFixes/**"
-    registries: "*"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-      - "area:benchmarks"
-    ignore:
-      ### Start Datadog.Trace.csproj ignored dependencies
-      # DiagnosticSource is kept at the lowest supported version for widest compatibility
-      - dependency-name: "System.Diagnostics.DiagnosticSource"
-
-      # AspNetCore reference libraries are kept at the lowest supported version for compatibility on netstandard2.0
-      - dependency-name: "Microsoft.AspNetCore.Hosting.Abstractions"
-      - dependency-name: "Microsoft.AspNetCore.Mvc.Abstractions"
-      - dependency-name: "Microsoft.AspNetCore.Routing"
-
-      # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
-      - dependency-name: "System.Reflection.Emit"
-      - dependency-name: "System.Reflection.Emit.Lightweight"
-      ### End Datadog.Trace.csproj ignored dependencies
 
   - package-ecosystem: "github-actions"
     directories:


### PR DESCRIPTION
## Summary of changes

It's still broken

## Reason for change

Dependabot hates me

## Implementation details

Instead of trying to have separate include files, and then excluding the analyzer projects (because they cause dependabot to break), take an alternative approach

## Test coverage

Nope, can't test this stuff AFAICT
