### PR TITLE
Ensure we publish all nuget packages during release

### DIFF
--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -178,7 +178,7 @@ jobs:
       - name: "Publish nuget packages to nuget.org"
         working-directory: ${{steps.assets.outputs.artifacts_path}}
         run: |
-          dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
+          dotnet nuget push "*.nupkg" --skip-duplicate --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
 
       - name: "Copy gitlab artifacts to artifacts_path"
         run: cp "${{steps.assets.outputs.gitlab_artifacts_path}}/"*.zip "${{steps.assets.outputs.artifacts_path}}/"


### PR DESCRIPTION
## Summary of changes

Removes the "version number" filter from the "push packages" stage of our release

## Reason for change

Just did a release, and noticed that the [Datadog.FeatureFlags.OpenFeature](https://www.nuget.org/packages/Datadog.FeatureFlags.OpenFeature) package _wasn't_ published. This is because we currently explicitly filter to only pushing packages for the _current_ version (e.g. 3.38.0), but the _Datadog.FeatureFlags.OpenFeature_ package is versioned independently (to match OpenFeature), so was not being automatically pushed.

## Implementation details

- Remove the version filter
- Add `--skip-duplicate` to avoid erroring when we try to re-push the immutable packages (e.g. _Datadog.Trace.Annotations_).

## Test coverage

Can't really test this, so 🤞 it works

## Other details

Noticed while doing the recent release