### PR TITLE
[ASM] Fix benchmarks

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
@@ -74,9 +74,8 @@ internal class AppSecBenchmarkUtils
             throw new DirectoryNotFoundException($"The Path: '{path}' doesn't exist.");
         }
 
-        Environment.SetEnvironmentVariable("DD_TRACE_LOGGING_RATE", "60");
-        Environment.SetEnvironmentVariable("DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH", path);
-        var libInitResult = WafLibraryInvoker.Initialize();
+        Environment.SetEnvironmentVariable(ConfigurationKeys.LogRateLimit, "60");
+        var libInitResult = WafLibraryInvoker.Initialize(path, path);
         if (!libInitResult.Success)
         {
             throw new ArgumentException("Waf could not load");


### PR DESCRIPTION
## Summary of changes

[Config Registry PR](https://github.com/DataDog/dd-trace-dotnet/pull/7932) broke asm benchmark base class 

## Reason for change

## Implementation details

## Test coverage

## Other details
Fixes asm benchmarks

