### PR TITLE
Rename telemetry `GetData` methods to `GetIncrementalData`

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationTelemetry.cs
@@ -74,7 +74,7 @@ public interface IConfigurationTelemetry
     /// Gets the stored configuration data and clears the stored data
     /// </summary>
     /// <returns>The stored configuration data</returns>
-    public ICollection<ConfigurationKeyValue>? GetData();
+    public ICollection<ConfigurationKeyValue>? GetIncrementalData();
 
     /// <summary>
     /// Copies the stored configuration to the provided destination

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/NullConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/NullConfigurationTelemetry.cs
@@ -38,7 +38,7 @@ internal sealed class NullConfigurationTelemetry : IConfigurationTelemetry
     {
     }
 
-    public ICollection<ConfigurationKeyValue>? GetData() => null;
+    public ICollection<ConfigurationKeyValue>? GetIncrementalData() => null;
 
     public ICollection<ConfigurationKeyValue>? GetFullData() => null;
 

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/AppEndpointsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/AppEndpointsTelemetryCollector.cs
@@ -26,7 +26,7 @@ internal sealed class AppEndpointsTelemetryCollector
     /// Returns the collected endpoints and clears the internal state.
     /// </summary>
     /// <returns>The collected endpoints.</returns>
-    public ICollection<AppEndpointData>? GetData()
+    public ICollection<AppEndpointData>? GetIncrementalData()
     {
         var endpoints = _endpoints;
         _endpoints = null;

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetry.Collector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetry.Collector.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Configuration.Telemetry
         /// Get the latest data to send to the intake.
         /// </summary>
         /// <returns>Null if there are no changes, or the collector is not yet initialized</returns>
-        public ICollection<ConfigurationKeyValue>? GetData()
+        public ICollection<ConfigurationKeyValue>? GetIncrementalData()
         {
             lock (_allData)
             {

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Telemetry
         /// Get the latest data to send to the intake.
         /// </summary>
         /// <returns>Null if there are no changes, or the collector is not yet initialized</returns>
-        public List<DependencyTelemetryData>? GetData()
+        public List<DependencyTelemetryData>? GetIncrementalData()
         {
             var hasChanges = Interlocked.CompareExchange(ref _hasChangesFlag, 0, 1) == 1;
 

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/IDependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/IDependencyTelemetryCollector.cs
@@ -21,7 +21,7 @@ internal interface IDependencyTelemetryCollector
     /// Get the latest data to send to the intake.
     /// </summary>
     /// <returns>Null if there are no changes, or the collector is not yet initialized</returns>
-    List<DependencyTelemetryData>? GetData();
+    List<DependencyTelemetryData>? GetIncrementalData();
 
     /// <summary>
     /// Gets all the assembly data recorded so far

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/IntegrationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/IntegrationTelemetryCollector.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace.Telemetry
         /// Get the latest data to send to the intake.
         /// </summary>
         /// <returns>Null if there are no changes, or the collector is not yet initialized</returns>
-        public ICollection<IntegrationTelemetryData>? GetData()
+        public ICollection<IntegrationTelemetryData>? GetIncrementalData()
         {
             var hasChanges = Interlocked.CompareExchange(ref _hasChangesFlag, 0, 1) == 1;
             if (!hasChanges)

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/NullDependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/NullDependencyTelemetryCollector.cs
@@ -17,7 +17,7 @@ internal sealed class NullDependencyTelemetryCollector : IDependencyTelemetryCol
     {
     }
 
-    public List<DependencyTelemetryData>? GetData() => null;
+    public List<DependencyTelemetryData>? GetIncrementalData() => null;
 
     public List<DependencyTelemetryData>? GetFullData() => null;
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ProductsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ProductsTelemetryCollector.cs
@@ -31,7 +31,7 @@ internal sealed class ProductsTelemetryCollector
     /// Get the latest data to send to the intake.
     /// </summary>
     /// <returns>Null if there are no changes, or the collector is not yet initialized</returns>
-    public ProductsData? GetData()
+    public ProductsData? GetIncrementalData()
     {
         var hasChanges = Interlocked.CompareExchange(ref _hasChangesFlag, 0, 1) == 1;
         if (!hasChanges)

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -199,7 +199,7 @@ internal sealed class TelemetryController : ITelemetryController
                 _configuration.GetFullData(),
                 _dependencies.GetFullData(),
                 _integrations.GetFullData(),
-                _appEndpoints.GetData(),
+                _appEndpoints.GetIncrementalData(),
                 metrics: null,
                 _products.GetFullData(),
                 sendAppStarted: false);
@@ -338,12 +338,12 @@ internal sealed class TelemetryController : ITelemetryController
 
             // use values from previous failed attempt if necessary
             var input = _aggregator.Combine(
-                _configuration.GetData(),
-                _dependencies.GetData(),
-                _integrations.GetData(),
-                _appEndpoints.GetData(),
+                _configuration.GetIncrementalData(),
+                _dependencies.GetIncrementalData(),
+                _integrations.GetIncrementalData(),
+                _appEndpoints.GetIncrementalData(),
                 in metrics,
-                _products.GetData());
+                _products.GetIncrementalData());
 
             var data = _dataBuilder.BuildTelemetryData(application, host, in input, _namingVersion, sendAppClosing);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
@@ -56,7 +56,7 @@ public class TelemetryHelperTests
         collector.IntegrationRunning(IntegrationId.Aerospike);
 
         metricsCollector.AggregateMetrics();
-        telemetryData.Add(BuildTelemetryData(collector.GetData(), metrics: metricsCollector.GetMetrics()));
+        telemetryData.Add(BuildTelemetryData(collector.GetIncrementalData(), metrics: metricsCollector.GetMetrics()));
 
         // The updates to both the IntegrationTelemetryCollector and the MetricsTelemetryCollector
         // are typically handled by TelemetryController.IntegrationGeneratedSpan(IntegrationId),
@@ -67,7 +67,7 @@ public class TelemetryHelperTests
         collector.IntegrationRunning(IntegrationId.Couchbase);
 
         metricsCollector.AggregateMetrics();
-        telemetryData.Add(BuildTelemetryData(collector.GetData(), metrics: metricsCollector.GetMetrics(), sendAppStarted: false));
+        telemetryData.Add(BuildTelemetryData(collector.GetIncrementalData(), metrics: metricsCollector.GetMetrics(), sendAppStarted: false));
 
         collector.IntegrationRunning(IntegrationId.Kafka);
         collector.IntegrationRunning(IntegrationId.Msmq);
@@ -78,7 +78,7 @@ public class TelemetryHelperTests
 
         collector.RecordTracerSettings(tracerSettings.Manager.InitialMutableSettings);
         metricsCollector.AggregateMetrics();
-        telemetryData.Add(BuildTelemetryData(collector.GetData(), metrics: metricsCollector.GetMetrics(), sendAppClosing: true));
+        telemetryData.Add(BuildTelemetryData(collector.GetIncrementalData(), metrics: metricsCollector.GetMetrics(), sendAppClosing: true));
 
         using var s = new AssertionScope();
         TelemetryHelper.AssertIntegration(telemetryData, IntegrationId.Aerospike, enabled: true, autoEnabled: true);
@@ -106,7 +106,7 @@ public class TelemetryHelperTests
         }
 
         collector.IntegrationRunning(IntegrationId.Aerospike);
-        telemetryData.Add(BuildTelemetryData(collector.GetData()));
+        telemetryData.Add(BuildTelemetryData(collector.GetIncrementalData()));
 
         if (errorIsFirstTelemetry)
         {
@@ -117,10 +117,10 @@ public class TelemetryHelperTests
             collector.IntegrationDisabledDueToError(IntegrationId.Grpc, "Some error");
         }
 
-        telemetryData.Add(BuildTelemetryData(collector.GetData(), sendAppStarted: false));
+        telemetryData.Add(BuildTelemetryData(collector.GetIncrementalData(), sendAppStarted: false));
 
         collector.IntegrationRunning(IntegrationId.Npgsql);
-        telemetryData.Add(BuildTelemetryData(collector.GetData(), sendAppStarted: false, sendAppClosing: true));
+        telemetryData.Add(BuildTelemetryData(collector.GetIncrementalData(), sendAppStarted: false, sendAppClosing: true));
 
         var checkTelemetryFunc = () => TelemetryHelper.AssertIntegration(telemetryData, IntegrationId.Aerospike, enabled: true, autoEnabled: true);
 
@@ -143,10 +143,10 @@ public class TelemetryHelperTests
 
         _ = new TracerSettings(config, collector, new OverrideErrorLog());
 
-        telemetryData.Add(BuildTelemetryData(null, collector.GetData()));
+        telemetryData.Add(BuildTelemetryData(null, collector.GetIncrementalData()));
 
         _ = new SecuritySettings(config, collector);
-        telemetryData.Add(BuildTelemetryData(null, collector.GetData(), sendAppStarted: false, sendAppClosing: true));
+        telemetryData.Add(BuildTelemetryData(null, collector.GetIncrementalData(), sendAppStarted: false, sendAppClosing: true));
 
         using var s = new AssertionScope();
         TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
@@ -396,7 +396,7 @@ public class CompositeConfigurationSourceTests
         public void Record(string key, int? value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
             => Telemetry.Add(new(key, value, origin, recordValue: true, error));
 
-        public ICollection<ConfigurationKeyValue> GetData() => null;
+        public ICollection<ConfigurationKeyValue> GetIncrementalData() => null;
 
         public ICollection<ConfigurationKeyValue> GetFullData() => null;
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
@@ -630,7 +630,7 @@ public class ConfigurationBuilderTests
                              converter: _nullableConverter);
 
             actual.Should().Be(_default);
-            var finalValue = telemetry.GetData()
+            var finalValue = telemetry.GetIncrementalData()
                                       .Where(x => x.Name == key)
                                       .OrderByDescending(x => x.SeqId)
                                       .FirstOrDefault()
@@ -658,7 +658,7 @@ public class ConfigurationBuilderTests
                              converter: _nullableConverter);
 
             actual.Should().Be(_default);
-            var finalValue = telemetry.GetData()
+            var finalValue = telemetry.GetIncrementalData()
                                       .Where(x => x.Name == key)
                                       .OrderByDescending(x => x.SeqId)
                                       .FirstOrDefault()
@@ -910,7 +910,7 @@ public class ConfigurationBuilderTests
                         .WithDefault(expected);
 
             actual.Should().Be(expected);
-            telemetry.GetData()
+            telemetry.GetIncrementalData()
                      .Should()
                      .ContainSingle()
                      .Which.Should()
@@ -1160,7 +1160,7 @@ public class ConfigurationBuilderTests
                         .WithDefault(new(null, expected));
 
             actual.Should().BeNull();
-            telemetry.GetData()
+            telemetry.GetIncrementalData()
                      .Should()
                      .ContainSingle()
                      .Which.Should()

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -682,7 +682,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             var telemetry = new ConfigurationTelemetry();
             var tracerSettings = new TracerSettings(NullConfigurationSource.Instance, telemetry);
-            var data = telemetry.GetData();
+            var data = telemetry.GetIncrementalData();
             var value = data
                        .GroupBy(x => x.Name)
                        .Should()

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -46,7 +46,7 @@ public class ConfigurationTelemetryCollectorTests
             new OverrideErrorLog());
 
         collector.HasChanges().Should().BeTrue();
-        GetLatestValueFromConfig(collector.GetData(), ConfigurationKeys.ServiceVersion).Should().Be("1.2.3");
+        GetLatestValueFromConfig(collector.GetIncrementalData(), ConfigurationKeys.ServiceVersion).Should().Be("1.2.3");
 
         collector.HasChanges().Should().BeFalse();
         var settings2 = new TracerSettings(
@@ -56,7 +56,7 @@ public class ConfigurationTelemetryCollectorTests
             new OverrideErrorLog());
 
         collector.HasChanges().Should().BeTrue();
-        GetLatestValueFromConfig(collector.GetData(), ConfigurationKeys.ServiceVersion).Should().Be("2.0.0");
+        GetLatestValueFromConfig(collector.GetIncrementalData(), ConfigurationKeys.ServiceVersion).Should().Be("2.0.0");
 
         collector.HasChanges().Should().BeFalse();
     }
