### PR TITLE
feat(telemetry): implement app-extended-heartbeat timer

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/configuration_keys_mapping.json
+++ b/tracer/src/Datadog.Trace/Configuration/configuration_keys_mapping.json
@@ -657,6 +657,10 @@
       "const_name": "HeartbeatIntervalSeconds"
     },
     {
+      "env_var": "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL",
+      "const_name": "ExtendedHeartbeatIntervalSeconds"
+    },
+    {
       "env_var": "DD_TELEMETRY_LOG_COLLECTION_ENABLED",
       "const_name": "TelemetryLogsEnabled"
     },

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations-docs.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations-docs.yaml
@@ -709,6 +709,11 @@ DD_TELEMETRY_HEARTBEAT_INTERVAL: |
   For testing purposes. Defaults to 60
   <see cref="Datadog.Trace.Telemetry.TelemetrySettings.HeartbeatInterval"/>
 
+DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL: |
+  Configuration key for how often extended heartbeat telemetry should be sent, in seconds.
+  For testing purposes. Defaults to 86400 (24 hours)
+  <see cref="Datadog.Trace.Telemetry.TelemetrySettings.ExtendedHeartbeatInterval"/>
+
 DD_TELEMETRY_LOG_COLLECTION_ENABLED: |
   Configuration key for whether to enable redacted error log collection.
 

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.json
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.json
@@ -1462,6 +1462,14 @@
         "product": "Telemetry"
       }
     ],
+    "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL": [
+      {
+        "implementation": "B",
+        "type": "decimal",
+        "default": "86400.0",
+        "product": "Telemetry"
+      }
+    ],
     "DD_TELEMETRY_LOG_COLLECTION_ENABLED": [
       {
         "implementation": "A",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
@@ -89,6 +89,13 @@ internal static partial class ConfigurationKeys
         public const string HeartbeatIntervalSeconds = "DD_TELEMETRY_HEARTBEAT_INTERVAL";
 
         /// <summary>
+        /// Configuration key for how often extended heartbeat telemetry should be sent, in seconds.
+        /// For testing purposes. Defaults to 86400 (24 hours)
+        /// <see cref="Datadog.Trace.Telemetry.TelemetrySettings.ExtendedHeartbeatInterval"/>
+        /// </summary>
+        public const string ExtendedHeartbeatIntervalSeconds = "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL";
+
+        /// <summary>
         /// Configuration key for whether to enable redacted error log collection.
         /// </summary>
         public const string TelemetryLogsEnabled = "DD_TELEMETRY_LOG_COLLECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
@@ -89,6 +89,13 @@ internal static partial class ConfigurationKeys
         public const string HeartbeatIntervalSeconds = "DD_TELEMETRY_HEARTBEAT_INTERVAL";
 
         /// <summary>
+        /// Configuration key for how often extended heartbeat telemetry should be sent, in seconds.
+        /// For testing purposes. Defaults to 86400 (24 hours)
+        /// <see cref="Datadog.Trace.Telemetry.TelemetrySettings.ExtendedHeartbeatInterval"/>
+        /// </summary>
+        public const string ExtendedHeartbeatIntervalSeconds = "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL";
+
+        /// <summary>
         /// Configuration key for whether to enable redacted error log collection.
         /// </summary>
         public const string TelemetryLogsEnabled = "DD_TELEMETRY_LOG_COLLECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
@@ -89,6 +89,13 @@ internal static partial class ConfigurationKeys
         public const string HeartbeatIntervalSeconds = "DD_TELEMETRY_HEARTBEAT_INTERVAL";
 
         /// <summary>
+        /// Configuration key for how often extended heartbeat telemetry should be sent, in seconds.
+        /// For testing purposes. Defaults to 86400 (24 hours)
+        /// <see cref="Datadog.Trace.Telemetry.TelemetrySettings.ExtendedHeartbeatInterval"/>
+        /// </summary>
+        public const string ExtendedHeartbeatIntervalSeconds = "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL";
+
+        /// <summary>
         /// Configuration key for whether to enable redacted error log collection.
         /// </summary>
         public const string TelemetryLogsEnabled = "DD_TELEMETRY_LOG_COLLECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Telemetry.g.cs
@@ -89,6 +89,13 @@ internal static partial class ConfigurationKeys
         public const string HeartbeatIntervalSeconds = "DD_TELEMETRY_HEARTBEAT_INTERVAL";
 
         /// <summary>
+        /// Configuration key for how often extended heartbeat telemetry should be sent, in seconds.
+        /// For testing purposes. Defaults to 86400 (24 hours)
+        /// <see cref="Datadog.Trace.Telemetry.TelemetrySettings.ExtendedHeartbeatInterval"/>
+        /// </summary>
+        public const string ExtendedHeartbeatIntervalSeconds = "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL";
+
+        /// <summary>
         /// Configuration key for whether to enable redacted error log collection.
         /// </summary>
         public const string TelemetryLogsEnabled = "DD_TELEMETRY_LOG_COLLECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -178,7 +178,8 @@ namespace Datadog.Trace.Telemetry
                         Metrics,
                         _logs.IsValueCreated ? _logs.Value : null, // if we haven't created it by now, we don't need it
                         transportManager,
-                        settings.HeartbeatInterval);
+                        settings.HeartbeatInterval,
+                        settings.ExtendedHeartbeatInterval);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace.Telemetry
             AgentlessSettings? agentlessSettings,
             bool agentProxyEnabled,
             TimeSpan heartbeatInterval,
