### PR TITLE
Assign area:builds to version bump PRs

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -47,6 +47,9 @@ labels:
   - name: "area:builds"
     title: "^\\[?(?i)build"
 
+  - name: "area:builds"
+    title: "^\\[?(?i)(version bump)"
+
   - name: "area:ssi"
     title: "^\\[?(?i)(fleet installer)"
 


### PR DESCRIPTION
## Summary of changes

This PR assigns the label area:builds to version bump PRs.

## Reason for change

During releases, version bump PRs are created and they have no label, which makes the workflow add-labels to fail. It's not a big deal, we can manually add a proper label and rerun the workflow, but it's better if we do that automatically.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