@@ -88,7 +88,7 @@ public class ConfigurationTelemetryCollectorTests
         // Merged changes should take precedence over existing
         secondary.CopyTo(collector);
 
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
         GetLatestValueFromConfig(data, ConfigurationKeys.ServiceVersion).Should().Be("1.2.3");
         collector.HasChanges().Should().BeFalse();
     }
@@ -104,7 +104,7 @@ public class ConfigurationTelemetryCollectorTests
             new NameValueConfigurationSource(new NameValueCollection { { ConfigurationKeys.AppSec.Enabled, enabled.ToString() }, }),
             collector);
 
-        GetLatestValueFromConfig(collector.GetData(), ConfigurationKeys.AppSec.Enabled).Should().Be(enabled);
+        GetLatestValueFromConfig(collector.GetIncrementalData(), ConfigurationKeys.AppSec.Enabled).Should().Be(enabled);
     }
 
     [Theory]
@@ -118,7 +118,7 @@ public class ConfigurationTelemetryCollectorTests
             new NameValueConfigurationSource(new NameValueCollection { { ConfigurationKeys.Iast.Enabled, enabled.ToString() }, }),
             collector);
 
-        GetLatestValueFromConfig(collector.GetData(), ConfigurationKeys.Iast.Enabled).Should().Be(enabled);
+        GetLatestValueFromConfig(collector.GetIncrementalData(), ConfigurationKeys.Iast.Enabled).Should().Be(enabled);
     }
 
     [Theory]
