### PR TITLE
[CIVIz] Generate MessagePack values at compile time

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIVisibilityEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIVisibilityEventMessagePackFormatter.cs
@@ -23,13 +23,13 @@ internal sealed class CIVisibilityEventMessagePackFormatter<T> : EventMessagePac
 
         offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 3);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TypeBytes);
+        offset += MessagePackBinary.WriteRaw(ref bytes, offset, TypeBytes);
         offset += MessagePackBinary.WriteString(ref bytes, offset, value.Type);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, VersionBytes);
+        offset += MessagePackBinary.WriteRaw(ref bytes, offset, VersionBytes);
         offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.Version);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ContentBytes);
+        offset += MessagePackBinary.WriteRaw(ref bytes, offset, ContentBytes);
         offset += formatterResolver.GetFormatter<T>().Serialize(ref bytes, offset, value.Content, formatterResolver);
 
         return offset - originalOffset;

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Ci.Agent.Payloads;
 using Datadog.Trace.Vendors.MessagePack;
 
@@ -12,19 +13,16 @@ namespace Datadog.Trace.Ci.Agent.MessagePack;
 
 internal sealed class CoveragePayloadMessagePackFormatter : EventMessagePackFormatter<CICodeCoveragePayload.CoveragePayload>
 {
-    private readonly byte[] _versionBytes = StringEncoding.UTF8.GetBytes("version");
-    private readonly byte[] _coveragesBytes = StringEncoding.UTF8.GetBytes("coverages");
-
     public override int Serialize(ref byte[] bytes, int offset, CICodeCoveragePayload.CoveragePayload value, IFormatterResolver formatterResolver)
     {
         var originalOffset = offset;
 
         offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 2);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _versionBytes);
+        offset += MessagePackBinary.WriteRaw(ref bytes, offset, MessagePackConstants.VersionBytes);
         offset += MessagePackBinary.WriteInt32(ref bytes, offset, 2);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _coveragesBytes);
+        offset += MessagePackBinary.WriteRaw(ref bytes, offset, MessagePackConstants.CoveragesBytes);
 
         // Write events
         if (value.TestCoverageData.Lock())

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/EventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/EventMessagePackFormatter.cs
@@ -6,6 +6,7 @@
 #pragma warning disable SA1402 // disable check to only have one class per file
 
 using System;
+using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.MessagePack;
 using Datadog.Trace.Vendors.MessagePack.Formatters;
@@ -16,14 +17,17 @@ internal abstract class EventMessagePackFormatter
 {
     private readonly IDatadogLogger _log;
 
-    protected static readonly byte[] TypeBytes = StringEncoding.UTF8.GetBytes("type");
-    protected static readonly byte[] VersionBytes = StringEncoding.UTF8.GetBytes("version");
-    protected static readonly byte[] ContentBytes = StringEncoding.UTF8.GetBytes("content");
-
     protected EventMessagePackFormatter()
     {
         _log = DatadogLogging.GetLoggerFor(GetType());
     }
+
+    // Use generated MessagePack constants
+    protected static ReadOnlySpan<byte> TypeBytes => MessagePackConstants.TypeBytes;
+
+    protected static ReadOnlySpan<byte> VersionBytes => MessagePackConstants.VersionBytes;
+
+    protected static ReadOnlySpan<byte> ContentBytes => MessagePackConstants.ContentBytes;
 
     protected IDatadogLogger Log => _log;
 }

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/MessagePackFieldNames.CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/MessagePackFieldNames.CIVisibility.cs
@@ -1,0 +1,52 @@
+// <copyright file="MessagePackFieldNames.CIVisibility.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.SourceGenerators;
+
+namespace Datadog.Trace.Agent.MessagePack
+{
+    /// <summary>
+    /// MessagePack field names for CI Visibility serialization (CI-specific part).
+    /// These constants are marked with [MessagePackField] to generate pre-serialized byte arrays.
+    /// </summary>
+    internal static partial class MessagePackFieldNames
+    {
+        [MessagePackField]
+        public const string Content = "content";
+
+        // CIEventMessagePackFormatter fields
+        [MessagePackField]
+        public const string Metadata = "metadata";
+
+        [MessagePackField]
+        public const string Asterisk = "*";
+
+        [MessagePackField]
+        public const string TestSessionName = "test_session.name";
+
+        // CoveragePayloadMessagePackFormatter fields
+        [MessagePackField]
+        public const string Coverages = "coverages";
+
+        // CI SpanMessagePackFormatter fields
+        [MessagePackField]
+        public const string ItrCorrelationId = "itr_correlation_id";
+
+        // Span types (duplicated from SpanTypes.cs which is shared with Manual)
+        [MessagePackField]
+        public const string Test = "test";
+
+        [MessagePackField]
+        public const string TestSuite = "test_suite_end";
+
+        [MessagePackField]
+        public const string TestModule = "test_module_end";
+
+        [MessagePackField]
+        public const string TestSession = "test_session_end";
+    }
+}

