### PR TITLE
Fix incorrect use of namespace breaking the build

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/GithubActionsEnvironmentValues.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -14,7 +15,6 @@ using System.Text.RegularExpressions;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Telemetry.Metrics;
-using Datadog.Trace.VendoredMicrosoftCode.System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 


### PR DESCRIPTION
## Summary of changes

Fixes the broken build

## Reason for change

#6726 was merged but needed a rebase, so this slipped in

## Implementation details

Don't use the non-existent "vendored" attributes. Always use the real ones

## Test coverage

If the build passes, we're good