@@ -148,7 +148,7 @@ public class ConfigurationTelemetryCollectorTests
 
         _ = new TracerSettings(new NameValueConfigurationSource(config), collector, new OverrideErrorLog());
 
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
 
         using var scope = new AssertionScope();
         GetLatestValueFromConfig(data, ConfigurationKeys.AzureAppService.SiteExtensionVersionKey).Should().Be("1.5.0");
@@ -176,7 +176,7 @@ public class ConfigurationTelemetryCollectorTests
         _ = new TracerSettings(new NameValueConfigurationSource(new NameValueCollection { { ConfigurationKeys.ServiceVersion, "1.2.3" } }), collector, new OverrideErrorLog());
 
         collector.Clear();
-        collector.GetData().Should().BeNull();
+        collector.GetIncrementalData().Should().BeNull();
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class ConfigurationTelemetryCollectorTests
 
         var s = new TracerSettings(NullConfigurationSource.Instance, collector, new OverrideErrorLog());
 
-        GetLatestValueFromConfig(collector.GetData(), ConfigTelemetryData.NativeTracerVersion).Should().Be("None");
+        GetLatestValueFromConfig(collector.GetIncrementalData(), ConfigTelemetryData.NativeTracerVersion).Should().Be("None");
     }
 
     [Theory]
