### PR TITLE
Stop recreating `SpanEventsManager`

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace
             RemoteConfigurationManager = remoteConfigurationManager;
             DynamicConfigurationManager = dynamicConfigurationManager;
             TracerFlareManager = tracerFlareManager;
-            SpanEventsManager = new SpanEventsManager(discoveryService);
+            SpanEventsManager = spanEventsManager;
 
             SpanContextPropagator = SpanContextPropagatorFactory.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract, settings.PropagationExtractFirstOnly, settings.PropagationBehaviorExtract);
             UpdatePerTraceSettings(settings.Manager.InitialMutableSettings);


### PR DESCRIPTION
## Summary of changes

Use the provided `SpanEventsManager` in `TracerManager` constructor

## Reason for change

While working on something else, @daniel-romano-DD noticed that we were recreating the `SpanEventsManager` in the `TracerManager` constructor, instead of using the value provided (which will have _just_ been created previously. Can't see a good reason for it, it looks like a bug.

## Implementation details

Just use the provided value

## Test coverage

Probably benign so not covered by anything else, but meh
