### PR TITLE
Replace remaining usages of `Environment.Version`

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProbe.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         private bool CheckIfMethodMayBeOmittedFromCallStack()
         {
             return ExceptionTrackManager.IsEditAndContinueFeatureEnabled &&
-                   FrameworkDescription.Instance.IsCoreClr() && RuntimeHelper.IsNetOnward(6) && Method.Method.DeclaringType?.Assembly != null && RuntimeHelper.IsModuleDebugCompiled(Method.Method.DeclaringType.Assembly);
+                   FrameworkDescription.Instance.RuntimeVersion.Major >= 6 && Method.Method.DeclaringType?.Assembly != null && RuntimeHelper.IsModuleDebugCompiled(Method.Method.DeclaringType.Assembly);
         }
 
         private void ProcessCase(ExceptionCase @case)

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/RuntimeHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/RuntimeHelper.cs
@@ -17,11 +17,6 @@ namespace Datadog.Trace.Debugger.Helpers
 {
     internal static class RuntimeHelper
     {
-        internal static bool IsNetOnward(int major)
-        {
-            return Environment.Version.Major >= major;
-        }
-
         internal static bool IsModuleDebugCompiled(Assembly assembly)
         {
             var debuggableAttribute = assembly.GetCustomAttributes(typeof(DebuggableAttribute), false).FirstOrDefault() as DebuggableAttribute;

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace
 
         public bool IsCoreClr()
         {
-            return Name.ToLowerInvariant().Contains("core") || IsNet5();
+            return RuntimeVersion.Major >= 5 || Name.IndexOf("core", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static void GetNetCoreOrNetFrameworkVersion(out Version version, out string productVersion)

--- a/tracer/src/Datadog.Trace/FrameworkDescription.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.cs
@@ -50,11 +50,6 @@ namespace Datadog.Trace
 
         public Version RuntimeVersion { get; }
 
-        public static bool IsNet5()
-        {
-            return Environment.Version.Major >= 5;
-        }
-
         public bool IsWindows()
         {
             return string.Equals(OSPlatform, OSPlatformName.Windows, StringComparison.OrdinalIgnoreCase);

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/DiagnosticsMetricsRuntimeMetricsListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/DiagnosticsMetricsRuntimeMetricsListener.cs
@@ -57,15 +57,16 @@ internal sealed class DiagnosticsMetricsRuntimeMetricsListener : IRuntimeMetrics
         };
 
         // ASP.NET Core metrics are only available on .NET 8+
-        _aspnetcoreMetricsAvailable = Environment.Version.Major >= 8;
+        var version = FrameworkDescription.Instance.RuntimeVersion;
+        _aspnetcoreMetricsAvailable = version.Major >= 8;
 
-        if (Environment.Version.Major >= 9)
+        if (version.Major >= 9)
         {
             // System.Runtime metrics are only available on .NET 9+, but the only one we need it for is GC pause time
             _getGcPauseTimeFunc = GetGcPauseTime_RuntimeMetrics;
         }
-        else if (Environment.Version.Major > 6
-                 || Environment.Version is { Major: 6, Build: >= 21 })
+        else if (version.Major > 6
+                 || version is { Major: 6, Build: >= 21 })
         {
             // .NET 6.0.21 introduced the GC.GetTotalPauseDuration() method https://github.com/dotnet/runtime/pull/87143
             // Which is what OTel uses where required: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/5aa6d868/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs#L105C40-L107

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -106,9 +106,9 @@ namespace Datadog.Trace.RuntimeMetrics
                 {
                     { } x when x.IsWindows() => true, // Works on Windows
                     { } x when !x.IsCoreClr() => true, // Works on .NET Framework
-                    _ when Environment.Version is { Major: >= 5 } => true, // Works on .NET 5 and above
-                    _ when Environment.Version is { Major: 3, Minor: > 0 } => true, // 3.1 works
-                    _ when Environment.Version is { Major: 3, Minor: 0 } => false, // 3.0 is broken on linux
+                    { RuntimeVersion: { Major: >= 5 } } => true, // Works on .NET 5 and above
+                    { RuntimeVersion: { Major: 3, Minor: > 0 } } => true, // 3.1 works
+                    { RuntimeVersion: { Major: 3, Minor: 0 } } => false, // 3.0 is broken on linux
                     _ => false, // everything else (i.e. <.NET Core 3.0) is broken
                 };
 #endif


### PR DESCRIPTION
## Summary of changes

Replaced remaining usages of `Environment.Version` other than `FrameworkDescription`

## Reason for change

`Environment.Version` allocates, but it's used in a bunch of places unnecessarily. Switching to use `FrameworkDescription.Runtimeversion` removes those allocations 

## Implementation details

- Find everywhere using `Environment.Version` and fix it to not
- Inlined a couple of places where it didn't seem necessary
- Remove an allocating path in `IsCoreClr()`

## Test coverage

Should be covered by existing

## Other details

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/8068