### PR TITLE
Add installation scripts for Windows and Linux

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,450 @@
+<#
+.SYNOPSIS
+    Install or uninstall the Datadog .NET APM Tracer on Windows.
+
+.DESCRIPTION
+    Downloads and installs the Datadog .NET APM Tracer MSI from GitHub releases.
+    Supports installation to custom paths and silent installation by default.
+
+.PARAMETER Version
+    Specify version to install (e.g., "v3.36.0" or "3.36.0").
+    Default: latest release
+
+.PARAMETER Path
+    Installation directory for the tracer.
+    Default: C:\Program Files\Datadog\.NET Tracer
+
+.PARAMETER Uninstall
+    Uninstall the tracer instead of installing.
+
+.PARAMETER Interactive
+    Show MSI UI during installation (default is silent).
+
+.PARAMETER NoCleanup
+    Keep the downloaded MSI file after installation.
+
+.EXAMPLE
+    .\install.ps1
+    Install the latest version to the default location.
+
+.EXAMPLE
+    .\install.ps1 -Version v3.36.0
+    Install a specific version.
+
+.EXAMPLE
+    .\install.ps1 -Version 3.36.0 -Path "C:\Custom\Path"
+    Install to a custom directory.
+
+.EXAMPLE
+    .\install.ps1 -Uninstall
+    Uninstall the tracer.
+
+.EXAMPLE
+    .\install.ps1 -Interactive
+    Install with MSI UI visible.
+
+.EXAMPLE
+    .\install.ps1 -Version v3.36.0 -WhatIf
+    Show what would happen without actually installing.
+
+.EXAMPLE
+    .\install.ps1 -Uninstall -Confirm:$false
+    Uninstall without confirmation prompt.
+
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [Parameter()]
+    [string]$Version,
+
+    [Parameter()]
+    [string]$Path = "C:\Program Files\Datadog\.NET Tracer",
+
+    [Parameter()]
+    [switch]$Uninstall,
+
+    [Parameter()]
+    [switch]$Interactive,
+
+    [Parameter()]
+    [switch]$NoCleanup
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Constants
+$GitHubRepo = "DataDog/dd-trace-dotnet"
+$Architecture = "x64"  # Windows MSI is always x64
+
+# Helper functions
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Green
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Warning "[WARN] $Message"
+}
+
+function Write-Err {
+    param([string]$Message)
+    Write-Error "[ERROR] $Message"
+}
+
+function Test-Administrator {
+    <#
+    .SYNOPSIS
+        Check if running as administrator.
+    #>
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-LatestVersion {
+    <#
+    .SYNOPSIS
+        Fetch the latest release version from GitHub.
+    #>
+    Write-Info "Fetching latest release version..."
+
+    $url = "https://api.github.com/repos/$GitHubRepo/releases/latest"
+
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method Get -ErrorAction Stop
+        return $response.tag_name
+    }
+    catch {
+        Write-Err "Failed to fetch latest version from GitHub: $_"
+        throw
+    }
+}
+
+function Get-NormalizedVersion {
+    <#
+    .SYNOPSIS
+        Normalize version to ensure 'v' prefix.
+    #>
+    param([string]$Version)
+
+    if ($Version -notmatch '^v') {
+        return "v$Version"
+    }
+    return $Version
+}
+
+function Get-VersionNumber {
+    <#
+    .SYNOPSIS
+        Strip 'v' prefix from version for artifact name.
+    #>
+    param([string]$Version)
+
+    return $Version -replace '^v', ''
+}
+
+function Get-MsiDownloadUrl {
+    <#
+    .SYNOPSIS
+        Construct the MSI download URL.
+    #>
+    param([string]$Version)
+
+    $versionNumber = Get-VersionNumber -Version $Version
+    $artifactName = "datadog-dotnet-apm-$versionNumber-$Architecture.msi"
+    $url = "https://github.com/$GitHubRepo/releases/download/$Version/$artifactName"
+
+    return @{
+        Url = $url
+        FileName = $artifactName
+    }
+}
+
+function Get-DownloadedMsi {
+    <#
+    .SYNOPSIS
+        Download the MSI installer.
+    #>
+    param(
+        [string]$Url,
+        [string]$FileName
+    )
+
+    $tempPath = Join-Path -Path $env:TEMP -ChildPath $FileName
+
+    Write-Info "Downloading $FileName..."
+    Write-Info "URL: $Url"
+
+    try {
+        # Use BITS transfer for better progress and resume capability
+        if (Get-Command Start-BitsTransfer -ErrorAction SilentlyContinue) {
+            Start-BitsTransfer -Source $Url -Destination $tempPath -Description "Downloading Datadog .NET Tracer" -ErrorAction Stop
+        }
+        else {
+            # Fallback to Invoke-WebRequest
+            $ProgressPreference = 'SilentlyContinue'  # Faster download
+            Invoke-WebRequest -Uri $Url -OutFile $tempPath -ErrorAction Stop
+            $ProgressPreference = 'Continue'
+        }
+
+        Write-Info "Download complete: $tempPath"
+        return $tempPath
+    }
+    catch {
+        Write-Err "Failed to download MSI: $_"
+        throw
+    }
+}
+
+function Install-Tracer {
+    <#
+    .SYNOPSIS
+        Install the tracer using msiexec.
+    #>
+    param(
+        [string]$MsiPath,
+        [string]$InstallPath,
+        [bool]$Silent
+    )
+
+    if (-not $PSCmdlet.ShouldProcess("Datadog .NET APM Tracer", "Install to $InstallPath")) {
+        return
+    }
+
+    Write-Info "Installing Datadog .NET APM Tracer..."
+    Write-Info "Installation path: $InstallPath"
+
+    # Build msiexec arguments
+    $msiArgs = @(
+        '/i', "`"$MsiPath`""
+        "INSTALLFOLDER=`"$InstallPath`""
+    )
+
+    if ($Silent) {
+        $msiArgs += '/quiet', '/norestart'
+        Write-Info "Running silent installation..."
+    }
+    else {
+        $msiArgs += '/passive', '/norestart'
+        Write-Info "Running interactive installation..."
+    }
+
+    # Add logging
+    $logPath = Join-Path -Path $env:TEMP -ChildPath "datadog-tracer-install.log"
+    $msiArgs += '/l*v', "`"$logPath`""
+
+    try {
+        $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+
+        if ($process.ExitCode -eq 0) {
+            Write-Info "Installation completed successfully!"
+        }
+        elseif ($process.ExitCode -eq 3010) {
+            Write-Warn "Installation completed successfully. A reboot is required."
+        }
+        else {
+            Write-Err "Installation failed with exit code: $($process.ExitCode)"
+            Write-Err "Check log file: $logPath"
+            throw "MSI installation failed"
+        }
+    }
+    catch {
+        Write-Err "Failed to install MSI: $_"
+        throw
+    }
+}
+
+function Uninstall-Tracer {
+    <#
+    .SYNOPSIS
+        Uninstall the tracer.
+    #>
+    if (-not $PSCmdlet.ShouldProcess("Datadog .NET APM Tracer", "Uninstall")) {
+        return
+    }
+
+    Write-Info "Uninstalling Datadog .NET APM Tracer..."
+
+    # Find installed product by searching for Datadog tracer
+    $productName = "Datadog APM"
+
+    try {
+        $product = Get-WmiObject -Class Win32_Product -Filter "Name LIKE '%Datadog%' AND Name LIKE '%APM%'" -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+
+        if ($null -eq $product) {
+            Write-Warn "Datadog .NET APM Tracer is not installed or could not be found."
+            Write-Info "Attempting uninstall via registry..."
+
+            # Try to find uninstall string in registry
+            $uninstallKey = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" |
+                Get-ItemProperty |
+                Where-Object { $_.DisplayName -like "*Datadog*" -and $_.DisplayName -like "*APM*" } |
+                Select-Object -First 1
+
+            if ($null -eq $uninstallKey) {
+                $uninstallKey = Get-ChildItem "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall" -ErrorAction SilentlyContinue |
+                    Get-ItemProperty |
+                    Where-Object { $_.DisplayName -like "*Datadog*" -and $_.DisplayName -like "*APM*" } |
+                    Select-Object -First 1
+            }
+
+            if ($null -ne $uninstallKey) {
+                $productCode = $uninstallKey.PSChildName
+
+                if ($productCode -match '^\{[A-F0-9-]+\}$') {
+                    Write-Info "Found product code: $productCode"
+
+                    $logPath = Join-Path -Path $env:TEMP -ChildPath "datadog-tracer-uninstall.log"
+                    $msiArgs = @('/x', $productCode, '/quiet', '/norestart', '/l*v', "`"$logPath`"")
+
+                    $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru -NoNewWindow
+
+                    if ($process.ExitCode -eq 0) {
+                        Write-Info "Uninstallation completed successfully!"
+                    }
+                    else {
+                        Write-Err "Uninstallation failed with exit code: $($process.ExitCode)"
+                        Write-Err "Check log file: $logPath"
+                        throw "MSI uninstallation failed"
+                    }
+                }
+                else {
+                    Write-Err "Could not determine product code for uninstallation."
+                    throw
+                }
+            }
+            else {
+                Write-Err "Datadog .NET APM Tracer installation not found."
+                throw
+            }
+        }
+        else {
+            Write-Info "Found installed product: $($product.Name)"
+            Write-Info "Uninstalling..."
+
+            $result = $product.Uninstall()
+
+            if ($result.ReturnValue -eq 0) {
+                Write-Info "Uninstallation completed successfully!"
+            }
+            else {
+                Write-Err "Uninstallation failed with return code: $($result.ReturnValue)"
+                throw "Uninstallation failed"
+            }
+        }
+
+        Write-Host ""
+        Write-Host "Uninstallation complete!" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Remember to remove or unset the following environment variables:" -ForegroundColor Yellow
+        Write-Host "    - COR_ENABLE_PROFILING"
+        Write-Host "    - COR_PROFILER"
+        Write-Host "    - COR_PROFILER_PATH"
+        Write-Host "    - CORECLR_ENABLE_PROFILING"
+        Write-Host "    - CORECLR_PROFILER"
+        Write-Host "    - CORECLR_PROFILER_PATH"
+        Write-Host "    - DD_DOTNET_TRACER_HOME"
+        Write-Host ""
+    }
+    catch {
+        Write-Err "Failed to uninstall: $_"
+        throw
+    }
+}
+
+function Show-EnvironmentVariables {
+    <#
+    .SYNOPSIS
+        Display environment variables to set after installation.
+    #>
+    param([string]$InstallPath)
+
+    Write-Host ""
+    Write-Host "Installation successful!" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "To enable automatic instrumentation, set the following environment variables:" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "For .NET Framework applications:" -ForegroundColor Yellow
+    Write-Host "    [System.Environment]::SetEnvironmentVariable('COR_ENABLE_PROFILING', '1', 'Machine')"
+    Write-Host "    [System.Environment]::SetEnvironmentVariable('COR_PROFILER', '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}', 'Machine')"
+    Write-Host "    [System.Environment]::SetEnvironmentVariable('COR_PROFILER_PATH', '$InstallPath\win-x64\Datadog.Trace.ClrProfiler.Native.dll', 'Machine')"
+    Write-Host ""
+    Write-Host "For .NET Core/.NET 5+ applications:" -ForegroundColor Yellow
+    Write-Host "    [System.Environment]::SetEnvironmentVariable('CORECLR_ENABLE_PROFILING', '1', 'Machine')"
+    Write-Host "    [System.Environment]::SetEnvironmentVariable('CORECLR_PROFILER', '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}', 'Machine')"
+    Write-Host "    [System.Environment]::SetEnvironmentVariable('CORECLR_PROFILER_PATH', '$InstallPath\win-x64\Datadog.Trace.ClrProfiler.Native.dll', 'Machine')"
+    Write-Host ""
+    Write-Host "For both:" -ForegroundColor Yellow
+    Write-Host "    [System.Environment]::SetEnvironmentVariable('DD_DOTNET_TRACER_HOME', '$InstallPath', 'Machine')"
+    Write-Host ""
+    Write-Host "For more information, see:" -ForegroundColor Cyan
+    Write-Host "    https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework"
+    Write-Host "    https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core"
+    Write-Host ""
+}
+
+# Main script
+function Main {
+    Write-Info "Datadog .NET APM Tracer Installer"
+    Write-Info "=================================="
+    Write-Host ""
+
+    # Check for administrator privileges (skip in WhatIf mode)
+    if (-not $WhatIfPreference -and -not (Test-Administrator)) {
+        Write-Err "This script requires administrator privileges."
+        Write-Err "Please run PowerShell as Administrator and try again."
+        exit 1
+    }
+
+    # Handle uninstall mode
+    if ($Uninstall) {
+        Uninstall-Tracer
+        return
+    }
+
+    # Normalize version
+    if ([string]::IsNullOrEmpty($Version)) {
+        $Version = Get-LatestVersion
+        Write-Info "Latest version: $Version"
+    }
+    else {
+        $Version = Get-NormalizedVersion -Version $Version
+        Write-Info "Installing version: $Version"
+    }
+
+    # Get download URL
+    $downloadInfo = Get-MsiDownloadUrl -Version $Version
+
+    # Download MSI
+    $msiPath = Get-DownloadedMsi -Url $downloadInfo.Url -FileName $downloadInfo.FileName
+
+    try {
+        # Install
+        Install-Tracer -MsiPath $msiPath -InstallPath $Path -Silent (-not $Interactive)
+
+        # Show environment variables
+        Show-EnvironmentVariables -InstallPath $Path
+    }
+    finally {
+        # Cleanup
+        if (-not $NoCleanup -and (Test-Path $msiPath)) {
+            Write-Info "Cleaning up downloaded MSI..."
+            Remove-Item -Path $msiPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# Run main function
+try {
+    Main
+}
+catch {
+    Write-Host ""
+    Write-Host "Installation failed: $_" -ForegroundColor Red
+    Write-Host ""
+    exit 1
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default values
+INSTALL_DIR="/opt/datadog"
+GITHUB_REPO="DataDog/dd-trace-dotnet"
+VERSION=""
+UNINSTALL=false
+
+# Print functions
+print_info() {
+    echo -e "${GREEN}[INFO]${NC} $1" >&2
+}
+
+print_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1" >&2
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+# Usage information
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Install or uninstall the Datadog .NET APM Tracer.
+
+OPTIONS:
+    -v, --version VERSION     Specify version to install (e.g., v3.36.0 or 3.36.0)
+                             Default: latest release
+    -p, --path DIRECTORY      Installation directory
+                             Default: /opt/datadog
+    -u, --uninstall          Uninstall the tracer from the specified path
+    -h, --help               Show this help message
+
+EXAMPLES:
+    # Install latest version to default location
+    sudo $0
+
+    # Install specific version (with or without 'v' prefix)
+    sudo $0 --version v3.36.0
+    sudo $0 --version 3.36.0
+
+    # Install to custom directory
+    sudo $0 --path /usr/local/datadog
+
+    # Uninstall from default location
+    sudo $0 --uninstall
+
+    # Uninstall from custom location
+    sudo $0 --uninstall --path /usr/local/datadog
+EOF
+    exit 0
+}
+
+# Parse command line arguments
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -v|--version)
+                VERSION="$2"
+                # Ensure version has 'v' prefix for GitHub API/download URLs
+                if [[ ! "$VERSION" =~ ^v ]]; then
+                    VERSION="v${VERSION}"
+                fi
+                shift 2
+                ;;
+            -p|--path)
+                INSTALL_DIR="$2"
+                shift 2
+                ;;
+            -u|--uninstall)
+                UNINSTALL=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+}
+
+# Detect architecture
+detect_architecture() {
+    local arch
+    arch=$(uname -m)
+
+    case $arch in
+        x86_64)
+            echo "x64"
+            ;;
+        aarch64|arm64)
+            echo "arm64"
+            ;;
+        *)
+            print_error "Unsupported architecture: $arch"
+            print_error "Supported architectures: x86_64 (x64), aarch64/arm64"
+            exit 1
+            ;;
+    esac
+}
+
+# Check if running with sudo/root
+check_permissions() {
+    if [[ $EUID -ne 0 ]] && [[ "$INSTALL_DIR" == /opt/* || "$INSTALL_DIR" == /usr/* ]]; then
+        print_error "This script must be run with sudo when installing to system directories"
+        print_error "Please run: sudo $0 $*"
+        exit 1
+    fi
+}
+
+# Check required commands
+check_requirements() {
+    local missing_commands=()
+
+    for cmd in curl tar; do
+        if ! command -v "$cmd" &> /dev/null; then
+            missing_commands+=("$cmd")
+        fi
+    done
+
+    if [[ ${#missing_commands[@]} -gt 0 ]]; then
+        print_error "Missing required commands: ${missing_commands[*]}"
+        print_error "Please install them and try again"
+        exit 1
+    fi
+}
+
+# Get latest release version from GitHub
+get_latest_version() {
+    print_info "Fetching latest release version..."
+
+    local latest_url="https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+    local version
+
+    version=$(curl -sL "$latest_url" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+    if [[ -z "$version" ]]; then
+        print_error "Failed to fetch latest version from GitHub"
+        exit 1
+    fi
+
+    echo "$version"
+}
+
+# Download artifact
+download_artifact() {
+    local version=$1
+    local arch=$2
+
+    # Strip 'v' prefix from version if present (e.g., v3.36.0 -> 3.36.0)
+    local version_number="${version#v}"
+
+    # Construct artifact name based on architecture
+    local artifact_name
+    if [[ "$arch" == "x64" ]]; then
+        artifact_name="datadog-dotnet-apm-${version_number}.tar.gz"
+    else
+        artifact_name="datadog-dotnet-apm-${version_number}.${arch}.tar.gz"
+    fi
+
+    local download_url="https://github.com/$GITHUB_REPO/releases/download/${version}/${artifact_name}"
+    local temp_file="/tmp/${artifact_name}"
+
+    print_info "Downloading $artifact_name..."
+    print_info "URL: $download_url"
+
+    if ! curl -SL --fail --progress-bar -o "$temp_file" "$download_url"; then
+        print_error "Failed to download artifact"
+        print_error "URL: $download_url"
+        exit 1
+    fi
+
+    echo "$temp_file"
+}
+
+# Install tracer
+install_tracer() {
+    local artifact_path=$1
+
+    print_info "Installing to $INSTALL_DIR..."
+
+    # Create installation directory if it doesn't exist
+    mkdir -p "$INSTALL_DIR"
+
+    # Extract tarball
+    if ! tar -C "$INSTALL_DIR" -xzf "$artifact_path"; then
+        print_error "Failed to extract artifact"
+        exit 1
+    fi
+
+    # Run createLogPath.sh if it exists
+    if [[ -f "$INSTALL_DIR/createLogPath.sh" ]]; then
+        print_info "Creating log directory..."
+        if ! "$INSTALL_DIR/createLogPath.sh"; then
+            print_warn "Failed to run createLogPath.sh, you may need to create log directories manually"
+        fi
+    fi
+
+    print_info "Installation complete!"
+}
+
+# Print environment variables to set
+print_env_vars() {
+    local arch=$1
+
+    cat << EOF
+
+${GREEN}Installation successful!${NC}
+
+To enable automatic instrumentation, set the following environment variables:
+
+    export CORECLR_ENABLE_PROFILING=1
+    export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    export CORECLR_PROFILER_PATH=$INSTALL_DIR/linux-$arch/Datadog.Trace.ClrProfiler.Native.so
+    export DD_DOTNET_TRACER_HOME=$INSTALL_DIR
+
+For .NET Framework on Linux (Mono):
+
+    export CORECLR_PROFILER_PATH=$INSTALL_DIR/linux-$arch/Datadog.Trace.ClrProfiler.Native.so
+
+For more information, see:
+    https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core
+
+EOF
+}
+
+# Cleanup
+cleanup() {
+    local temp_file=$1
+    if [[ -f "$temp_file" ]]; then
+        print_info "Cleaning up temporary files..."
+        rm -f "$temp_file"
+    fi
+}
+
+# Uninstall tracer
+uninstall_tracer() {
+    print_info "Uninstalling Datadog .NET APM Tracer from $INSTALL_DIR..."
+
+    # Check if directory exists
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+        print_error "Installation directory does not exist: $INSTALL_DIR"
+        exit 1
+    fi
+
+    # Verify it looks like a Datadog installation
+    if [[ ! -f "$INSTALL_DIR/version" ]] && [[ ! -d "$INSTALL_DIR/netcoreapp3.1" ]]; then
+        print_error "Directory does not appear to be a Datadog tracer installation: $INSTALL_DIR"
+        print_error "Refusing to delete for safety. Please verify the path and remove manually if needed."
+        exit 1
+    fi
+
+    # Remove the installation directory
+    print_info "Removing $INSTALL_DIR..."
+    if ! rm -rf "$INSTALL_DIR"; then
+        print_error "Failed to remove installation directory"
+        exit 1
+    fi
+
+    # Remove log directory if it exists
+    local log_dir="/var/log/datadog/dotnet"
+    if [[ -d "$log_dir" ]]; then
+        print_info "Removing log directory: $log_dir..."
+        rm -rf "$log_dir" || print_warn "Failed to remove log directory: $log_dir"
+    fi
+
+    cat << EOF
+
+${GREEN}Uninstallation complete!${NC}
+
+The Datadog .NET APM Tracer has been removed from $INSTALL_DIR.
+
+Remember to remove or unset the following environment variables:
+    - CORECLR_ENABLE_PROFILING
+    - CORECLR_PROFILER
+    - CORECLR_PROFILER_PATH
+    - DD_DOTNET_TRACER_HOME
+
+EOF
+}
+
+# Main
+main() {
+    parse_args "$@"
+
+    print_info "Datadog .NET APM Tracer Installer"
+    print_info "=================================="
+
+    check_permissions "$@"
+
+    # Handle uninstall mode
+    if [[ "$UNINSTALL" == true ]]; then
+        uninstall_tracer
+        exit 0
+    fi
+
+    # Continue with installation
+    check_requirements
+
+    # Detect architecture
+    ARCH=$(detect_architecture)
+    print_info "Detected architecture: $ARCH"
+
+    # Get version
+    if [[ -z "$VERSION" ]]; then
+        VERSION=$(get_latest_version)
+        print_info "Latest version: $VERSION"
+    else
+        print_info "Installing version: $VERSION"
+    fi
+
+    # Download artifact
+    TEMP_FILE=$(download_artifact "$VERSION" "$ARCH")
+
+    # Install
+    install_tracer "$TEMP_FILE"
+
+    # Cleanup
+    cleanup "$TEMP_FILE"
+
+    # Print environment variables
+    print_env_vars "$ARCH"
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary of changes

Add `install.ps1`/`install.sh` scripts to simplify installing the Datadog .NET APM Tracer from GitHub releases.

## Reason for change

Provide a convenient command-line installation method as an alternative to MSI/package managers, useful for CI/CD pipelines, containers, and custom deployments.

## Implementation details

**`install.ps1` (Windows):**
- Downloads and installs MSI using `msiexec`
- Supports silent/interactive modes, custom paths, and uninstall

**`install.sh` (Linux):**
- Downloads and extracts tarball
- Auto-detects x64/arm64 architecture
- Supports custom paths and uninstall

Both scripts fetch latest version by default or accept a specific version, and display required environment variables after installation.

## Test coverage

Manually tested installation, version selection, custom paths, and uninstall functionality.