### PR TITLE
Enable Datadog Claude Marketplace plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,8 @@
       "Skill(dd:render-helm *)",
       "Skill(dd:deploy-yaml-local-dev *)",
       "Skill(dd:integrate *)",
-      "Skill(dd:live-test-api *)"
+      "Skill(dd:live-test-api *)",
+      "Skill(dd:debug-ddci-request *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary of changes

Adds `.claude/settings.json` to enable the [Datadog Claude Marketplace](https://github.com/DataDog/claude-marketplace) plugins, with irrelevant skills filtered out via permission deny rules.

**No manual setup required** — the `settings.json` handles marketplace registration and plugin activation automatically when Claude Code is launched from this repo.

## Reason for change

Gives contributors access to shared Datadog-wide Claude Code tooling (CI debugging, PR workflows, employee lookup, Jira integration) that complements the repo-specific local skills already defined under `.claude/skills/`.

## Implementation details

Enables the `dd` plugin bundle from the marketplace, then uses `permissions.deny` rules to block skills not relevant to dd-trace-dotnet.

### Marketplace skills — allowed

| Skill | Purpose |
|---|---|
| `dd:\ci:fix` | Analyze CI failures and propose fixes |
| `dd:fetch-ci-results` | Fetch CI logs, detect flakes, retry jobs |
| `dd:\pr:address-feedback` | Address PR review feedback |
| `dd:get-pr-feedback` | Fetch and structure PR review comments |
| `dd:jira-ticket-solver` | Jira ticket workflow automation |
| `dd:whoisthis` | Employee lookup by email/GitHub username |

### Marketplace skills — denied

| Skill | Reason |
|---|---|
| `dd:conductor` | Deployment platform — not used by dd-trace-dotnet |
| `dd:trebuchet` | logs-backend repo only |
| `dd:render-helm` | Helm charts for dd-source services |
| `dd:deploy-yaml-local-dev` | deploy.yaml for dd-source services |
| `dd:integrate` | devflow integration branches — not used in this repo |
| `dd:live-test-api` | Live Datadog API calls — not needed for tracer development |
| `dd:debug-ddci-request` | DDCI request debugging — covered by local CI skills |

### Existing local skills (unchanged)

| Skill | Purpose |
|---|---|
| `/analyze-crash` | Native crash stack trace analysis |
| `/analyze-error` | Managed error analysis with fix recommendations |
| `/review-pr` | PR review with inline GitHub comments |
| `/troubleshoot-ci-build` | Azure DevOps pipeline troubleshooting |

## Test coverage

Configuration-only change, no code changes.

## Other details

The `DataDog/claude-marketplace` repo is **private**. For external contributors, the marketplace plugins will simply fail to load — local skills and core Claude Code functionality remain fully available.