### PR TITLE
Downgrade DSM flush shutdown log from Error to Warning

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -184,7 +184,7 @@ internal sealed class DataStreamsWriter : IDataStreamsWriter
 
         if (completedTask != allTasks)
         {
-            Log.Error("Could not flush all data streams stats before process exit");
+            Log.Warning("Could not flush all data streams stats before process exit");
         }
 
         await FlushAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary of changes
Addressing some [test flake](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=192892&view=logs&j=31acdf08-3064-571d-e44c-78b15fe9b1f9&t=582a4466-53a3-57ed-5676-bdeb8e6ba7e6). This can happen in an overloaded CI environment.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
