### PR TITLE
Prevent debugger init crash on span create

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Debugger
                                   .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries) ??
                                    Enumerable.Empty<string>();
 
-            ThirdPartyDetectionIncludes = thirdPartyIncludes.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            ThirdPartyDetectionIncludes = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase).Union(thirdPartyIncludes);
 
             var thirdPartyExcludes = config
                                     .WithKeys(ConfigurationKeys.Debugger.ThirdPartyDetectionExcludes)
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Debugger
                                     .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries) ??
                                      Enumerable.Empty<string>();
 
-            ThirdPartyDetectionExcludes = thirdPartyExcludes.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            ThirdPartyDetectionExcludes = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase).Union(thirdPartyExcludes);
 
             var symDb3rdPartyIncludeLibraries = config
                                                .WithKeys(ConfigurationKeys.Debugger.SymDbThirdPartyDetectionIncludes)
@@ -85,7 +85,8 @@ namespace Datadog.Trace.Debugger
                                                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries) ??
                                                 Enumerable.Empty<string>();
 
-            SymDbThirdPartyDetectionIncludes = new HashSet<string>([.. symDb3rdPartyIncludeLibraries, .. ThirdPartyDetectionIncludes]).ToImmutableHashSet();
+            var symDbThirdPartyDetectionIncludes = new HashSet<string>([.. symDb3rdPartyIncludeLibraries, .. ThirdPartyDetectionIncludes]);
+            SymDbThirdPartyDetectionIncludes = ImmutableHashSet<string>.Empty.Union(symDbThirdPartyDetectionIncludes);
 
             var symDb3rdPartyExcludeLibraries = config
                                                .WithKeys(ConfigurationKeys.Debugger.SymDbThirdPartyDetectionExcludes)
@@ -93,7 +94,8 @@ namespace Datadog.Trace.Debugger
                                                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries) ??
                                                 Enumerable.Empty<string>();
 
-            SymDbThirdPartyDetectionExcludes = new HashSet<string>([.. symDb3rdPartyExcludeLibraries, .. ThirdPartyDetectionExcludes]).ToImmutableHashSet();
+            var symDbThirdPartyDetectionExcludes = new HashSet<string>([.. symDb3rdPartyExcludeLibraries, .. ThirdPartyDetectionExcludes]);
+            SymDbThirdPartyDetectionExcludes = ImmutableHashSet<string>.Empty.Union(symDbThirdPartyDetectionExcludes);
 
             DiagnosticsIntervalSeconds = config
                                         .WithKeys(ConfigurationKeys.Debugger.DiagnosticsInterval)

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyConfigurationReader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyConfigurationReader.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty
                 }
             }
 
-            return modules.ToImmutableHashSet();
+            return ImmutableHashSet<string>.Empty.Union(modules);
         }
 
         private static bool TryGetThirdPartyManifestStream(out Stream? resourceStream)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8f841bc9-b23b-429e-b2c5-024f29a76d80","source":"chat","resourceId":"77b041fa-b04f-4aea-98aa-c62ee24b4370","workflowId":"1abe0115-0586-4cd7-a199-70b463c96c12","codeChangeId":"1abe0115-0586-4cd7-a199-70b463c96c12","sourceType":"error_tracking_investigator"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/77b041fa-b04f-4aea-98aa-c62ee24b4370)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

## Summary of changes
- replace DebuggerSettings immutable set construction to avoid the ToImmutableHashSet overload during debugger initialization
- build third-party module sets with ImmutableHashSet<T>.Empty/Union in both DebuggerSettings and ThirdPartyConfigurationReader

## Reason for change
- prevent DebuggerSettings initialization from throwing MissingMethodException, which blocks DebuggerManager startup and span creation during exception replay setup

## Implementation details
- use ImmutableHashSet<T>.Empty.WithComparer(...).Union(...) to build case-insensitive include/exclude sets
- use ImmutableHashSet<T>.Empty.Union(...) for combined third-party module sets without relying on the missing extension method

## Test coverage
- Not run (formatting failed: required .NET SDK 10.0.100 not available; no tests executed)

## Other details
<!-- Fixes #{issue} -->