### PR TITLE
Ensure we run the BenchmarksOpenTelemetryApi benchmarks on master

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -573,20 +573,32 @@ partial class Build : NukeBuild
         .Description("Runs the Benchmarks project")
         .Executes(() =>
         {
-            var benchmarkProjectsWithSettings = new Tuple<string, Func<DotNetRunSettings, DotNetRunSettings>>[] {
-                new(Projects.BenchmarksTrace, s => s),
+            var benchmarkProjectsWithSettings = new List<(string Project, Func<DotNetRunSettings, DotNetRunSettings> Configure)>
+            {
+                (Projects.BenchmarksTrace, s => s),
                 // new(Projects.BenchmarksOpenTelemetryApi, s => s),
-                new(Projects.BenchmarksOpenTelemetryInstrumentedApi,
+                (Projects.BenchmarksOpenTelemetryInstrumentedApi,
                     s => s.SetProcessEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true")
                           .SetProcessEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false")
                           .SetProcessEnvironmentVariable("DD_INTERNAL_AGENT_STANDALONE_MODE_ENABLED", "true")
                           .SetProcessEnvironmentVariable("DD_CIVISIBILITY_FORCE_AGENT_EVP_PROXY", "V4")),
             };
 
+            var isPr = int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var _);
+            // We don't run the base Otel benchmarks on PRs as nothing we do should change them.
+            // We _do_ run them on master, so we have up-to-date comparison data
+            // We can't easily use the benchmark "category" approach that we use below, because the BenchmarksOpenTelemetryApi
+            // project shares the same tests as BenchmarksOpenTelemetryInstrumentedApi.
+            if (!isPr)
+            {
+                benchmarkProjectsWithSettings.Add((Projects.BenchmarksOpenTelemetryApi, s => s));
+            }
+
+
             foreach (var tuple in benchmarkProjectsWithSettings)
             {
-                var benchmarkProjectName = tuple.Item1;
-                var configureDotNetRunSettings = tuple.Item2;
+                var benchmarkProjectName = tuple.Project;
+                var configureDotNetRunSettings = tuple.Configure;
 
                 var benchmarksProject = Solution.GetProject(benchmarkProjectName);
                 var resultsDirectory = benchmarksProject.Directory / "BenchmarkDotNet.Artifacts" / "results";
@@ -608,7 +620,6 @@ partial class Build : NukeBuild
                     };
 
                     // We could choose to not run asm on non-ASM PRs (for example) but for now we just run all categories
-                    var isPr = int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var _);
                     var categories = (BenchmarkCategory, isPr) switch
                     {
                         ({ Length: > 0 }, _) => BenchmarkCategory,


### PR DESCRIPTION
## Summary of changes

Make sure we run the "OTel API only" benchmarks on master

## Reason for change

We created "OTel API only" benchmarks in #6968 to compare with our "DD instrumented OTel API" benchmarks, but we're currently never running them, so we have no data. This ensures we run them on master (only) so we have comparison data.

## Implementation details

Check if we're on a PR (which we are already doing). If not, then run the OTel API only benchmarks.

## Test coverage

By its nature, hard to confirm it's working exactly as expected. Will confirm after merge
