### PR TITLE
Simplify Windows macrobenchmarks AMI build

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -66,7 +66,7 @@ build-dd-trace-dotnet-macrobenchmarks-ami:
     AWS_REGION: "us-east-1"
 
     # Branch containing a provision for building the macrobenchmarks AMI
-    BP_INFRA_BENCHMARKING_PLATFORM_BRANCH: "augusto/dd-trace-dotnet/macro/simplify-ami-build-for-windows-benchmarks"
+    BP_INFRA_BENCHMARKING_PLATFORM_BRANCH: "dd-trace-dotnet/macro"
 
     # Whether to cleanup instances after building the AMI, since the AMI is 
     # based on an instance that is created in this job


### PR DESCRIPTION
- [x] Revert [point to testing branch](https://github.com/DataDog/dd-trace-dotnet/pull/7928/commits/7a65ba33a25f1cd9be3e5064dd9658d41f7d1341)
- [x] Make sure `HARDCODED_BUILD_ID` is set to `""` before merging.

## Summary of changes

- Remove unnecessary `.setup` hidden job and its references
- Reorganize CI job keys for readability across build and benchmarking jobs.
- Rename AMI build job and stage to better match what's already on `microbenchmarks.yml`.

## Reason for change

Improve readability on dd-trace-dotnet's macrobenchmark AMI build jobs.

## Implementation details

## Test coverage

AMI build job correctly running: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1283243374

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
