### PR TITLE
[CI] Add CultureInvariant to a test that was failing locally

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/MongoDb/TruncatedTextWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/MongoDb/TruncatedTextWriterTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Globalization;
 using System.Text;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb.BsonSerialization;
 using FluentAssertions;
@@ -35,7 +36,7 @@ public class TruncatedTextWriterTests
         using var sw = new TruncatedTextWriter(sb);
         for (var i = 0; i < 2 * TruncatedTextWriter.MaxLength; i++)
         {
-            sw.Write("Format {0:E} ", 1_000_000);
+            sw.Write(string.Format(CultureInfo.InvariantCulture, "Format {0:E} ", 1_000_000));
         }
 
         var finalString = sw.ToString();


### PR DESCRIPTION
## Summary of changes
Fixing a test that was failing on my env, because of a `,` instead of a `.`.

## Reason for change
The test was the issue not the code it tested.

## Implementation details
Just adding a good old `CultureInfo.InvariantCulture` as Lucas has been doing everywhere since ever :p

## Test coverage
N/A