@@ -204,7 +204,7 @@ public class ConfigurationTelemetryCollectorTests
 
         _ = new TracerSettings(new NameValueConfigurationSource(config), collector, new OverrideErrorLog());
 
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
 
         using var scope = new AssertionScope();
         var (extractKey, extractValue) = (propagationStyleExtract, propagationStyle) switch
@@ -235,7 +235,7 @@ public class ConfigurationTelemetryCollectorTests
         _ = new ProfilerSettings(source, source, collector);
         _ = new SecuritySettings(source, collector);
 
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
 
         GetLatestValueFromConfig(data, "DD_TRACE_ENABLED", ConfigurationOrigins.Default).Should().Be(true);
         var expected = ProfilerSettings.IsProfilingSupported ? "false" : null;
@@ -259,7 +259,7 @@ public class ConfigurationTelemetryCollectorTests
         var source = new NameValueConfigurationSource(new NameValueCollection());
         _ = new TracerSettings(source, collector, new OverrideErrorLog());
         _ = new SecuritySettings(source, collector);
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
         GetLatestValueFromConfig(data, ConfigTelemetryData.SsiInjectionEnabled).Should().Be("tracer");
         GetLatestValueFromConfig(data, ConfigTelemetryData.SsiAllowUnsupportedRuntimesEnabled).Should().Be("true");
         GetLatestValueFromConfig(data, ConfigTelemetryData.InstrumentationSource).Should().Be("ssi");
