### PR TITLE
Add missing permissions to release process

### DIFF
--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -44,6 +44,7 @@ jobs:
   create_draft_release:
     runs-on: ubuntu-latest
     environment: publish-debug-symbols-env
+    # These permissions need to map to the ones demanded in create_normal_draft_release.yml and create_hotfix_draft_release.yml
     permissions:
       contents: write # create release
       actions: read # read secrets

--- a/.github/workflows/create_hotfix_draft_release.yml
+++ b/.github/workflows/create_hotfix_draft_release.yml
@@ -28,6 +28,11 @@ jobs:
     create_hotfix_draft_release:
         needs: check_branch
         uses: ./.github/workflows/_create_draft_release.yml
+        # These permissions need to map to the ones demanded in _create_draft_release.yml
+        permissions:
+          contents: write # create release
+          actions: read # read secrets
+          issues: write # change milestones 
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}

--- a/.github/workflows/create_normal_draft_release.yml
+++ b/.github/workflows/create_normal_draft_release.yml
@@ -28,6 +28,11 @@ jobs:
     create_normal_draft_release:
         needs: check_branch
         uses: ./.github/workflows/_create_draft_release.yml
+        # These permissions need to map to the ones demanded in _create_draft_release.yml
+        permissions:
+          contents: write # create release
+          actions: read # read secrets
+          issues: write # change milestones 
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}


### PR DESCRIPTION
## Summary of changes

Add missing permissions to the new release actions

## Reason for change

The release failed because the new processes were missing permissions

## Implementation details

Copy the permissions that are demanded in _create_draft_release into the two callers. I think we just have to accept the duplication here, so added comments to make sure updates are mirrored

## Test coverage

Can't test this stuff very easily unfortunately, hence all this trial and error every 2 weeks 😅 
