### PR TITLE
Fix broken release scripts

### DIFF
--- a/.github/workflows/create_hotfix_draft_release.yml
+++ b/.github/workflows/create_hotfix_draft_release.yml
@@ -37,8 +37,6 @@ jobs:
             NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
             GH_APP_ID: ${{ secrets.GH_APP_ID }}
             GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
-            DD_PREPROD_API_KEY: ${{ secrets.DD_PREPROD_API_KEY }}
-            DD_PUBLIC_SYMBOL_API_KEY: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}
             DD_PUBLIC_SYMBOL_PREPROD_API_KEY: ${{ secrets.DD_PUBLIC_SYMBOL_PREPROD_API_KEY }}
             DD_PUBLIC_SYMBOL_API_KEY_US1: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US1 }}
             DD_PUBLIC_SYMBOL_API_KEY_US3: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US3 }}

--- a/.github/workflows/create_normal_draft_release.yml
+++ b/.github/workflows/create_normal_draft_release.yml
@@ -37,8 +37,6 @@ jobs:
             NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
             GH_APP_ID: ${{ secrets.GH_APP_ID }}
             GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
-            DD_PREPROD_API_KEY: ${{ secrets.DD_PREPROD_API_KEY }}
-            DD_PUBLIC_SYMBOL_API_KEY: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY }}
             DD_PUBLIC_SYMBOL_PREPROD_API_KEY: ${{ secrets.DD_PUBLIC_SYMBOL_PREPROD_API_KEY }}
             DD_PUBLIC_SYMBOL_API_KEY_US1: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US1 }}
             DD_PUBLIC_SYMBOL_API_KEY_US3: ${{ secrets.DD_PUBLIC_SYMBOL_API_KEY_US3 }}


### PR DESCRIPTION
## Summary of changes

These were removed from the reusable workflow in https://github.com/DataDog/dd-trace-dotnet/pull/7828/, but didn't get removed from these. 

## Reason for change

They were broken and GitHub said:

```
The workflow is not valid. .github/workflows/create_normal_draft_release.yml (Line: 40, Col: 33): Invalid secret, DD_PREPROD_API_KEY is not defined in the referenced workflow. .github/workflows/create_normal_draft_release.yml (Line: 41, Col: 39): Invalid secret, DD_PUBLIC_SYMBOL_API_KEY is not defined in the referenced workflow.
```

## Implementation details

Deleted them

## Test coverage

Can try them out next time 😄 

## Other details
<!-- Fixes #{issue} -->

We still have our old release script which doesn't have the issue

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
