### PR TITLE
Add configuration log if RuntimeMetricsDiagnosticsMetricsApiEnabled is enabled

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -446,6 +446,12 @@ namespace Datadog.Trace
                     writer.WritePropertyName("runtime_metrics_enabled");
                     writer.WriteValue(instanceSettings.RuntimeMetricsEnabled);
 
+                    if (instanceSettings.RuntimeMetricsDiagnosticsMetricsApiEnabled)
+                    {
+                        writer.WritePropertyName("runtime_metrics_diagnostics_metrics_api_enabled");
+                        writer.WriteValue(instanceSettings.RuntimeMetricsDiagnosticsMetricsApiEnabled);
+                    }
+
                     writer.WritePropertyName("disabled_integrations");
                     writer.WriteStartArray();
 


### PR DESCRIPTION
## Summary of changes
Add configuration log if RuntimeMetricsDiagnosticsMetricsApiEnabled is enabled

## Reason for change
to see it in the logs as otherwise if it's enabled we don't know

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
