### PR TITLE
fix(DSM): Fix race condition on DataStreamsWriter disposal

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -171,17 +171,18 @@ internal sealed class DataStreamsWriter : IDataStreamsWriter
         }
 
         // nothing else to do, since the writer was not fully initialized
-        if (!Volatile.Read(ref _isInitialized) || _processTask == null)
+        if (!Volatile.Read(ref _isInitialized) || _processTask == null || _flushTask == null)
         {
             return;
         }
 
+        var allTasks = Task.WhenAll(_processTask, _flushTask);
         var completedTask = await Task.WhenAny(
-                                           _processTask,
+                                           allTasks,
                                            Task.Delay(TimeSpan.FromSeconds(1)))
                                       .ConfigureAwait(false);
 
-        if (completedTask != _processTask)
+        if (completedTask != allTasks)
         {
             Log.Error("Could not flush all data streams stats before process exit");
         }


### PR DESCRIPTION
## Summary of changes
Fixes a race condition where we attempt to dispose of a semaphore when it is being held by another task.

## Reason for change
I think this is the root cause behind some unit test flake, and some errors when disposing DataStreamsWriter.

## Implementation details
There are two tasks that run: `flushTask` and `processTask`. `DataStreamsWriter::DisposeAsync` calls `_flushSemaphore.Dispose();` after `FlushAndCloseAsync()`.

`FlushAndCloseAsync` sets an exit flag for the task, but only waits for `processTask` to complete. If `flushTask` is running and has already acquired the semaphore, the `DisposeAsync` will still dispose of the semaphore even though flushTask is still using it.

Fixed by waiting for both tasks to complete, as flushTask will finish once processTask finishes. And we still have the 1 second fallback.

This should also fix the test flake. The unit test immediately calls dispose after adding the data points:
```
writer.Add(CreateStatsPoint(timestamp));
writer.AddBacklog(CreateBacklogPoint(timestamp));

await writer.DisposeAsync();
```

So it seems likely that we might dispose the semaphore before flush has a chance to run.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
