### PR TITLE
(CI) Migrating benchmark-serverless CI job to short-lived tokens

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.2.25502.107",
+    "version": "10.0.100",
     "rollForward": "minor"
   }
 }


### PR DESCRIPTION
## Summary of changes
Migrated from use of Gitlab personal access token to short-lived token (using authanywhere) when cloning the serverless-tools repo for the benchmark-serverless CI job.

## Reason for change
Keeping up-to-date with current policies about tokens, avoiding token expiry issues.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
