### PR TITLE
Retry ChromeDriver startup in Selenium tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Selenium/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.Selenium/TestSuite.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using Xunit;
@@ -8,8 +9,38 @@ namespace Samples.Selenium;
 
 public class TestSuite(ITestOutputHelper output) : IDisposable
 {
-    private readonly WebDriver _driver = new ChromeDriver();
+    private readonly WebDriver _driver = CreateChromeDriverWithRetry(output);
     private readonly string _url = Environment.GetEnvironmentVariable("SAMPLES_SELENIUM_TEST_URL") ?? "http://localhost:62100/";
+
+    private static WebDriver CreateChromeDriverWithRetry(ITestOutputHelper output)
+    {
+        const int maxAttempts = 3;
+        var delay = TimeSpan.FromSeconds(5);
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            WebDriver driver = null;
+            try
+            {
+                driver = new ChromeDriver();
+                return driver;
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or WebDriverException)
+            {
+                driver?.Dispose();
+
+                if (attempt == maxAttempts)
+                {
+                    throw;
+                }
+
+                output.WriteLine($"ChromeDriver initialization failed on attempt {attempt}/{maxAttempts}. Retrying in {delay.TotalSeconds} second(s). Error: {ex.Message}");
+                Thread.Sleep(delay);
+            }
+        }
+
+        throw new InvalidOperationException("Failed to initialize ChromeDriver.");
+    }
 
     [Fact]
     public void SeleniumTest()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5d5a8ab7-cda5-48c4-85e8-2eee4bebe9fa","source":"chat","resourceId":"edb8418c-6513-4707-a649-1a74f8d8cc5a","workflowId":"1a1e3ffe-b6c3-4088-82e5-f2474a241011","codeChangeId":"1a1e3ffe-b6c3-4088-82e5-f2474a241011","sourceType":"action_platform_custom_agent"} -->
## Summary of changes
Improve resilience of the Selenium CI integration path against transient Chrome startup crashes by retrying the ChromeDriver initialization.
```
System.InvalidOperationException: session not created: Chrome failed to start: crashed.
(session not created: DevToolsActivePort file doesn't exist)
(The process started from chrome location C:\Users\AzDevOps\.cache\selenium\chrome\win64\146.0.7680.66\chrome.exe is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

## Reason for change
We observed failures that appear to conflict when tests start close together in CI. A longer pause between ChromeDriver startup retries reduces pressure on shared CI resources and gives Chrome more time to recover between attempts.

## Implementation details
- Existing behavior retained:
  - ChromeDriver creation is retried up to 3 total attempts.
  - Startup exceptions (`InvalidOperationException` and `WebDriverException`) are retried.
  - Partially initialized driver instances are disposed before retry.
- Scope remains minimal and targeted: only ChromeDriver initialization is retried.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/edb8418c-6513-4707-a649-1a74f8d8cc5a)

Comment @datadog to request changes