### PR TITLE
Revert "Restore null scope check to stop EventBridge injection"

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
@@ -63,11 +63,8 @@ public sealed class PutEventsAsyncIntegration
             }
         }
 
-        if (scope?.Span.Context is { } context)
-        {
-            var propagationContext = new PropagationContext(context, Baggage.Current);
-            ContextPropagation.InjectContext(tracer, request, propagationContext);
-        }
+        var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+        ContextPropagation.InjectContext(tracer, request, context);
 
         return new CallTargetState(scope);
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
@@ -60,11 +60,8 @@ public sealed class PutEventsIntegration
             }
         }
 
-        if (scope?.Span.Context is { } context)
-        {
-            var propagationContext = new PropagationContext(context, Baggage.Current);
-            ContextPropagation.InjectContext(tracer, request, propagationContext);
-        }
+        var context = new PropagationContext(scope?.Span.Context, Baggage.Current);
+        ContextPropagation.InjectContext(tracer, request, context);
 
         return new CallTargetState(scope);
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/ContextPropagation.cs
@@ -48,6 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
             }
 
             Dictionary<string, object>? jsonData = null;
+            var context = new PropagationContext(scope.Span.Context, Baggage.Current);
             if (record.Data is not null)
             {
                 jsonData = ParseDataObject(record.Data);
@@ -86,26 +87,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return;
             }
 
-            if (scope.Span.Context is { } context)
+            try
             {
-                try
-                {
-                    var propagationContext = new PropagationContext(context, Baggage.Current);
-                    tracer.TracerManager.SpanContextPropagator.Inject(propagationContext, propagatedContext, default(DictionaryGetterAndSetter));
-                    jsonData[KinesisKey] = propagatedContext;
+                tracer.TracerManager.SpanContextPropagator.Inject(context, propagatedContext, default(DictionaryGetterAndSetter));
+                jsonData[KinesisKey] = propagatedContext;
 
-                    var memoryStreamData = DictionaryToMemoryStream(jsonData);
-                    if (memoryStreamData.Length > MaxKinesisDataSize)
-                    {
-                        return;
-                    }
-
-                    record.Data = memoryStreamData;
-                }
-                catch (Exception)
+                var memoryStreamData = DictionaryToMemoryStream(jsonData);
+                if (memoryStreamData.Length > MaxKinesisDataSize)
                 {
-                    Log.Debug("Unable to inject trace context to Kinesis data.");
+                    return;
                 }
+
+                record.Data = memoryStreamData;
+            }
+            catch (Exception)
+            {
+                Log.Debug("Unable to inject trace context to Kinesis data.");
             }
         }
 


### PR DESCRIPTION

## Summary

Reverting #7919 as we _should_ inject independently of whether there is a span/scope active.
Will need to follow up on the issue noted.

## Reason for change

If the instrumentation is disabled we should still be injecting context / baggage as they are independent of eachother.

