### PR TITLE
Add Defender processes to exclusion list

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/constants.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/constants.h
@@ -25,11 +25,17 @@ const shared::WSTRING default_exclude_processes[]{
     WStr("Microsoft.ServiceHub.Controller.exe"),
     WStr("MSBuild.exe"),
     WStr("MsDtsSrvr.exe"),
+    WStr("MsSense.exe"), // Defender: https://learn.microsoft.com/en-us/defender-endpoint/switch-to-mde-troubleshooting
     WStr("msvsmon.exe"),
     WStr("PerfWatson2.exe"),
     WStr("powershell.exe"),
     WStr("pwsh.exe"),
     WStr("pwsh"),
+    WStr("SenseCE.exe"),             // 
+    WStr("SenseCM.exe"),             // Defender processes
+    WStr("SenseCnCProxy.exe"),       // https://learn.microsoft.com/en-us/defender-endpoint/switch-to-mde-troubleshooting
+    WStr("SenseIR.exe"),             // 
+    WStr("SenseSampleUploader.exe"), // 
     WStr("ServiceHub.DataWarehouseHost.exe"),
     WStr("ServiceHub.Host.CLR.exe"),
     WStr("ServiceHub.Host.CLR.x86.exe"),


### PR DESCRIPTION
## Summary of changes

Adds some Defender processes to the exclude list

## Reason for change

We can't actually inject into these, but we try, and it adds noise.

## Implementation details

Added all the Windows Server processes listed [here](https://learn.microsoft.com/en-us/defender-endpoint/switch-to-mde-troubleshooting) to our explicit exclude list
