### PR TITLE
Try disable the pull-request-freshness feature

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -6,6 +6,8 @@ enable: false
 schema-version: v1
 kind: mergegate
 rules:
+  - require: pull-request-freshness
+    enforcement: disabled
   - require: commit-signatures
     excluded_emails:
       - '49699333+dependabot[bot]@users.noreply.github.com' # dependabot


### PR DESCRIPTION
## Summary of changes

Disable Doggo's `pull-request-freshness` feature

## Reason for change

It puts pressure on CI that we don't want

## Implementation details

Try to disable it [following the docs](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/4948100574/MergeGate#Require-Pull-Request-Freshness)

## Test coverage

We'll just see if it works (needs to be merged first)