@@ -300,7 +300,7 @@ public class ConfigurationTelemetryCollectorTests
 
         // Now call GetData() - should also contain all values since
         // GetFullData() does not update _reportedCount
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
         data.Should()
             .HaveCount(2)
             .And
@@ -334,7 +334,7 @@ public class ConfigurationTelemetryCollectorTests
             });
             var s = new TracerSettings(source, collector, new OverrideErrorLog());
 
-            return GetLatestValueFromConfig(collector.GetData(), ConfigTelemetryData.FullTrustAppDomain);
+            return GetLatestValueFromConfig(collector.GetIncrementalData(), ConfigTelemetryData.FullTrustAppDomain);
         }
     }
 #endif

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(assemblyName, moduleVersionId);
 
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
 
             var dependency = data.Should().ContainSingle().Subject;
             dependency.Name.Should().Be(name);
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(thisAssembly);
 
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
 
             var dependency = data.Should().ContainSingle().Subject;
             dependency.Name.Should().Be("Datadog.Trace.Tests");
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Tests.Telemetry
         {
             var collector = new DependencyTelemetryCollector();
 
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
             data.Should().BeNull();
             collector.HasChanges().Should().BeFalse();
 
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Tests.Telemetry
 
             collector.HasChanges().Should().BeTrue();
 
-            data = collector.GetData();
+            data = collector.GetIncrementalData();
             data.Should()
                 .HaveCount(1)
                 .And.ContainSingle(x => x.Name == "Datadog.Trace.Tests");
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.AssemblyLoaded(assembly);
             collector.HasChanges().Should().BeTrue();
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.AssemblyLoaded(assembly);
@@ -265,12 +265,12 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(assemblyV1, "mvid");
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.AssemblyLoaded(assemblyV2, "mvid");
             collector.HasChanges().Should().BeTrue();
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
             data.Should().NotBeNull();
             data.Should()
                 .NotBeNullOrEmpty()
@@ -287,12 +287,12 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(assemblyName, assemblyV1ModuleVersionId);
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.AssemblyLoaded(assemblyName, assemblyV2ModuleVersionId);
             collector.HasChanges().Should().BeTrue();
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
             data.Should().NotBeNull();
             data.Should()
                 .NotBeNullOrEmpty()

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/IntegrationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/IntegrationTelemetryCollectorTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new IntegrationTelemetryCollector();
             collector.RecordTracerSettings(new TracerSettings().Manager.InitialMutableSettings);
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.IntegrationRunning(IntegrationId);
@@ -38,12 +38,12 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new IntegrationTelemetryCollector();
             collector.RecordTracerSettings(new TracerSettings().Manager.InitialMutableSettings);
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.IntegrationRunning(IntegrationId);
             collector.HasChanges().Should().BeTrue();
-            collector.GetData();
+            collector.GetIncrementalData();
 
             collector.IntegrationRunning(IntegrationId);
             collector.HasChanges().Should().BeFalse();
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new IntegrationTelemetryCollector();
             collector.RecordTracerSettings(new TracerSettings().Manager.InitialMutableSettings);
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.IntegrationGeneratedSpan(IntegrationId);
@@ -68,12 +68,12 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new IntegrationTelemetryCollector();
             collector.RecordTracerSettings(new TracerSettings().Manager.InitialMutableSettings);
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.IntegrationGeneratedSpan(IntegrationId);
             collector.HasChanges().Should().BeTrue();
-            collector.GetData();
+            collector.GetIncrementalData();
 
             collector.IntegrationGeneratedSpan(IntegrationId);
             collector.HasChanges().Should().BeFalse();
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new IntegrationTelemetryCollector();
             collector.RecordTracerSettings(new TracerSettings().Manager.InitialMutableSettings);
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.IntegrationDisabledDueToError(IntegrationId, "Testing!");
@@ -98,12 +98,12 @@ namespace Datadog.Trace.Tests.Telemetry
             var collector = new IntegrationTelemetryCollector();
             collector.RecordTracerSettings(new TracerSettings().Manager.InitialMutableSettings);
 
-            collector.GetData();
+            collector.GetIncrementalData();
             collector.HasChanges().Should().BeFalse();
 
             collector.IntegrationDisabledDueToError(IntegrationId, "Testing");
             collector.HasChanges().Should().BeTrue();
-            collector.GetData();
+            collector.GetIncrementalData();
 
             collector.IntegrationDisabledDueToError(IntegrationId, "Another error");
             collector.HasChanges().Should().BeFalse();
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.IntegrationRunning(IntegrationId);
             collector.IntegrationGeneratedSpan(IntegrationId);
 
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
             var integration = data.FirstOrDefault(x => x.Name == IntegrationName);
             integration.Should().NotBeNull();
             integration.AutoEnabled.Should().BeTrue();
@@ -134,7 +134,7 @@ namespace Datadog.Trace.Tests.Telemetry
 
             collector.IntegrationRunning(IntegrationId);
 
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
             var integration = data.FirstOrDefault(x => x.Name == IntegrationName);
             integration.Should().NotBeNull();
             integration.AutoEnabled.Should().BeTrue();
@@ -152,7 +152,7 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.IntegrationRunning(IntegrationId);
             collector.IntegrationDisabledDueToError(IntegrationId, error);
 
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
             var integration = data.FirstOrDefault(x => x.Name == IntegrationName);
             integration.Should().NotBeNull();
             integration.AutoEnabled.Should().BeTrue();
@@ -171,7 +171,7 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.IntegrationGeneratedSpan(IntegrationId);
             collector.IntegrationDisabledDueToError(IntegrationId, error);
 
-            var data = collector.GetData();
+            var data = collector.GetIncrementalData();
             var integration = data.FirstOrDefault(x => x.Name == IntegrationName);
             integration.Should().NotBeNull();
             integration.AutoEnabled.Should().BeTrue();
@@ -187,29 +187,29 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.RecordTracerSettings(new TracerSettings().Manager.InitialMutableSettings);
 
             // first call
-            collector.GetData().Should().NotBeEmpty();
+            collector.GetIncrementalData().Should().NotBeEmpty();
             // second call
-            collector.GetData().Should().BeNullOrEmpty();
+            collector.GetIncrementalData().Should().BeNullOrEmpty();
 
             // Make change
             collector.IntegrationRunning(IntegrationId);
 
             collector.HasChanges().Should().BeTrue();
-            collector.GetData().Should().ContainSingle().Which.Should().BeEquivalentTo(new { Name = IntegrationName });
+            collector.GetIncrementalData().Should().ContainSingle().Which.Should().BeEquivalentTo(new { Name = IntegrationName });
 
             // Make identical change
             collector.IntegrationRunning(IntegrationId);
-            collector.GetData().Should().BeNullOrEmpty();
+            collector.GetIncrementalData().Should().BeNullOrEmpty();
 
             // new change
             collector.IntegrationGeneratedSpan(IntegrationId);
-            collector.GetData().Should().ContainSingle().Which.Should().BeEquivalentTo(new { Name = IntegrationName });
-            collector.GetData().Should().BeNullOrEmpty();
+            collector.GetIncrementalData().Should().ContainSingle().Which.Should().BeEquivalentTo(new { Name = IntegrationName });
+            collector.GetIncrementalData().Should().BeNullOrEmpty();
 
             // new change
             collector.IntegrationDisabledDueToError(IntegrationId, error);
-            collector.GetData().Should().ContainSingle().Which.Should().BeEquivalentTo(new { Name = IntegrationName });
-            collector.GetData().Should().BeNullOrEmpty();
+            collector.GetIncrementalData().Should().ContainSingle().Which.Should().BeEquivalentTo(new { Name = IntegrationName });
+            collector.GetIncrementalData().Should().BeNullOrEmpty();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ProductsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ProductsTelemetryCollectorTests.cs
@@ -18,7 +18,7 @@ public class ProductsTelemetryCollectorTests
         var collector = new ProductsTelemetryCollector();
 
         collector.HasChanges().Should().BeFalse();
-        collector.GetData().Should().BeNull();
+        collector.GetIncrementalData().Should().BeNull();
     }
 
     [Theory]
