### PR TITLE
Add process tags to service discovery

### DIFF
--- a/tracer/src/Datadog.Trace/LibDatadog/ServiceDiscovery/ServiceDiscoveryHelper.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/ServiceDiscovery/ServiceDiscoveryHelper.cs
@@ -39,8 +39,8 @@ internal static class ServiceDiscoveryHelper
                     mutableSettings.DefaultServiceName,
                     mutableSettings.Environment,
                     mutableSettings.ServiceVersion,
-                    tracerSettings.PropagateProcessTags ? ProcessTags.SerializedTags : null, // TODO get the process tags from MutableSettings after https://github.com/DataDog/dd-trace-dotnet/pull/8106 is merged
-                    ContainerMetadata.Instance.ContainerId);
+                    tracerSettings.PropagateProcessTags ? ProcessTags.SerializedTags : string.Empty, // TODO get the process tags from MutableSettings after https://github.com/DataDog/dd-trace-dotnet/pull/8106 is merged
+                    ContainerMetadata.Instance.ContainerId ?? string.Empty);
 
                 if (result.Tag == ResultTag.Error)
                 {
@@ -75,8 +75,8 @@ internal static class ServiceDiscoveryHelper
         string? serviceName,
         string? serviceEnv,
         string? serviceVersion,
-        string? processTags,
-        string? containerId)
+        string processTags,
+        string containerId)
     {
         IntPtr ptr = IntPtr.Zero;
         try


### PR DESCRIPTION
## Summary of changes

Populate process tags and container ID in the tracer metadata stored via libdatadog for service discovery.

The struct being filled is defined here:
https://github.com/DataDog/libdatadog/blob/bc8f7642ece80d32f171efb51e6e4ddbbd2f6399/libdd-data-pipeline/src/trace_exporter/mod.rs#L119-L133

## Reason for change

Service discovery needs process tags and container ID in the tracer metadata to fully identify services running in containerized environments.

## Implementation details

- Add `ProcessTags` and `ContainerId` parameters to `StoreTracerMetadata`
- Pass `ProcessTags.SerializedTags` (when `PropagateProcessTags` is enabled) and `ContainerMetadata.Instance.ContainerId` to the metadata store
- A TODO remains to source process tags from `MutableSettings` after #8106 is merged

## Test coverage

No new tests — this wires existing values (`ProcessTags`, `ContainerMetadata`) into an existing code path.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->

