### PR TITLE
Add `#nullable enable` to UriHelpers

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -208,7 +208,6 @@ src/Datadog.Trace/Util/System.Diagnostics.CodeAnalysis.Attributes.cs
 src/Datadog.Trace/Util/System.Runtime.CompilerServices.Attributes.cs
 src/Datadog.Trace/Util/ThrowHelper.cs
 src/Datadog.Trace/Util/TimeHelpers.cs
-src/Datadog.Trace/Util/UriHelpers.cs
 src/Datadog.Trace/Activity/Handlers/ActivityMappingExtensions.cs
 src/Datadog.Trace/Agent/MessagePack/SpanFormatterResolver.cs
 src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Proxy/AwsApiGatewaySpanFactory.cs
@@ -24,7 +24,7 @@ internal sealed class AwsApiGatewaySpanFactory : IInferredSpanFactory
     {
         try
         {
-            var resourceUrl = UriHelpers.GetCleanUriPath(data.Path).ToLowerInvariant();
+            var resourceUrl = data.Path is null ? string.Empty : UriHelpers.GetCleanUriPath(data.Path).ToLowerInvariant();
 
             var tags = new InferredProxyTags
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
@@ -201,12 +201,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                 return action;
             }
 
-            if (Tracer.Instance.Settings.WcfObfuscationEnabled)
+            var absolutePath = requestHeaders?.To?.LocalPath;
+            if (absolutePath is null)
             {
-                return UriHelpers.GetCleanUriPath(requestHeaders?.To?.LocalPath);
+                return null;
             }
 
-            return requestHeaders?.To?.LocalPath;
+            if (Tracer.Instance.Settings.WcfObfuscationEnabled)
+            {
+                return UriHelpers.GetCleanUriPath(absolutePath);
+            }
+
+            return absolutePath;
         }
 
         private static Func<object>? CreateGetCurrentOperationContextDelegate()

--- a/tracer/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/UriHelpers.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace.Util
@@ -47,9 +49,9 @@ namespace Datadog.Trace.Util
         /// <param name="absolutePath">The path to clean</param>
         /// <param name="virtualPathToRemove">The optional virtual path to remove from the front of the path</param>
         /// <returns>The cleaned path</returns>
-        public static string GetCleanUriPath(string absolutePath, string virtualPathToRemove)
+        public static string GetCleanUriPath(string absolutePath, string? virtualPathToRemove)
         {
-            if (string.IsNullOrWhiteSpace(absolutePath) || (absolutePath.Length == 1 && absolutePath[0] == '/'))
+            if (StringUtil.IsNullOrWhiteSpace(absolutePath) || (absolutePath.Length == 1 && absolutePath[0] == '/'))
             {
                 return absolutePath;
             }
@@ -62,18 +64,20 @@ namespace Datadog.Trace.Util
             // If the virtual path is "/" then we're hosted at the root, so nothing to remove
             // If not, it will be of the form "/myapp", so remove whole thing
             // Make sure we only remove _whole_ segment i.e. /myapp/controller, but not /myappcontroller
-            var hasPrefix = !string.IsNullOrEmpty(virtualPathToRemove)
-                         && virtualPathToRemove != "/"
-                         && virtualPathToRemove[0] == '/'
-                         && absolutePath.StartsWith(virtualPathToRemove, StringComparison.OrdinalIgnoreCase)
-                         && absolutePath.Length > virtualPathToRemove.Length
-                         && absolutePath[virtualPathToRemove.Length] == '/';
+            var prefixLength = !StringUtil.IsNullOrEmpty(virtualPathToRemove)
+                            && virtualPathToRemove != "/"
+                            && virtualPathToRemove[0] == '/'
+                            && absolutePath.StartsWith(virtualPathToRemove, StringComparison.OrdinalIgnoreCase)
+                            && absolutePath.Length > virtualPathToRemove.Length
+                            && absolutePath[virtualPathToRemove.Length] == '/'
+                                   ? virtualPathToRemove.Length
+                                   : 0;
 
             // Sanitized url will be at worse as long as the original, minus a removed virtual path
-            var maxLength = absolutePath.Length - (hasPrefix ? virtualPathToRemove.Length : 0);
+            var maxLength = absolutePath.Length - prefixLength;
             var sb = StringBuilderCache.Acquire(maxLength);
 
-            int previousIndex = hasPrefix ? virtualPathToRemove.Length : 0;
+            int previousIndex = prefixLength;
             int index;
             int segmentLength;
             int indexOfFileExtension = 0;


### PR DESCRIPTION
## Summary of changes

Adds `#nullable enable` to `UriHelpers` and fix usages

## Reason for change

I was working with the file, so decided to cleanup

## Implementation details

Add `#nullable enable`, fix the complaints

## Test coverage

I'm assuming already has coverage