@@ -41,7 +41,7 @@ public class ProductsTelemetryCollectorTests
             collector.ProductChanged(TelemetryProductType.DynamicInstrumentation, enabled: debuggerEnabled.Value, error: null);
         }
 
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
         (data?.Appsec?.Enabled).Should().Be(appsecEnabled);
         (data?.Profiler?.Enabled).Should().Be(profilerEnabled);
         (data?.DynamicInstrumentation?.Enabled).Should().Be(debuggerEnabled);
@@ -55,10 +55,10 @@ public class ProductsTelemetryCollectorTests
 
         collector.ProductChanged(TelemetryProductType.AppSec, enabled: true, error: null);
         collector.HasChanges().Should().BeTrue();
-        collector.GetData().Should().NotBeNull();
+        collector.GetIncrementalData().Should().NotBeNull();
 
         collector.HasChanges().Should().BeFalse();
-        collector.GetData().Should().BeNull();
+        collector.GetIncrementalData().Should().BeNull();
     }
 
     [Fact]
@@ -69,11 +69,11 @@ public class ProductsTelemetryCollectorTests
 
         collector.ProductChanged(TelemetryProductType.AppSec, enabled: true, error: null);
         collector.HasChanges().Should().BeTrue();
-        collector.GetData().Should().NotBeNull();
+        collector.GetIncrementalData().Should().NotBeNull();
 
         collector.ProductChanged(TelemetryProductType.AppSec, enabled: true, error: null);
         collector.HasChanges().Should().BeTrue();