--- a/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.SourceGenerators;
+
 namespace Datadog.Trace.Ci.Tags;
 
 /// <summary>
@@ -164,6 +166,7 @@ internal static class CommonTags
     /// <summary>
     /// Library Version
     /// </summary>
+    [MessagePackField]
     public const string LibraryVersion = "library_version";
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Ci/Tags/TestSuiteVisibilityTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/TestSuiteVisibilityTags.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.SourceGenerators;
+
 namespace Datadog.Trace.Ci.Tags;
 
 internal static class TestSuiteVisibilityTags
@@ -11,15 +13,18 @@ internal static class TestSuiteVisibilityTags
     /// <summary>
     /// Test session id
     /// </summary>
+    [MessagePackField]
     public const string TestSessionId = "test_session_id";
 
     /// <summary>
     /// Test module id
     /// </summary>
+    [MessagePackField]
     public const string TestModuleId = "test_module_id";
 
     /// <summary>
     /// Test suite id
     /// </summary>
+    [MessagePackField]
     public const string TestSuiteId = "test_suite_id";
 }

--- a/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
@@ -4,6 +4,8 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.SourceGenerators;
+
 namespace Datadog.Trace.Ci.Tags;
 
 /// <summary>
@@ -104,6 +106,7 @@ internal static class TestTags
     /// <summary>
     /// Origin value for CIApp Test
     /// </summary>
+    [MessagePackField]
     public const string CIAppTestOriginName = "ciapp-test";
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
@@ -219,6 +219,111 @@ internal static class MessagePackConstants
     internal static readonly byte[] DotnetLanguageValueBytes = new byte[] { 166, 100, 111, 116, 110, 101, 116 };
 #endif
 
