### PR TITLE
[AAS] Set `DataPipelineEnabled=0` by default

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -676,7 +676,7 @@ namespace Datadog.Trace.Configuration
 
             DataPipelineEnabled = config
                                   .WithKeys(ConfigurationKeys.TraceDataPipelineEnabled)
-                                  .AsBool(defaultValue: EnvironmentHelpers.IsUsingAzureAppServicesSiteExtension() && !EnvironmentHelpers.IsAzureFunctions());
+                                  .AsBool(defaultValue: false);
 
             if (DataPipelineEnabled)
             {


### PR DESCRIPTION
## Summary of changes

Disables the data pipeline by default

## Reason for change

We noticed a potential issue in the settings-update path for data pipelines, that could cause problems if a trace exporter instance is disposed while a request is in flight. Working around the issue requires either a bunch of extra locks (undesirable) or more extensive rework. Rather than risk causing a crash, this PR disables the datapipeline by default temporarily.

## Implementation details

Default to `false` instead of just AAS

## Test coverage

Covered by existing
