### PR TITLE
Revert "[SINT-4550] Use CI Identities in Windows CI Jobs (#8033)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ variables:
   DOTNET_PACKAGE_VERSION:
     description: "Used by the package stage when triggered manually"
   REPO_NOTIFICATION_CHANNEL: "#apm-dotnet-bots"
-  CI_IDENTITIES_CLIENT_URL: s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/v0.2.0/ci-identities-gitlab-job-client-windows-amd64.exe
 
 build:
   except:
@@ -38,9 +37,7 @@ build:
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `
         -e NUGET_CERT_REVOCATION_MODE=offline `
-        -e CI_IDENTITIES_GITLAB_ID_TOKEN `
-        -e CI_PROJECT_NAME `
-        registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:ci-identities `
+        registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:dotnet10 `
         Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi DownloadWinSsiTelemetryForwarder
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out
@@ -51,9 +48,6 @@ build:
     expire_in: 2 weeks
     paths:
     - artifacts-out
-  id_tokens:
-    CI_IDENTITIES_GITLAB_ID_TOKEN:
-      aud: ci-identities
 
 publish:
   only:
@@ -73,17 +67,19 @@ publish:
     pre_get_sources_script:
       - git config --system core.longpaths true
   script:
-    # TODO remove the aws s3 cp command
-    # when the client is installed in the Windows runner image
-    - aws s3 cp --only-show-errors ${CI_IDENTITIES_CLIENT_URL} ./ci-identities-gitlab-job-client.exe
-    - ./ci-identities-gitlab-job-client.exe assume-role
+    - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
+    - $resultjson = $result | convertfrom-json
+    - $credentials = $($resultjson.Credentials)
+    - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
+    - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
+    - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
     - |
       $i = 0
       do {
           try {
               # The grants option at the end is used to allow public access on the files we upload as the acls only aren't enough.
               aws s3 cp artifacts-out/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --include "telemetry_forwarder.exe" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-              If ($LASTEXITCODE -eq 0) {
+              If ($LASTEXITCODE -eq 0) { 
                 return
               }
 
@@ -99,11 +95,6 @@ publish:
       # If we got here, all retries failed – fail the job:
       Write-Error "Failed to upload artifacts to S3 after $i attempts."
       exit 1
-  variables:
-    AWS_SHARED_CREDENTIALS_FILE: ${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}
-  id_tokens:
-    CI_IDENTITIES_GITLAB_ID_TOKEN:
-      aud: ci-identities
 
 
 download-single-step-artifacts:

--- a/tracer/build/_build/docker/gitlab/UPDATING_IMAGE.md
+++ b/tracer/build/_build/docker/gitlab/UPDATING_IMAGE.md
@@ -48,13 +48,6 @@ docker inspect --format='{{index .RepoDigests 0}}' datadog/dd-trace-dotnet-docke
 
 Extract the SHA256 hash from the output (format: `docker.io/datadog/dd-trace-dotnet-docker-build@sha256:<HASH>`).
 
-You can also use [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md)
-
-```
-$ crane digest datadog/dd-trace-dotnet-docker-build:dotnet10-rc1
-sha256:180cb096b25d9c53e24b23d0324cd403cc7fe4e99c88ec2c20e851dc37d359ef
-```
-
 ### 6. Create Mirror PR
 
 In the `DataDog/images` repository, add entries to two files:

--- a/tracer/build/_build/docker/gitlab/entrypoint.bat
+++ b/tracer/build/_build/docker/gitlab/entrypoint.bat
@@ -36,10 +36,6 @@ if "%nuke_args%"=="" (
     exit /b 1
 )
 
-:: the CI Identities client will write the credentials to the path in the environment variable AWS_SHARED_CREDENTIALS_FILE,
-:: and if the variable is not set, it will write to %USERPROFILE%\.aws\credentials
-c:\devtools\ci-identities-gitlab-job-client.exe assume-role
-
 dotnet run --project tracer/build/_build/_build.csproj -- %nuke_args% --Artifacts "build-out\%CI_JOB_ID%"
 
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -40,19 +40,27 @@ ENV DOTNET_VERSION="10.0.100" \
 COPY install_dotnet.ps1 .
 RUN powershell -Command .\install_dotnet.ps1  -Version $ENV:DOTNET_VERSION -Sha512 $ENV:DOTNET_SHA512 $ENV:DOTNET_DOWNLOAD_URL
 
-# Copy the CI Identities GitLab Job Client
-COPY --from=registry.ddbuild.io/ci-identities/ci-identities-gitlab-job-client:v0.2.0-windows-amd64 C:/ci-identities-gitlab-job-client.exe c:/devtools/ci-identities-gitlab-job-client.exe
-
 # Java and code signing tool environment variables
-ENV JAVA_VERSION "25.0.1"
-ENV JAVA_SHA256 "d56bed274adb2b16deea2dce3f21718d1b0dcdbe2253bc5cc332b525cbcd1fd1"
+ENV JAVA_VERSION "17.0.8"
+ENV JAVA_SHA256 "db6e7e7506296b8a2338f6047fdc94bf4bbc147b7a3574d9a035c3271ae1a92b"
+ENV WINSIGN_VERSION "0.3.5"
+ENV WINSIGN_SHA256 "b2ba5127a5c5141e04d42444ca115af4c95cc053a743caaa9b33c68dd6b13f68"
+ENV PYTHON_VERSION "3.8.2"
+
+# Install Python
+COPY install_python3.ps1 .
+RUN powershell -Command .\install_python3.ps1 -Version $ENV:PYTHON_VERSION
+
+COPY requirements.txt constraints.txt install_python_packages.ps1 ./
+RUN powershell -Command .\install_python_packages.ps1
 
 # Install JAVA
 COPY helpers.ps1 install_java.ps1 ./
 RUN powershell -Command .\install_java.ps1
 
-# Install Windows Code Signer
-COPY --from=registry.ddbuild.io/windows-code-signer/go:v0.6.0-ltsc2019 c:/windows-code-signer/windows-code-signer.exe c:/devtools/windows-code-signer.exe
+# Install 
+COPY install_winsign.ps1 .
+RUN powershell -Command .\install_winsign.ps1
 
 # Copy everything else
 COPY . .

--- a/tracer/build/_build/docker/gitlab/install_java.ps1
+++ b/tracer/build/_build/docker/gitlab/install_java.ps1
@@ -44,9 +44,9 @@ Write-Host -ForegroundColor Green 'java --version'; java --version
 
 ## need to have more rigorous download at some point, but
 #$jsignjarsrc = "https://s3.amazonaws.com/dd-agent-omnibus/jsign/jsign-4.2.jar"
-$jsignjarsrc = "https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar"
+$jsignjarsrc = "https://github.com/ebourg/jsign/releases/download/5.0/jsign-5.0.jar"
 $jsignjardir = "c:\devtools\jsign"
-$jsignout = "$($jsignjardir)\jsign-7.4.jar"
+$jsignout = "$($jsignjardir)\jsign-5.0.jar"
 if (-Not (test-path $jsignjardir)) {
     mkdir $jsignjardir
 }

--- a/tracer/build/_build/docker/gitlab/install_python3.ps1
+++ b/tracer/build/_build/docker/gitlab/install_python3.ps1
@@ -1,0 +1,35 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$ApplicationName = "Python"
+$Installer = "$($PSScriptRoot)\python.exe"
+$DownloadUrl = "https://www.python.org/ftp/python/$Version/python-$Version-amd64.exe"
+$InstallDir = "c:\tmp\Python38"
+$PythonScriptsDir = "c:\tmp\Python38\scripts"
+
+Write-Host -ForegroundColor Green "========= Installing Python $Version ========="
+
+# Download installer
+Write-Host "Downloading $ApplicationName"
+(New-Object System.Net.WebClient).DownloadFile($DownloadUrl, $Installer)
+
+# Start the installer
+Write-Host "Installing $ApplicationName"
+Start-Process $Installer -ArgumentList '/quiet InstallAllUsers=1 TargetDir=C:\tmp\Python38' -Wait
+
+# Test to make sure the application actually installed.
+if (!(Test-Path $InstallDir)) {
+    throw "FATAL: '$ApplicationName' was not found after MSI installation"
+}
+else {
+    # Cleanup
+    Remove-Item $Installer
+    # Add application to PATH
+    [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$InstallDir;$PythonScriptsDir", [EnvironmentVariableTarget]::Machine)
+    Write-Host -ForegroundColor Green "$ApplicationName has been installed successfully"
+}

--- a/tracer/build/_build/docker/gitlab/install_python_packages.ps1
+++ b/tracer/build/_build/docker/gitlab/install_python_packages.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+Write-Host -ForegroundColor Green "========= Installing python packages  ========="
+& python -m pip install -r "$($PSScriptRoot)\requirements.txt"

--- a/tracer/build/_build/docker/gitlab/install_winsign.ps1
+++ b/tracer/build/_build/docker/gitlab/install_winsign.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+$TargetContainer = $true
+. "$($PSScriptRoot)\helpers.ps1"
+Write-Host -ForegroundColor Green "Installing Windows Codesign Helper $ENV:WINSIGN_VERSION"
+
+## need to have more rigorous download at some point, but
+$codesign_base = "windows_code_signer-$($ENV:WINSIGN_VERSION)-py3-none-any.whl"
+$codesign_wheel = "https://s3.amazonaws.com/dd-agent-omnibus/windows-code-signer/$($codesign_base)"
+$codesign_wheel_target = "c:\devtools\$($codesign_base)"
+(New-Object System.Net.WebClient).DownloadFile($codesign_wheel, $codesign_wheel_target)
+
+Get-RemoteFile -RemoteFile $codesign_wheel -LocalFile $codesign_wheel_target -VerifyHash $ENV:WINSIGN_SHA256
+
+python -m pip install $codesign_wheel_target


### PR DESCRIPTION
## Summary of changes

This reverts commit aa68bc54b7f81dd5e2b77fdb0dc11f9a8ec42940.

## Reason for change

The publish job is currently failing due to AWS permission issues

## Implementation details

Just revert