+    // ContentBytes = MessagePack.Serialize("content");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ContentBytes => new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#else
+    internal static readonly byte[] ContentBytes = new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#endif
+
+    // MetadataBytes = MessagePack.Serialize("metadata");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> MetadataBytes => new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#else
+    internal static readonly byte[] MetadataBytes = new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#endif
+
+    // AsteriskBytes = MessagePack.Serialize("*");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> AsteriskBytes => new byte[] { 161, 42 };
+#else
+    internal static readonly byte[] AsteriskBytes = new byte[] { 161, 42 };
+#endif
+
+    // TestSessionNameBytes = MessagePack.Serialize("test_session.name");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionNameBytes => new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#else
+    internal static readonly byte[] TestSessionNameBytes = new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#endif
+
+    // CoveragesBytes = MessagePack.Serialize("coverages");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CoveragesBytes => new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#else
+    internal static readonly byte[] CoveragesBytes = new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#endif
+
+    // ItrCorrelationIdBytes = MessagePack.Serialize("itr_correlation_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ItrCorrelationIdBytes => new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] ItrCorrelationIdBytes = new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestBytes = MessagePack.Serialize("test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestBytes => new byte[] { 164, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] TestBytes = new byte[] { 164, 116, 101, 115, 116 };
+#endif
+
+    // TestSuiteBytes = MessagePack.Serialize("test_suite_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteBytes => new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSuiteBytes = new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestModuleBytes = MessagePack.Serialize("test_module_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleBytes => new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestModuleBytes = new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestSessionBytes = MessagePack.Serialize("test_session_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionBytes => new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSessionBytes = new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#endif
+
+    // LibraryVersionBytes = MessagePack.Serialize("library_version");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#else
+    internal static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#endif
+
+    // TestSessionIdBytes = MessagePack.Serialize("test_session_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionIdBytes => new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSessionIdBytes = new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestModuleIdBytes = MessagePack.Serialize("test_module_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleIdBytes => new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestModuleIdBytes = new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#endif
+
+    // TestSuiteIdBytes = MessagePack.Serialize("test_suite_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteIdBytes => new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSuiteIdBytes = new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#endif
+
+    // CIAppTestOriginNameBytes = MessagePack.Serialize("ciapp-test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CIAppTestOriginNameBytes => new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] CIAppTestOriginNameBytes = new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#endif
+
     // EnvDSMBytes = MessagePack.Serialize("Env");
 #if NETCOREAPP
     internal static ReadOnlySpan<byte> EnvDSMBytes => new byte[] { 163, 69, 110, 118 };

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
@@ -219,6 +219,111 @@ internal static class MessagePackConstants
     internal static readonly byte[] DotnetLanguageValueBytes = new byte[] { 166, 100, 111, 116, 110, 101, 116 };
 #endif
 
+    // ContentBytes = MessagePack.Serialize("content");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ContentBytes => new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#else
+    internal static readonly byte[] ContentBytes = new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#endif
+
+    // MetadataBytes = MessagePack.Serialize("metadata");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> MetadataBytes => new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#else
+    internal static readonly byte[] MetadataBytes = new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#endif
+
+    // AsteriskBytes = MessagePack.Serialize("*");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> AsteriskBytes => new byte[] { 161, 42 };
+#else
+    internal static readonly byte[] AsteriskBytes = new byte[] { 161, 42 };
+#endif
+
+    // TestSessionNameBytes = MessagePack.Serialize("test_session.name");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionNameBytes => new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#else
+    internal static readonly byte[] TestSessionNameBytes = new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#endif
+
+    // CoveragesBytes = MessagePack.Serialize("coverages");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CoveragesBytes => new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#else
+    internal static readonly byte[] CoveragesBytes = new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#endif
+
+    // ItrCorrelationIdBytes = MessagePack.Serialize("itr_correlation_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ItrCorrelationIdBytes => new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] ItrCorrelationIdBytes = new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestBytes = MessagePack.Serialize("test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestBytes => new byte[] { 164, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] TestBytes = new byte[] { 164, 116, 101, 115, 116 };
+#endif
+
+    // TestSuiteBytes = MessagePack.Serialize("test_suite_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteBytes => new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSuiteBytes = new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestModuleBytes = MessagePack.Serialize("test_module_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleBytes => new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestModuleBytes = new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestSessionBytes = MessagePack.Serialize("test_session_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionBytes => new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSessionBytes = new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#endif
+
+    // LibraryVersionBytes = MessagePack.Serialize("library_version");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#else
+    internal static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#endif
+
+    // TestSessionIdBytes = MessagePack.Serialize("test_session_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionIdBytes => new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSessionIdBytes = new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestModuleIdBytes = MessagePack.Serialize("test_module_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleIdBytes => new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestModuleIdBytes = new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#endif
+
+    // TestSuiteIdBytes = MessagePack.Serialize("test_suite_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteIdBytes => new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSuiteIdBytes = new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#endif
+
+    // CIAppTestOriginNameBytes = MessagePack.Serialize("ciapp-test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CIAppTestOriginNameBytes => new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] CIAppTestOriginNameBytes = new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#endif
+
     // EnvDSMBytes = MessagePack.Serialize("Env");
 #if NETCOREAPP
     internal static ReadOnlySpan<byte> EnvDSMBytes => new byte[] { 163, 69, 110, 118 };

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
@@ -219,6 +219,111 @@ internal static class MessagePackConstants
     internal static readonly byte[] DotnetLanguageValueBytes = new byte[] { 166, 100, 111, 116, 110, 101, 116 };
 #endif
 
