### PR TITLE
Improve performance of `AspNetCoreResourceNameHelper.SimplifyRoutePattern`

### DIFF
--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
@@ -236,6 +236,12 @@ internal static class AspNetCoreResourceNameHelper
 
         return sb.ToString();
 #else
+        if (sb.Length <= 1)
+        {
+            StringBuilderCache.Release(sb);
+            return "/";
+        }
+
         return StringBuilderCache.GetStringAndRelease(sb).ToLowerInvariant();
 #endif
     }


### PR DESCRIPTION
## Summary of changes

Switches to using `ValueStringBuilder` and other minor perf improvements

## Reason for change

Same as #8170, we want to improve performance where we can. Unfortunately, we can't easily avoid the enumeration allocation like we did in that PR, so most of the benefits here are simply from using `ValueStringBuilder` and other minor changes.

## Implementation details

Incorporated various changes based on the `SimplifyRoutePattern` that we use in the single-span aspnetcore observer and the changes made in #8170. The gains aren't as high here, because we can't reduce enumeration allocation.

## Test coverage

Covered by existing tests.

Ran benchmarks using the values. In general, there's a slight regression in duration for an improvement in Alloc Ratio. It's not very consistent though, particularly in <.NET Core 3.1. I think it's probably still worth the change, but open to thoughts


| Method   | Runtime       | Has Defaults | Expand Templates |      Mean | Allocated | Alloc Ratio |
| -------- | ------------- | ------------ | ---------------- | --------: | --------: | ----------: |
| Original | .NET 10.0     | False        | False            |  6.605 us |   6.51 KB |        1.00 |
| Updated  | .NET 10.0     | False        | False            |  8.559 us |    4.8 KB |        0.74 |
| Original | .NET 6.0      | False        | False            | 11.466 us |   6.51 KB |        1.00 |
| Updated  | .NET 6.0      | False        | False            | 11.654 us |    4.8 KB |        0.74 |
| Original | .NET Core 3.1 | False        | False            | 13.808 us |   6.51 KB |        1.00 |
| Updated  | .NET Core 3.1 | False        | False            | 15.266 us |    4.8 KB |        0.74 |
| Original | .NET Core 3.0 | False        | False            | 13.962 us |   6.51 KB |        1.00 |
| Updated  | .NET Core 3.0 | False        | False            | 19.757 us |   6.51 KB |        1.00 |
|          |               |              |                  |           |           |             |
| Original | .NET 10.0     | False        | True             |  6.453 us |    6.2 KB |        0.99 |
| Updated  | .NET 10.0     | False        | True             |  8.116 us |   4.65 KB |        0.75 |
| Original | .NET 6.0      | False        | True             | 11.121 us |   6.23 KB |        1.00 |
| Updated  | .NET 6.0      | False        | True             | 11.375 us |   4.65 KB |        0.75 |
| Original | .NET Core 3.1 | False        | True             | 14.075 us |   6.23 KB |        1.00 |
| Updated  | .NET Core 3.1 | False        | True             | 15.000 us |   4.65 KB |        0.75 |
| Original | .NET Core 3.0 | False        | True             | 14.027 us |   6.23 KB |        1.00 |
| Updated  | .NET Core 3.0 | False        | True             | 13.687 us |    6.2 KB |        0.99 |
|          |               |              |                  |           |           |             |
| Original | .NET 10.0     | True         | False            |  6.348 us |   6.51 KB |        1.00 |
| Updated  | .NET 10.0     | True         | False            |  8.310 us |    4.8 KB |        0.74 |
| Original | .NET 6.0      | True         | False            | 11.082 us |   6.51 KB |        1.00 |
| Updated  | .NET 6.0      | True         | False            | 11.406 us |    4.8 KB |        0.74 |
| Original | .NET Core 3.1 | True         | False            |  9.853 us |   6.51 KB |        1.00 |
| Updated  | .NET Core 3.1 | True         | False            | 10.865 us |    4.8 KB |        0.74 |
| Original | .NET Core 3.0 | True         | False            | 14.879 us |   6.51 KB |        1.00 |
| Updated  | .NET Core 3.0 | True         | False            | 10.221 us |   6.51 KB |        1.00 |
|          |               |              |                  |           |           |             |
| Original | .NET 10.0     | True         | True             |  4.002 us |    6.2 KB |        0.99 |
| Updated  | .NET 10.0     | True         | True             |  5.685 us |   4.65 KB |        0.75 |
| Original | .NET 6.0      | True         | True             |  7.964 us |   6.23 KB |        1.00 |
| Updated  | .NET 6.0      | True         | True             |  8.385 us |   4.65 KB |        0.75 |
| Original | .NET Core 3.1 | True         | True             | 13.949 us |   6.23 KB |        1.00 |
| Updated  | .NET Core 3.1 | True         | True             | 15.370 us |   4.65 KB |        0.75 |
| Original | .NET Core 3.0 | True         | True             | 10.116 us |   6.23 KB |        1.00 |
| Updated  | .NET Core 3.0 | True         | True             | 10.241 us |    6.2 KB |        0.99 |


## Other details
Part of a stack
https://datadoghq.atlassian.net/browse/LANGPLAT-842

- https://github.com/DataDog/dd-trace-dotnet/pull/8167
- https://github.com/DataDog/dd-trace-dotnet/pull/8170
- https://github.com/DataDog/dd-trace-dotnet/pull/8180 👈