### PR TITLE
Flaky tests: Debugger

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -397,6 +397,7 @@ public class ProbesTests : TestHelper
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
     [MemberData(nameof(SpanDecorationMemberData))]
+    [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
     public async Task SpanDecorationTest(Type testType)
     {
         var method = testType.FullName + "[Annotate]";

--- a/tracer/test/Datadog.Trace.Tests/Debugger/CacheTests/ConcurrentAdaptiveCacheTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/CacheTests/ConcurrentAdaptiveCacheTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Debugger.Caching;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Util;
 using Moq;
 using Xunit;
@@ -285,6 +286,7 @@ namespace Datadog.Trace.Tests.Debugger.CacheTests
         }
 
         [Fact]
+        [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
         public async Task AdaptiveCleanupAsync_Should_Handle_Cancellation_Gracefully()
         {
             // Setup


### PR DESCRIPTION
## Summary of changes

The following tests we detected as flaky:
```
Datadog.Trace.Tests.Debugger.CacheTests.ConcurrentAdaptiveCacheTests.AdaptiveCleanupAsync_Should_Handle_Cancellation_Gracefully (13 failures in different pipelines the last month)
Datadog.Trace.Debugger.IntegrationTests.ProbesTests.SpanDecorationTest (3 failures in different pipelines the last month)
```

The complete flakiness report can be found here:
[https://docs.google.com/spreadsheets/d/1Gftmhb-66Dag4qFEXw9tyXp7U0fOQsdCE2gI-1voWyA/edit?gid=1708590243#gid=1708590243](https://docs.google.com/spreadsheets/d/1Gftmhb-66Dag4qFEXw9tyXp7U0fOQsdCE2gI-1voWyA/edit?gid=1708590243#gid=1708590243)

The affected tests have been marked as flaky by using the flaky decorator.

This PR is part of an initiative of marking the most flaky tests of all the teams.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
