### PR TITLE
fix bug where process tags were never initialized for telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ApplicationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ApplicationTelemetryCollector.cs
@@ -23,7 +23,7 @@ internal sealed class ApplicationTelemetryCollector
         if (tracerSettings.PropagateProcessTags)
         {
             var pTags = ProcessTags.SerializedTags;
-            if (!string.IsNullOrEmpty(processTags))
+            if (!string.IsNullOrEmpty(pTags))
             {
                 processTags = pTags;
             }


### PR DESCRIPTION
## Summary of changes

The wrong variable was checked for null, resulting in the process tags never being assigned

## Reason for change

noticed this bug as I was trying to enable system tests for dotnet

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
