### PR TITLE
[Profiler] Disable a test on x86 with Managed Code Cache

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -139,6 +139,14 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
         [TestAppFact("Samples.ExceptionGenerator")]
         public void ThrowExceptionsInParallelWithCustomGetFunctionFromIp(string appName, string framework, string appAssembly)
         {
+            // Test is currently failing on x86 architecture
+            // TODO: fix it
+            if (IntPtr.Size == 4)
+            {
+                // Test skipped on x86 architecture
+                return;
+            }
+
             StackTrace expectedStack;
 
             if (framework == "net48")


### PR DESCRIPTION
## Summary of changes

Disable `ThrowExceptionsInParallelWithCustomGetFunctionFromIp` when running on x86 for now.

## Reason for change

It seems that the callstack is not the expected one. Since Managed Code Cache is not enabled by default, we can disable the test on x86 only.


## Implementation details

Skip the test on x86

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
