### PR TITLE
[Dynamic Instrumentation] Disable AppDomain related log flooding on .NET Framework

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.SingleProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.SingleProbe.cs
@@ -87,7 +87,14 @@ namespace Datadog.Trace.Debugger.Instrumentation
             ref var probeData = ref ProbeDataCollection.Instance.TryCreateProbeDataIfNotExists(probeMetadataIndex, probeId);
             if (probeData.IsEmpty())
             {
+                // In .NET Framework, we have en issue with multiple AppDomains. We can't easily share probe metadata
+                // between different AppDomain. The domain that request to put a probe might be different from the one that executes it.
+                // It results in entering into this branch. There is ongoing effort to fix this issue entirely in .NET Framework,
+                // for now as a quick fix to unblock a customer, this patch is being applied, to avoid logging tremendous amount of
+                // log entries.
+                #if !NETFRAMEWORK
                 Log.Warning("BeginMethod_StartMarker: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId });
+                #endif
                 return CreateInvalidatedDebuggerState();
             }
 


### PR DESCRIPTION
## Summary of changes
In legacy .NET Framework, a single process can host multiple logically isolated applications ("AppDomains") managed by the runtime. The machine code produced from jitting a method is used among the app domains. Thus, instrumentation is also being shared. The runtime isolates those different domains and prevents data sharing (that is only possible through marshalling/proxying). Each probe has metadata associated with it that is either received through the network (Remote Configuration) or created locally as in Exception Replay. This metadata is kept in memory and is crucial for the instrumentation to function correctly. When a method with an instrumentation is executed in a different domain from the one that kept this metadata, it can't retrieve it, thus bails out with a log message.
If such method executes many times, we may log plenty of time, result in log files rotation and flooding the disk. We have a customer that complaint about it.

As a quick fix for now, I'm disabling those log messages on .NET Framework.

## Reason for change
Flooding log files with the log message `BeginMethod_StartMarker: Failed to receive the ProbeData associated with the executing probe <...>`

## Implementation details
Disabling the log message on .NET Framework using a preprocessor directive that prevents the compilation of this log message on .NET Framework builds.