### PR TITLE
Clean up SafeHandle use in LibDatadog.

### DIFF
--- a/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/TraceExporterConfiguration.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/TraceExporterConfiguration.cs
@@ -168,15 +168,20 @@ internal sealed class TraceExporterConfiguration : SafeHandle
             _telemetryConfigPtr = IntPtr.Zero;
         }
 
+        if (IsInvalid)
+        {
+            return true;
+        }
+
         try
         {
             NativeInterop.Config.Free(handle);
+            return true;
         }
         catch (Exception ex)
         {
             Logger.Error(ex, "An error occurred while releasing the handle for TraceExporterConfiguration.");
+            return false;
         }
-
-        return true;
     }
 }

--- a/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/TraceExporterResponse.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/TraceExporterResponse.cs
@@ -22,19 +22,21 @@ internal sealed class TraceExporterResponse(IntPtr handle) : SafeHandle(handle, 
 
     protected override bool ReleaseHandle()
     {
-        if (!IsInvalid)
+        if (IsInvalid)
         {
-            try
-            {
-                NativeInterop.Exporter.FreeResponse(handle);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to free TraceExporterResponse handle");
-            }
+            return true;
         }
 
-        return true;
+        try
+        {
+            NativeInterop.Exporter.FreeResponse(handle);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to free TraceExporterResponse handle");
+            return false;
+        }
     }
 
     /// <summary>
@@ -43,7 +45,7 @@ internal sealed class TraceExporterResponse(IntPtr handle) : SafeHandle(handle, 
     /// <returns>The response body as a string, or null if the response is invalid or empty</returns>
     public unsafe string? ReadAsString()
     {
-        if (IsInvalid)
+        if (IsInvalid || IsClosed)
         {
             return null;
         }


### PR DESCRIPTION
* Minimize the chances of using TraceExporter and TraceExporterResponse after disposal.
* Return proper value whenever ReleaseHandle is called.
* Prevent calling ToException if the handle is closed.

## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
