### PR TITLE
Retry on profiler failed integration jobs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2723,6 +2723,7 @@ stages:
 
     - script: tracer\build.cmd BuildProfilerSamples BuildAndRunProfilerIntegrationTests --TargetPlatform $(targetPlatform)
       displayName: Run Profiler Integration tests
+      retryCountOnTaskFailure: 2
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -2830,6 +2831,7 @@ stages:
           -e baseImage=$(baseImage) \
           ProfilerIntegrationTests
       displayName: docker-compose run --no-deps ProfilerIntegrationTests
+      retryCountOnTaskFailure: 2
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         baseImage: $(baseImage) # for interpolation in the docker-compose file


### PR DESCRIPTION
## Summary of changes

The following jobs we detected as flaky (pipeline failures / last month):
```
profiler_integration_tests_linux | Test alpine | 34
profiler_integration_tests_windows | Win x86 | 7
profiler_integration_tests_windows | Win x64 | 6
```

The complete flakiness report can be found here:
[https://docs.google.com/spreadsheets/d/1Gftmhb-66Dag4qFEXw9tyXp7U0fOQsdCE2gI-1voWyA/edit?gid=1708590243#gid=1708590243](https://docs.google.com/spreadsheets/d/1Gftmhb-66Dag4qFEXw9tyXp7U0fOQsdCE2gI-1voWyA/edit?gid=1708590243#gid=1708590243)

The affected jobs will be retried on error. This PR can be reverted after handling flaky errors.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
