### PR TITLE
[Profiler] Add tracer in the profiling benchmarks

### DIFF
--- a/profiler/build/Allocations.linux.json
+++ b/profiler/build/Allocations.linux.json
@@ -14,7 +14,7 @@
       "name": "Profiler_allocation",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -24,7 +24,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_ALLOCATION_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -42,7 +42,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_ALLOCATION_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/Allocations.windows.json
+++ b/profiler/build/Allocations.windows.json
@@ -14,7 +14,7 @@
       "name": "Profiler_allocation",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -24,7 +24,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_ALLOCATION_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -42,7 +42,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_ALLOCATION_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/Contention.linux.json
+++ b/profiler/build/Contention.linux.json
@@ -14,7 +14,7 @@
       "name": "Profiler_contention",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -23,7 +23,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_LOCK_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -40,7 +40,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_LOCK_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/Contention.windows.json
+++ b/profiler/build/Contention.windows.json
@@ -14,7 +14,7 @@
       "name": "Profiler_contention",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -23,7 +23,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_LOCK_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -40,7 +40,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_LOCK_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/CpuWallTime.linux.json
+++ b/profiler/build/CpuWallTime.linux.json
@@ -14,7 +14,7 @@
       "name": "Profiler_walltime",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
 
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -23,7 +23,7 @@
         "DD_GC_THREADS_CPUTIME_ENABLED": "0",
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
-        "DD_TRACE_ENABLED" : "0"
+        "DD_TRACE_ENABLED" : "1"
       }
     },
     {
@@ -40,7 +40,7 @@
         "DD_INTERNAL_USE_BACKTRACE2": "1",
         "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
 
-        "DD_TRACE_ENABLED" : "0"
+        "DD_TRACE_ENABLED" : "1"
       }
     },
     {
@@ -57,7 +57,7 @@
 
         "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
         "DD_INTERNAL_USE_BACKTRACE2": "0",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -75,7 +75,7 @@
 
         "DD_INTERNAL_USE_BACKTRACE2": "1",
         "DD_INTERNAL_CPU_PROFILER_TYPE": "ManualCpuTime",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/CpuWallTime.windows.json
+++ b/profiler/build/CpuWallTime.windows.json
@@ -14,7 +14,7 @@
       "name": "Profiler_walltime",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
 
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -23,7 +23,7 @@
         "DD_GC_THREADS_CPUTIME_ENABLED": "0",
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
-        "DD_TRACE_ENABLED": "0",
+        "DD_TRACE_ENABLED": "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -40,7 +40,7 @@
         "DD_GC_THREADS_CPUTIME_ENABLED": "0",
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/Exceptions.linux.json
+++ b/profiler/build/Exceptions.linux.json
@@ -14,7 +14,7 @@
       "name": "Profiler_exceptions",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_LOCK_ENABLED": "0",
@@ -23,7 +23,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_EXCEPTION_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -40,7 +40,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_EXCEPTION_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/Exceptions.windows.json
+++ b/profiler/build/Exceptions.windows.json
@@ -15,7 +15,7 @@
       "name": "Profiler_exceptions",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_LOCK_ENABLED": "0",
@@ -24,7 +24,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_EXCEPTION_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -41,7 +41,7 @@
         "DD_PROFILING_GC_ENABLED": "0",
         "DD_GC_THREADS_CPUTIME_ENABLED": "0",
         "DD_THREAD_LIFETIME_ENABLED": "0",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/GarbageCollections.linux.json
+++ b/profiler/build/GarbageCollections.linux.json
@@ -15,7 +15,7 @@
       "name": "Profiler_garbagecollections",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -24,7 +24,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_GC_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -41,7 +41,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_GC_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/GarbageCollections.windows.json
+++ b/profiler/build/GarbageCollections.windows.json
@@ -15,7 +15,7 @@
       "name": "Profiler_garbagecollections",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -24,7 +24,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_GC_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -42,7 +42,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_GC_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/LiveHeap.linux.json
+++ b/profiler/build/LiveHeap.linux.json
@@ -15,7 +15,7 @@
       "name": "Profiler_liveheap",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -25,7 +25,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_HEAP_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -44,7 +44,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_HEAP_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/LiveHeap.windows.json
+++ b/profiler/build/LiveHeap.windows.json
@@ -15,7 +15,7 @@
       "name": "Profiler_liveheap",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_EXCEPTION_ENABLED": "0",
@@ -25,7 +25,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_HEAP_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -44,7 +44,7 @@
         "DD_THREAD_LIFETIME_ENABLED": "0",
 
         "DD_PROFILING_HEAP_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/OutgoingHttpRequests.linux.json
+++ b/profiler/build/OutgoingHttpRequests.linux.json
@@ -15,7 +15,7 @@
       "name": "Profiler_outgoinghttprequests",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_GC_ENABLED": "0",
@@ -26,7 +26,7 @@
 
         "DD_PROFILING_DD_INTERNAL_PROFILING_HTTP_ENABLED": "1",
         "DD_INTERNAL_PROFILING_FORCE_HTTP_SAMPLING": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -45,7 +45,7 @@
 
         "DD_PROFILING_DD_INTERNAL_PROFILING_HTTP_ENABLED": "1",
         "DD_INTERNAL_PROFILING_FORCE_HTTP_SAMPLING": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }

--- a/profiler/build/OutgoingHttpRequests.windows.json
+++ b/profiler/build/OutgoingHttpRequests.windows.json
@@ -15,7 +15,7 @@
       "name": "Profiler_outgoinghttprequests",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_ENABLED": "0",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
         "DD_PROFILING_GC_ENABLED": "0",
@@ -26,7 +26,7 @@
 
         "DD_PROFILING_DD_INTERNAL_PROFILING_HTTP_ENABLED": "1",
         "DD_INTERNAL_PROFILING_FORCE_HTTP_SAMPLING": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     },
@@ -45,7 +45,7 @@
 
         "DD_PROFILING_DD_INTERNAL_PROFILING_HTTP_ENABLED": "1",
         "DD_INTERNAL_PROFILING_FORCE_HTTP_SAMPLING": "1",
-        "DD_TRACE_ENABLED" : "0",
+        "DD_TRACE_ENABLED" : "1",
         "DD_PROFILING_MANAGED_ACTIVATION_ENABLED" : "0"
       }
     }


### PR DESCRIPTION
## Summary of changes
Benchmarks are now looking at tracer only and tracer+profiler scenarios

## Reason for change
Try to understand regression identified when benchmarks were switched from .NET 7.0 to .NET 10 

## Implementation details
Switch env vars 

## Test coverage
N/A

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
