### PR TITLE
Fix Benchmark tests

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
@@ -75,7 +75,6 @@ internal class AppSecBenchmarkUtils
         }
 
         Environment.SetEnvironmentVariable("DD_TRACE_LOGGING_RATE", "60");
-        Environment.SetEnvironmentVariable("DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH", path);
         var libInitResult = WafLibraryInvoker.Initialize(ddDotnetTracerHome: path, traceNativeEnginePath: path);
         if (!libInitResult.Success)
         {


### PR DESCRIPTION
## Summary of changes

In [this PR](https://github.com/DataDog/dd-trace-dotnet/pull/7932), benchmark tests were broken because of a compilation error. We did not detect that until merged into master since the task run-benchmarks is not required for merging into master.

`    [ERR] RunBenchmarks: C:\dd-trace-dotnet\tracer\test\benchmarks\Benchmarks.Trace\Asm\AppSecBenchmarkUtils.cs(79,47): error CS7036: There is no argument given that corresponds to the required parameter 'ddDotnetTracerHome' of 'WafLibraryInvoker.Initialize(string, string, string)' [C:\dd-trace-dotnet\tracer\test\benchmarks\Benchmarks.Trace\Benchmarks.Trace.csproj::TargetFramework=net472]
    `
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
