### PR TITLE
[DSM] Fix Kafka pathway context encoding for batch consume pairing

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -262,7 +262,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                         // write the _new_ pathway (the "consume" checkpoint that we just set above) to the headers as a way to pass its value to an eventual
                         // call to SpanContextExtractor.Extract by a user who'd like to re-pair pathways after a batch consume.
                         // Note that this header only exists on the consume side, and Kafka never sees it.
-                        var base64PathwayContext = Convert.ToBase64String(BitConverter.GetBytes(span.Context.PathwayContext.Value.Hash.Value));
+                        var base64PathwayContext = Convert.ToBase64String(PathwayContextEncoder.Encode(span.Context.PathwayContext.Value));
                         message.Headers.Add(DataStreamsPropagationHeaders.TemporaryBase64PathwayContext, Encoding.UTF8.GetBytes(base64PathwayContext));
                     }
                 }


### PR DESCRIPTION
## Summary

- **Bug**: When `DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED=false`, the temporary base64 pathway context written to Kafka message headers only encoded the 8-byte hash (`BitConverter.GetBytes(hash)`) instead of the full `PathwayContext` (hash + pathwayStart + edgeStart via `PathwayContextEncoder.Encode`)
- **Impact**: `PathwayContextEncoder.Decode` requires a minimum of 10 bytes, so decoding always failed silently — breaking DSM pathway linking for users who consume in batch and call `SpanContextExtractor.Extract` to re-pair messages before producing downstream
- **Fix**: Use `PathwayContextEncoder.Encode` (consistent with `DataStreamsContextPropagator`) to encode the full pathway context

## Test plan

- [ ] Existing Kafka integration tests pass
- [ ] Verify with a batch-consume → produce pipeline using `KafkaCreateConsumerScopeEnabled=false` + `SpanContextExtractor.Extract` that DSM pathways now link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)