### PR TITLE
Add `Base64DecodingStream`

### DIFF
--- a/tracer/src/Datadog.Trace/Util/Streams/Base64DecodingStream.cs
+++ b/tracer/src/Datadog.Trace/Util/Streams/Base64DecodingStream.cs
@@ -113,6 +113,17 @@ internal sealed class Base64DecodingStream : Stream
 #else
     public override int Read(byte[] buffer, int offset, int count)
     {
+        if (count == 0)
+        {
+            return 0;
+        }
+
+        // Added for consistency with .NET Core case
+        if (count < 3)
+        {
+            ThrowDestinationTooSmall();
+        }
+
         var totalRead = 0;
 
         while (count > 0)

--- a/tracer/test/Datadog.Trace.Tests/Util/Base64DecodingStreamTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Base64DecodingStreamTests.cs
@@ -269,7 +269,6 @@ namespace Datadog.Trace.Tests.Util
             actual.Should().Equal(expected);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Theory]
         [InlineData(1)]
         [InlineData(2)]
@@ -284,7 +283,6 @@ namespace Datadog.Trace.Tests.Util
 
             act.Should().Throw<ArgumentException>();
         }
-#endif
 
         private static byte[] CreateSequentialBytes(int count)
         {


### PR DESCRIPTION
## Summary of changes

Adds `Base64DecodingStream` helper class

## Reason for change

In a few places (particularly Remote Config and Newtonsoft.JSON) we have code like this:

```csharp
string someValue = // 
var contentDecode = Convert.FromBase64String(someValue);
using var stream = new MemoryStream(contentDecode);
```

This takes an existing `string`, decodes it from base64 to a `byte[]`, then feeds that `byte[]` into a `MemoryStream`. For big strings, that's a potentially large extra array allocation we can avoid. Instead, `Base64DecodingStream` acts effectively as a `MemoryStream` over the `string`, doing the decode either on the fly (.NET Core), or by using a pooled buffer to decode the input string in chunks.

## Implementation details

Basically asked 🤖 Claude to do this, then reviewed and tidied up and iterated. The general idea is:

- Keep track of where in the string we are
- **.NET Framework/.NET Standard only**
  - Decode the next section of the string into an array-pool rented buffer, using the vendored `Base64.DecodeFromUtf8InPlace`
  - Copy the buffer into the destination `byte[]`
- **.NET Core only**
  - Decode the next section of the string directly into the destination `Span<T>`

It didn't seem worth trying to unify these two paths, given the lack of `Convert.TryFromBase64Chars` in .NET Framework. We _could_ use `Base64.DecodeFromUtf8` to write directly to the destination span instead, but we would still need to do the narrowing, and doing that in the destination span is a little risky, as it would mean we write a bunch of bytes which are then leftover junk. It's _probably_ still fine, but I don't know that it's worth the complexity/risk.

> [!WARNING]
> Rather than handle the case where you're passed a destination buffer that's <3 bytes, this implementation currently just throws. Otherwise we have to decode into a stackallocated buffer, and hang onto the "overflow" bytes to avoid returning 0 when we're not EOF, which is a bit of a pain. For the places we currently use it, I don't think this will be a problem, but if others disagree, we can handle the edge case too.

## Test coverage

Added a variety of unit tests for the implementation

## Other details

https://datadoghq.atlassian.net/browse/LANGPLAT-940

This will be part of a Remote config stack, but for now kept it agnostic