### PR TITLE
Fix Datadog.Trace.Annotations dependency version in Datadog.AzureFunctions nuspec

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -429,8 +429,7 @@ partial class Build : NukeBuild
                 .EnableNoDependencies()
                 .SetConfiguration(BuildConfiguration)
                 .SetNoWarnDotNetCore3()
-                .SetProperty("PackageOutputPath", ArtifactsDirectory / "nuget" / "azure-functions")
-                .SetVersion(Version));
+                .SetProperty("PackageOutputPath", ArtifactsDirectory / "nuget" / "azure-functions"));
         });
 
     Target BuildBenchmarkNuget => _ => _


### PR DESCRIPTION
## Summary of changes

The `BuildAzureFunctionsNuget` target used `.SetVersion(Version)` which appears to pass a `-p:Version` global MSBuild property, which overrode the version of the Annotations project in the generated nuspec for the Datadog.AzureFunctions package. 

## Reason for change

In 3.39.0 we realized that this `SetVersion` overrides the version of dependent projects when we build and pack them in CI, intention of the `SetVersion` call was to ease local development / debugging.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

This was used for Build-AzureFunctionsNuget.ps1 to help with local development / debugging for generating versions to avoid NuGet caching but had the side effect of changing the version of the Annotations in the nuspec 

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
