### PR TITLE
Revert "Don't do `DynamicMethod` based allocation-free enumeration on…

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Helpers/ActivityEnumerationHelper.cs
+++ b/tracer/src/Datadog.Trace/Activity/Helpers/ActivityEnumerationHelper.cs
@@ -35,17 +35,6 @@ internal static class ActivityEnumerationHelper
     public static void EnumerateTagObjects<T>(T activity5, ref OtelTagsEnumerationState state, TagObjectsEnumerator.ForEachDelegate funcToRun)
         where T : IActivity5
     {
-        if (Environment.Version.Major >= 10)
-        {
-            // .NET 10 doesn't allocate _anyway_, so we should just do naive enumeration
-            foreach (var value in activity5.TagObjects)
-            {
-                funcToRun(ref state, value);
-            }
-
-            return;
-        }
-
         var tagObjects = activity5.TagObjects;
         var runtimeType = tagObjects.GetType();
 
@@ -83,17 +72,6 @@ internal static class ActivityEnumerationHelper
     public static void EnumerateTags<T>(T activity, ref OtelTagsEnumerationState state, TagsEnumerator.ForEachDelegate funcToRun)
         where T : IActivity
     {
-        if (Environment.Version.Major >= 10)
-        {
-            // .NET 10 doesn't allocate _anyway_, so we should just do naive enumeration
-            foreach (var value in activity.Tags)
-            {
-                funcToRun(ref state, value);
-            }
-
-            return;
-        }
-
         var tags = activity.Tags;
         var runtimeType = tags.GetType();
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <!-- benchmarkdotnet only support numberic values, not "latest"-->
@@ -20,7 +20,6 @@
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
… .NET 10 (#8058)"

This reverts commit 1472f1b2b77d0d0741152007c20816f8296a7e3c.

## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
