### PR TITLE
Only allow creating hotfix branches from a tag

### DIFF
--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -12,7 +12,19 @@ on:
         required: true
 
 jobs:
+  check_tag:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Verify running from a tag
+          run: |
+            if [[ "${{  github.ref }}" != refs/tags/* ]]; then
+              echo "Error: This workflow can only be run from a tag"
+              echo "Current ref: ${{ github.ref }}"
+              exit 1
+            fi
+
   bump_version:
+    needs: check_tag
     runs-on: windows-latest
     permissions:
       contents: write # Push branches


### PR DESCRIPTION
## Summary of changes

Ensures you're creating a hotfix branch from a tag

## Reason for change

The "correct" usage is to create a hotfix from a previous normal release, or from a previous hotfix. The easy way to enforce that is to ensure you create from a tag

## Implementation details

Check the reference passed in, like we do for other workflows

## Test coverage

Tested it [here](https://github.com/DataDog/dd-trace-dotnet/actions/runs/23005198182) and it failed (as expected). 
