### PR TITLE
Increase timeout DiscoveryService Tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -177,9 +177,6 @@ public class DiscoveryServiceTests
             });
 
         var ds = new DiscoveryService(factory, NullContainerMetadata, InitialRetryDelayMs, MaxRetryDelayMs, recheckIntervalMs);
-
-        // Subscribe BEFORE Request 1 completes
-        // This tests the asynchronous notification path in NotifySubscribers
         ds.SubscribeToChanges(x => Interlocked.Increment(ref notificationCount));
         // fire first request
         mutex1.Set();
@@ -212,9 +209,6 @@ public class DiscoveryServiceTests
             });
 
         var ds = new DiscoveryService(factory, NullContainerMetadata, InitialRetryDelayMs, MaxRetryDelayMs, recheckIntervalMs);
-
-        // Subscribe BEFORE Request 1 completes
-        // This tests the asynchronous notification path in NotifySubscribers
         ds.SubscribeToChanges(x => Interlocked.Increment(ref notificationCount));
         // fire first request
         mutex1.Set();


### PR DESCRIPTION
## Summary of changes

 Increases mutex timeouts from 10s to 30s in DiscoveryServiceTests to reduce flakiness on slow CI environments.

## Reason for change

Three DiscoveryServiceTests tests were intermittently failing.

## Implementation details

- Increased mutex.Wait timeouts from 10,000ms to 30,000ms across affected tests

## Test coverage

## Other details
<!-- Fixes #{issue} -->
