### PR TITLE
Flaky tests: Tracer

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DatadogSinkTests.cs" company="Datadog">
+// <copyright file="DatadogSinkTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -28,6 +28,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         private static readonly TimeSpan TinyWait = TimeSpan.FromMilliseconds(50);
 
         [Fact]
+        [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
         public void SinkSendsMessagesToLogsApi()
         {
             using var mutex = new ManualResetEventSlim();
@@ -49,6 +50,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         }
 
         [Fact]
+        [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
         public void SinkRejectsGiantMessages()
         {
             using var mutex = new ManualResetEventSlim();

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/OtlpSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/OtlpSinkTests.cs
@@ -16,6 +16,7 @@ using Datadog.Trace.Logging.DirectSubmission.Sink;
 using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
 using Datadog.Trace.OpenTelemetry;
 using Datadog.Trace.OpenTelemetry.Logs;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Util;
 using FluentAssertions;
 using Xunit;
@@ -55,6 +56,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         }
 
         [Fact]
+        [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
         public void SinkBatchesMultipleLogs()
         {
             using var mutex = new ManualResetEventSlim();


### PR DESCRIPTION
## Summary of changes

The following tests we detected as flaky:
```
Datadog.Trace.Tests.Logging.DirectSubmission.Sink.DatadogSinkTests.SinkSendsMessagesToLogsApi (3 failures in different pipelines the last month)
Datadog.Trace.Tests.Logging.DirectSubmission.Sink.OtlpSinkTests.SinkBatchesMultipleLogs (3 failures in different pipelines the last month)
Datadog.Trace.Tests.Logging.DirectSubmission.Sink.DatadogSinkTests.SinkRejectsGiantMessages (5 failures in different pipelines the last month)
```

The complete flakiness report can be found here:
[https://docs.google.com/spreadsheets/d/1Gftmhb-66Dag4qFEXw9tyXp7U0fOQsdCE2gI-1voWyA/edit?gid=1708590243#gid=1708590243](https://docs.google.com/spreadsheets/d/1Gftmhb-66Dag4qFEXw9tyXp7U0fOQsdCE2gI-1voWyA/edit?gid=1708590243#gid=1708590243)

The affected tests have been marked as flaky by using the flaky decorator.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
