### PR TITLE
[ASM] Fix RC configs apply order

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rcm/AsmFeaturesProduct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/AsmFeaturesProduct.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AsmFeaturesProduct.cs" company="Datadog">
+// <copyright file="AsmFeaturesProduct.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -13,32 +13,35 @@ namespace Datadog.Trace.AppSec.Rcm;
 
 internal sealed class AsmFeaturesProduct : IAsmConfigUpdater
 {
-    public void ProcessUpdates(ConfigurationState configurationStatus, List<RemoteConfiguration> files)
+    public void ProcessUpdates(ConfigurationState configurationStatus, List<RemoteConfigurationPath>? removedConfigs, List<RemoteConfiguration>? files)
     {
-        foreach (var file in files)
+        if (removedConfigs is { Count: > 0 })
         {
-            var asmFeatures = new NamedRawFile(file.Path, file.Contents).Deserialize<AsmFeatures>();
-            if (asmFeatures.TypedFile != null)
+            foreach (var removedConfig in removedConfigs)
             {
-                if (asmFeatures.TypedFile.Asm?.Enabled is not null)
-                {
-                    configurationStatus.AsmFeaturesByFile[file.Path.Path] = asmFeatures.TypedFile.Asm;
-                }
-
-                if (asmFeatures.TypedFile.AutoUserInstrum?.Mode is not null)
-                {
-                    configurationStatus.AutoUserInstrumByFile[file.Path.Path] = asmFeatures.TypedFile.AutoUserInstrum;
-                }
+                configurationStatus.AsmFeaturesByFile.Remove(removedConfig.Path);
+                configurationStatus.AutoUserInstrumByFile.Remove(removedConfig.Path);
             }
         }
-    }
 
-    public void ProcessRemovals(ConfigurationState configurationStatus, List<RemoteConfigurationPath> removedConfigsForThisProduct)
-    {
-        foreach (var removedConfig in removedConfigsForThisProduct)
+        if (files is { Count: > 0 })
         {
-            configurationStatus.AsmFeaturesByFile.Remove(removedConfig.Path);
-            configurationStatus.AutoUserInstrumByFile.Remove(removedConfig.Path);
+            foreach (var file in files)
+            {
+                var asmFeatures = new NamedRawFile(file.Path, file.Contents).Deserialize<AsmFeatures>();
+                if (asmFeatures.TypedFile != null)
+                {
+                    if (asmFeatures.TypedFile.Asm?.Enabled is not null)
+                    {
+                        configurationStatus.AsmFeaturesByFile[file.Path.Path] = asmFeatures.TypedFile.Asm;
+                    }
+
+                    if (asmFeatures.TypedFile.AutoUserInstrum?.Mode is not null)
+                    {
+                        configurationStatus.AutoUserInstrumByFile[file.Path.Path] = asmFeatures.TypedFile.AutoUserInstrum;
+                    }
+                }
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Rcm/AsmGenericProduct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/AsmGenericProduct.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AsmGenericProduct.cs" company="Datadog">
+// <copyright file="AsmGenericProduct.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -22,21 +22,33 @@ internal sealed class AsmGenericProduct : IAsmConfigUpdater
         _getCollection = getCollection;
     }
 
-    public void ProcessUpdates(ConfigurationState configurationStatus, List<RemoteConfiguration> files)
+    public void ProcessUpdates(ConfigurationState configurationStatus, List<RemoteConfigurationPath>? removedConfigs, List<RemoteConfiguration>? files)
     {
         var collection = _getCollection();
-        foreach (var file in files)
+
+        if (removedConfigs is { Count: > 0 })
         {
-            var payload = new NamedRawFile(file.Path, file.Contents).Deserialize<JToken>();
-            if (payload.TypedFile == null)
+            foreach (var configurationPath in removedConfigs)
             {
-                continue;
+                collection.Remove(configurationPath.Path);
             }
+        }
 
-            var asmConfig = payload.TypedFile;
-            var asmConfigName = payload.Name;
+        if (files is { Count: > 0 })
+        {
+            foreach (var file in files)
+            {
+                var payload = new NamedRawFile(file.Path, file.Contents).Deserialize<JToken>();
+                if (payload.TypedFile == null)
+                {
+                    continue;
+                }
 
-            collection[asmConfigName] = asmConfig;
+                var asmConfig = payload.TypedFile;
+                var asmConfigName = payload.Name;
+
+                collection[asmConfigName] = asmConfig;
+            }
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Rcm/IAsmConfigUpdater.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/IAsmConfigUpdater.cs
@@ -12,7 +12,5 @@ namespace Datadog.Trace.AppSec.Rcm;
 
 internal interface IAsmConfigUpdater
 {
-    void ProcessUpdates(ConfigurationState configurationStatus, List<RemoteConfiguration> files);
-
-    void ProcessRemovals(ConfigurationState configurationStatus, List<RemoteConfigurationPath> removedConfigsForThisProduct);
+    void ProcessUpdates(ConfigurationState configurationStatus, List<RemoteConfigurationPath>? removedConfigsForThisProduct, List<RemoteConfiguration>? files);
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -212,7 +212,7 @@ public class WafLibraryRequiredTest : SettingsTestsBase
         return CreateConfigurationState(creation, ruleFile, null, asmConfigs, asmDataConfigs);
     }
 
-    private static ConfigurationState CreateConfigurationState(bool creation, string? ruleFile = null, Dictionary<string, RuleSet>? rulesetConfigs = null, Dictionary<string, AppSec.Rcm.Models.Asm.Payload>? asmConfigs = null, Dictionary<string, AppSec.Rcm.Models.AsmData.Payload>? asmDataConfigs = null)
+    private static ConfigurationState CreateConfigurationState(bool creation, string? ruleFile = null, List<KeyValuePair<string, RuleSet>>? rulesetConfigs = null, Dictionary<string, AppSec.Rcm.Models.Asm.Payload>? asmConfigs = null, Dictionary<string, AppSec.Rcm.Models.AsmData.Payload>? asmDataConfigs = null)
     {
         var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Rules, ruleFile), (ConfigurationKeys.AppSec.Enabled, "1"));
         var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);


### PR DESCRIPTION
## Summary of changes
- Refactors ASM Remote Configuration application to process **removals and updates together** per product, instead of handling them in two separate passes.

## Reason for change
- Fixes incorrect or unstable **apply order** when Remote Configuration delivers a mix of removals and updates for ASM products, which could lead to stale configs being retained or ordering-dependent behavior.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
