### PR TITLE
reorder `CODEOWNERS` so debugger lines override serverless

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,29 @@
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs                       @DataDog/tracing-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs                               @DataDog/tracing-dotnet
 
+## Serverless (AWS Lambda)
+/tracer/src/**/*Lambda*                                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/**/*Lambda*                                                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/build/_build/docker/serverless.lambda.dockerfile                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/docker-compose.serverless.yml                                                  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/.gitlab/download-serverless-artifacts.sh                                       @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/docs/development/**/*Lambda*.md                                                @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+
+## Serverless (Azure)
+/tracer/src/**/*AzureAppService*.cs                                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/src/**/*AzureFunctions*.cs                                              @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/src/Datadog.AzureFunctions/                                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/**/*AzureAppService*.cs                                            @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/**/*AzureFunctions*.cs                                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/test-applications/azure-functions/                                 @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/HttpBypassTests.cs         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/samples/AzureFunctionsWithAgentLessLogging/                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/docs/development/**/AzureFunctions*.md                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+
+## Serverless (GCP)
+/tracer/src/**/*GCP*.cs                                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/**/*GCP*.cs                                                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+
 # ASM
 /tracer/src/Datadog.Trace/AppSec/         @DataDog/asm-dotnet
 /tracer/src/Datadog.Tracer.Native/iast/    @DataDog/asm-dotnet
@@ -141,29 +164,6 @@ Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 
 # Exploration tests
 /tracer/build/_build/Build.ExplorationTests.cs @DataDog/debugger-dotnet @DataDog/tracing-dotnet @DataDog/profiling-dotnet
-
-## Serverless (AWS Lambda)
-/tracer/src/**/*Lambda*                                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/test/**/*Lambda*                                                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/tracer/build/_build/docker/serverless.lambda.dockerfile                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/docker-compose.serverless.yml                                                  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/.gitlab/download-serverless-artifacts.sh                                       @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-/docs/development/**/*Lambda*.md                                                @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
-
-## Serverless (Azure)
-/tracer/src/**/*AzureAppService*.cs                                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/src/**/*AzureFunctions*.cs                                              @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/src/Datadog.AzureFunctions/                                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/test/**/*AzureAppService*.cs                                            @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/test/**/*AzureFunctions*.cs                                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/test/test-applications/azure-functions/                                 @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/HttpBypassTests.cs         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/samples/AzureFunctionsWithAgentLessLogging/                             @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/docs/development/**/AzureFunctions*.md                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-
-## Serverless (GCP)
-/tracer/src/**/*GCP*.cs                                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
-/tracer/test/**/*GCP*.cs                                                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 
 ## Feature Flagging and Experimentation
 /tracer/src/Datadog.Trace/FeatureFlags/                                                        @DataDog/feature-flagging-and-experimentation-sdk @DataDog/tracing-dotnet


### PR DESCRIPTION
## Summary of changes

Reorder `CODEOWNERS` so debugger lines override serverless.

## Reason for change

Some debugger files were being caught by serverless.

For example:
```
tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithStaticFieldClosure.verified.txt
```
should be debugger, but it was falling under serverless with
```
/tracer/test/**/*Lambda*
```

## Implementation details

Move the serverless lines up above the debugger lines.

## Test coverage

n/a

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
