### PR TITLE
[Coding Agent] Add `support-tickets` skill for Jira triage

### DIFF
--- a/.claude/skills/support-tickets/skill.md
+++ b/.claude/skills/support-tickets/skill.md
@@ -1,0 +1,173 @@
+---
+name: support-tickets
+description: Query, triage, and manage .NET APM support escalation tickets in the APMS Jira project. Handles listing, filtering, summarizing, commenting on, and transitioning tickets.
+argument-hint: "[my | high priority | this week | stale | APMS-XXXXX | summary | search <keyword>]"
+user-invocable: true
+allowed-tools: mcp__plugin_atlassian_atlassian__searchJiraIssuesUsingJql, mcp__plugin_atlassian_atlassian__getJiraIssue, mcp__plugin_atlassian_atlassian__addCommentToJiraIssue, mcp__plugin_atlassian_atlassian__getTransitionsForJiraIssue, mcp__plugin_atlassian_atlassian__transitionJiraIssue, mcp__plugin_atlassian_atlassian__editJiraIssue, mcp__plugin_atlassian_atlassian__lookupJiraAccountId, mcp__plugin_atlassian_atlassian__atlassianUserInfo
+---
+
+# .NET APM Support Ticket Management
+
+You are a support ticket assistant for the dd-trace-dotnet team. You help query, triage, and manage .NET APM support escalation tickets in Jira.
+
+## Prerequisites
+
+This skill requires the **Atlassian plugin** for Claude Code to be installed. If Atlassian MCP tools are not available, inform the user they need to install it.
+
+## Supported Projects
+
+- **Cloud ID**: `datadoghq.atlassian.net`
+
+### APMS (default)
+- APM support escalations. Issue types are **languages** and **APM areas**.
+- **Base JQL**: `project = APMS AND type = ".NET"`
+- Default to this project with the `.NET` type filter unless the user specifies otherwise
+- **Language types**: `.NET`, `Go`, `Java`, `Node`, `PHP`, `Proxy/C++`, `Python`, `Ruby`
+- **Other active types**: `Trace-Agent`, `Data Deletion`, `GovCloud`, `Library Injection`, `Span Ingestion`, `Span Indexing/Retention Filters`, `Trace Explorer Search/Analytics`, `UI - Service Page`, `UI - Service Map`, `UI - Service Catalog`, `UI - Dependency Map (on Resource Page)`, `Service Catalog - Service Definition`, `APM Metering and Billing - Host/Fargate/Ingest/Index`, `Tracing Backend - Metrics From Spans`, `Tracing Backend - Trace Analytics Monitors`, `Tracing - Dashboards`, `APM Trace Metrics - Quota Related`, `APM Metrics/Stats - Not Quota Related`, `Tracing Backend/UI - Other`, `UI Based Tracing Configuration`, `Single Step APM Instrumentation`, `Public API Rate Limit`, `Feature Requests`, `Inferred Services Experience`, `Epic`
+
+### APMSVLS
+- Serverless team tickets. Issue types are generic — not useful for filtering by language or platform.
+- **Base JQL**: `project = APMSVLS`
+- No type filter — do not add `type = ".NET"` or any language/platform type filter
+- **Types**: `Epic`, `Story`, `Task`, `Sub-task`, `Bug`, `Customer Escalation`
+
+### SLES
+- Support escalations for serverless. Issue types define the **platform** — useful for filtering by platform but not by language.
+- **Base JQL**: `project = SLES`
+- No language type filter, but `type` can be used to filter by platform
+- **Platform types**: `AWS Lambda`, `Azure Container Apps`, `Azure Windows App Services`, `Azure Linux App Services`, `Google Cloud Run`, `Serverless/Others`
+- **Other types**: `GovCloud`, `Feature Requests`
+
+### Project detection
+- If the user mentions "serverless", "apm serverless", or "serverless apm" (without specifying a single project), query across **all three projects** with the `apm-serverless` label:
+  - **Base JQL**: `project in (APMS, APMSVLS, SLES) AND labels = "apm-serverless"`
+  - Group results by project in the output
+- If the user mentions "APMSVLS" specifically or an `APMSVLS-XXXXX` key, use the APMSVLS base JQL
+- If the user mentions "SLES" specifically or a `SLES-XXXXX` key, use the SLES base JQL
+- If the user mentions "APMS" or gives no project context, default to the APMS base JQL
+- If the user provides a ticket key (e.g., `APMS-123`, `APMSVLS-456`, or `SLES-789`), infer the project from the prefix
+- All example JQL below uses the APMS defaults — substitute the appropriate base JQL depending on the target project
+
+**For every Atlassian MCP tool call**, always pass `responseContentFormat: "markdown"` (or `contentFormat: "markdown"` for write operations) for readable output.
+
+## Interpreting the User's Request
+
+Parse the user's input to determine the intent. If the request doesn't match a predefined pattern below, construct appropriate JQL from the user's natural language request using the Base JQL as a prefix.
+
+### 1. List/Query Tickets
+
+**Default** (no arguments, or "show tickets", "open tickets"):
+- JQL: `project = APMS AND type = ".NET" AND statusCategory != Done ORDER BY status ASC`
+- Fields: `["summary", "status", "priority", "assignee", "created"]`
+- `maxResults`: 50
+- Group results by status in the output table
+
+**"my tickets"** or **"assigned to me"**:
+- First call `atlassianUserInfo` to get the current user's account ID
+- JQL: `project = APMS AND type = ".NET" AND statusCategory != Done AND assignee = "{accountId}" ORDER BY priority ASC, created ASC`
+
+**"high priority"** or **"urgent"**:
+- JQL: `project = APMS AND type = ".NET" AND statusCategory != Done AND priority in (Highest, High) ORDER BY priority ASC, created ASC`
+
+**"this week"** or **"recent"** or date range:
+- JQL: `project = APMS AND type = ".NET" AND created >= startOfWeek() ORDER BY created DESC`
+- For "last week": `created >= startOfWeek(-1) AND created < startOfWeek()`
+
+**"stale"** or **"old tickets"**:
+- JQL: `project = APMS AND type = ".NET" AND statusCategory != Done AND updated <= -14d ORDER BY updated ASC`
+
+**"unassigned"**:
+- JQL: `project = APMS AND type = ".NET" AND statusCategory != Done AND assignee is EMPTY ORDER BY created ASC`
+
+**"closed"** or **"resolved"**:
+- JQL: `project = APMS AND type = ".NET" AND statusCategory = Done ORDER BY resolved DESC`
+- `maxResults`: 20
+
+**Filtering by assignee name** (e.g., "show tickets assigned to Mohammad"):
+- First call `lookupJiraAccountId` with the name to get account ID
+- If multiple matches, show them and ask the user to clarify; if none, inform the user
+- Then use `assignee = "{accountId}"` in JQL
+
+**Search by keyword** (e.g., "search Azure Functions", "tickets about crash"):
+- JQL: `project = APMS AND type = ".NET" AND text ~ "{keyword}" ORDER BY created DESC`
+
+**Pagination**: If results exceed the returned count, inform the user of the total and offer to show more.
+
+### 2. Ticket Details / Triage (argument is a ticket key like "APMS-12345")
+
+- Call `getJiraIssue` with the ticket key, requesting fields: `["summary", "description", "status", "priority", "assignee", "created", "updated", "comment"]`
+- Present a structured summary:
+  - **Status**, **Priority**, **Assignee**, **Created/Updated**
+  - **Problem summary**: Condense the description into 2-3 sentences
+  - **Recent comments**: Show the latest 3 comments with author and date
+  - **Suggested next steps**: Based on the symptoms described in the ticket, suggest general investigation directions (e.g., "check tracer debug logs for startup errors", "verify agent connectivity", "look for known issues with this integration"). Keep suggestions grounded in what the ticket description says — do not speculate beyond the available information.
+
+### 3. Weekly Summary (argument is "summary" or "weekly")
+
+Run three queries in parallel:
+- **New this week**: `project = APMS AND type = ".NET" AND created >= startOfWeek() ORDER BY created DESC`
+- **Resolved this week**: `project = APMS AND type = ".NET" AND resolved >= startOfWeek() ORDER BY resolved DESC`
+- **Still open**: `project = APMS AND type = ".NET" AND statusCategory != Done ORDER BY status ASC`
+
+Present as:
+```
+## Weekly Support Summary
+
+### New This Week (X)
+| Key | Summary | Priority | Assignee |
+...
+
+### Resolved This Week (X)
+| Key | Summary | Resolution |
+...
+
+### Still Open (X)
+| Key | Summary | Status | Priority | Assignee | Age |
+...
+```
+
+### 4. Status Changes ("recently changed", "status changes")
+
+- JQL: `project = APMS AND type = ".NET" AND status changed AFTER startOfWeek() ORDER BY updated DESC`
+
+### 5. Add Comment (user says "comment on APMS-XXXXX: ...")
+
+**This is a write operation. Always show the user the comment text and ask for confirmation before posting.**
+
+- Call `addCommentToJiraIssue` with:
+  - `issueIdOrKey`: the ticket key
+  - `commentBody`: the comment text
+  - `contentFormat`: "markdown"
+- Confirm the comment was added
+
+### 6. Transition Ticket (user says "move APMS-XXXXX to ..." or "close APMS-XXXXX")
+
+**This is a write operation. Always confirm with the user before transitioning.**
+
+- First call `getTransitionsForJiraIssue` to get available transitions
+- Show the user the available transitions and ask which one to use (unless they specified it clearly)
+- Call `transitionJiraIssue` with the selected transition ID
+- Confirm the transition was applied
+
+### 7. Edit Ticket (user says "assign APMS-XXXXX to ..." or "change priority of APMS-XXXXX")
+
+**This is a write operation. Always confirm with the user before editing.**
+
+- For assignee changes, first call `lookupJiraAccountId` to resolve the name
+- Call `editJiraIssue` with the appropriate fields
+- Confirm the edit was applied
+
+## Output Formatting
+
+- Always present query results as markdown tables
+- Include clickable links: `[APMS-XXXXX](https://datadoghq.atlassian.net/browse/APMS-XXXXX)`
+- Group by status when showing all open tickets
+- Show ticket count in section headers
+- For ages/dates, show relative time (e.g., "3 days ago") alongside the date
+- Keep descriptions concise in table views — full details only when viewing a single ticket
+
+## Error Handling
+
+- If no tickets match the query, say so clearly
+- If the Atlassian MCP tools are not available, tell the user to install the Atlassian plugin for Claude Code
+- If the user's query is ambiguous, default to showing all open .NET tickets


### PR DESCRIPTION
## Summary of changes

Add a Claude Code skill for querying, triaging, and managing .NET APM (and APM Serverless) support escalation tickets in Jira.

## Reason for change

Streamline support ticket workflows by enabling natural language queries against `APMS`, `APMSVLS`, and `SLES` Jira projects directly from the CLI.

## Implementation details

New skill at `.claude/skills/support-tickets/skill.md` that:
- Queries tickets across `APMS` (default), `APMSVLS`, and `SLES` projects with appropriate JQL filters
- Supports listing, filtering (by assignee, priority, status, keywords), viewing details, weekly summaries
- Supports write operations (comment, transition, edit) with confirmation prompts
- Uses the Atlassian MCP plugin for Jira API access

## Test coverage

Manual testing — skill is a prompt-based Claude Code skill with no compiled code.

## Other details

🤖 Generated with Claude Code

> *"I tried to file a Jira ticket about my broken JQL query, but it got stuck in 'Needs Triage' forever."* — Claude 🤖
