### PR TITLE
Add Windows Command Line Best Practices to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,7 @@ The tracer runs in-process with customer applications and must have minimal perf
 ## Commit & Pull Request Guidelines
 
 **Commits:**
-- Imperative mood; optional scope tag (e.g., `fix(telemetry): …` 1utf5ircvb6md08776ap5d70fj47h7f5gkxo05qaasor `[Debugger] …`)
+- Imperative mood; optional scope tag (e.g., `fix(telemetry): …` or `[Debugger] …`)
 - Reference issues when applicable
 - Keep messages concise - avoid full diffs or extensive details
 


### PR DESCRIPTION
## Summary of changes

Added clear guidelines to AGENTS.md about avoiding `>nul` and `2>nul` redirections on Windows, which can create literal "nul" files that are extremely difficult to delete.

## Reason for change

On Windows, redirecting to `nul` (e.g., `command 2>nul`) can create a literal file named "nul" in the current directory instead of properly redirecting to the NUL device. These files are problematic because:
- They cannot be deleted using standard Windows commands
- They cause repository hygiene issues
- They're confusing and frustrating to deal with

This issue was documented in https://github.com/anthropics/claude-code/issues/4928

## Implementation details

1. **Added new section**: "Windows Command Line Best Practices" in AGENTS.md after the Coding Standards section
2. **Provided clear examples** of problematic commands (including `findstr` with `2>nul`)
3. **Documented safe alternatives**:
   - Let error output show naturally (don't suppress)
   - Use full device path `\\.\NUL` if suppression is essential
   - Prefer PowerShell or dedicated tools over piped bash commands

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
