### PR TITLE
[Benchmark] Enable runtime metrics by default (EventListener)

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -177,7 +177,11 @@ namespace Datadog.Trace.Configuration
                 ErrorLog.LogInvalidConfiguration(ConfigurationKeys.OpenTelemetry.MetricsExporter);
             }
 
+#if NET6_0_OR_GREATER
             RuntimeMetricsEnabled = runtimeMetricsEnabledResult.WithDefault(true);
+#else
+            RuntimeMetricsEnabled = runtimeMetricsEnabledResult.WithDefault(false);
+#endif
 
             RuntimeMetricsDiagnosticsMetricsApiEnabled = config.WithKeys(ConfigurationKeys.RuntimeMetricsDiagnosticsMetricsApiEnabled).AsBool(false);
 


### PR DESCRIPTION
Enable runtime metrics with EventListener to run benchmarks.

Do not merge.

Made with [Cursor](https://cursor.com)