### PR TITLE
Disable Ryuk images

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -97,6 +97,7 @@ variables:
   Verify_DisableClipboard: true
   DiffEngine_Disabled: true
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])]
+  TESTCONTAINERS_RYUK_DISABLED: true
   NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY: true
   NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
   # Retry parameters for network operations to improve CI resilency

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -502,7 +502,7 @@ services:
       - COSMOSDB_ENDPOINT=https://cosmosdb-emulator:8081
       - TEST_AGENT_HOST=test-agent
       - CONTAINER_HOSTNAME=http://integrationtests
-      - TESTCONTAINERS_RYUK_DISABLED=true
+      - TESTCONTAINERS_RYUK_DISABLED
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
@@ -555,7 +555,7 @@ services:
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
-      - TESTCONTAINERS_RYUK_DISABLED=true
+      - TESTCONTAINERS_RYUK_DISABLED
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
@@ -611,7 +611,7 @@ services:
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
-      - TESTCONTAINERS_RYUK_DISABLED=true
+      - TESTCONTAINERS_RYUK_DISABLED
       - CONTAINER_HOSTNAME=http://integrationtests
       - IncludeAllTestFrameworks
       - DD_LOGGER_DD_API_KEY
@@ -757,7 +757,7 @@ services:
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
-      - TESTCONTAINERS_RYUK_DISABLED=true
+      - TESTCONTAINERS_RYUK_DISABLED
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - IncludeAllTestFrameworks
       - MONGO_HOST=mongo_arm64
@@ -858,7 +858,7 @@ services:
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
-      - TESTCONTAINERS_RYUK_DISABLED=true
+      - TESTCONTAINERS_RYUK_DISABLED
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE


### PR DESCRIPTION
## Summary of changes

Disable Testcontainers Ryuk (Resource Reaper) in CI by setting `TESTCONTAINERS_RYUK_DISABLED=true` in the tests of the docker-compose service

## Reason for change

The Aerospike integration tests (and any other Testcontainers-based tests)[ intermittently fail in CI](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.status%3Afail%20%40git.branch%3Amaster&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZxIR7mu03_XKQAAABhBWnhJVHFPM0FBQmdrOFo0elg3OTZVUnEAAAAkZjE5YzQ4NDctZWZmZi00YTljLTg2YTctMzBiOGI0MTI1MmY5AANnIg&fromUser=false&index=citest&testId=AwAAAZxIR7mu03_XKQAAABhBWnhJVHFPM0FBQmdrOFo0elg3OTZVUnEAAAAkZjE5YzQ4NDctZWZmZi00YTljLTg2YTctMzBiOGI0MTI1MmY5AANnIg&trace=AwAAAZxIR7mu03_XKQAAABhBWnhJVHFPM0FBQmdrOFo0elg3OTZVUnEAAAAkZjE5YzQ4NDctZWZmZi00YTljLTg2YTctMzBiOGI0MTI1MmY5AANnIg&start=1770716185071&end=1771320985071&paused=false) with:
```
Docker.DotNet.DockerImageNotFoundException: No such image: testcontainers/ryuk:0.5.1
```
Ryuk is a sidecar container that Testcontainers starts **by default** before every test container to handle resource cleanup on process exit. Since it needs to be pulled from Docker Hub, it is susceptible to transient failures (rate limiting, network issues), causing flaky test runs.

The CI pipeline already has its own Docker cleanup step (`.azure-pipelines/steps/clean-docker-containers.yml`) that runs `docker rm -f` on all containers after test execution, making Ryuk redundant.

Skipping the Ryuk image pull saves CI time on every Docker-based integration test run.

- [Testcontainers .NET - Custom Configuration](https://dotnet.testcontainers.org/custom_configuration/)
- [Testcontainers .NET - Resource Reaper](https://dotnet.testcontainers.org/api/resource_reaper/)

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
