### PR TITLE
[FFE] Fix asserts being ignored in release builds

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/FeatureFlags/FeatureFlagsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/FeatureFlags/FeatureFlagsTests.cs
@@ -97,6 +97,7 @@ public abstract class FeatureFlagsTestsBase : TestHelper
         Assert.Contains("Eval (numeric-rule-flag) : <OK: ", output);
         Assert.Contains("Eval (time-based-flag) : <OK: ", output);
         Assert.Contains("Eval (exposure-flag) : <OK: ", output);
+        Assert.Contains("Exit. OK", output);
         Assert.True(eventsReceived > 0);
     }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/FeatureFlagsHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/FeatureFlagsHelpers.cs
@@ -26,7 +26,7 @@ internal static class FeatureFlagsHelpers
             ["numeric-rule-flag"] = CreateNumericRuleFlag(),
             ["time-based-flag"] = CreateTimeBasedFlag(),
             ["exposure-flag"] = FeatureFlagsHelpers.CreateExposureFlag(),
-            ["json-flag"] = CreateSimpleFlag("simple-json", ValueType.Json, new Dictionary<string, object> { { "integer", 1 }, { "string", "one" }, { "float", 1.0 } }, "on"),
+            ["simple-json"] = CreateSimpleFlag("simple-json", ValueType.Json, new Dictionary<string, object> { { "integer", 1 }, { "string", "one" }, { "float", 1.0 } }, "on"),
         };
 
         return flags;

--- a/tracer/test/test-applications/integrations/Samples.FeatureFlags/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.FeatureFlags/Program.cs
@@ -45,6 +45,7 @@ class Program
 
         Console.WriteLine("Extra checks...");
         Evaluator.ExtraChecks();
+        Console.WriteLine("Exit. OK");
     }
 
 

--- a/tracer/test/test-applications/integrations/Samples.OpenFeature/Evaluator.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenFeature/Evaluator.cs
@@ -61,11 +61,21 @@ class Evaluator
         var defaultValue = new Value("Not found");
         var evaluation = client.GetObjectDetailsAsync(key, defaultValue, context).Result;
 
-        Debug.Assert(evaluation is not null);
-        Debug.Assert(evaluation.ErrorMessage is null);
-        Debug.Assert(evaluation.Value != defaultValue);
-        Debug.Assert(evaluation.Value.IsStructure);
-        Debug.Assert(evaluation.Value.AsStructure.ContainsKey("integer"));
-        Debug.Assert(evaluation.Value.AsStructure.GetValue("integer").AsInteger == 1);
+        Assert(evaluation is not null, "Null eval");
+        Assert(evaluation.ErrorMessage is null, $"Non Null error ({evaluation.ErrorMessage})");
+        Assert(evaluation.Value != defaultValue, "Default value");
+        Assert(evaluation.Value.IsStructure, "No structure value");
+        Assert(evaluation.Value.AsStructure.ContainsKey("integer"), "Integer value not found");
+        Assert(evaluation.Value.AsStructure.GetValue("integer").AsInteger == 1, "Wrong Integer value");
+
+        static void Assert(bool condition, string message = "")
+        {
+            if (!condition)
+            {
+                var error = $"ERROR: Assertion failed. {message}";
+                Console.WriteLine(error);
+                throw new Exception(error);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes
Removed `Debug.Assert` calls as they were being ignored in release builds

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