+    // ContentBytes = MessagePack.Serialize("content");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ContentBytes => new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#else
+    internal static readonly byte[] ContentBytes = new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#endif
+
+    // MetadataBytes = MessagePack.Serialize("metadata");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> MetadataBytes => new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#else
+    internal static readonly byte[] MetadataBytes = new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#endif
+
+    // AsteriskBytes = MessagePack.Serialize("*");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> AsteriskBytes => new byte[] { 161, 42 };
+#else
+    internal static readonly byte[] AsteriskBytes = new byte[] { 161, 42 };
+#endif
+
+    // TestSessionNameBytes = MessagePack.Serialize("test_session.name");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionNameBytes => new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#else
+    internal static readonly byte[] TestSessionNameBytes = new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#endif
+
+    // CoveragesBytes = MessagePack.Serialize("coverages");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CoveragesBytes => new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#else
+    internal static readonly byte[] CoveragesBytes = new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#endif
+
+    // ItrCorrelationIdBytes = MessagePack.Serialize("itr_correlation_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ItrCorrelationIdBytes => new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] ItrCorrelationIdBytes = new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestBytes = MessagePack.Serialize("test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestBytes => new byte[] { 164, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] TestBytes = new byte[] { 164, 116, 101, 115, 116 };
+#endif
+
+    // TestSuiteBytes = MessagePack.Serialize("test_suite_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteBytes => new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSuiteBytes = new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestModuleBytes = MessagePack.Serialize("test_module_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleBytes => new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestModuleBytes = new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestSessionBytes = MessagePack.Serialize("test_session_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionBytes => new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSessionBytes = new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#endif
+
+    // LibraryVersionBytes = MessagePack.Serialize("library_version");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#else
+    internal static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#endif
+
+    // TestSessionIdBytes = MessagePack.Serialize("test_session_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionIdBytes => new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSessionIdBytes = new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestModuleIdBytes = MessagePack.Serialize("test_module_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleIdBytes => new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestModuleIdBytes = new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#endif
+
+    // TestSuiteIdBytes = MessagePack.Serialize("test_suite_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteIdBytes => new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSuiteIdBytes = new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#endif
+
+    // CIAppTestOriginNameBytes = MessagePack.Serialize("ciapp-test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CIAppTestOriginNameBytes => new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] CIAppTestOriginNameBytes = new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#endif
+
     // EnvDSMBytes = MessagePack.Serialize("Env");
 #if NETCOREAPP
     internal static ReadOnlySpan<byte> EnvDSMBytes => new byte[] { 163, 69, 110, 118 };

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/MessagePackConstantsGenerator/MessagePackConstants.g.cs
@@ -219,6 +219,111 @@ internal static class MessagePackConstants
     internal static readonly byte[] DotnetLanguageValueBytes = new byte[] { 166, 100, 111, 116, 110, 101, 116 };
 #endif
 
