### PR TITLE
[Profiler] Fix UB in DebugInfoStore::Get(): re-acquire iterator after map insertion

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
@@ -45,9 +45,10 @@ SymbolDebugInfo DebugInfoStore::Get(ModuleID moduleId, mdMethodDef methodDef)
     if (it == _modulesInfo.cend())
     {
         ParseModuleDebugInfo(moduleId);
+        it = _modulesInfo.find(moduleId);
     }
 
-    ModuleDebugInfo& info = (it == _modulesInfo.cend()) ? _modulesInfo[moduleId] : it->second;
+    ModuleDebugInfo& info = it->second;
 
     // we should support 2 situations:
     //  - portable .pdb was found and we can use methodDef as RID


### PR DESCRIPTION
## Summary

In `DebugInfoStore::Get()`, `ParseModuleDebugInfo(moduleId)` inserts into the `_modulesInfo` unordered_map via `_modulesInfo[moduleId]`, which may trigger a rehash that invalidates all iterators. The old code reused a stale iterator obtained before the insertion — undefined behavior per the C++ standard. Fix: re-acquire the iterator via `find()` after insertion, and simplify the now-unnecessary ternary.

### Proof of UB

Per [cppreference `unordered_map::insert`](https://en.cppreference.com/w/cpp/container/unordered_map/insert.html):

> If rehashing occurs (due to the insertion), **all iterators are invalidated**. Otherwise iterators are not invalidated.

And [`unordered_map::operator[]`](https://en.cppreference.com/w/cpp/container/unordered_map/operator_at.html) performs an insert if the key doesn't exist, with the same invalidation rules.

In the original code:
```cpp
auto it = _modulesInfo.find(moduleId);           // iterator obtained
if (it == _modulesInfo.cend())
{
    ParseModuleDebugInfo(moduleId);               // inserts via _modulesInfo[moduleId]
}
ModuleDebugInfo& info = (it == _modulesInfo.cend()) ? _modulesInfo[moduleId] : it->second;
                         // ^^^ stale iterator compared after insertion — UB if rehash occurred
```

**Severity: Low.** In practice this bug does not cause any observable problem. libstdc++ and libc++ use a node-based `unordered_map` implementation where rehash re-links nodes into new buckets but never frees or moves the nodes themselves. Stale iterators still point to valid memory and the `end()` sentinel comparison happens to produce correct results. The fix is still warranted to eliminate the UB — a different stdlib implementation or future change could break this.

## Changes

- `profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp`: After `ParseModuleDebugInfo()` inserts into the map, re-acquire the iterator with `it = _modulesInfo.find(moduleId)`. Remove the ternary that compared the stale iterator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)