### PR TITLE
Do not mark empty frame crashes as complete

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
@@ -284,7 +284,11 @@ int32_t CrashReporting::ResolveStacks(int32_t crashingThreadId, ResolveManagedCa
             CHECK_RESULT(ddog_crasht_StackTrace_push_frame(&stackTrace, &frame, /*is incomplete*/ true));
         }
 
-        CHECK_RESULT(ddog_crasht_StackTrace_set_complete(&stackTrace));
+        // Only mark the stack trace as complete if we actually captured frames
+        if (!frames.empty())
+        {
+            CHECK_RESULT(ddog_crasht_StackTrace_set_complete(&stackTrace));
+        }
 
         auto threadIdStr = std::to_string(threadId);
         // stackTrace is consumed by the API, meaning that we *MUST* not use this handle


### PR DESCRIPTION
## Summary of changes

Checks that `frames` isn't empty before we mark it as `complete`. The default from `libdatadog` is an `incomplete` crash.

## Reason for change

Saw crashes getting sent that had no message and no frames, yet were marked as `complete`.

## Implementation details

Check if `frames` isn't empty.

## Test coverage

None 😢 
The tests that I see would need quite a bit of work to be able to mock/test the verify that we don't call `ddog_crasht_StackTrace_set_complete`

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