-        collector.GetData().Should().NotBeNull();
+        collector.GetIncrementalData().Should().NotBeNull();
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class ProductsTelemetryCollectorTests
         collector.ProductChanged(TelemetryProductType.AppSec, enabled: false, error: new ErrorData(errorCode, errorMessage));
 
         collector.HasChanges().Should().BeTrue();
-        var data = collector.GetData();
+        var data = collector.GetIncrementalData();
         (data?.Appsec?.Enabled).Should().BeFalse();
         data.Appsec.Error.Should().NotBeNull();
         data.Appsec.Error.Value.Code.Should().Be((int)errorCode);
@@ -112,8 +112,8 @@ public class ProductsTelemetryCollectorTests
         data.DynamicInstrumentation.Should().BeNull();
 
         // do some "normal" telemetry collections, but ignore it
-        _ = collector.GetData();
-        _ = collector.GetData();
+        _ = collector.GetIncrementalData();
+        _ = collector.GetIncrementalData();
 
         // make sure we still have all the data we expect
         data = collector.GetFullData();


### PR DESCRIPTION
## Summary of changes

Renames `GetData` to `GetIncrementalData` to differentiate from `GetFullData()`

## Reason for change

In #8227 it was flagged that `GetData()` and `GetFullData()` are easy to confuse. Renaming `GetData` to `GetIncrementalData` should solve it.

## Implementation details

Deterministic rename (thank you IDEs, take that AI)

## Test coverage

All covered by existing
