### PR TITLE
Fix dd-octo-sts policy used in SLO checks

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -740,7 +740,9 @@ check-slo-breaches:
   when: always
   allow_failure: true # Allowed to fail since we don't want it to block releases yet
   variables:
+    DDOCTOSTS_POLICY: "gitlab.github-access.read-contents"
     ARTIFACTS_DIR: "reports"
+    SLO_FILE: ".gitlab/benchmarks/bp-runner.fail-on-breach.yml"
 
 notify-slo-breaches:
   extends: .notify-slo-breaches


### PR DESCRIPTION
## Summary of changes

Changes dd-octo-sts policy used in SLO checks to `gitlab.github-access.read-contents`.

## Reason for change

The SLO check job was pointing at a default dd-octo-sts policy (`self.gitlab.read`), not present in this repo.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
