### PR TITLE
[docs for ai] Add configuration reference docs to `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,7 +399,11 @@ The tracer runs in-process with customer applications and must have minimal perf
 ## Configuration
 
 📖 **Load when**: Need reference for tracer configuration settings and environment variables
-- **`tracer/src/Datadog.Trace/Configuration/supported-configurations-docs.yaml`** — Complete reference of all `DD_*` environment variables with descriptions and default values
+- **`tracer/src/Datadog.Trace/Configuration/supported-configurations-docs.yaml`** — Human-readable descriptions and default values for all `DD_*` environment variables
+- **`tracer/src/Datadog.Trace/Configuration/supported-configurations.json`** — Machine-readable config metadata: product categorization, key aliases, and deprecations (consumed by source generators)
+
+📖 **Load when**: Adding a new `DD_*` configuration key or modifying the configuration system
+- **`docs/development/Configuration/AddingConfigurationKeys.md`** — Step-by-step guide for adding config keys: JSON/YAML definitions, source generators, aliases, telemetry normalization, and related analyzers
 
 ## Security & Configuration
 


### PR DESCRIPTION
## Summary of changes

Added a **Configuration** section to `AGENTS.md` with references to:
- `supported-configurations-docs.yaml` — human-readable descriptions and defaults for all `DD_*` env vars
- `supported-configurations.json` — machine-readable metadata (product categorization, aliases, deprecations)
- `docs/development/Configuration/AddingConfigurationKeys.md` — step-by-step guide for adding new config keys

## Reason for change

AI agents working in this repo need quick access to tracer configuration documentation. The two reference files and the how-to guide were not linked from `AGENTS.md`.

## Implementation details

Added entries following the established "📖 Load when..." pattern, with two load-when groups:
1. **Reference lookup** — for querying existing config settings
2. **Adding/modifying config keys** — for the procedural guide

## Test coverage

Documentation-only change.

## Other details

N/A

> *"I linked three config files so AI agents can finally stop grepping for DD_TRACE_ENABLED like it's a scavenger hunt."* — Claude 🤖