### PR TITLE
Update local smoke testing docs

### DIFF
--- a/docs/development/CI/RunSmokeTestsLocally.md
+++ b/docs/development/CI/RunSmokeTestsLocally.md
@@ -8,7 +8,7 @@ To run the smoke tests locally, you can do the following.
 
 **Windows (PowerShell):**
 ```powershell
-tracer\build.cmd RunArtifactSmokeTests CheckSmokeTestsForErrors -SmokeTestCategory 'LinuxX64Installer' -SmokeTestScenario 'ubuntu_10_0-noble' --Artifacts './artifacts'
+.\tracer\build.ps1 RunArtifactSmokeTests CheckSmokeTestsForErrors -SmokeTestCategory 'LinuxX64Installer' -SmokeTestScenario 'ubuntu_10_0-noble' --Artifacts './artifacts'
 ```
 
 **macOS/Linux:**


### PR DESCRIPTION
## Summary of changes

Updates the local smoke-testing docs to explain required steps

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/8271 we updated the smoke tests to be orchestrated by Nuke, which makes running the tests locally much easier, and makes these docs out of date

## Implementation details

Wrote the doc. It currently only shows the Windows instructions, as that's all I can test...

## Test coverage

I ran it, and tested that it worked

## Other details

Would be great if someone could try these on macos and update them 😄 This _may_ not work quite as expected, seeing as that's not a scenario we run in CI, and I can't test it 😅 