### PR TITLE
Introduce `ActivityKey` to remove string concatenation

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityKey.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityKey.cs
@@ -1,0 +1,50 @@
+// <copyright file="ActivityKey.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Trace.Activity.Handlers;
+
+internal readonly struct ActivityKey : IEquatable<ActivityKey>
+{
+    private readonly string _traceId;
+    private readonly string _spanId;
+
+    public ActivityKey(string traceId, string spanId)
+    {
+        _traceId = traceId;
+        _spanId = spanId;
+    }
+
+    public ActivityKey(string id)
+    {
+        // Arbitrary which way around these are
+        _spanId = id;
+        _traceId = string.Empty;
+    }
+
+    public bool IsValid() => _traceId is not null && _spanId is not null;
+
+    public bool Equals(ActivityKey other) =>
+        string.Equals(_traceId, other._traceId, StringComparison.Ordinal) &&
+        string.Equals(_spanId, other._spanId, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) =>
+        obj is ActivityKey other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        // TraceId and SpanId must be non-null, so can just just the values directly.
+        // If we allow this to be called with any null values, then we must add null checks here
+        unchecked
+        {
+            return (StringComparer.Ordinal.GetHashCode(_traceId) * 397)
+                 ^ StringComparer.Ordinal.GetHashCode(_spanId);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Activity/Handlers/AzureServiceBusActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/AzureServiceBusActivityHandler.cs
@@ -46,17 +46,17 @@ namespace Datadog.Trace.Activity.Handlers
                 // then we can retrieve the active message object using our mapping. With access to the message
                 // object, we can accurately calculate the payload size for the DataStreamsCheckpoint
 
-                string key;
+                ActivityKey key;
                 if (activity is IW3CActivity w3cActivity)
                 {
-                    key = w3cActivity.TraceId + w3cActivity.SpanId;
+                    key = new(w3cActivity.TraceId, w3cActivity.SpanId);
                 }
                 else
                 {
-                    key = activity.Id;
+                    key = new ActivityKey(activity.Id);
                 }
 
-                if (ActivityHandlerCommon.ActivityMappingById.TryRemove(key, out ActivityMapping activityMapping)
+                if (key.IsValid() && ActivityHandlerCommon.ActivityMappingById.TryRemove(key, out ActivityMapping activityMapping)
                     && activityMapping.Scope?.Span is Span span)
                 {
                     // Copy over the data to our Span object so we can do an efficient tags lookup

--- a/tracer/src/Datadog.Trace/Activity/Handlers/QuartzActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/QuartzActivityHandler.cs
@@ -45,13 +45,13 @@ namespace Datadog.Trace.Activity.Handlers
             where T : IActivity
         {
             // Find the span and update it before the common handler processes it
-            string key = activity switch
+            ActivityKey key = activity switch
             {
-                IW3CActivity w3cActivity => w3cActivity.TraceId + w3cActivity.SpanId,
-                _ => activity.Id
+                IW3CActivity w3cActivity => new(w3cActivity.TraceId, w3cActivity.SpanId),
+                _ => new(activity.Id)
             };
 
-            if (key != null && ActivityHandlerCommon.ActivityMappingById.TryRemove(key, out var activityMapping) && activityMapping.Scope.Span is Span span)
+            if (key.IsValid() && ActivityHandlerCommon.ActivityMappingById.TryRemove(key, out var activityMapping) && activityMapping.Scope.Span is Span span)
             {
                 Log.Debug("ActivityStopped: Processing span for activity '{ActivityId}'", activity.Id);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -31,17 +31,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
                 return;
             }
 
-            string key;
+            ActivityKey key;
             if (activityData.TryDuckCast<IW3CActivity>(out var w3cActivity) && w3cActivity.TraceId is { } traceId && w3cActivity.SpanId is { } spanId)
             {
-                key = traceId + spanId;
+                key = new(traceId, spanId);
             }
             else
             {
-                key = activity.Id;
+                key = new(activity.Id);
             }
 
-            if (ActivityHandlerCommon.ActivityMappingById.TryGetValue(key, out var activityMapping))
+            if (key.IsValid() && ActivityHandlerCommon.ActivityMappingById.TryGetValue(key, out var activityMapping))
             {
                 if (baseProcessor.ParentProvider is not null)
                 {

--- a/tracer/test/Datadog.Trace.Tests/Activity/ActivityKeyTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Activity/ActivityKeyTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="ActivityKeyTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Activity.Handlers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Activity;
+
+public class ActivityKeyTests
+{
+    [Theory]
+    [InlineData("spanId", "traceId")]
+    [InlineData("id", "")]
+    public void Equality(string spanId, string traceId)
+    {
+        var activity1 = new ActivityKey(traceId: traceId, spanId: spanId);
+        var activity2 = new ActivityKey(traceId: traceId, spanId: spanId);
+        activity1.Equals(activity2).Should().BeTrue();
+        activity1.GetHashCode().Should().Be(activity2.GetHashCode());
+
+        var other = new ActivityKey(traceId: traceId, spanId: "newId");
+        activity1.Equals(other).Should().BeFalse();
+        activity1.GetHashCode().Should().NotBe(other.GetHashCode());
+        activity2.Equals(other).Should().BeFalse();
+        activity2.GetHashCode().Should().NotBe(other.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData("spanId", "traceId")]
+    [InlineData("id", "")]
+    public void Equality_DefaultComparer(string spanId, string traceId)
+    {
+        var activity1 = new ActivityKey(traceId: traceId, spanId: spanId);
+        var activity2 = new ActivityKey(traceId: traceId, spanId: spanId);
+
+        EqualityComparer<ActivityKey>.Default.Equals(activity1, activity2).Should().BeTrue();
+        var hashCode1 = EqualityComparer<ActivityKey>.Default.GetHashCode(activity1).GetHashCode();
+        var hashCode2 = EqualityComparer<ActivityKey>.Default.GetHashCode(activity2);
+        hashCode1.Should().Be(hashCode2);
+
+        var other = new ActivityKey(traceId: traceId, spanId: "newId");
+        var hashCodeOther = EqualityComparer<ActivityKey>.Default.GetHashCode(other).GetHashCode();
+        EqualityComparer<ActivityKey>.Default.Equals(activity1, other).Should().BeFalse();
+        hashCode1.Should().NotBe(hashCodeOther);
+        EqualityComparer<ActivityKey>.Default.Equals(activity2, other).Should().BeFalse();
+        hashCode2.Should().NotBe(hashCodeOther);
+    }
+
+    [Theory]
+    [InlineData("spanId", "traceId", true)]
+    [InlineData("spanId", "", true)]
+    [InlineData("", "traceId", true)]
+    [InlineData("", "", true)]
+    [InlineData("spanId", null, false)]
+    [InlineData(null, "traceId", false)]
+    public void IsValid_SpanId_TraceId(string traceId, string spanId, bool isValid)
+    {
+        new ActivityKey(traceId: traceId, spanId: spanId).IsValid().Should().Be(isValid);
+    }
+
+    [Theory]
+    [InlineData("some_id", true)]
+    [InlineData("", true)]
+    [InlineData(null, false)]
+    public void IsValid_SpanId_Id(string id, bool isValid)
+    {
+        new ActivityKey(id).IsValid().Should().Be(isValid);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
@@ -207,12 +207,12 @@ namespace Datadog.Trace.Tests
 
             public ActivityFixture()
             {
-                Activity.ActivityListener.Initialize();
+                Datadog.Trace.Activity.ActivityListener.Initialize();
             }
 
             public void Dispose()
             {
-                Activity.ActivityListener.StopListeners();
+                Datadog.Trace.Activity.ActivityListener.StopListeners();
             }
 
             public void StartActivity(SD.Activity activity)


### PR DESCRIPTION
## Summary of changes

Reduce allocation of `ActivityHandlerCommon` by removing `string` concatenation

## Reason for change

The `ActivityHandlerCommon.ActivityStarted` and `ActivityStopped` methods need to store and retrieve `Activity` instances from a `ConcurrentDictionary<>`. Today they're doing that be concatenating the `Activity`'s `TraceId` and `SpanID`, or by using it's `ID`. All that concatenation causes a bunch of allocation, so instead introduce a simple `struct` to use as the key instead

## Implementation details

Introduce `ActivityKey`, which is essentially `internal readonly record struct ActivityKey(string TraceId, string SpanId`, and use that for all of the dictionary lookups. Which avoids all the string concatenation allocations.

## Test coverage

Added some unit tests for `ActivityKey`, by mostly covered by existing integration tests for correctness. Benchmarks show a significant improvement over [the previous results](https://github.com/DataDog/dd-trace-dotnet/pull/8036), particularly for Hierachical IDs which clearly were buggy


| Method                          | Runtime              |     Mean |    StdDev |   Gen0 | Allocated | Compared to #8036 |
| ------------------------------- | -------------------- | -------: | --------: | -----: | --------: | ----------------: |
| StartStopWithChild_Hierarchical | .NET 6.0             | 4.217 us | 0.3227 us | 0.0153 |   4.09 KB |          -6.38 KB |
| StartStopWithChild_Hierarchical | .NET 8.0             | 3.413 us | 0.2505 us | 0.0076 |   4.09 KB |          -6.39 KB |
| StartStopWithChild_Hierarchical | .NET Core 3.1        | 5.676 us | 0.4636 us | 0.0153 |   4.32 KB |          -6.43 KB |
| StartStopWithChild_Hierarchical | .NET Framework 4.7.2 | 6.813 us | 0.4969 us | 0.7324 |   4.53 KB |          -7.24 KB |
|                                 |                      |          |           |        |           |                   |
| StartStopWithChild              | .NET 6.0             | 4.105 us | 0.2677 us | 0.0153 |    4.3 KB |          -0.57 KB |
| StartStopWithChild              | .NET 8.0             | 3.475 us | 0.1570 us | 0.0114 |    4.2 KB |          -0.57 KB |
| StartStopWithChild              | .NET Core 3.1        | 5.647 us | 0.3129 us | 0.0153 |   4.48 KB |          -0.57 KB |
| StartStopWithChild              | .NET Framework 4.7.2 | 6.842 us | 0.2992 us | 0.7629 |   4.69 KB |          -0.61 KB |



## Other details

https://datadoghq.atlassian.net/browse/LANGPLAT-915

Part of a stack working to improve OTel performance

- https://github.com/DataDog/dd-trace-dotnet/pull/8036 
- https://github.com/DataDog/dd-trace-dotnet/pull/8037 👈
- https://github.com/DataDog/dd-trace-dotnet/pull/8038
- https://github.com/DataDog/dd-trace-dotnet/pull/8039
- https://github.com/DataDog/dd-trace-dotnet/pull/8040
- https://github.com/DataDog/dd-trace-dotnet/pull/8041
- https://github.com/DataDog/dd-trace-dotnet/pull/8042