### PR TITLE
Fix `DuckTypeFieldIsReadonlyException` in RabbitMQ v7+ auto-instrumentation

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishAsyncCachedStringsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishAsyncCachedStringsIntegration.cs
@@ -55,8 +55,8 @@ public sealed class BasicPublishAsyncCachedStringsIntegration
 internal interface ICachedStringProxy : IDuckType
 {
     /// <summary>
-    /// Gets or sets a value of System.String
+    /// Gets the value of System.String
     /// </summary>
     [DuckField(Name = "Value")]
-    string Value { get; set; }
+    string Value { get; }
 }

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -135,7 +135,19 @@ namespace Samples.RabbitMQ
                 string message = $"{messagePrefix} - Message";
                 var body = Encoding.UTF8.GetBytes(message);
 
+#if RABBITMQ_7_0
+                // Use CachedString parameters to trigger BasicPublishAsyncCachedStringsIntegration
+                var cachedExchange = new CachedString(publishExchangeName);
+                var cachedRoutingKey = new CachedString(publishRoutingKey);
+                await channel.BasicPublishAsync(
+                    exchange: cachedExchange,
+                    routingKey: cachedRoutingKey,
+                    mandatory: false,
+                    basicProperties: properties,
+                    body: body);
+#else
                 await Helper.BasicPublishAsync(channel, publishExchangeName, publishRoutingKey, body, properties);
+#endif
 
                 Console.WriteLine($"BasicPublish - Sent message: {message}");
             }
@@ -180,9 +192,19 @@ namespace Samples.RabbitMQ
                         string message = $"Send - Message #{i}";
                         var body = Encoding.UTF8.GetBytes(message);
 
+#if RABBITMQ_7_0
+                        // Use CachedString parameters to trigger BasicPublishAsyncCachedStringsIntegration
+                        var cachedExchange = new CachedString("");
+                        var cachedRoutingKey = new CachedString("hello");
+                        await channel.BasicPublishAsync(
+                            exchange: cachedExchange,
+                            routingKey: cachedRoutingKey,
+                            body: body);
+#else
                         await Helper.BasicPublishAsync (channel, exchange: "",
                                              routingKey: "hello",
                                              body: body);
+#endif
                         Console.WriteLine("[Send] - [x] Sent \"{0}\"", message);
 
 


### PR DESCRIPTION
## Summary of changes

Fixes a `DuckTypeFieldIsReadonlyException` happening in the RabbitMQ v7+ instrumentation when `BasicPublish` is called with `CachedString`s.

## Reason for change

https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/94147996821f6a77bed0e77fd1886e75b08a31f9/projects/RabbitMQ.Client/CachedString.cs#L16

is defined as `readonly`

Our DuckType had was a `get/set` property.

When calling `BasicPublish` with `CachedString` we'd get the following error:

```
2025-12-23 09:52:24.105 -05:00 [ERR] Exception occurred when calling the CallTarget integration continuation. System.TypeInitializationException: The type initializer for 'Datadog.Trace.ClrProfiler.CallTarget.Handlers.BeginMethodHandler`8' threw an exception.
 ---> Datadog.Trace.ClrProfiler.CallTarget.CallTargetInvokerException: The field 'Value' is marked as readonly, you should remove the setter from the base type class or interface.
 ---> Datadog.Trace.DuckTyping.DuckTypeFieldIsReadonlyException: The field 'Value' is marked as readonly, you should remove the setter from the base type class or interface.
   at Datadog.Trace.DuckTyping.DuckTypeFieldIsReadonlyException.Throw(FieldInfo field) in C:\Users\steven.bouwkamp\source\repos\dd-trace-dotnet2\tracer\src\Datadog.Trace\DuckTyping\DuckTypeExceptions.cs:line 171
   at Datadog.Trace.DuckTyping.DuckType.CreateProperties(TypeBuilder proxyTypeBuilder, Type proxyDefinitionType, Type targetType, FieldInfo instanceField) in C:\Users\steven.bouwkamp\source\repos\dd-trace-dotnet2\tracer\src\Datadog.Trace\DuckTyping\DuckType.cs:line 774
   at Datadog.Trace.DuckTyping.DuckType.CreateProxyType(Type proxyDefinitionType, Type targetType, Boolean dryRun) in C:\Users\steven.bouwkamp\source\repos\dd-trace-dotnet2\tracer\src\Datadog.Trace\DuckTyping\DuckType.cs:line 215
--- End of stack trace from previous location ---
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.IntegrationMapper.CreateBeginMethodDelegate(Type integrationType, Type targetType, Type[] argumentsTypes) in C:\Users\steven.bouwkamp\source\repos\dd-trace-dotnet2\tracer\src\Datadog.Trace\ClrProfiler\CallTarget\Handlers\IntegrationMapper.cs:line 142
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.BeginMethodHandler`8..cctor() in C:\Users\steven.bouwkamp\source\repos\dd-trace-dotnet2\tracer\src\Datadog.Trace\ClrProfiler\CallTarget\Handlers\BeginMethodHandler`6.cs:line 28
   --- End of inner exception stack trace ---
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.BeginMethodHandler`8..cctor() in C:\Users\steven.bouwkamp\source\repos\dd-trace-dotnet2\tracer\src\Datadog.Trace\ClrProfiler\CallTarget\Handlers\BeginMethodHandler`6.cs:line 35
   --- End of inner exception stack trace ---
   at RabbitMQ.Client.Impl.Channel.BasicPublishAsync[TProperties](CachedString exchange, CachedString routingKey, Boolean mandatory, TProperties basicProperties, ReadOnlyMemory`1 body, CancellationToken cancellationToken)
 { MachineName: ".", Process: "[68600 Samples.RabbitMQ]", AppDomain: "[1 Samples.RabbitMQ]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #2", TracerVersion: "3.35.0.0" }
```

## Implementation details

Removed the `set`.

## Test coverage

So, I updated the sample application to make a call with `CachedString`s on V7+ _instead_ of the normal `string` calls. So no new spans, we would expect the spans to be the same and they are.

Without this fix (removing the `set`) the tests fail as the snapshots are different for V7. I didn't think it was super valuable to update the sample application to call both versions of `BasicPublish` for V7 (one with `CachedString` and one without) as `BasicPublishAsyncCachedStringsIntegration` just calls `return BasicPublishAsyncIntegration.OnMethodBegin` so 🤷 

## Other details
<!-- Fixes #{issue} -->

Fixes [this error identified by Error Tracking](https://app.datadoghq.com/error-tracking/issue/b5bb096c-6bd4-11f0-adde-da7ad0900002)

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
