### PR TITLE
Skip some errors from being sent to telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace
                 var azureAppServiceSettings = new ImmutableAzureAppServiceSettings(GlobalConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
                 if (azureAppServiceSettings.IsUnsafeToTrace)
                 {
-                    Log.Error("The Azure Site Extension doesn't have the required parameters to work. The API_KEY is likely missing. The trace_agent and dogstatsd process will not be started. Check your app configuration and restart the app service to try again.");
+                    Log.ErrorSkipTelemetry("The Azure Site Extension doesn't have the required parameters to work. The API_KEY is likely missing. The trace_agent and dogstatsd process will not be started. Check your app configuration and restart the app service to try again.");
                     return;
                 }
 

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Util/CoverageUtils.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Util/CoverageUtils.cs
@@ -73,7 +73,7 @@ internal static class CoverageUtils
             var jsonFiles = Directory.GetFiles(inputFolder, "*.json", SearchOption.TopDirectoryOnly);
             if (jsonFiles.Length == 0)
             {
-                Log.Error("'{InputFolder}' doesn't contain any json file.", inputFolder);
+                Log.ErrorSkipTelemetry("'{InputFolder}' doesn't contain any json file.", inputFolder);
                 return false;
             }
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Configuration
 
             if (string.IsNullOrEmpty(apiKey))
             {
-                Log.Error("The Azure Site Extension will not work if you have not configured DD_API_KEY.");
+                Log.ErrorSkipTelemetry("The Azure Site Extension will not work if you have not configured DD_API_KEY.");
                 IsUnsafeToTrace = true;
             }
 


### PR DESCRIPTION
## Summary of changes

Skips a few errors that are `Ignored` in Error Tracking and shouldn't really be sent to telemetry as we can't act on them.

## Reason for change

Nothing we can really do about these.

## Implementation details

Marked as `ErrorSkipTelemetry`

## Test coverage

N/A

## Other details
<!-- Fixes #{issue} -->

I guess one thing we do lose here is whether we _want_ to see how often these happen?


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
