### PR TITLE
Skip NUnitTests.SubmitTraces

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -53,6 +53,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [Trait("Category", "TestIntegrations")]
         public async Task SubmitTraces(string packageVersion)
         {
+            // Right now, the test is very flaky under Linux. Skip to avoid flakiness until solved.
+            SkipOn.Platform(SkipOn.PlatformValue.Linux);
+
             if (new Version(FrameworkDescription.Instance.ProductVersion).Major >= 5)
             {
                 if (!string.IsNullOrWhiteSpace(packageVersion) && new Version(packageVersion) < new Version("3.13"))


### PR DESCRIPTION
## Summary of changes

Test Datadog.Trace.ClrProfiler.IntegrationTests.CI.NUnitTests.SubmitTraces is failing on different branches unuder Linux. Skip while it's fixed.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
