### PR TITLE
Pre-cache reference assemblies as package references in analyzers tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <!-- .NET Core 3.1 and .NET 5+ -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFramework)' != 'netcoreapp2.1' AND '$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('netcoreapp3.1', '$(TargetFramework)'))">
     <PackageReference Include="Microsoft.NETCore.App.Ref" Version="3.1.0" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
   


### PR DESCRIPTION
## Summary of changes

Pre-cache reference assemblies as package references in `Datadog.Trace.Tools.Analyzers.Tests` to prevent flaky test failures caused by NuGet 503 errors during test runtime.

## Reason for change

The analyzer tests experience [intermittent failures](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=192493&view=logs&j=81bda331-088f-5202-d9c0-0b03003dbe08&t=5f8ca1e9-a770-5d9a-8d72-a98115d35a54) in CI when NuGet.org returns 503 errors. This happens because `Microsoft.CodeAnalysis.Testing` framework dynamically downloads reference assemblies (e.g., `Microsoft.NETCore.App.Ref`, `NETStandard.Library`) at test runtime to compile analyzer test code snippets.

  Example error:
  NuGet.Protocol.Core.Types.FatalProtocolException : An error occurred while retrieving package metadata for 'Microsoft.NETCore.App.Ref.3.1.0' from source 'nuget.org'.

The issue occurs because while build-time packages are restored during the `Restore` target, the `Microsoft.CodeAnalysis.Testing` framework requires additional reference assemblies that aren't direct dependencies of the test project. When these aren't in the local NuGet cache, the framework attempts to download them at runtime, which fails when NuGet.org is experiencing issues.

## Implementation details

Added conditional package references to `tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj` based on actual runtime monitoring of which packages are requested during test execution:

  **Package mapping by target framework:**
  - **.NET Framework** (`TargetFrameworkIdentifier == '.NETFramework'`):
    - `Microsoft.NETFramework.ReferenceAssemblies.net472 1.0.2`
  - **.NET Core 2.1/3.0** (`TargetFramework == 'netcoreapp2.1' OR 'netcoreapp3.0'`):
    - `NETStandard.Library 2.0.3`
    - `Microsoft.NETCore.Platforms 1.1.0`
  - **.NET Core 3.1 and .NET 5+** (`TargetFrameworkIdentifier == '.NETCoreApp' AND NOT netcoreapp2.1/3.0`):
    - `Microsoft.NETCore.App.Ref 3.1.0`

  All packages use `PrivateAssets="all" ExcludeAssets="all"` to:
  - Download packages during the `Restore` target
  - Store them in the NuGet global cache
  - Exclude them from build to avoid compatibility issues
  - Make them available for `Microsoft.CodeAnalysis.Testing` at test runtime

  Added `NoWarn` suppression for NU1605 (package downgrade warning) since `Microsoft.NETCore.Platforms 1.1.0` is intentionally used despite being an older version.
  
## Test coverage

- Validated locally by running analyzer tests across all target frameworks (netcoreapp2.1, netcoreapp3.0, netcoreapp3.1, net5.0, net6.0, net7.0, net8.0, net9.0, net10.0, net48).
- Reproduced locally the issue by removing nuget cache files, compiling and running tests without internet connection.
- Used Process Monitor to check the nuget requested at runtime for each framework.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
