### PR TITLE
Attempt to prevent crash when enumerating integration_definitions

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2012,6 +2012,10 @@ long CorProfiler::EnableCallTargetDefinitions(UINT32 enabledCategories)
         auto _ = trace::Stats::Instance()->InitializeProfilerMeasure();
         Logger::Info("EnableCallTargetDefinitions: enabledCategories: ", enabledCategories, " from managed side.");
 
+        // Hold module_ids lock while iterating and mutating integration_definitions_
+        // to prevent concurrent modification from ModuleLoadFinished or RegisterCallTargetDefinitions
+        auto modules = module_ids.Get();
+
         std::vector<IntegrationDefinition> affectedDefinitions;
         for (auto& integration : integration_definitions_)
         {
@@ -2023,7 +2027,6 @@ long CorProfiler::EnableCallTargetDefinitions(UINT32 enabledCategories)
 
         if (affectedDefinitions.size() > 0)
         {
-            auto modules = module_ids.Get();
             auto promise = std::make_shared<std::promise<ULONG>>();
             std::future<ULONG> future = promise->get_future();
             tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(modules.Ref(), affectedDefinitions,
@@ -2044,6 +2047,10 @@ long CorProfiler::DisableCallTargetDefinitions(UINT32 disabledCategories)
         auto _ = trace::Stats::Instance()->InitializeProfilerMeasure();
         Logger::Info("DisableCallTargetDefinitions: enabledCategories: ", disabledCategories, " from managed side.");
 
+        // Hold module_ids lock while iterating and mutating integration_definitions_
+        // to prevent concurrent modification from ModuleLoadFinished or RegisterCallTargetDefinitions
+        auto modules = module_ids.Get();
+
         std::vector<IntegrationDefinition> affectedDefinitions;
         for (auto& integration : integration_definitions_)
         {
@@ -2055,7 +2062,6 @@ long CorProfiler::DisableCallTargetDefinitions(UINT32 disabledCategories)
 
         if (affectedDefinitions.size() > 0)
         {
-            auto modules = module_ids.Get();
             auto promise = std::make_shared<std::promise<ULONG>>();
             std::future<ULONG> future = promise->get_future();
             tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(modules.Ref(), affectedDefinitions, promise);


### PR DESCRIPTION
## Summary of changes

Attempt to fix race in integration_definitions_ in EnableCallTargetDefinitions / DisableCallTargetDefinitions

## Reason for change

I've noticed a lot (I guess not really _a lot_ but multiple instances of) crashes that happen seemingly around enumeration of these integration_definitions via Crash Tracking.

e.g. `trace::RejitPreprocessor<trace::IntegrationDefinition>::EnqueueRequestRejitForLoadedModules`

I think it has been mentioned previously that we may be missing locks here/there in the native bits.

This moves the lock up for the modules which I do see in the stacks. Seems reasonable to me and the AI said so too, but it is honestly just a guess to be honest.

## Implementation details

This moves the lock up for the modules which I do see in the stacks.

## Test coverage

I don't know.

I think since this is a supposed race condition it'd be difficult to test.

## Other details
<!-- Fixes #{issue} -->

Took several of our crash reports that all pointed 

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
