### PR TITLE
Update CODEOWNERS for feature flagging work

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -165,6 +165,13 @@ Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 /tracer/src/**/*GCP*.cs                                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 /tracer/test/**/*GCP*.cs                                                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 
+## Feature Flagging and Experimentation (Currently developed by ASM)
+/tracer/src/Datadog.Trace/FeatureFlags/                                         @DataDog/tracing-dotnet @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace.Manual/FeatureFlags/                                  @DataDog/tracing-dotnet @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.Tests/FeatureFlags/                                  @DataDog/tracing-dotnet @DataDog/asm-dotnet
+/tracer/test/test-applications/integrations/Samples.FeatureFlags/               @DataDog/tracing-dotnet @DataDog/asm-dotnet
+/tracer/test/test-applications/integrations/Samples.OpenFeature/                @DataDog/tracing-dotnet @DataDog/asm-dotnet
+
 # Shared code we could move to the root folder
 /tracer/build/                            @DataDog/apm-dotnet
 


### PR DESCRIPTION
## Summary of changes

Adds FFE to codeowners

## Reason for change

The FFE work is being owned by ASM at the moment

## Implementation details

Add ASM to be co-owners of some core FFE-specific parts

