### PR TITLE
Fix broken build in Rider

### DIFF
--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -102,11 +102,7 @@
   <!-- we don't need the vendored .NET runtime code when targetting .NET Core 3.1+ -->
   <!-- but keep Vendors/System.Reflection.Metadata/** for now because we use it to access internal members -->
   <PropertyGroup>
-    <DotNetRuntimeFiles>
-      Vendors/System.Collections.Immutable/**;
-      Vendors/System.Memory/**;
-      Vendors/System.Runtime.CompilerServices.Unsafe/**;
-    </DotNetRuntimeFiles>
+    <DotNetRuntimeFiles>Vendors/System.Collections.Immutable/**;Vendors/System.Memory/**;Vendors/System.Runtime.CompilerServices.Unsafe/**</DotNetRuntimeFiles>
   </PropertyGroup>
 
     <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))">


### PR DESCRIPTION
## Summary of changes

Fix Datadog.Trace.csproj not loading in Rider

## Reason for change

Rider fails to load Datadog.Trace.csproj due to the use of new lines in a property

## Implementation details

Remove the new lines

## Test coverage

It works, Rider can now load it
