### PR TITLE
Adjust Log levels in OltpExporter

### DIFF
--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpExporter.cs
@@ -326,7 +326,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
 
                     if (statusCode == 400)
                     {
-                        Log.Warning("Bad Request (400) - not retrying: {StatusCode}", response.StatusCode);
+                        Log.Error("Bad Request (400) - not retrying: {StatusCode}", response.StatusCode);
                         return false;
                     }
 
@@ -349,6 +349,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
                         }
                     }
 
+                    Log.ErrorSkipTelemetry("An error occurred while sending OTLP request to {AgentEndpoint}. If the error isn't transient, please check https://docs.datadoghq.com/tracing/troubleshooting/connection_errors/?code-lang=dotnet for guidance.", _endpoint);
                     return false;
                 }
                 catch (TaskCanceledException) when (attempt < maxRetries)
@@ -358,7 +359,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Error sending OTLP request (attempt {Attempt})", (attempt + 1).ToString());
+                    Log.Debug<int>(ex, "Error sending OTLP request (attempt {Attempt})", attempt + 1);
                     if (attempt < maxRetries)
                     {
                         retryDelay = TimeSpan.FromMilliseconds((long)(retryDelay.TotalMilliseconds * 2));
@@ -366,6 +367,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
                     }
                     else
                     {
+                        Log.ErrorSkipTelemetry("An error occurred after {Attempt} attempts while sending OTLP request to {AgentEndpoint}. If the error isn't transient, please check https://docs.datadoghq.com/tracing/troubleshooting/connection_errors/?code-lang=dotnet for guidance.", attempt + 1, _endpoint);
                         return false;
                     }
                 }


### PR DESCRIPTION
## Summary of changes

Changes the log levels in `OtlpExporter` to skip telemetry for some errors (while making them go from Debug to Error) and swapping some Debug 

## Reason for change

Noticed a lot of new errors but they just seem to be transient networking errors.
https://app.datadoghq.com/error-tracking/issue/443da854-fe18-11f0-ae87-da7ad0900002

Some of the current logs were either the wrong level or absent.

## Implementation details

- Bad Request (400) - not retrying - swapped to Error from Warning
- Add two `Log.ErrorSkipTelemetry("An error occurred while sending OTLP request to {AgentEndpoint}.` for when we get transient network issue
- `Log.Error(ex, "Error sending OTLP request (attempt {Attempt})", (attempt + 1).ToString());` -> `Log.Debug<int>(ex, "Error sending OTLP request (attempt {Attempt})", attempt + 1);` along with removing the string allocation

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
