### PR TITLE
[Config Registry] Fix source generators: downgrade System.text.json version

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.csproj
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0-rc.2.25502.107" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="9.0.11" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>    
     <Compile Include="..\Datadog.Trace\ClrProfiler\InstrumentationCategory.cs" Link="InstrumentationDefinitions\InstrumentationCategory.cs" />    


### PR DESCRIPTION
## Summary of changes

Due to this [Rider](https://youtrack.jetbrains.com/projects/RIDER/issues/RIDER-132634/Source-Generated-files-missing-when-using-System.Text.Json) issue , the IDE doesn't index source generated files using the last version of the package properly which considerably degrades the dev experience. And following the merge [of this PR](https://github.com/DataDog/dd-trace-dotnet/pull/7931), we now have the issue:
<img width="2148" height="980" alt="image" src="https://github.com/user-attachments/assets/5c113a18-9126-4a57-9cda-eb1168a41876" />

It still builds but Rider doesn't see the generated sources and generates errors and doesn't autocompletes or index anything.

## Reason for change

Downgrade the package version to fix the dev experience.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
