### PR TITLE
[Azure Functions] Improve local NuGet build script

### DIFF
--- a/tracer/tools/Build-AzureFunctionsNuget.ps1
+++ b/tracer/tools/Build-AzureFunctionsNuget.ps1
@@ -70,9 +70,8 @@ $globalPackagesPath = & dotnet nuget locals global-packages --list | ForEach-Obj
 }
 Write-Verbose "NuGet global packages path: $globalPackagesPath"
 
-# Remove package Datadog.AzureFunctions from NuGet cache
-$packageId = 'Datadog.AzureFunctions'
-Write-Verbose "Removing $packageId from NuGet cache."
+# Remove packages from NuGet cache
+$packagesToRemove = @('Datadog.AzureFunctions', 'Datadog.Serverless.Compat')
 
 if (-not $globalPackagesPath)
 {
@@ -80,17 +79,21 @@ if (-not $globalPackagesPath)
 }
 else
 {
-    $packagePath = Join-Path -Path $globalPackagesPath -ChildPath $packageId
+    foreach ($packageId in $packagesToRemove)
+    {
+        Write-Verbose "Removing $packageId from NuGet cache."
+        $packagePath = Join-Path -Path $globalPackagesPath -ChildPath $packageId
 
-    if (Test-Path $packagePath)
-    {
-        Write-Verbose "Deleting `"$packagePath`" from NuGet cache."
-        Remove-Item -Path $packagePath -Recurse -Force # -ErrorAction SilentlyContinue
-        Write-Host "Deleted `"$packagePath`" from NuGet cache." -ForegroundColor Green
-    }
-    else
-    {
-        Write-Verbose "Package `"$packagePath`" not found in the NuGet cache."
+        if (Test-Path $packagePath)
+        {
+            Write-Verbose "Deleting `"$packagePath`" from NuGet cache."
+            Remove-Item -Path $packagePath -Recurse -Force # -ErrorAction SilentlyContinue
+            Write-Host "Deleted `"$packagePath`" from NuGet cache." -ForegroundColor Green
+        }
+        else
+        {
+            Write-Verbose "Package `"$packagePath`" not found in the NuGet cache."
+        }
     }
 }
 


### PR DESCRIPTION
## Summary of changes

Improves the `Build-AzureFunctionsNuget.ps1` script with better verbosity control, clearer output, improved error handling, and enhanced NuGet cache cleanup.

## Reason for change

The script previously had:
- Inconsistent verbosity levels and minimal user feedback during execution
- Only removed `Datadog.AzureFunctions` from NuGet cache, missing `Datadog.Serverless.Compat`
- Missing `dotnet restore` step that was sometimes required

## Implementation details

Add missing NuGet restore
- Adds explicit `dotnet restore` step before building the package to ensure dependencies are resolved. This was step is sometimes required and had to be done manually.

Output verbosity
- Adds `-Verbose` parameter support to control verbosity of `dotnet` and `nuke` commands
- Maps PowerShell's `$VerbosePreference` to appropriate verbosity levels for dotnet (`detailed`/`quiet`) and nuke (`normal`/`quiet`)
- Improves output messages with color-coded success indicators using `Write-Host -ForegroundColor Green`
- Miscellaneous message formatting consistency

NuGet cache cleanup
- Refactors NuGet cache cleanup to use a loop over a list of packages (`Datadog.AzureFunctions`, `Datadog.Serverless.Compat`)
- Fixes NuGet cache cleanup to report success/failure clearly

Misc
- Improves error handling when copying the package to destination with proper file existence check

## Test coverage

Tested manually.

## Other details

🤖 Co-Authored-By: Claude Code