+            TimeSpan extendedHeartbeatInterval,
             bool dependencyCollectionEnabled,
             bool metricsEnabled,
             bool debugEnabled,
@@ -31,6 +32,7 @@ namespace Datadog.Trace.Telemetry
             Agentless = agentlessSettings;
             AgentProxyEnabled = agentProxyEnabled;
             HeartbeatInterval = heartbeatInterval;
+            ExtendedHeartbeatInterval = extendedHeartbeatInterval;
             DependencyCollectionEnabled = dependencyCollectionEnabled;
             MetricsEnabled = metricsEnabled;
             DebugEnabled = debugEnabled;
@@ -48,6 +50,8 @@ namespace Datadog.Trace.Telemetry
         public AgentlessSettings? Agentless { get; }
 
         public TimeSpan HeartbeatInterval { get; }
+
+        public TimeSpan ExtendedHeartbeatInterval { get; }
 
         public bool AgentProxyEnabled { get; }
 
@@ -141,6 +145,11 @@ namespace Datadog.Trace.Telemetry
                                    .AsDouble(defaultValue: 60, rawInterval => rawInterval is > 0 and <= 3600)
                                    .Value;
 
+            var extendedHeartbeatInterval = config
+                                           .WithKeys(ConfigurationKeys.Telemetry.ExtendedHeartbeatIntervalSeconds)
+                                           .AsDouble(defaultValue: 86400, rawInterval => rawInterval > 0)
+                                           .Value;
+
             var dependencyCollectionEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DependencyCollectionEnabled).AsBool(true);
 
             var telemetryCompressionMethod = config.WithKeys(ConfigurationKeys.Telemetry.TelemetryCompressionMethod).AsString("gzip");
@@ -168,6 +177,7 @@ namespace Datadog.Trace.Telemetry
                 agentless,
                 agentProxyEnabled,
                 TimeSpan.FromSeconds(heartbeatInterval),
+                TimeSpan.FromSeconds(extendedHeartbeatInterval),
                 dependencyCollectionEnabled,
                 metricsEnabled,
                 debugEnabled,

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerSchedulerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerSchedulerTests.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.Tests.Telemetry;
 public class TelemetryControllerSchedulerTests
 {
     private static readonly TimeSpan FlushInterval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan ExtendedHeartbeatInterval = TimeSpan.FromSeconds(86400);
     private static readonly TimeSpan FiveSeconds = TimeSpan.FromSeconds(5);
     private static readonly Task NeverComplete = Task.Delay(Timeout.Infinite);
     private readonly TaskCompletionSource<bool> _processExit = new();
@@ -24,7 +25,7 @@ public class TelemetryControllerSchedulerTests
 
     public TelemetryControllerSchedulerTests()
     {
-        _scheduler = new TelemetryController.Scheduler(FlushInterval, () => NeverComplete, _processExit, _clock, _delayFactory);
+        _scheduler = new TelemetryController.Scheduler(FlushInterval, ExtendedHeartbeatInterval, () => NeverComplete, _processExit, _clock, _delayFactory);
     }
 
     [Fact]
@@ -288,7 +289,7 @@ public class TelemetryControllerSchedulerTests
     }
 
     private TelemetryController.Scheduler GetScheduler(QueueTaskGenerator queueTaskGenerator = null)
-        => new(FlushInterval, (queueTaskGenerator ?? new()).GetTask, _processExit, _clock, _delayFactory);
+        => new(FlushInterval, ExtendedHeartbeatInterval, (queueTaskGenerator ?? new()).GetTask, _processExit, _clock, _delayFactory);
 
     private class DelayFactory : TelemetryController.Scheduler.IDelayFactory
     {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.Tests.Telemetry;
 public class TelemetryControllerTests
 {
     private readonly TimeSpan _flushInterval = TimeSpan.FromMilliseconds(100);
+    private readonly TimeSpan _extendedHeartbeatInterval = TimeSpan.FromMilliseconds(86400_000);
     // private readonly TimeSpan _heartbeatInterval = TimeSpan.FromMilliseconds(10_000); // We don't need them for most tests
     private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(60_000); // definitely should receive telemetry by now
 
@@ -44,7 +45,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         controller.Start();
 
@@ -65,7 +67,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         var sha = "testCommitSha";
         var repo = "testRepositoryUrl";
@@ -114,7 +117,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         controller.Start();
 
@@ -148,7 +152,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         await controller.DisposeAsync();
         await controller.DisposeAsync();
@@ -167,7 +172,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         controller.Start();
 
@@ -212,7 +218,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         controller.Start();
 
@@ -251,7 +258,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         controller.RecordAppEndpoints(new List<AppEndpointData>
         {
@@ -297,7 +305,8 @@ public class TelemetryControllerTests
             new NullMetricsTelemetryCollector(),
             new RedactedErrorLogCollector(),
             transportManager,
-            _flushInterval);
+            _flushInterval,
+            _extendedHeartbeatInterval);
 
         // before the controller is started, nothing should be written when we try to dump telemetry
         var tempFile = Path.GetTempFileName();


### PR DESCRIPTION
Add timer-based scheduling for app-extended-heartbeat telemetry events. Sends configuration, dependencies, and integrations data every 24 hours to improve reliability in long-running sessions.

Changes:
- Add ExtendedHeartbeatInterval setting to TelemetrySettings
- Add TelemetryExtendedHeartbeatInterval configuration key
- Implement _extendedHeartbeatTimer in TelemetryController
- Wire up PushExtendedHeartbeat() method
- Update test files with new configuration parameter
- Reuse existing BuildExtendedHeartbeatData() payload builder

## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
