### PR TITLE
Fix null ref in IpcTcpProcessMessageIntegration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessAndSendIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessAndSendIntegration.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, IMessage msg, ITransportHeaders headers, Stream inputStream)
         {
-            if (Tracer.Instance.InternalActiveScope is var scope)
+            if (Tracer.Instance.InternalActiveScope is { } scope)
             {
                 return new CallTargetState(scope);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessResponseExceptionIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessResponseExceptionIntegration.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, WebException webException, ref HttpWebResponse response)
         {
-            if (Tracer.Instance.InternalActiveScope is var scope)
+            if (Tracer.Instance.InternalActiveScope is { } scope)
             {
                 scope.Span?.SetException(webException);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpReceiveAndProcessIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpReceiveAndProcessIntegration.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, HttpWebResponse response, ref ITransportHeaders returnHeaders, ref Stream returnStream)
         {
-            if (Tracer.Instance.InternalActiveScope is var scope)
+            if (Tracer.Instance.InternalActiveScope is { } scope)
             {
                 return new CallTargetState(scope, state: response);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/IpcTcpProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/IpcTcpProcessMessageIntegration.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, IMessage msg, ITransportHeaders requestHeaders, Stream requestStream, ref ITransportHeaders responseHeaders, ref Stream responseStream)
         {
             var tracer = Tracer.Instance;
-            if (tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(RemotingIntegration.IntegrationId) && tracer.InternalActiveScope is var scope)
+            if (tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(RemotingIntegration.IntegrationId) && tracer.InternalActiveScope is { } scope)
             {
                 var context = new PropagationContext(scope.Span.Context, Baggage.Current);
                 tracer.TracerManager.SpanContextPropagator.Inject(context, requestHeaders, (headers, key, value) => headers[key] = value);


### PR DESCRIPTION
## Summary of changes

Fixes a `NullReferenceException` in `IpcTcpProcessMessageIntegration`.

## Reason for change

Previously the code was just doing this: `tracer.InternalActiveScope is var scope`

And then we were calling `scope.Span.Context` but the `Span` property can be `null`.

## Implementation details

Swapped to the property pattern `{ }` which should address it.

## Test coverage

I didn't update any tests


## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
