### PR TITLE
Add more Claude Code files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -390,7 +390,7 @@ datadog-coverage-*
 .nuke/build.schema.json
 
 # Claude Code
-.claude/settings.local.json
+.claude/*.local.*
 .claude/worktrees
 CLAUDE.local.md
 


### PR DESCRIPTION
## Summary of changes

Add `.claude/worktrees` and `*.local.*` to `.gitignore`.

## Reason for change

Claude Code creates temporary git worktrees under `.claude/worktrees/` for isolated agent work. These should not be tracked in git.

Local files like `settings.local.json` and local Hookify files (`hookify.*.local.md`) shouldn't be tracked, either.

## Implementation details

Add `.claude/worktrees` and `*.local.*` to `.gitignore`.

## Test coverage

N/A — `.gitignore` only change.

## Other details

**NOTE: this PR will auto-merge after the first approval.**

> *"I tried to push my worktree to remote, but git said it was already branching out on its own."* — Claude 🤖