+    // ContentBytes = MessagePack.Serialize("content");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ContentBytes => new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#else
+    internal static readonly byte[] ContentBytes = new byte[] { 167, 99, 111, 110, 116, 101, 110, 116 };
+#endif
+
+    // MetadataBytes = MessagePack.Serialize("metadata");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> MetadataBytes => new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#else
+    internal static readonly byte[] MetadataBytes = new byte[] { 168, 109, 101, 116, 97, 100, 97, 116, 97 };
+#endif
+
+    // AsteriskBytes = MessagePack.Serialize("*");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> AsteriskBytes => new byte[] { 161, 42 };
+#else
+    internal static readonly byte[] AsteriskBytes = new byte[] { 161, 42 };
+#endif
+
+    // TestSessionNameBytes = MessagePack.Serialize("test_session.name");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionNameBytes => new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#else
+    internal static readonly byte[] TestSessionNameBytes = new byte[] { 177, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 46, 110, 97, 109, 101 };
+#endif
+
+    // CoveragesBytes = MessagePack.Serialize("coverages");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CoveragesBytes => new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#else
+    internal static readonly byte[] CoveragesBytes = new byte[] { 169, 99, 111, 118, 101, 114, 97, 103, 101, 115 };
+#endif
+
+    // ItrCorrelationIdBytes = MessagePack.Serialize("itr_correlation_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> ItrCorrelationIdBytes => new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] ItrCorrelationIdBytes = new byte[] { 178, 105, 116, 114, 95, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestBytes = MessagePack.Serialize("test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestBytes => new byte[] { 164, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] TestBytes = new byte[] { 164, 116, 101, 115, 116 };
+#endif
+
+    // TestSuiteBytes = MessagePack.Serialize("test_suite_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteBytes => new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSuiteBytes = new byte[] { 174, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestModuleBytes = MessagePack.Serialize("test_module_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleBytes => new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestModuleBytes = new byte[] { 175, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 101, 110, 100 };
+#endif
+
+    // TestSessionBytes = MessagePack.Serialize("test_session_end");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionBytes => new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#else
+    internal static readonly byte[] TestSessionBytes = new byte[] { 176, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 101, 110, 100 };
+#endif
+
+    // LibraryVersionBytes = MessagePack.Serialize("library_version");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#else
+    internal static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
+#endif
+
+    // TestSessionIdBytes = MessagePack.Serialize("test_session_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSessionIdBytes => new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSessionIdBytes = new byte[] { 175, 116, 101, 115, 116, 95, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100 };
+#endif
+
+    // TestModuleIdBytes = MessagePack.Serialize("test_module_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestModuleIdBytes => new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestModuleIdBytes = new byte[] { 174, 116, 101, 115, 116, 95, 109, 111, 100, 117, 108, 101, 95, 105, 100 };
+#endif
+
+    // TestSuiteIdBytes = MessagePack.Serialize("test_suite_id");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> TestSuiteIdBytes => new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#else
+    internal static readonly byte[] TestSuiteIdBytes = new byte[] { 173, 116, 101, 115, 116, 95, 115, 117, 105, 116, 101, 95, 105, 100 };
+#endif
+
+    // CIAppTestOriginNameBytes = MessagePack.Serialize("ciapp-test");
+#if NETCOREAPP
+    internal static ReadOnlySpan<byte> CIAppTestOriginNameBytes => new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#else
+    internal static readonly byte[] CIAppTestOriginNameBytes = new byte[] { 170, 99, 105, 97, 112, 112, 45, 116, 101, 115, 116 };
+#endif
+
     // EnvDSMBytes = MessagePack.Serialize("Env");
 #if NETCOREAPP
     internal static ReadOnlySpan<byte> EnvDSMBytes => new byte[] { 163, 69, 110, 118 };


### PR DESCRIPTION
## Summary of changes
Generate MessagePack values at compile time in CI Viz MessagePackFormatters

## Reason for change
Consistency with SpanMessagePackFormatter and micro optimization of startup time.

## Implementation details
Based on top of https://github.com/DataDog/dd-trace-dotnet/pull/8175 and #8220
Pushing as draft as I need to re review with fresh eyes

## Test coverage
Covered by current CIVIz tests (which may not be complete as one bug slipped through when I was doing the change)