### PR TITLE
[SymDB] Increase SymDB upload batch default to 1MB

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Debugger
         public const int DefaultMaxProbesPerType = 0;
 
         private const int DefaultUploadBatchSize = 100;
-        public const int DefaultSymbolBatchSizeInBytes = 100000;
+        public const int DefaultSymbolBatchSizeInBytes = 1 * 1024 * 1024; // 1 MB
         private const int DefaultDiagnosticsIntervalSeconds = 60 * 60; // 1 hour
         private const int DefaultUploadFlushIntervalMilliseconds = 0;
         public const int DefaultCodeOriginExitSpanFrames = 8;

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -349,6 +349,10 @@ namespace Datadog.Trace.Debugger.Symbols
 
         private async Task<bool> SendSymbol(string symbol, SymDbUploadMetadata metadata)
         {
+            // TODO: Consider streaming SymDB payload bytes directly to the stream
+            // to avoid the extra `string -> UTF8 bytes` encoding step and intermediate byte[] allocations/copies.
+            // Similar allocation reductions were done in https://github.com/DataDog/dd-trace-dotnet/pull/8017
+            // and https://github.com/DataDog/dd-trace-dotnet/pull/8019).
             var count = Encoding.UTF8.GetByteCount(symbol);
             if (_payload == null || count > _payload.Length)
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -257,7 +257,7 @@ namespace Datadog.Trace.Tests.Debugger
                 new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.SymbolDatabaseBatchSizeInBytes, value }, }),
                 NullConfigurationTelemetry.Instance);
 
-            settings.SymbolDatabaseBatchSizeInBytes.Should().Be(100000);
+            settings.SymbolDatabaseBatchSizeInBytes.Should().Be(DebuggerSettings.DefaultSymbolBatchSizeInBytes);
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes
Update the default SymDB upload batch size from 100KB to 1MB (DD_SYMBOL_DATABASE_BATCH_SIZE_BYTES still overrides).
Update DebuggerSettingsTests to assert against DebuggerSettings.DefaultSymbolBatchSizeInBytes.

## Reason for change
We have to keep number of uploads as low as possible.

## Test coverage
`DebuggerSettingsTests` and existing `SymbolUploaderTest`