### PR TITLE
Fix usages of `new Tracer()` which are never cleaned up

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SNS/AwsSnsCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SNS/AwsSnsCommonTests.cs
@@ -5,10 +5,12 @@
 
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -42,14 +44,14 @@ public class AwsSnsCommonTests
 
     [Theory]
     [MemberData(nameof(SchemaSpanKindOperationNameData))]
-    public void GetCorrectOperationName(string schemaVersion, string spanKind, string expected)
+    public async Task GetCorrectOperationName(string schemaVersion, string spanKind, string expected)
     {
-        var tracer = GetTracer(schemaVersion);
+        await using var tracer = GetTracer(schemaVersion);
 
         AwsSnsCommon.GetOperationName(tracer, spanKind).Should().Be(expected);
     }
 
-    private static Tracer GetTracer(string schemaVersion)
+    private static ScopedTracer GetTracer(string schemaVersion)
     {
         var collection = new NameValueCollection { { ConfigurationKeys.MetadataSchemaVersion, schemaVersion } };
         IConfigurationSource source = new NameValueConfigurationSource(collection);
@@ -57,6 +59,6 @@ public class AwsSnsCommonTests
         var writerMock = new Mock<IAgentWriter>();
         var samplerMock = new Mock<ITraceSampler>();
 
-        return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+        return TracerHelper.Create(settings, writerMock.Object, samplerMock.Object);
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SQS/AwsSqsCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SQS/AwsSqsCommonTests.cs
@@ -5,10 +5,12 @@
 
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -43,14 +45,14 @@ public class AwsSqsCommonTests
 
     [Theory]
     [MemberData(nameof(SchemaSpanKindOperationNameData))]
-    public void GetCorrectOperationName(string schemaVersion, string spanKind, string expected)
+    public async Task GetCorrectOperationName(string schemaVersion, string spanKind, string expected)
     {
-        var tracer = GetTracer(schemaVersion);
+        await using var tracer = GetTracer(schemaVersion);
 
         AwsSqsCommon.GetOperationName(tracer, spanKind).Should().Be(expected);
     }
 
-    private static Tracer GetTracer(string schemaVersion)
+    private static ScopedTracer GetTracer(string schemaVersion)
     {
         var collection = new NameValueCollection { { ConfigurationKeys.MetadataSchemaVersion, schemaVersion } };
         IConfigurationSource source = new NameValueConfigurationSource(collection);
@@ -58,6 +60,6 @@ public class AwsSqsCommonTests
         var writerMock = new Mock<IAgentWriter>();
         var samplerMock = new Mock<ITraceSampler>();
 
-        return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+        return TracerHelper.Create(settings, writerMock.Object, samplerMock.Object);
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactoryTests.cs
@@ -6,22 +6,28 @@
 #nullable enable
 
 using System;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Proxy;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Proxy;
 
-public class AwsApiGatewaySpanFactoryTests
+public class AwsApiGatewaySpanFactoryTests : IAsyncLifetime
 {
     private readonly AwsApiGatewaySpanFactory _factory;
-    private readonly Tracer _tracer; // this is a mocked instance of the tracer
+    private readonly ScopedTracer _tracer; // this is a mocked instance of the tracer
 
     public AwsApiGatewaySpanFactoryTests()
     {
         _factory = new AwsApiGatewaySpanFactory();
         _tracer = ProxyTestHelpers.GetMockTracer();
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _tracer.DisposeAsync();
 
     [Fact]
     public void CreateSpan_CreatesSpanWithCorrectProperties()

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Proxy/InferredProxyCoordinatorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Proxy/InferredProxyCoordinatorTests.cs
@@ -6,20 +6,22 @@
 #nullable enable
 
 using System;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Proxy;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Proxy;
 
-public class InferredProxyCoordinatorTests
+public class InferredProxyCoordinatorTests : IAsyncLifetime
 {
     private readonly Mock<IInferredProxyExtractor> _extractor;
     private readonly Mock<IInferredSpanFactory> _factory;
-    private readonly Tracer _tracer; // this is a mock instance
+    private readonly ScopedTracer _tracer; // this is a mock instance
     private readonly InferredProxyCoordinator _coordinator;
 
     public InferredProxyCoordinatorTests()
@@ -29,6 +31,10 @@ public class InferredProxyCoordinatorTests
         _tracer = ProxyTestHelpers.GetMockTracer();
         _coordinator = new InferredProxyCoordinator(_extractor.Object, _factory.Object);
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _tracer.DisposeAsync();
 
     [Fact]
     public void ExtractAndCreateScope_WhenExtractorReturnsFalse_ShouldReturnNull()

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Proxy/ProxyTestHelpers.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Proxy/ProxyTestHelpers.cs
@@ -13,20 +13,21 @@ using Datadog.Trace.ClrProfiler.AutoInstrumentation.Proxy;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers.TestTracer;
 using Moq;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Proxy;
 
 internal static class ProxyTestHelpers
 {
-    internal static Tracer GetMockTracer(NameValueCollection? collection = null)
+    internal static ScopedTracer GetMockTracer(NameValueCollection? collection = null)
     {
         collection ??= new NameValueCollection { { ConfigurationKeys.FeatureFlags.InferredProxySpansEnabled, "true" } };
         IConfigurationSource source = new NameValueConfigurationSource(collection);
         var settings = new TracerSettings(source);
         var writerMock = new Mock<IAgentWriter>();
         var samplerMock = new Mock<ITraceSampler>();
-        return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+        return TracerHelper.Create(settings, writerMock.Object, samplerMock.Object);
     }
 
     internal static NameValueHeadersCollection CreateValidHeaders(string? start = null)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -4,9 +4,11 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Xunit;
 
@@ -18,10 +20,10 @@ public class AppSecContextTests
     [InlineData(2, -2, -1, 1, null, -1)]
     [InlineData(2, 2, 1, 2, null, null)]
     [Theory]
-    public void GivenAQuery_WhenWAFError_ThenSpanHasErrorTags(int raspErrorCode, int wafErrorCode, int wafErrorCode2, int wafTimeouts, int? expectedRaspErrorCode, int? expectedWafErrorCode)
+    public async Task GivenAQuery_WhenWAFError_ThenSpanHasErrorTags(int raspErrorCode, int wafErrorCode, int wafErrorCode2, int wafTimeouts, int? expectedRaspErrorCode, int? expectedWafErrorCode)
     {
         var settings = TracerSettings.Create(new Dictionary<string, object>());
-        var tracer = new Tracer(settings, null, null, null, null);
+        await using var tracer = TracerHelper.Create(settings);
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
 
         var appSecContext = rootTestScope.Span.Context.TraceContext.AppSecRequestContext;

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/EventTrackingSdkTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/EventTrackingSdkTests.cs
@@ -5,11 +5,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers.Stats;
+using Datadog.Trace.TestHelpers.TestTracer;
 using Datadog.Trace.Vendors.StatsdClient;
 using Moq;
 using Xunit;
@@ -19,12 +21,12 @@ namespace Datadog.Trace.Security.Unit.Tests;
 public class EventTrackingSdkTests
 {
     [Fact]
-    public void TrackUserLoginSuccessEvent_OnRootSpanDirectly_ShouldSetOnTrace()
+    public async Task TrackUserLoginSuccessEvent_OnRootSpanDirectly_ShouldSetOnTrace()
     {
         var scopeManager = new AsyncLocalScopeManager();
 
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
-        var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, new TestStatsdManager(Mock.Of<IDogStatsd>()));
+        await using var tracer = TracerHelper.Create(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
         var childTestScope = (Scope)tracer.StartActive("test.trace.child");
@@ -41,12 +43,12 @@ public class EventTrackingSdkTests
     }
 
     [Fact]
-    public void TrackUserLoginSuccessEvent_WithMeta_OnRootSpanDirectly_ShouldSetOnTrace()
+    public async Task TrackUserLoginSuccessEvent_WithMeta_OnRootSpanDirectly_ShouldSetOnTrace()
     {
         var scopeManager = new AsyncLocalScopeManager();
 
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
-        var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, new TestStatsdManager(Mock.Of<IDogStatsd>()));
+        await using var tracer = TracerHelper.Create(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
         var childTestScope = (Scope)tracer.StartActive("test.trace.child");
@@ -75,12 +77,12 @@ public class EventTrackingSdkTests
     }
 
     [Fact]
-    public void TrackUserLoginFailureEvent_OnRootSpanDirectly_ShouldSetOnTrace()
+    public async Task TrackUserLoginFailureEvent_OnRootSpanDirectly_ShouldSetOnTrace()
     {
         var scopeManager = new AsyncLocalScopeManager();
 
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
-        var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, new TestStatsdManager(Mock.Of<IDogStatsd>()));
+        await using var tracer = TracerHelper.Create(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
         var childTestScope = (Scope)tracer.StartActive("test.trace.child");
@@ -98,12 +100,12 @@ public class EventTrackingSdkTests
     }
 
     [Fact]
-    public void TrackUserLoginFailureEvent_WithMeta_OnRootSpanDirectly_ShouldSetOnTrace()
+    public async Task TrackUserLoginFailureEvent_WithMeta_OnRootSpanDirectly_ShouldSetOnTrace()
     {
         var scopeManager = new AsyncLocalScopeManager();
 
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
-        var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, new TestStatsdManager(Mock.Of<IDogStatsd>()));
+        await using var tracer = TracerHelper.Create(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
         var childTestScope = (Scope)tracer.StartActive("test.trace.child");
@@ -132,12 +134,12 @@ public class EventTrackingSdkTests
     }
 
     [Fact]
-    public void TrackCustomEvent_OnRootSpanDirectly_ShouldSetOnTrace()
+    public async Task TrackCustomEvent_OnRootSpanDirectly_ShouldSetOnTrace()
     {
         var scopeManager = new AsyncLocalScopeManager();
 
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
-        var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, new TestStatsdManager(Mock.Of<IDogStatsd>()));
+        await using var tracer = TracerHelper.Create(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
         var childTestScope = (Scope)tracer.StartActive("test.trace.child");
@@ -153,12 +155,12 @@ public class EventTrackingSdkTests
     }
 
     [Fact]
-    public void TrackCustomEvent_WithMeta_OnRootSpanDirectly_ShouldSetOnTrace()
+    public async Task TrackCustomEvent_WithMeta_OnRootSpanDirectly_ShouldSetOnTrace()
     {
         var scopeManager = new AsyncLocalScopeManager();
 
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
-        var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, new TestStatsdManager(Mock.Of<IDogStatsd>()));
+        await using var tracer = TracerHelper.Create(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
         var childTestScope = (Scope)tracer.StartActive("test.trace.child");

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
@@ -96,10 +96,10 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Fact]
-        public void GivenHttpTransportInstanceWithUninitializedContext_WhenRunWaf_ThenResultIsNull()
+        public async Task GivenHttpTransportInstanceWithUninitializedContext_WhenRunWaf_ThenResultIsNull()
         {
             var settings = TracerSettings.Create(new Dictionary<string, object>());
-            var tracer = new Tracer(settings, null, null, null, null);
+            await using var tracer = TracerHelper.Create(settings);
             var rootTestScope = (Scope)tracer.StartActive("test.trace");
 
             var contextMoq = new Mock<HttpContext>();
@@ -120,10 +120,10 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Fact]
-        public void GivenHttpTransportInstanceWithUninitializedContext_WhenAccessingStatusCode_ThenResultIsNull()
+        public async Task GivenHttpTransportInstanceWithUninitializedContext_WhenAccessingStatusCode_ThenResultIsNull()
         {
             var settings = TracerSettings.Create(new Dictionary<string, object>());
-            var tracer = new Tracer(settings, null, null, null, null);
+            await using var tracer = TracerHelper.Create(settings);
             var rootTestScope = (Scope)tracer.StartActive("test.trace");
 
             var wafContext = new Mock<IContext>();

--- a/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/DuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/DuckTypingTests.cs
@@ -9,6 +9,7 @@ extern alias DatadogTraceManual;
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tagging;
@@ -18,6 +19,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Moq;
@@ -40,19 +42,13 @@ namespace Datadog.Trace.Tests.ManualInstrumentation;
 [TracerRestorer]
 public class DuckTypingTests
 {
-    private readonly AsyncLocalScopeManager _scopeManager = new();
-    private readonly TracerSettings _settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
-    private readonly Tracer _tracer;
-
-    public DuckTypingTests()
-    {
-        _tracer = new Tracer(_settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object, scopeManager: _scopeManager, statsd: null);
-    }
-
     [Fact]
-    public void CanDuckTypeScopeAsManualIScope()
+    public async Task CanDuckTypeScopeAsManualIScope()
     {
-        var scope = _tracer.StartActiveInternal("manual");
+        var settings = TracerSettings.Create(new() { { ConfigurationKeys.StartupDiagnosticLogEnabled, false } });
+        await using var tracer = TracerHelper.Create(settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object);
+
+        var scope = tracer.StartActiveInternal("manual");
         var span = scope.Span;
         var spanContext = span.Context;
 

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetrySpecialTagRemapperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetrySpecialTagRemapperTests.cs
@@ -5,20 +5,22 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Datadog.Trace.Activity;
 using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers.TestTracer;
 using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests
 {
     [Collection(nameof(OpenTelemetrySpecialTagRemapperTests))]
-    public class OpenTelemetrySpecialTagRemapperTests
+    public class OpenTelemetrySpecialTagRemapperTests : IAsyncLifetime
     {
-        private readonly Tracer _tracer;
+        private readonly ScopedTracer _tracer;
 
         public OpenTelemetrySpecialTagRemapperTests()
         {
@@ -26,8 +28,12 @@ namespace Datadog.Trace.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ITraceSampler>();
 
-            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+            _tracer = TracerHelper.Create(settings, writerMock.Object, samplerMock.Object);
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync() => await _tracer.DisposeAsync();
 
         [Fact]
         public void OperationName_Tag_Should_Override_OperationName()

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -6,11 +6,13 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -87,7 +89,7 @@ namespace Datadog.Trace.Tests.Propagators
         }
 
         [Fact]
-        public void Inject_IHeadersCollection_Tag_Propagation_Disabled()
+        public async Task Inject_IHeadersCollection_Tag_Propagation_Disabled()
         {
             KeyValuePair<string, string>[] expectedHeaders =
                 {
@@ -98,7 +100,7 @@ namespace Datadog.Trace.Tests.Propagators
                 };
 
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.TagPropagation.HeaderMaxLength, 0 } });
-            var tracer = new Tracer(settings, agentWriter: Mock.Of<IAgentWriter>(), sampler: null, scopeManager: null, null, telemetry: null);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
 
             var traceContext = new TraceContext(tracer);
             traceContext.SetSamplingPriority(SamplingPriority);

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers.TestTracer;
 using Datadog.Trace.Tests.Util;
 using FluentAssertions;
 using Moq;
@@ -21,11 +22,11 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Tests
 {
-    public class SpanTests
+    public class SpanTests : IAsyncLifetime
     {
         private readonly ITestOutputHelper _output;
         private readonly Mock<IAgentWriter> _writerMock;
-        private readonly Tracer _tracer;
+        private readonly ScopedTracer _tracer;
 
         public SpanTests(ITestOutputHelper output)
         {
@@ -40,8 +41,12 @@ namespace Datadog.Trace.Tests
             _writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ITraceSampler>();
 
-            _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+            _tracer = TracerHelper.Create(settings, _writerMock.Object, samplerMock.Object);
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync() => await _tracer.DisposeAsync();
 
         [Fact]
         public void SetTag_KeyValue_KeyValueSet()

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -15,6 +15,7 @@ using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.Stats;
+using Datadog.Trace.TestHelpers.TestTracer;
 using Datadog.Trace.Util;
 using FluentAssertions;
 using Moq;
@@ -22,9 +23,9 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.Tagging
 {
-    public class TagsListTests
+    public class TagsListTests : IAsyncLifetime
     {
-        private readonly Tracer _tracer;
+        private readonly ScopedTracer _tracer;
         private readonly MockApi _testApi;
 
         public TagsListTests()
@@ -32,8 +33,12 @@ namespace Datadog.Trace.Tests.Tagging
             var settings = new TracerSettings();
             _testApi = new MockApi();
             var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
-            _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
+            _tracer = TracerHelper.Create(settings, agentWriter);
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync() => await _tracer.DisposeAsync();
 
         [Fact]
         public void GetTag_GetMetric_ReturnUpdatedValues()

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -4,10 +4,12 @@
 // </copyright>
 
 using System;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.TestTracer;
 using Datadog.Trace.Tests.Util;
 using Datadog.Trace.Util;
 using FluentAssertions;
@@ -203,13 +205,13 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void Null_Service_Names_Dont_Throw()
+        public async Task Null_Service_Names_Dont_Throw()
         {
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ITraceSampler>();
 
-            var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+            await using var tracer = TracerHelper.Create(settings, writerMock.Object, samplerMock.Object);
 
             var span = tracer.StartSpan("operation");
             span.ServiceName = null;

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -27,9 +27,9 @@ using Xunit;
 namespace Datadog.Trace.Tests
 {
     [Collection(nameof(WebRequestCollection))]
-    public class TracerTests
+    public class TracerTests : IAsyncLifetime
     {
-        private readonly Tracer _tracer;
+        private readonly ScopedTracer _tracer;
 
         public TracerTests()
         {
@@ -37,8 +37,12 @@ namespace Datadog.Trace.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ITraceSampler>();
 
-            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+            _tracer = TracerHelper.Create(settings, writerMock.Object, samplerMock.Object);
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync() => await _tracer.DisposeAsync();
 
         [Fact]
         public void StartActive_SetOperationName_OperationNameIsSet()

--- a/tracer/test/Datadog.Trace.Tests/Util/RandomIdGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RandomIdGeneratorTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
@@ -13,6 +14,7 @@ using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.Stats;
+using Datadog.Trace.TestHelpers.TestTracer;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
@@ -153,14 +155,14 @@ public class RandomIdGeneratorTests
     }
 
     [Fact]
-    public void Default_Is_128Bit_TraceId()
+    public async Task Default_Is_128Bit_TraceId()
     {
-        var tracer = new Tracer(
+        await using var tracer = TracerHelper.Create(
             new TracerSettings(),
             Mock.Of<IAgentWriter>(),
             Mock.Of<ITraceSampler>(),
             new AsyncLocalScopeManager(),
-            new TestStatsdManager(Mock.Of<IDogStatsd>()),
+            Mock.Of<IDogStatsd>(),
             Mock.Of<ITelemetryController>(),
             Mock.Of<IDiscoveryService>());
 
@@ -171,16 +173,16 @@ public class RandomIdGeneratorTests
     }
 
     [Fact]
-    public void Configure_128Bit_TraceId_Disabled()
+    public async Task Configure_128Bit_TraceId_Disabled()
     {
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled, false } });
 
-        var tracer = new Tracer(
+        await using var tracer = TracerHelper.Create(
             settings,
             Mock.Of<IAgentWriter>(),
             Mock.Of<ITraceSampler>(),
             new AsyncLocalScopeManager(),
-            new TestStatsdManager(Mock.Of<IDogStatsd>()),
+            Mock.Of<IDogStatsd>(),
             Mock.Of<ITelemetryController>(),
             Mock.Of<IDiscoveryService>());
 
@@ -191,16 +193,16 @@ public class RandomIdGeneratorTests
     }
 
     [Fact]
-    public void Configure_128Bit_TraceId_Enabled()
+    public async Task Configure_128Bit_TraceId_Enabled()
     {
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled, true } });
 
-        var tracer = new Tracer(
+        await using var tracer = TracerHelper.Create(
             settings,
             Mock.Of<IAgentWriter>(),
             Mock.Of<ITraceSampler>(),
             new AsyncLocalScopeManager(),
-            new TestStatsdManager(Mock.Of<IDogStatsd>()),
+            Mock.Of<IDogStatsd>(),
             Mock.Of<ITelemetryController>(),
             Mock.Of<IDiscoveryService>());
 


### PR DESCRIPTION
## Summary of changes

Fixes places in tests that currently use `new Tracer()` to use `ScopedTracer` instead

## Reason for change

When you call `new Tracer()`, a bunch of background jobs are started, some on thread pool threads, some on dedicated threads. If you don't explicitly shut down the tracer, these jobs may keep living, and ultimately act as a drain on resources in CI, leading to flake. e.g. a check of a recent failing test in CI revealed a lot of threads running the serialization loop, which potentially points to this kind of issue

<img width="221" height="90" alt="image" src="https://github.com/user-attachments/assets/f8bc5970-d3d6-4395-968e-cf655b2176c5" />

## Implementation details

We introduced `ScopedTracer` and `TracerHelper.Create()` to make doing this easier, by having a simple async disposable. This PR updates everywhere that was previously doing `new Tracer()` to use the helpers instead. There are basically 3 patterns for this:

- If `new Tracer()` was called in a constructor, implement `IAsyncLifetime` and dispose it in the `DisposeAsync()` call.
- If `new Tracer()` is called inline, use `await using var tracer = TracerHelper.Create()`
- If a helper is used, find all usages, and ensure they always call `await using`

## Test coverage

All covered by existing tests, so hopefully we're good 🤞 

## Other details

This seems to be a _relatively_ recent issue in CI, but I'm not sure why, these usages have persisted for a long time...