### PR TITLE
[Github] Add permission for the apm-sdks-benchmarks repo

### DIFF
--- a/.github/chainguard/gitlab.github-access.read-contents.sts.yaml
+++ b/.github/chainguard/gitlab.github-access.read-contents.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-dotnet:ref_type:(branch|tag):ref:.*"
+subject_pattern: "project_path:DataDog/apm-reliability/(dd-trace-dotnet|apm-sdks-benchmarks):ref_type:(branch|tag):ref:.*"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary of changes
Changes the dd-octo-sts setup to give access to the new repo.
## Reason for change
Implementation of new benchmarks.
## Implementation details
[User guide](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts)
## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
