### PR TITLE
feat: add capped sampling rate increase

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/AgentSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/AgentSamplingRule.cs
@@ -65,19 +65,22 @@ namespace Datadog.Trace.Sampling
         /// Rate decreases and transitions from zero are applied immediately.
         /// When <paramref name="canIncrease"/> is false (cooldown not elapsed), increases are held at <paramref name="oldRate"/>.
         /// </summary>
-        internal static float CappedRate(float oldRate, float newRate, bool canIncrease)
+        internal static bool CappedRate(float oldRate, float newRate, bool canIncrease, out float effectiveRate)
         {
             if (newRate <= oldRate || oldRate == 0)
             {
-                return newRate;
+                effectiveRate = newRate;
+                return false;
             }
 
             if (!canIncrease)
             {
-                return oldRate;
+                effectiveRate = oldRate;
+                return fase;
             }
 
-            return Math.Min(oldRate * 2, newRate);
+            effectiveRate = Math.Min(oldRate * 2, newRate);
+            return true;
         }
 
         public void SetDefaultSampleRates(IReadOnlyDictionary<string, float> sampleRates)
@@ -94,7 +97,7 @@ namespace Datadog.Trace.Sampling
             var defaultSamplingRate = _defaultSamplingRate;
 
             var now = Clock.UtcNow;
-            var canIncrease = _lastCapped == default || (now - _lastCapped) >= RampUpInterval;
+            var canIncrease = (now - _lastCapped) >= RampUpInterval;
             var capApplied = false;
 
             foreach (var pair in sampleRates)
@@ -102,9 +105,7 @@ namespace Datadog.Trace.Sampling
                 if (string.Equals(pair.Key, DefaultKey, StringComparison.OrdinalIgnoreCase))
                 {
                     var oldDefault = _defaultSamplingRate ?? 1f;
-                    var effective = CappedRate(oldDefault, pair.Value, canIncrease);
-                    capApplied = capApplied || effective != pair.Value;
-                    defaultSamplingRate = effective;
+                    capApplied = CappedRate(oldDefault, pair.Value, canIncrease, out defaultSamplingRate) || capApplied;
                     continue;
                 }
 
@@ -116,14 +117,12 @@ namespace Datadog.Trace.Sampling
                     continue;
                 }
 
-                float oldRate;
-                if (!_sampleRates.TryGetValue(key.Value, out oldRate))
+                if (!_sampleRates.TryGetValue(key.Value, out var oldRate))
                 {
                     oldRate = _defaultSamplingRate ?? 1f;
                 }
 
-                var effectiveRate = CappedRate(oldRate, pair.Value, canIncrease);
-                capApplied = capApplied || effectiveRate != pair.Value;
+                capApplied = CappedRate(oldRate, pair.Value, canIncrease, out var effectiveRate) || capApplied;
                 rates.Add(key.Value, effectiveRate);
             }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/AgentSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/AgentSamplingRuleTests.cs
@@ -225,16 +225,17 @@ namespace Datadog.Trace.Tests.Sampling
 
             rule.GetSamplingRate(span).Should().BeApproximately(0.2f, 0.01f);
 
-            // Try again immediately (within cooldown) — rate stays at 0.2
+            // Try again after 0.5s (within cooldown) — rate stays at 0.2
+            clock.UtcNow = clock.UtcNow.AddSeconds(0.5);
             rule.SetDefaultSampleRates(new Dictionary<string, float>
             {
                 { "service:web,env:prod", 1.0f },
             });
 
-            rule.GetSamplingRate(span).Should().BeApproximately(0.2f, 0.01f);
+            rule.GetSamplingRate(span).Should().BeApproximately(0.2f, 0.01f);          
 
-            // After cooldown elapsed — rate doubles to 0.4
-            clock.UtcNow = clock.UtcNow.AddSeconds(1.1);
+            // Try again after 0.6s (puts total since change above cooldown) — rate doubles to 0.4
+            clock.UtcNow = clock.UtcNow.AddSeconds(0.6);
             rule.SetDefaultSampleRates(new Dictionary<string, float>
             {
                 { "service:web,env:prod", 1.0f },


### PR DESCRIPTION
When the trace-agent is restarted, a rate of 100% is initially provided by the trace-agent, increasing dramatically the number of traces sampled. A rate could go suddenly from 0.1% to 100% and back to 0.1% when the trace-agent eventually computes the new sampling rate.

In particular it is observed that when the agent restarts, the payload buffering that waits for new container tags breaches its memory limit and we send spans without container tags.

This PR applies a limit of sampling rate increases of x2 every 1s resulting in a x10 completed every 3-4s
1->100% takes 7s
0.1 -> 100% takes 10s

RFC: https://docs.google.com/document/d/1h8cnGfOUx688pvRVqbhp6irn8s29LIwNYL1ge17nLyw/edit?usp=sharing

Similar PRs
- dd-trace-java https://github.com/DataDog/dd-trace-java/pull/10715
- dd-trace-go  https://github.com/DataDog/dd-trace-go/pull/4488

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
