### PR TITLE
[Dynamic Instrumentation] DEBUG-5018 Send logs to debugger intake

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AgentConfiguration.cs" company="Datadog">
+// <copyright file="AgentConfiguration.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -48,6 +48,18 @@ internal sealed record AgentConfiguration
     public string? DebuggerV2Endpoint { get; }
 
     public string? DiagnosticsEndpoint { get; }
+
+    /// <summary>
+    /// Gets the preferred endpoint for debugger uploads that support the v2 intake.
+    /// Falls back to the diagnostics endpoint when the v2 endpoint is not available.
+    /// </summary>
+    public string? DebuggerUploadEndpoint => DebuggerV2Endpoint ?? DiagnosticsEndpoint;
+
+    /// <summary>
+    /// Gets the preferred endpoint for debugger diagnostics uploads.
+    /// Falls back to the v1 debugger input endpoint when the diagnostics endpoint is not available.
+    /// </summary>
+    public string? DebuggerDiagnosticsUploadEndpoint => DiagnosticsEndpoint ?? DebuggerEndpoint;
 
     public string? SymbolDbEndpoint { get; }
 

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiscoveryService.cs" company="Datadog">
+// <copyright file="DiscoveryService.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -404,7 +404,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
             var newConfig = new AgentConfiguration(
                 configurationEndpoint: configurationEndpoint,
                 debuggerEndpoint: debuggerEndpoint,
-                debuggerV2Endpoint: debuggerV2Endpoint ?? diagnosticsEndpoint,
+                debuggerV2Endpoint: debuggerV2Endpoint,
                 diagnosticsEndpoint: diagnosticsEndpoint,
                 symbolDbEndpoint: symbolDbEndpoint,
                 agentVersion: agentVersion,

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
@@ -35,7 +35,7 @@ internal sealed class DebuggerFactory
         var diagnosticsSink = DiagnosticsSink.Create(serviceNameProvider, debuggerSettings);
 
         var snapshotUploader = CreateSnapshotUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, true), snapshotSink);
-        var logUploader = CreateSnapshotUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, false), logSink);
+        var logUploader = CreateLogUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, false), logSink);
         var diagnosticsUploader = CreateDiagnosticsUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, true), diagnosticsSink);
         var lineProbeResolver = LineProbeResolver.Create(debuggerSettings.ThirdPartyDetectionExcludes, debuggerSettings.ThirdPartyDetectionIncludes);
         var probeStatusPoller = ProbeStatusPoller.Create(diagnosticsSink, debuggerSettings);

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiagnosticsUploadApi.cs" company="Datadog">
+// <copyright file="DiagnosticsUploadApi.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Debugger.Upload
         {
             discoveryService.SubscribeToChanges(c =>
             {
-                Endpoint = c.DiagnosticsEndpoint ?? c.DebuggerEndpoint;
+                Endpoint = c.DebuggerDiagnosticsUploadEndpoint;
                 Log.Debug("DiagnosticsUploadApi: Updated endpoint to {Endpoint}", Endpoint);
             });
         }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LogUploadApi.cs" company="Datadog">
+// <copyright file="LogUploadApi.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Debugger.Upload
         {
             discoveryService.SubscribeToChanges(c =>
             {
-                Endpoint = c.DebuggerEndpoint;
+                Endpoint = c.DebuggerUploadEndpoint;
                 Log.Debug("LogUploadApi: Updated endpoint to {Endpoint}", Endpoint);
             });
         }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SnapshotUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SnapshotUploadApi.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SnapshotUploadApi.cs" company="Datadog">
+// <copyright file="SnapshotUploadApi.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Debugger.Upload
             {
                 discoveryService.SubscribeToChanges(c =>
                 {
-                    Endpoint = c.DebuggerV2Endpoint ?? c.DiagnosticsEndpoint;
+                    Endpoint = c.DebuggerUploadEndpoint;
                     Log.Debug("SnapshotUploadApi: Updated endpoint to {Endpoint}", Endpoint);
                 });
             }


### PR DESCRIPTION
## Summary of changes
Updated logs to use the same preferred endpoint selection as snapshots.

## Reason for change
Logs should be sent to the debugger intake so we can redact them like snapshots.

## Implementation details
Centralized endpoint fallback selection in AgentConfiguration:
DebuggerUploadEndpoint: `DebuggerV2Endpoint ?? DiagnosticsEndpoint` (used by snapshots and logs)
DebuggerDiagnosticsUploadEndpoint: `DiagnosticsEndpoint ?? DebuggerEndpoint` (used by diagnostics)
Updated upload APIs to use the centralized properties:
SnapshotUploadApi → `c.DebuggerUploadEndpoint`
LogUploadApi → `c.DebuggerUploadEndpoint`
DiagnosticsUploadApi → `c.DebuggerDiagnosticsUploadEndpoint`