### PR TITLE
Fix AssemblyReferencesHaveNotChanged tests flakiness

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/PublicApiTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/PublicApiTestsBase.cs
@@ -77,8 +77,14 @@ namespace Datadog.Trace.Tests
                 // Exclusions
                 // Datadog.Trace: This dependency is fine and the version will change over time
                 // netstandard: This dependency is fine and there's a discrepancy between local builds and CI builds containing/not containing a reference to it
+                // System.Runtime.CompilerServices.Unsafe: This dependency is vendored internally and the assembly version can vary across platforms due to transitive dependencies. Observed under NETCORE 3.
                 if (!referencedAssembly.Name.StartsWith("Datadog.Trace")
+#if NETCOREAPP3_0
+                    && !referencedAssembly.Name.Equals("netstandard")
+                    && !referencedAssembly.Name.Equals("System.Runtime.CompilerServices.Unsafe"))
+#else
                     && !referencedAssembly.Name.Equals("netstandard"))
+#endif
                 {
                     sb.AppendLine(referencedAssembly.FullName);
                 }


### PR DESCRIPTION
## Summary of changes

Fix flakiness in the `AssemblyReferencesHaveNotChanged` unit test on .NET Core 3.0 by excluding `System.Runtime.CompilerServices.Unsafe` from assembly reference validation on this specific framework

## Reason for change

 **Problem:** The `AssemblyReferencesHaveNotChanged` test was experiencing [flakiness ](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.status%3Afail%20%40test.suite%3ADatadog.Trace.Tests.PublicApiTests.DatadogTraceTests&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch%2C%40test.module%2C%40ci.stage.name%2C%40ci.job.name&currentTab=overview&eventStack=AwAAAZrnpNmG2RA5ZQAAABhBWnJucGdudkFBQ1FCdWd6bUlwaHlOOHUAAAAkZjE5YWU3YTUtNDc3OC00ZDMwLWIxODAtNmQ3NjdiODZiMzIwAABTnQ&fromUser=false&index=citest&testId=AwAAAZrnpNmG2RA5ZQAAABhBWnJucGdudkFBQ1FCdWd6bUlwaHlOOHUAAAAkZjE5YWU3YTUtNDc3OC00ZDMwLWIxODAtNmQ3NjdiODZiMzIwAABTnQ&trace=AwAAAZrnpNmG2RA5ZQAAABhBWnJucGdudkFBQ1FCdWd6bUlwaHlOOHUAAAAkZjE5YWU3YTUtNDc3OC00ZDMwLWIxODAtNmQ3NjdiODZiMzIwAABTnQ&start=1758029675532&end=1765805675532&paused=false)specifically on .NET Core 3.0 builds. This test validates that tracer assembly dependencies haven't unexpectedly changed, helping catch unintended dependency additions.

  **Root cause:** `System.Runtime.CompilerServices.Unsafe` is vendored internally in the tracer, and its assembly version can vary across different platforms due to transitive dependencies. On .NET Core 3.0, this variation causes the test to fail intermittently as the actual assembly version doesn't match the expected snapshot, even though this variance is expected and harmless.

```
Exception: String has differences from expected value because Assembly references should match the verified list of assembly references. Update the verified snapshot when the assembly references change. Diff:
+13:System.Runtime.CompilerServices.Unsafe, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
at Execution.XUnit2TestFramework.Throw(String message)
at Execution.TestFrameworkProvider.Throw(String message)
at Execution.DefaultAssertionStrategy.HandleFailure(String message)
at Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
at Execution.GivenSelector`1.FailWith(String message, Object[] args)
```

  **Similar precedent:** The test already excludes `netstandard` for similar reasons (discrepancy between local builds and CI builds), as documented in the existing code comments.

## Implementation details

Added a conditional compilation directive to exclude `System.Runtime.CompilerServices.Unsafe` from the assembly reference check, but **only for .NET Core 3.0** builds:

  - For `NETCOREAPP3_0`: Excludes both `netstandard` AND `System.Runtime.CompilerServices.Unsafe`
  - For all other frameworks: Continues to exclude only `netstandard` (existing behavior)

  This targeted fix ensures:
  - No false positives from expected platform-specific assembly version variance
  - Other frameworks continue to validate `System.Runtime.CompilerServices.Unsafe` as before
  - The test remains effective at catching unintended dependency changes

## Test coverage

The fix will be validated by:
  - Existing `AssemblyReferencesHaveNotChanged` unit tests on all target frameworks
  - CI builds on .NET Core 3.0 should no longer experience flakiness from this specific assembly version mismatch
  - All other framework builds (net461, net6.0, netstandard2.0, etc.) remain unchanged

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
