### PR TITLE
Add ErrorCode enum to feature flag evaluations

### DIFF
--- a/tracer/src/Datadog.Trace/FeatureFlags/ErrorCode.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/ErrorCode.cs
@@ -1,0 +1,44 @@
+// <copyright file="ErrorCode.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.ComponentModel;
+
+namespace Datadog.Trace.FeatureFlags;
+
+/// <summary>Evaluation error codes that map to OpenFeature ErrorType.</summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Browsable(false)]
+#if INTERNAL_FFE
+internal enum ErrorCode
+#else
+public enum ErrorCode
+#endif
+{
+    /// <summary>No error occurred.</summary>
+    None,
+
+    /// <summary>The provider is not ready to evaluate flags.</summary>
+    ProviderNotReady,
+
+    /// <summary>The flag was not found.</summary>
+    FlagNotFound,
+
+    /// <summary>The flag type does not match the requested type.</summary>
+    TypeMismatch,
+
+    /// <summary>An error occurred parsing the flag configuration.</summary>
+    ParseError,
+
+    /// <summary>The targeting key is missing from the evaluation context.</summary>
+    TargetingKeyMissing,
+
+    /// <summary>The evaluation context is invalid.</summary>
+    InvalidContext,
+
+    /// <summary>A general error occurred.</summary>
+    General
+}

--- a/tracer/src/Datadog.Trace/FeatureFlags/Evaluation.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Evaluation.cs
@@ -14,7 +14,7 @@ using System.Web;
 
 namespace Datadog.Trace.FeatureFlags;
 
-internal sealed class Evaluation(string flagKey, object? value, EvaluationReason reason, string? variant = null, string? error = null, IDictionary<string, string>? metadata = null)
+internal sealed class Evaluation(string flagKey, object? value, EvaluationReason reason, string? variant = null, string? error = null, ErrorCode errorCode = ErrorCode.None, IDictionary<string, string>? metadata = null)
     : IEvaluation
 {
     public string FlagKey { get; } = flagKey;
@@ -26,6 +26,8 @@ internal sealed class Evaluation(string flagKey, object? value, EvaluationReason
     public string? Variant { get; } = variant;
 
     public string? Error { get; } = error;
+
+    public ErrorCode ErrorCode { get; } = errorCode;
 
     public IDictionary<string, string>? FlagMetadata { get; } = metadata;
 }

--- a/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsEvaluator.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsEvaluator.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.FeatureFlags
                         defaultValue,
                         EvaluationReason.Error,
                         error: "PROVIDER_NOT_READY",
+                        errorCode: ErrorCode.ProviderNotReady,
                         metadata: new Dictionary<string, string>
                         {
                             ["errorCode"] = "PROVIDER_NOT_READY"
@@ -69,6 +70,7 @@ namespace Datadog.Trace.FeatureFlags
                         defaultValue,
                         EvaluationReason.Error,
                         error: "FLAG_NOT_FOUND",
+                        errorCode: ErrorCode.FlagNotFound,
                         metadata: new Dictionary<string, string>
                         {
                             ["errorCode"] = "FLAG_NOT_FOUND"
@@ -90,6 +92,7 @@ namespace Datadog.Trace.FeatureFlags
                         defaultValue,
                         EvaluationReason.Error,
                         error: "TYPE_MISMATCH",
+                        errorCode: ErrorCode.TypeMismatch,
                         metadata: new Dictionary<string, string>
                         {
                             ["errorCode"] = "TYPE_MISMATCH"
@@ -165,6 +168,7 @@ namespace Datadog.Trace.FeatureFlags
                     defaultValue,
                     EvaluationReason.Error,
                     error: "PARSE_ERROR",
+                    errorCode: ErrorCode.ParseError,
                     metadata: new Dictionary<string, string>
                     {
                         ["errorCode"] = "PARSE_ERROR",
@@ -178,6 +182,7 @@ namespace Datadog.Trace.FeatureFlags
                     defaultValue,
                     EvaluationReason.Error,
                     error: "TARGETING_KEY_MISSING",
+                    errorCode: ErrorCode.TargetingKeyMissing,
                     metadata: new Dictionary<string, string>
                     {
                         ["errorCode"] = "TARGETING_KEY_MISSING"
@@ -190,6 +195,7 @@ namespace Datadog.Trace.FeatureFlags
                     defaultValue,
                     EvaluationReason.Error,
                     error: ex.Message,
+                    errorCode: ErrorCode.General,
                     metadata: new Dictionary<string, string>
                     {
                         ["errorCode"] = "GENERAL",
@@ -636,6 +642,7 @@ namespace Datadog.Trace.FeatureFlags
                     defaultValue,
                     EvaluationReason.Error,
                     error: error,
+                    errorCode: ErrorCode.ParseError,
                     metadata: new Dictionary<string, string>
                     {
                         ["errorCode"] = "PARSE_ERROR",

--- a/tracer/src/Datadog.Trace/FeatureFlags/IEvaluation.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/IEvaluation.cs
@@ -31,8 +31,11 @@ public partial interface IEvaluation
     /// <summary> Gets the evaluation result variant </summary>
     string? Variant { get; }
 
-    /// <summary> Gets the evaluation error </summary>
+    /// <summary> Gets the evaluation error message </summary>
     string? Error { get; }
+
+    /// <summary> Gets the evaluation error code </summary>
+    ErrorCode ErrorCode { get; }
 
     /// <summary> Gets the evaluation metadata </summary>
     IDictionary<string, string>? FlagMetadata { get; }


### PR DESCRIPTION
## Motivation

When integrating with OpenFeature, providers need to map Datadog's error conditions to OpenFeature's `ErrorType` enum. Currently, the `IEvaluation.Error` property is a string, requiring providers to do string matching to determine the error type.

## Changes

- Add `ErrorCode` enum with values that map to OpenFeature's `ErrorType`:
  - `None`, `ProviderNotReady`, `FlagNotFound`, `TypeMismatch`, `ParseError`, `TargetingKeyMissing`, `InvalidContext`, `General`
- Add `ErrorCode` property to `IEvaluation` interface
- Update `Evaluation` class to include `ErrorCode` parameter
- Update `FeatureFlagsEvaluator` to set appropriate `ErrorCode` for each error case

## Decisions

- **Keep both `Error` (string) and `ErrorCode` (enum)**: The string property is preserved for backwards compatibility and to allow custom error messages (e.g., exception details). This follows the same pattern as Java's OpenFeature integration which has both `errorCode` and `errorMessage`.