### PR TITLE
Make `ValueStringBuilder` available in `.NET Core 3.1`

### DIFF
--- a/tracer/src/Datadog.Trace/Util/ValueStringBuilder.cs
+++ b/tracer/src/Datadog.Trace/Util/ValueStringBuilder.cs
@@ -3,17 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NET6_0_OR_GREATER
+#if NETCOREAPP
+
+#nullable enable
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Buffers;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-#nullable enable
 
 namespace Datadog.Trace.Util
 {
@@ -299,6 +299,7 @@ namespace Datadog.Trace.Util
             }
         }
 
+#if NET6_0_OR_GREATER
         internal void AppendSpanFormattable<T>(T value, string? format = null, IFormatProvider? provider = null)
             where T : ISpanFormattable
         {
@@ -311,6 +312,7 @@ namespace Datadog.Trace.Util
                 Append(value.ToString(format, provider));
             }
         }
+#endif
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.Tests/Util/ValueStringBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/ValueStringBuilderTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
 
 // Based on tests from https://github.com/dotnet/runtime/blob/b1e550cccc539b438a19f45816e8c5030ebb89db/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
 // Licensed to the .NET Foundation under one or more agreements.


### PR DESCRIPTION
## Summary of changes

Makes `ValueStringBuilder` usable in .NET Core 3.1+, instead of just .NET 6

## Reason for change

I want to use it in some aspnetcore improvements, but currently it's only exposed in .NET 6

## Implementation details

Update the `#if`. Note that I originally made this available in _all_ TFMs, using our vendored spans, but benchmarking showed that this was actively harmful compared to just using `StringBuilderCache`, so to avoid incorrect use, just restricting it for now.

## Test coverage

Updated the tests to cover .NET Core 3.1 too.

## Other details

Part of a stack
https://datadoghq.atlassian.net/browse/LANGPLAT-842


- https://github.com/DataDog/dd-trace-dotnet/pull/8167 👈
- https://github.com/DataDog/dd-trace-dotnet/pull/8170