### PR TITLE
Add /analyze-crash and /analyze-error Claude commands

### DIFF
--- a/.claude/commands/analyze-crash.md
+++ b/.claude/commands/analyze-crash.md
@@ -177,7 +177,10 @@ Generate a well-formatted markdown document with these sections:
 
 ## Output File Management
 
-1. **Create output directory**: Use Bash to create `~/.claude/analysis/` if it doesn't exist
+1. **Create output directory**:
+   - On Windows: Use `powershell.exe -NoProfile -Command 'New-Item -ItemType Directory -Force -Path (Join-Path $env:USERPROFILE ".claude\analysis") | Select-Object -ExpandProperty FullName'`
+   - On Linux/Mac: Use `mkdir -p ~/.claude/analysis && echo ~/.claude/analysis`
+   - **IMPORTANT**: On Windows, you MUST use single quotes around the PowerShell command to prevent bash from interpreting `$env:USERPROFILE`
 2. **Generate filename**: Use format `crash-analysis-{YYYYMMDD-HHMMSS}.md` (e.g., `crash-analysis-20250316-143022.md`)
 3. **Save file**: Write the markdown analysis to the file
 4. **Return path**: Tell the user the full path where the analysis was saved


### PR DESCRIPTION
## Summary of changes

When investigating crashes or errors a main difficulty (in my opinion) is both the volume of them 😭 but also unfamiliarity of the various frames in the stacks. This PR adds two (experimental) Claude Code commands to assist with this `/analyze-crash` and `/analyze-error`.

## Reason for change

As I have been going through stacks and frames from Crash Tracking I found myself constantly having to look up what things mean as I'm just not super familiar with most of the native bits at the moment. These two commands are largely created to help me speed up initial understanding and analysis of stacks from reported crashes that are (likely) caused by `dd-trace-dotnet`.

In addition to this, it made some sense to include a similar command for errors (that are not crashes, but are caused by us).

The analysis documents are intended to help de-mystify both and provide more human readable information.

## Implementation details

Both commands will output a markdown file within your user `.claude\analysis\` directory (creates it if necessary).

## Test coverage

## Other details
<!-- Fixes #{issue} -->

I would consider these experimental and will continue to test them out.

To use:

Intention is to click the `Copy` stack button in Error Tracking and then paste it into the command. That is it!

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
