### PR TITLE
Transient shutdown timeout

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2506,6 +2506,8 @@ partial class Build
                new(@".*Noop\dArgumentsVoidIntegration\.OnMethodBegin.*CallTargetNativeTest.*", RegexOptions.Compiled | RegexOptions.Singleline),
                new(@".*Noop\dArgumentsVoidIntegration\.OnMethodEnd.*CallTargetNativeTest.*", RegexOptions.Compiled | RegexOptions.Singleline),
                new(@".*System.Threading.ThreadAbortException: Thread was being aborted\.", RegexOptions.Compiled),
+               // Transient shutdown timeout - LifetimeManager hooks may not complete within 30s under CI resource pressure
+               new(@".*Error running shutdown hooks System\.TimeoutException.*", RegexOptions.Compiled),
                new(@".*System.InvalidOperationException: Module Samples.Trimming.dll has no HINSTANCE.*", RegexOptions.Compiled),
                // CI Visibility known errors
                new(@".*The Git repository couldn't be automatically extracted.*", RegexOptions.Compiled),


### PR DESCRIPTION
## Summary of changes

Add Error running shutdown hooks System.TimeoutException to the CheckBuildLogsForErrors known patterns allowlist to prevent flaky CI failures.

## Reason for change

 The CheckBuildLogsForErrors post-test step scans tracer log files for [Error] entries and fails the build if it finds unrecognized ones. Under CI resource pressure, LifetimeManager.RunShutdownTasks can exceed its 30s timeout during
  process shutdown, logging a TimeoutException. This causes builds to fail even though all tests passed (e.g., Test debian_net8.0 in https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=196033).
  

>   10:42:51 [ERR] 02/18/2026 10:12:46 +00:00 [Error] Error running shutdown hooks System.TimeoutException: The operation has timed out.

## Implementation details

 Added one regex to the knownPatterns list in Build.Steps.cs, next to the existing ThreadAbortException pattern since both are transient shutdown errors.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
