### PR TITLE
[Dynamic Instrumentation] DEBUG-4871 Added a managed guard in LogLocal and LogArg to detect null byrefs

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
-using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Debugger.Instrumentation
@@ -44,6 +43,20 @@ namespace Datadog.Trace.Debugger.Instrumentation
             {
                 if (!state.IsActive)
                 {
+                    return;
+                }
+
+                if (Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.IsNullRef(ref local))
+                {
+                    if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
+                    {
+                        Log.Debug(
+                        "LogLocal: Skipping null byref local. probeId={ProbeId}, Index={Index}, TLocal={TLocal}",
+                        property0: state.ProbeData.ProbeId,
+                        property1: index,
+                        property2: typeof(TLocal).FullName);
+                    }
+
                     return;
                 }
 
@@ -85,7 +98,12 @@ namespace Datadog.Trace.Debugger.Instrumentation
                     return;
                 }
 
-                Log.Warning(exception, "Error caused by our instrumentation");
+                Log.Warning(
+                    exception,
+                    "Error caused by our instrumentation. probeId={ProbeId}, Method={TypeName}.{MethodName}",
+                    property0: state.ProbeId,
+                    property1: state.MethodMetadataInfo.DeclaringType?.Name,
+                    property2: state.MethodMetadataInfo.Method.Name);
                 state.IsActive = false;
             }
             catch

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.SingleProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.SingleProbe.cs
@@ -9,9 +9,7 @@ using System.Runtime.CompilerServices;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
-using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Logging;
-using Datadog.Trace.RemoteConfigurationManagement.Protocol.Tuf;
 
 namespace Datadog.Trace.Debugger.Instrumentation
 {
@@ -150,6 +148,20 @@ namespace Datadog.Trace.Debugger.Instrumentation
                 return;
             }
 
+            if (Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.IsNullRef(ref arg))
+            {
+                if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
+                {
+                    Log.Debug(
+                    "LogArg: Skipping null byref argument. probeId={ProbeId}, Index={Index}, TArg={TArg}",
+                    property0: state.ProbeData.ProbeId,
+                    property1: index,
+                    property2: typeof(TArg).FullName);
+                }
+
+                return;
+            }
+
             var paramName = state.MethodMetadataInfo.ParameterNames[index];
             var captureInfo = new CaptureInfo<TArg>(state.MethodMetadataIndex, value: arg, methodState: MethodState.LogArg, name: paramName, memberKind: ScopeMemberKind.Argument);
             var probeData = state.ProbeData;
@@ -174,6 +186,20 @@ namespace Datadog.Trace.Debugger.Instrumentation
         {
             if (!state.IsActive)
             {
+                return;
+            }
+
+            if (Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.IsNullRef(ref local))
+            {
+                if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
+                {
+                    Log.Debug(
+                    "LogLocal: Skipping null byref local. probeId={ProbeId}, Index={Index}, TLocal={TLocal}",
+                    property0: state.ProbeData.ProbeId,
+                    property1: index,
+                    property2: typeof(TLocal).FullName);
+                }
+
                 return;
             }
 
@@ -338,7 +364,12 @@ namespace Datadog.Trace.Debugger.Instrumentation
                     return;
                 }
 
-                Log.Warning(exception, "Error caused by our instrumentation");
+                Log.Warning(
+                    exception,
+                    "Error caused by our instrumentation. probeId={ProbeId}, Method={TypeName}.{MethodName}",
+                    property0: state.ProbeId,
+                    property1: state.MethodMetadataInfo.DeclaringType?.Name,
+                    property2: state.MethodMetadataInfo.Method.Name);
                 state.IsActive = false;
                 state.ProbeData.Processor.LogException(exception, state.SnapshotCreator);
             }


### PR DESCRIPTION
## Reason for change
Some methods can legitimately produce null managed byrefs (e.g., MemoryMarshal.GetReference(emptySpan)), which makes ref T point to address 0. Attempting to capture such locals/args would dereference an invalid reference and could crash in LogLocal/LogArg (NullReferenceException). This change makes DI runs stable and keeps probes installed while avoiding unsafe dereferences

## Implementation details
Before reading a ref T capture input, we check Unsafe.IsNullRef(ref value) and return early to avoid dereferencing an invalid reference.

Current behavior is to skip capturing that member entirely (no misleading null value for non-nullable types like byte).
Follow-up option: if we decide we want the snapshot to explicitly show this case, we can reuse the existing snapshot notCapturedReason mechanism (no new reason added in this PR).

## Test coverage
https://github.com/DataDog/dd-trace-dotnet/pull/7987

## Other details
This PR is part of an effort to make the Snapshot Exploration Test run successfully end-to-end.
https://github.com/DataDog/dd-trace-dotnet/pull/7988
https://github.com/DataDog/dd-trace-dotnet/pull/7989

