### PR TITLE
Skip telemetry for span sampling rules

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Sampling
             }
             catch (Exception e)
             {
-                Log.Error(e, "Unable to parse the span sampling rules.");
+                Log.ErrorSkipTelemetry(e, "Unable to parse the span sampling rules.");
             }
 
             return [];


### PR DESCRIPTION
## Summary of changes

Skip sending errors in span sampling rules to telemetry

## Reason for change

These rules come from user input, so can easily be wrong, and there's no action on our part

## Implementation details

`Error` => `ErrorSkipTelemetry`

## Test coverage

N/A

## Other details

[Error tracking](https://app.datadoghq.com/error-tracking/issue/7a606890-01c9-11f1-b79f-da7ad0900002)