### PR TITLE
 Add dd-autoinstrumentation CLI with LLM-native structured output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,11 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 - Implement `OnMethodBegin` and `OnMethodEnd`/`OnAsyncMethodEnd` handlers
 - Use duck typing constraints (`where TReq : IMyShape, IDuckType`) or `obj.DuckCast<IMyShape>()` for third-party types
 - Tests: Add under `tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests` with samples in `tracer/test/test-applications/integrations`
-- Generate boilerplate: `./tracer/build.ps1 RunInstrumentationGenerator`
+- Generate boilerplate (GUI): `./tracer/build.ps1 RunInstrumentationGenerator`
+- Generate boilerplate (CLI): `./tracer/build.ps1 RunInstrumentationGeneratorCli --assembly-path <dll> --type-name <type> --method-name <method>`
 
 - **`docs/development/AutomaticInstrumentation.md`** — Complete guide to creating integrations, CallTarget wiring, testing strategies, package version configuration, and CI testing
+- **`docs/development/InstrumentationGenerator.md`** — GUI and CLI instrumentation generator tools, Nuke integration, duck typing flags, JSON output, and two-tool workflow with dotnet-inspect
 
 - **`docs/development/DuckTyping.md`** — Duck typing patterns, proxy types, binding attributes, best practices, and performance benchmarks
 
@@ -258,6 +260,7 @@ The tracer runs in-process with customer applications and must have minimal perf
 
 **Development guides:**
 - `docs/development/AutomaticInstrumentation.md` — Creating integrations
+- `docs/development/InstrumentationGenerator.md` — GUI and CLI instrumentation generator tools
 - `docs/development/DuckTyping.md` — Duck typing guide
 - `docs/development/TracerDebugging.md` — Local debugging, IDE configuration, path issues, and troubleshooting
 - `docs/development/AzureFunctions.md` — Azure Functions integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,6 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 
 - **`docs/development/AutomaticInstrumentation.md`** — Complete guide to creating integrations, CallTarget wiring, testing strategies, package version configuration, and CI testing
 - **`docs/development/InstrumentationGenerator.md`** — GUI and CLI instrumentation generator tools, Nuke integration, duck typing flags, JSON output, and two-tool workflow with dotnet-inspect
-
 - **`docs/development/DuckTyping.md`** — Duck typing patterns, proxy types, binding attributes, best practices, and performance benchmarks
 
 ## Azure Functions & Serverless
@@ -261,6 +260,7 @@ The tracer runs in-process with customer applications and must have minimal perf
 **Development guides:**
 - `docs/development/AutomaticInstrumentation.md` — Creating integrations
 - `docs/development/InstrumentationGenerator.md` — GUI and CLI instrumentation generator tools
+- `docs/development/for-ai/InstrumentationGenerator-CLI.md` — LLM reference for the CLI (commands, JSON schemas, error handling)
 - `docs/development/DuckTyping.md` — Duck typing guide
 - `docs/development/TracerDebugging.md` — Local debugging, IDE configuration, path issues, and troubleshooting
 - `docs/development/AzureFunctions.md` — Azure Functions integration

--- a/Datadog.Trace.Build.g.sln
+++ b/Datadog.Trace.Build.g.sln
@@ -269,6 +269,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.FeatureFlags.OpenFe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.AutoInstrumentation.Generator.Core", "tracer\src\Datadog.AutoInstrumentation.Generator.Core\Datadog.AutoInstrumentation.Generator.Core.csproj", "{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.AutoInstrumentation.Generator.Cli", "tracer\src\Datadog.AutoInstrumentation.Generator.Cli\Datadog.AutoInstrumentation.Generator.Cli.csproj", "{8D722514-8BAD-4069-84D0-15797026E0ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -553,6 +555,10 @@ Global
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9518425A-36A5-4B8F-B0B8-6137DB88441D} = {8CEC2042-F11C-49F5-A674-2355793B600A}
@@ -643,5 +649,6 @@ Global
 		{64258238-DE63-4A0F-A618-DF51735BA22A} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{CFECF8D4-3A46-35A8-7CB1-BA359974A1A9} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{8D722514-8BAD-4069-84D0-15797026E0ED} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 	EndGlobalSection
 EndGlobal

--- a/Datadog.Trace.OSX.slnf
+++ b/Datadog.Trace.OSX.slnf
@@ -3,6 +3,8 @@
     "path": "Datadog.Trace.sln",
     "projects": [
       "tracer\\build\\_build\\_build.csproj",
+      "tracer\\src\\Datadog.AutoInstrumentation.Generator.Cli\\Datadog.AutoInstrumentation.Generator.Cli.csproj",
+      "tracer\\src\\Datadog.AutoInstrumentation.Generator.Core\\Datadog.AutoInstrumentation.Generator.Core.csproj",
       "tracer\\src\\Datadog.InstrumentedAssemblyGenerator\\Datadog.InstrumentedAssemblyGenerator.csproj",
       "tracer\\src\\Datadog.InstrumentedAssemblyVerification\\Datadog.InstrumentedAssemblyVerification.csproj",
       "tracer\\src\\Datadog.Trace.Annotations\\Datadog.Trace.Annotations.csproj",

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -643,6 +643,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Ocelot.DistributedT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.AutoInstrumentation.Generator.Core", "tracer\src\Datadog.AutoInstrumentation.Generator.Core\Datadog.AutoInstrumentation.Generator.Core.csproj", "{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.AutoInstrumentation.Generator.Cli", "tracer\src\Datadog.AutoInstrumentation.Generator.Cli\Datadog.AutoInstrumentation.Generator.Cli.csproj", "{8D722514-8BAD-4069-84D0-15797026E0ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1567,6 +1569,10 @@ Global
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D722514-8BAD-4069-84D0-15797026E0ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1822,6 +1828,7 @@ Global
 		{0E3E1069-80FF-99C9-D29F-936D96D5F516} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{08C6510D-42DC-C8B4-CC79-26349F2D6DBB} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{B3A07CA3-3536-4D43-81A3-A5A73FB76F22} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{8D722514-8BAD-4069-84D0-15797026E0ED} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/docs/development/AutomaticInstrumentation.md
+++ b/docs/development/AutomaticInstrumentation.md
@@ -291,19 +291,29 @@ Additional information regarding the specific limitations with these can be foun
 
 ### AutoInstrumentation Generator
 
-There's a tool to help developers in the process of creating all the boilerplate code for new instrumentations.
+There are two tools to help developers create the boilerplate code for new instrumentations: an interactive **GUI** and a scriptable **CLI**. See [InstrumentationGenerator.md](./InstrumentationGenerator.md) for full documentation.
 
-To run the tool use: `./tracer/build.ps1 RunInstrumentationGenerator`
+**GUI** (interactive browsing and generation):
 
-#### Nuke command:
+```bash
+./tracer/build.ps1 RunInstrumentationGenerator
+```
+
+**CLI** (scriptable, CI-friendly, AI-assisted workflows):
+
+```bash
+# Via Nuke
+.\tracer\build.cmd RunInstrumentationGeneratorCli --assembly-path "path/to/MyLib.dll" --type-name "MyLib.MyClass" --method-name "DoSomething"
+
+# Via dotnet run
+dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ --framework net8.0 -- generate path/to/MyLib.dll -t MyLib.MyClass -m DoSomething
+```
+
+#### GUI screenshots:
 
 ![nuke command](./images/gen01.jpg)
 
-#### Main window:
-
 ![tool main window](./images/gen02.jpg)
-
-#### Creating a new Instrumentation class with the DuckType proxies:
 
 ![tool main window](./images/gen03.jpg)
 

--- a/docs/development/AutomaticInstrumentation.md
+++ b/docs/development/AutomaticInstrumentation.md
@@ -305,8 +305,8 @@ There are two tools to help developers create the boilerplate code for new instr
 # Via Nuke
 .\tracer\build.cmd RunInstrumentationGeneratorCli --assembly-path "path/to/MyLib.dll" --type-name "MyLib.MyClass" --method-name "DoSomething"
 
-# Via dotnet run
-dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ --framework net8.0 -- generate path/to/MyLib.dll -t MyLib.MyClass -m DoSomething
+# Via dotnet run (the CLI targets net10.0; omit --framework or pass net10.0 explicitly)
+dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ -- generate path/to/MyLib.dll -t MyLib.MyClass -m DoSomething
 ```
 
 #### GUI screenshots:

--- a/docs/development/AutomaticInstrumentation.md
+++ b/docs/development/AutomaticInstrumentation.md
@@ -305,8 +305,8 @@ There are two tools to help developers create the boilerplate code for new instr
 # Via Nuke
 .\tracer\build.cmd RunInstrumentationGeneratorCli --assembly-path "path/to/MyLib.dll" --type-name "MyLib.MyClass" --method-name "DoSomething"
 
-# Via dotnet run (the CLI targets net10.0; omit --framework or pass net10.0 explicitly)
-dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ -- generate path/to/MyLib.dll -t MyLib.MyClass -m DoSomething
+# Via dotnet run (--framework is required because the project's TargetFrameworks is plural even with a single TFM)
+dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ --framework net10.0 -- generate path/to/MyLib.dll -t MyLib.MyClass -m DoSomething
 ```
 
 #### GUI screenshots:

--- a/docs/development/InstrumentationGenerator.md
+++ b/docs/development/InstrumentationGenerator.md
@@ -1,0 +1,336 @@
+## Instrumentation Generator <!-- omit in toc -->
+
+The Instrumentation Generator produces CallTarget auto-instrumentation boilerplate code from .NET assemblies. It loads an assembly via [dnlib](https://github.com/yck1509/dnlib), inspects types and methods, and generates integration classes with `[InstrumentMethod]` attributes, `OnMethodBegin`/`OnMethodEnd` handlers, and DuckType proxy definitions.
+
+The tooling is split into three projects:
+
+| Project | Purpose |
+|---|---|
+| `Datadog.AutoInstrumentation.Generator.Core` | Shared library with all generation logic (no UI dependencies) |
+| `Datadog.AutoInstrumentation.Generator` | Avalonia GUI for interactive browsing and generation |
+| `Datadog.AutoInstrumentation.Generator.Cli` | CLI tool for scriptable/automated generation |
+
+- [GUI Tool](#gui-tool)
+  - [Running the GUI](#running-the-gui)
+  - [GUI Workflow](#gui-workflow)
+- [CLI Tool](#cli-tool)
+  - [Running the CLI](#running-the-cli)
+  - [Basic Usage](#basic-usage)
+  - [Using Nuke](#using-nuke)
+  - [Method Resolution](#method-resolution)
+  - [Generation Flags](#generation-flags)
+  - [Configuration Overrides](#configuration-overrides)
+  - [File-Based Configuration](#file-based-configuration)
+  - [Discovering Available Keys](#discovering-available-keys)
+  - [Output Options](#output-options)
+  - [Auto-Detection](#auto-detection)
+  - [JSON Output](#json-output)
+  - [Configuration Precedence](#configuration-precedence)
+- [Two-Tool Workflow with dotnet-inspect](#two-tool-workflow-with-dotnet-inspect)
+- [Architecture](#architecture)
+  - [Core Library](#core-library)
+  - [Generation Configuration](#generation-configuration)
+
+### GUI Tool
+
+The GUI provides an interactive tree view for browsing assemblies and a live code preview that updates as you toggle options.
+
+#### Running the GUI
+
+```bash
+# Via Nuke
+./tracer/build.ps1 RunInstrumentationGenerator    # Windows
+./tracer/build.sh RunInstrumentationGenerator      # Linux/macOS
+
+# Via dotnet directly
+dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator/ --framework net10.0
+```
+
+#### GUI Workflow
+
+1. Click the file icon to open an assembly (`.dll`)
+2. Browse the tree: Assembly > Module > Namespace > Type > Method
+3. Select a method to see generated code in the editor
+4. Toggle options (duck typing, async handlers, etc.) in the sidebar
+5. Copy the generated code to your integration file
+
+### CLI Tool
+
+The CLI exposes the same generation logic as a command-line tool, suitable for scripting, CI, and AI-assisted workflows.
+
+#### Running the CLI
+
+```bash
+# Via dotnet run
+dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ --framework net10.0 -- \
+  generate <assembly-path> --type <type> --method <method> [options]
+
+# Or install as a global tool
+dotnet pack tracer/src/Datadog.AutoInstrumentation.Generator.Cli/
+dotnet tool install --global --add-source ./tracer/src/Datadog.AutoInstrumentation.Generator.Cli/bin/Debug dd-autoinstrumentation
+dd-autoinstrumentation generate <assembly-path> --type <type> --method <method> [options]
+```
+
+#### Basic Usage
+
+Generate an integration for a specific method and write it to the correct location:
+
+```bash
+dd-autoinstrumentation generate path/to/MyLib.dll \
+  --type MyLib.MyClass \
+  --method DoSomething \
+  --output tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MyLib/MyClassDoSomethingIntegration.cs
+```
+
+The tool prints the generated source code to stdout by default, or writes to a file with `--output`.
+
+#### Using Nuke
+
+The CLI is integrated into the Nuke build system:
+
+```bash
+# Windows
+.\tracer\build.cmd RunInstrumentationGeneratorCli ^
+  --assembly-path "path/to/MyLib.dll" ^
+  --type-name "MyLib.MyClass" ^
+  --method-name "DoSomething" ^
+  --output-path "src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MyLib/MyClassDoSomethingIntegration.cs"
+
+# Linux/macOS
+./tracer/build.sh RunInstrumentationGeneratorCli \
+  --assembly-path "path/to/MyLib.dll" \
+  --type-name "MyLib.MyClass" \
+  --method-name "DoSomething" \
+  --output-path "src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MyLib/MyClassDoSomethingIntegration.cs"
+```
+
+Overload disambiguation is available as direct Nuke parameters:
+
+```bash
+.\tracer\build.cmd RunInstrumentationGeneratorCli ^
+  --assembly-path "path/to/MyLib.dll" ^
+  --type-name "MyLib.MyClass" ^
+  --method-name "DoSomething" ^
+  --overload-index 0
+```
+
+Additional CLI flags (--set, --config-file, JSON output, etc.) can be passed via `--generator-args` as a single space-separated string:
+
+```bash
+.\tracer\build.cmd RunInstrumentationGeneratorCli ^
+  --assembly-path "path/to/MyLib.dll" ^
+  --type-name "MyLib.MyClass" ^
+  --method-name "DoSomething" ^
+  --generator-args "--set createDucktypeInstance=true --json"
+```
+
+Nuke parameters:
+
+| Parameter | Required | Description |
+|---|---|---|
+| `--assembly-path` | Yes | Path to the .NET assembly (.dll) |
+| `--type-name` | Yes | Fully qualified type name |
+| `--method-name` | Yes | Method name to instrument |
+| `--output-path` | No | Output file path (prints to stdout if omitted) |
+| `--overload-index` | No | 0-based overload index for method disambiguation |
+| `--parameter-types` | No | Parameter type full names (space-separated) for disambiguation |
+| `--generator-args` | No | Additional flags passed through to the CLI (space-separated string) |
+
+#### Method Resolution
+
+When a type has multiple overloads of the same method, use one of these to disambiguate:
+
+```bash
+# By parameter type signatures
+dd-autoinstrumentation generate lib.dll \
+  -t MyLib.MyClass -m Send \
+  --parameter-types System.String System.Int32
+
+# By 0-based overload index
+dd-autoinstrumentation generate lib.dll \
+  -t MyLib.MyClass -m Send \
+  --overload-index 1
+```
+
+If disambiguation is needed but not provided, the tool lists available overloads with their signatures.
+
+#### Generation Flags
+
+Three shortcut flags are available for the most common toggles:
+
+| Flag | Description |
+|---|---|
+| `--no-method-begin` | Skip `OnMethodBegin` handler |
+| `--no-method-end` | Skip `OnMethodEnd` handler |
+| `--async-method-end` | Generate `OnAsyncMethodEnd` handler |
+| `--no-auto-detect` | Disable smart defaults (see [Auto-Detection](#auto-detection)) |
+
+#### Configuration Overrides
+
+For fine-grained control over all generation options, use `--set key=value`. This replaces the previous 25+ individual duck typing flags with a single, repeatable mechanism:
+
+```bash
+# Enable instance duck typing with methods
+dd-autoinstrumentation generate lib.dll \
+  -t MyLib.MyClass -m DoWork \
+  --set createDucktypeInstance=true --set ducktypeInstanceMethods=true
+
+# Disable what auto-detect enabled
+dd-autoinstrumentation generate lib.dll \
+  -t MyLib.MyClass -m DoWork \
+  --set createOnAsyncMethodEnd=false --set createOnMethodEnd=true
+
+# Use DuckCopy structs
+dd-autoinstrumentation generate lib.dll \
+  -t MyLib.MyClass -m DoWork \
+  --set useDuckCopyStruct=true --set createDucktypeInstance=true
+```
+
+Keys use camelCase names matching the JSON output from `--json`. Use `--list-keys` to see all available keys.
+
+#### File-Based Configuration
+
+Use `--config-file` to load configuration from a JSON file. This is useful for reusable templates or for round-tripping with `--json` output:
+
+```bash
+# Save configuration to a file
+dd-autoinstrumentation generate lib.dll -t MyLib.MyClass -m DoWork --json > config.json
+
+# Re-run with saved config, optionally with tweaks
+dd-autoinstrumentation generate lib.dll -t MyLib.MyClass -m DoWork \
+  --config-file config.json --set ducktypeInstanceMethods=true
+```
+
+The `--config-file` option accepts either:
+- A bare configuration object (just the boolean flags)
+- A full `--json` output envelope (the tool auto-extracts the `configuration` block)
+
+For inline JSON (useful for AI agents), use `--config`:
+
+```bash
+dd-autoinstrumentation generate lib.dll -t MyLib.MyClass -m DoWork \
+  --config '{"createDucktypeInstance": true, "ducktypeInstanceProperties": true}'
+```
+
+Note: `--config` and `--config-file` are mutually exclusive.
+
+#### Discovering Available Keys
+
+Use `--list-keys` to see all available configuration keys with their types and default values:
+
+```bash
+dd-autoinstrumentation generate --list-keys
+```
+
+This prints a table of all keys that can be used with `--set`, `--config`, or `--config-file`.
+
+#### Output Options
+
+| Flag | Description |
+|---|---|
+| `--json` | Output structured JSON (see [JSON Output](#json-output)) |
+| `-o, --output <path>` | Write to file instead of stdout |
+
+#### Auto-Detection
+
+By default, the CLI applies the same smart defaults as the GUI:
+
+- **Async methods** (returning `Task` or `ValueTask`): generates `OnAsyncMethodEnd` instead of `OnMethodEnd`
+- **Static methods**: disables instance duck typing
+- **Void methods**: uses the void variant of `OnMethodEnd`
+
+Use `--no-auto-detect` to start from a blank configuration and control everything explicitly.
+
+#### JSON Output
+
+The `--json` flag produces structured output for machine consumption:
+
+```json
+{
+  "success": true,
+  "fileName": "MyClassDoSomething",
+  "sourceCode": "// <copyright ...\n...",
+  "metadata": {
+    "assemblyName": "MyLib",
+    "typeName": "MyLib.MyClass",
+    "methodName": "DoSomething",
+    "returnTypeName": "ClrNames.Void",
+    "parameterTypeNames": "[ClrNames.String, ClrNames.Int32]",
+    "minimumVersion": "1.0.0",
+    "maximumVersion": "1.*.*",
+    "integrationName": "nameof(IntegrationId.MyLib)",
+    "integrationClassName": "MyClassDoSomething",
+    "isInterface": false
+  },
+  "configuration": {
+    "createOnMethodBegin": true,
+    "createOnMethodEnd": true,
+    "createOnAsyncMethodEnd": false
+  }
+}
+```
+
+#### Configuration Precedence
+
+Configuration is applied in layers (lowest to highest precedence):
+
+1. **Auto-detect** (`CreateForMethod`) — unless `--no-auto-detect`
+2. **Base config** — `--config-file` OR `--config` (mutually exclusive; replaces layer 1 entirely)
+3. **Shortcut flags + `--set` overrides** — applied on top of the base config
+
+### Two-Tool Workflow with dotnet-inspect
+
+The CLI is designed to pair with [`dotnet-inspect`](https://github.com/richlander/dotnet-inspect) for a complete workflow. `dotnet-inspect` handles assembly/package browsing (finding the right type and method), while `dd-autoinstrumentation` handles code generation.
+
+```bash
+# 1. Browse the target library to find the method
+dotnet-inspect member MyClass --package MyLib@2.0.0 --oneline
+
+# 2. Find the local DLL path
+dotnet-inspect library --package MyLib@2.0.0
+
+# 3. Generate the instrumentation
+dd-autoinstrumentation generate ~/.nuget/packages/mylib/2.0.0/lib/net6.0/MyLib.dll \
+  --type MyLib.MyClass \
+  --method DoSomething \
+  --output tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MyLib/MyClassDoSomethingIntegration.cs
+```
+
+### Architecture
+
+#### Core Library
+
+`Datadog.AutoInstrumentation.Generator.Core` contains all generation logic with zero UI dependencies:
+
+| Type | Purpose |
+|---|---|
+| `InstrumentationGenerator` | Stateless engine: takes a `MethodDef` + `GenerationConfiguration`, returns a `GenerationResult` |
+| `GenerationConfiguration` | POCO with all boolean flags controlling generation |
+| `GenerationResult` | Output: source code, file name, namespace, structured metadata |
+| `InstrumentMethodMetadata` | Structured `[InstrumentMethod]` attribute values |
+| `AssemblyBrowser` | Thin dnlib wrapper for loading assemblies and resolving methods |
+| `EditorHelper` | Type name conversion, duck type proxy generation, version extraction |
+| `ResourceLoader` | Loads embedded code templates (`Integration.cs`, `OnMethodBegin.cs`, etc.) |
+
+Both the GUI and CLI depend on Core. The GUI adds Avalonia UI and ReactiveUI for the interactive experience. The CLI adds System.CommandLine for argument parsing.
+
+#### Generation Configuration
+
+`GenerationConfiguration.CreateForMethod(methodDef)` applies the same smart defaults as the GUI:
+
+```csharp
+// Auto-detects async, static, void and sets appropriate defaults
+var config = GenerationConfiguration.CreateForMethod(methodDef);
+
+// Or start from scratch
+var config = new GenerationConfiguration
+{
+    CreateOnMethodBegin = true,
+    CreateOnAsyncMethodEnd = true,
+    CreateDucktypeInstance = true,
+    DucktypeInstanceProperties = true,
+};
+
+var generator = new InstrumentationGenerator();
+var result = generator.Generate(methodDef, config);
+```

--- a/docs/development/InstrumentationGenerator.md
+++ b/docs/development/InstrumentationGenerator.md
@@ -17,6 +17,7 @@ The tooling is split into three projects:
   - [Running the CLI](#running-the-cli)
   - [Basic Usage](#basic-usage)
   - [Using Nuke](#using-nuke)
+  - [Assembly Inspection](#assembly-inspection)
   - [Method Resolution](#method-resolution)
   - [Generation Flags](#generation-flags)
   - [Configuration Overrides](#configuration-overrides)
@@ -25,7 +26,9 @@ The tooling is split into three projects:
   - [Output Options](#output-options)
   - [Auto-Detection](#auto-detection)
   - [JSON Output](#json-output)
+  - [Structured Error Handling](#structured-error-handling)
   - [Configuration Precedence](#configuration-precedence)
+- [LLM / AI Agent Usage](#llm--ai-agent-usage)
 - [Two-Tool Workflow with dotnet-inspect](#two-tool-workflow-with-dotnet-inspect)
 - [Architecture](#architecture)
   - [Core Library](#core-library)
@@ -136,6 +139,28 @@ Nuke parameters:
 | `--parameter-types` | No | Parameter type full names (space-separated) for disambiguation |
 | `--generator-args` | No | Additional flags passed through to the CLI (space-separated string) |
 
+#### Assembly Inspection
+
+The `inspect` subcommand discovers types and methods in an assembly without generating code. This is useful for exploring unfamiliar libraries or for LLM agents that need to pick instrumentation targets.
+
+**List all types:**
+
+```bash
+dd-autoinstrumentation inspect path/to/MyLib.dll --list-types
+```
+
+Output includes visibility, kind (class/interface/struct/abstract/sealed), method count, and nested type count.
+
+**List methods on a type:**
+
+```bash
+dd-autoinstrumentation inspect path/to/MyLib.dll --list-methods MyLib.MyClass
+```
+
+Output includes return type, parameters, visibility, modifiers (static/virtual/async), and overload index/count for disambiguation.
+
+Both modes support `--json` for structured output (see [JSON Output](#json-output)).
+
 #### Method Resolution
 
 When a type has multiple overloads of the same method, use one of these to disambiguate:
@@ -243,7 +268,9 @@ Use `--no-auto-detect` to start from a blank configuration and control everythin
 
 #### JSON Output
 
-The `--json` flag produces structured output for machine consumption:
+`--json` is a global flag that works with all subcommands (`generate`, `inspect`). It can appear before or after the subcommand name. When active, **all** output (success and error) goes to stdout as structured JSON.
+
+The `generate` command's success output includes the generated source code and metadata:
 
 ```json
 {
@@ -270,6 +297,50 @@ The `--json` flag produces structured output for machine consumption:
 }
 ```
 
+Other commands (`inspect`, `generate --list-keys`) use a unified envelope:
+
+```json
+{
+  "success": true,
+  "command": "inspect",
+  "data": { ... }
+}
+```
+
+#### Structured Error Handling
+
+When `--json` is active, errors return a structured envelope instead of plain text to stderr:
+
+```json
+{
+  "success": false,
+  "command": "generate",
+  "errorCode": "AMBIGUOUS_OVERLOAD",
+  "errorMessage": "Error: Could not resolve method 'Send' on type 'MyLib.MyClass'. Found 3 overload(s)...",
+  "data": {
+    "overloads": [
+      { "index": 0, "fullName": "...", "parameters": [...] },
+      { "index": 1, "fullName": "...", "parameters": [...] }
+    ]
+  }
+}
+```
+
+Machine-readable error codes:
+
+| Error Code | When |
+|---|---|
+| `FILE_NOT_FOUND` | Assembly file does not exist |
+| `TYPE_NOT_FOUND` | Type not found in assembly |
+| `METHOD_NOT_FOUND` | Method not found on type (zero overloads) |
+| `AMBIGUOUS_OVERLOAD` | Multiple overloads, no disambiguation provided. Includes overload data in response |
+| `INVALID_ARGUMENT` | Missing required arguments |
+| `INVALID_CONFIG` | Bad JSON in `--config` or `--config-file` |
+| `UNKNOWN_KEY` | Unrecognized key in `--set` |
+| `GENERATION_ERROR` | Code generation failed |
+
+The `AMBIGUOUS_OVERLOAD` error is notable: it includes the full overload list in `data`, so you can immediately retry with `--overload-index` without a separate inspect call.
+
 #### Configuration Precedence
 
 Configuration is applied in layers (lowest to highest precedence):
@@ -277,6 +348,39 @@ Configuration is applied in layers (lowest to highest precedence):
 1. **Auto-detect** (`CreateForMethod`) — unless `--no-auto-detect`
 2. **Base config** — `--config-file` OR `--config` (mutually exclusive; replaces layer 1 entirely)
 3. **Shortcut flags + `--set` overrides** — applied on top of the base config
+
+### LLM / AI Agent Usage
+
+The CLI is designed for autonomous LLM use. An agent can discover targets, generate code, and recover from errors entirely through structured JSON — no human in the loop required.
+
+**End-to-end workflow:**
+
+```bash
+# 1. Discover types in the target assembly
+dd-autoinstrumentation inspect MyLib.dll --list-types --json
+
+# 2. Pick a type and list its methods
+dd-autoinstrumentation inspect MyLib.dll --list-methods MyLib.HttpClient --json
+
+# 3. Generate instrumentation (if overloadCount > 1, use --overload-index)
+dd-autoinstrumentation generate MyLib.dll \
+  -t MyLib.HttpClient -m SendAsync --overload-index 0 --json
+
+# 4. On error, parse errorCode and retry
+#    AMBIGUOUS_OVERLOAD → read data.overloads, pick index, retry with --overload-index
+#    METHOD_NOT_FOUND   → go back to step 2
+#    FILE_NOT_FOUND     → fix the path
+```
+
+**Key design points for LLM consumers:**
+
+- **Always use `--json`** — all output (success and error) is structured JSON on stdout
+- **Check `success` first**, then `errorCode` on failure for machine-readable dispatch
+- **`AMBIGUOUS_OVERLOAD` includes overload data** — no need for a separate inspect call
+- **`inspect --list-methods` includes `overloadIndex` and `overloadCount`** — the agent knows upfront if disambiguation is needed
+- **`generate --list-keys --json`** returns all configuration keys as structured data
+
+For a detailed LLM-focused reference with full JSON schemas, see [`docs/development/for-ai/InstrumentationGenerator-CLI.md`](for-ai/InstrumentationGenerator-CLI.md).
 
 ### Two-Tool Workflow with dotnet-inspect
 

--- a/docs/development/InstrumentationGenerator.md
+++ b/docs/development/InstrumentationGenerator.md
@@ -181,14 +181,15 @@ If disambiguation is needed but not provided, the tool lists available overloads
 
 #### Generation Flags
 
-Three shortcut flags are available for the most common toggles:
+Shortcut flags for the most common toggles. Async methods are auto-detected and generate `OnAsyncMethodEnd` automatically — no explicit flag required.
 
 | Flag | Description |
 |---|---|
 | `--no-method-begin` | Skip `OnMethodBegin` handler |
 | `--no-method-end` | Skip `OnMethodEnd` handler |
-| `--async-method-end` | Generate `OnAsyncMethodEnd` handler |
 | `--no-auto-detect` | Disable smart defaults (see [Auto-Detection](#auto-detection)) |
+
+For finer control (e.g., forcing `OnAsyncMethodEnd` on a non-async method), use `--set createOnAsyncMethodEnd=true`.
 
 #### Configuration Overrides
 

--- a/docs/development/InstrumentationGenerator.md
+++ b/docs/development/InstrumentationGenerator.md
@@ -338,6 +338,7 @@ Machine-readable error codes:
 | `INVALID_CONFIG` | Bad JSON in `--config` or `--config-file` |
 | `UNKNOWN_KEY` | Unrecognized key in `--set` |
 | `GENERATION_ERROR` | Code generation failed |
+| `BAD_ASSEMBLY` | File is not a valid .NET assembly (corrupted, native, etc.) |
 
 The `AMBIGUOUS_OVERLOAD` error is notable: it includes the full overload list in `data`, so you can immediately retry with `--overload-index` without a separate inspect call.
 

--- a/docs/development/for-ai/InstrumentationGenerator-CLI.md
+++ b/docs/development/for-ai/InstrumentationGenerator-CLI.md
@@ -1,0 +1,311 @@
+# dd-autoinstrumentation CLI — LLM Reference
+
+> This document is a complete reference for AI agents using the `dd-autoinstrumentation` CLI to generate CallTarget auto-instrumentation code. It covers all commands, options, JSON schemas, error codes, and recommended workflows.
+
+## Quick Start
+
+```bash
+# Run via dotnet (from repo root)
+dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ --framework net10.0 -- <command> [options]
+
+# Or if installed as a global tool
+dd-autoinstrumentation <command> [options]
+```
+
+Always pass `--json` for structured output. It is a global flag and can appear anywhere on the command line.
+
+## Commands
+
+### `inspect` — Discover types and methods
+
+#### List types
+
+```bash
+dd-autoinstrumentation inspect <assembly-path> --list-types --json
+```
+
+Response:
+```json
+{
+  "success": true,
+  "command": "inspect",
+  "data": {
+    "types": [
+      {
+        "fullName": "MyLib.HttpClient",
+        "namespace": "MyLib",
+        "name": "HttpClient",
+        "isPublic": true,
+        "isInterface": false,
+        "isAbstract": false,
+        "isSealed": false,
+        "isValueType": false,
+        "methodCount": 12,
+        "nestedTypes": 0
+      }
+    ]
+  }
+}
+```
+
+Notes:
+- Includes ALL access levels (not just public) — CallTarget hooks any visibility
+- Excludes compiler-generated types (e.g., `<>c__DisplayClass`, async state machines)
+- Excludes the `<Module>` type
+
+#### List methods
+
+```bash
+dd-autoinstrumentation inspect <assembly-path> --list-methods <type-full-name> --json
+```
+
+Response:
+```json
+{
+  "success": true,
+  "command": "inspect",
+  "data": {
+    "type": "MyLib.HttpClient",
+    "methods": [
+      {
+        "name": "SendAsync",
+        "fullName": "System.Threading.Tasks.Task`1<MyLib.Response> MyLib.HttpClient::SendAsync(MyLib.Request,System.Threading.CancellationToken)",
+        "returnType": "System.Threading.Tasks.Task`1<MyLib.Response>",
+        "isPublic": true,
+        "isStatic": false,
+        "isVirtual": true,
+        "isAsync": true,
+        "parameters": [
+          { "name": "request", "type": "MyLib.Request", "index": 0 },
+          { "name": "cancellationToken", "type": "System.Threading.CancellationToken", "index": 1 }
+        ],
+        "overloadIndex": 0,
+        "overloadCount": 2
+      }
+    ]
+  }
+}
+```
+
+Notes:
+- Excludes compiler-generated methods and special-name methods (property getters/setters, event accessors)
+- `overloadIndex` and `overloadCount` tell you upfront if disambiguation is needed
+- `isAsync` is true when return type starts with `System.Threading.Tasks.Task` or `System.Threading.Tasks.ValueTask`
+
+### `generate` — Generate instrumentation code
+
+```bash
+dd-autoinstrumentation generate <assembly-path> \
+  --type <type-full-name> \
+  --method <method-name> \
+  [--overload-index <n>] \
+  [--parameter-types <type1> <type2> ...] \
+  [--json]
+```
+
+Required arguments: `assembly-path`, `--type` (`-t`), `--method` (`-m`).
+
+#### Overload disambiguation
+
+If a method has multiple overloads, you must provide one of:
+- `--overload-index <n>` — 0-based index (matches `overloadIndex` from inspect output)
+- `--parameter-types <type1> <type2>` — full type names of each parameter
+
+#### Generation flags
+
+| Flag | Effect |
+|---|---|
+| `--no-method-begin` | Skip `OnMethodBegin` handler |
+| `--no-method-end` | Skip `OnMethodEnd` handler |
+| `--async-method-end` | Generate `OnAsyncMethodEnd` handler |
+| `--no-auto-detect` | Disable smart defaults |
+
+#### Configuration overrides
+
+```bash
+--set key=value          # Repeatable, e.g., --set createDucktypeInstance=true
+--config '{"key": val}'  # Inline JSON configuration object
+--config-file path.json  # Load from file
+```
+
+`--config` and `--config-file` are mutually exclusive. Both are overridden by `--set`.
+
+#### List available keys
+
+```bash
+dd-autoinstrumentation generate --list-keys --json
+```
+
+Response:
+```json
+{
+  "success": true,
+  "command": "generate",
+  "data": {
+    "configurationKeys": [
+      { "key": "createDucktypeInstance", "type": "Boolean", "defaultValue": "False" },
+      { "key": "createOnMethodBegin", "type": "Boolean", "defaultValue": "True" }
+    ]
+  }
+}
+```
+
+#### Success response
+
+```json
+{
+  "success": true,
+  "fileName": "HttpClientSendAsyncIntegration",
+  "sourceCode": "// generated C# source code...",
+  "metadata": {
+    "assemblyName": "MyLib",
+    "typeName": "MyLib.HttpClient",
+    "methodName": "SendAsync",
+    "returnTypeName": "...",
+    "parameterTypeNames": "...",
+    "minimumVersion": "1.0.0",
+    "maximumVersion": "1.*.*",
+    "integrationName": "nameof(IntegrationId.MyLib)",
+    "integrationClassName": "HttpClientSendAsyncIntegration",
+    "isInterface": false
+  },
+  "configuration": {
+    "createOnMethodBegin": true,
+    "createOnAsyncMethodEnd": true
+  }
+}
+```
+
+The `sourceCode` field contains the complete, ready-to-save C# file.
+
+#### Output to file
+
+```bash
+dd-autoinstrumentation generate ... --output path/to/Integration.cs
+```
+
+Creates directories as needed. Prints confirmation to stdout.
+
+## Error Handling
+
+When `--json` is active, all errors are returned as structured JSON on stdout (not stderr):
+
+```json
+{
+  "success": false,
+  "command": "generate",
+  "errorCode": "AMBIGUOUS_OVERLOAD",
+  "errorMessage": "human-readable description",
+  "data": { }
+}
+```
+
+### Error codes and recovery
+
+| Error Code | Meaning | Recovery |
+|---|---|---|
+| `FILE_NOT_FOUND` | Assembly path doesn't exist | Fix the path |
+| `TYPE_NOT_FOUND` | Type not in assembly | Use `inspect --list-types` to find correct name |
+| `METHOD_NOT_FOUND` | Method not on type (0 overloads) | Use `inspect --list-methods` to find correct name |
+| `AMBIGUOUS_OVERLOAD` | Multiple overloads, no disambiguation | Read `data.overloads`, pick one, retry with `--overload-index` |
+| `INVALID_ARGUMENT` | Missing required args | Add missing `assembly-path`, `--type`, or `--method` |
+| `INVALID_CONFIG` | Bad JSON in `--config` or `--config-file` | Fix JSON syntax |
+| `UNKNOWN_KEY` | Bad key in `--set` | Use `--list-keys` to see valid keys |
+| `GENERATION_ERROR` | Code generation failed | Check error message for details |
+
+### AMBIGUOUS_OVERLOAD detail
+
+This is the most common error. The response includes the overload list so you can immediately retry:
+
+```json
+{
+  "success": false,
+  "command": "generate",
+  "errorCode": "AMBIGUOUS_OVERLOAD",
+  "errorMessage": "Error: Could not resolve method 'Send' on type 'MyLib.HttpClient'. Found 2 overload(s):...",
+  "data": {
+    "overloads": [
+      {
+        "index": 0,
+        "fullName": "System.Void MyLib.HttpClient::Send(System.String)",
+        "parameters": [{ "name": "url", "type": "System.String" }]
+      },
+      {
+        "index": 1,
+        "fullName": "System.Void MyLib.HttpClient::Send(System.String,System.Int32)",
+        "parameters": [
+          { "name": "url", "type": "System.String" },
+          { "name": "timeout", "type": "System.Int32" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Retry: `dd-autoinstrumentation generate ... --overload-index 0 --json`
+
+## Recommended LLM Workflow
+
+### Step 1 — Find the assembly
+
+Locate the target library's DLL. Common locations:
+- NuGet cache: `~/.nuget/packages/<name>/<version>/lib/<tfm>/<name>.dll`
+- Build output: `bin/Debug/<tfm>/`
+
+### Step 2 — Discover types
+
+```bash
+dd-autoinstrumentation inspect <dll> --list-types --json
+```
+
+Filter by `isPublic`, `isInterface`, `methodCount` to find interesting types.
+
+### Step 3 — Discover methods
+
+```bash
+dd-autoinstrumentation inspect <dll> --list-methods <type> --json
+```
+
+Look at `isAsync`, `isVirtual`, `overloadCount` to inform generation choices.
+
+### Step 4 — Generate
+
+```bash
+dd-autoinstrumentation generate <dll> -t <type> -m <method> --json [--overload-index <n>]
+```
+
+- If `overloadCount > 1` in step 3, pass `--overload-index` immediately
+- Parse `success` — if false, check `errorCode` and handle accordingly
+
+### Step 5 — Save the output
+
+Extract `sourceCode` from the JSON response and write to the correct path:
+```
+tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/<Area>/<IntegrationClassName>.cs
+```
+
+The `metadata.integrationClassName` field provides the suggested file name.
+
+### Error recovery loop
+
+```
+if errorCode == "AMBIGUOUS_OVERLOAD":
+    pick overload from data.overloads
+    retry with --overload-index
+
+if errorCode == "TYPE_NOT_FOUND":
+    run inspect --list-types, pick correct type, retry
+
+if errorCode == "METHOD_NOT_FOUND":
+    run inspect --list-methods, pick correct method, retry
+```
+
+## Configuration Precedence
+
+Applied in order (highest wins):
+
+1. **Auto-detect** from method signature (unless `--no-auto-detect`)
+2. **Base config** from `--config-file` or `--config` (replaces layer 1)
+3. **Shortcut flags** (`--no-method-begin`, `--async-method-end`, etc.)
+4. **`--set` overrides** (applied last, highest priority)

--- a/docs/development/for-ai/InstrumentationGenerator-CLI.md
+++ b/docs/development/for-ai/InstrumentationGenerator-CLI.md
@@ -212,6 +212,7 @@ When `--json` is active, all errors are returned as structured JSON on stdout (n
 | `INVALID_CONFIG` | Bad JSON in `--config` or `--config-file` | Fix JSON syntax |
 | `UNKNOWN_KEY` | Bad key in `--set` | Use `--list-keys` to see valid keys |
 | `GENERATION_ERROR` | Code generation failed | Check error message for details |
+| `BAD_ASSEMBLY` | File is not a valid .NET assembly | Verify the file is a .NET DLL (not native, not corrupted) |
 
 ### AMBIGUOUS_OVERLOAD detail
 

--- a/docs/development/for-ai/InstrumentationGenerator-CLI.md
+++ b/docs/development/for-ai/InstrumentationGenerator-CLI.md
@@ -91,7 +91,7 @@ Notes:
 - Excludes compiler-generated methods
 - Includes constructors (`.ctor`), property accessors (`get_*`, `set_*`), event accessors, and operators — CallTarget can instrument all of these
 - `overloadIndex` and `overloadCount` tell you upfront if disambiguation is needed
-- `isAsync` is true when return type starts with `System.Threading.Tasks.Task` or `System.Threading.Tasks.ValueTask`
+- `isAsync` is true when the return type is exactly `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` (not `TaskScheduler`, `TaskCompletionSource`, etc.)
 
 ### `generate` — Generate instrumentation code
 

--- a/docs/development/for-ai/InstrumentationGenerator-CLI.md
+++ b/docs/development/for-ai/InstrumentationGenerator-CLI.md
@@ -88,7 +88,8 @@ Response:
 ```
 
 Notes:
-- Excludes compiler-generated methods and special-name methods (property getters/setters, event accessors)
+- Excludes compiler-generated methods
+- Includes constructors (`.ctor`), property accessors (`get_*`, `set_*`), event accessors, and operators — CallTarget can instrument all of these
 - `overloadIndex` and `overloadCount` tell you upfront if disambiguation is needed
 - `isAsync` is true when return type starts with `System.Threading.Tasks.Task` or `System.Threading.Tasks.ValueTask`
 

--- a/docs/development/for-ai/InstrumentationGenerator-CLI.md
+++ b/docs/development/for-ai/InstrumentationGenerator-CLI.md
@@ -2,17 +2,17 @@
 
 > This document is a complete reference for AI agents using the `dd-autoinstrumentation` CLI to generate CallTarget auto-instrumentation code. It covers all commands, options, JSON schemas, error codes, and recommended workflows.
 
-## Quick Start
+## Invocation
 
 ```bash
-# Run via dotnet (from repo root)
+# From repo root
 dotnet run --project tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ --framework net10.0 -- <command> [options]
 
-# Or if installed as a global tool
+# Or, if installed as a global tool
 dd-autoinstrumentation <command> [options]
 ```
 
-Always pass `--json` for structured output. It is a global flag and can appear anywhere on the command line.
+Always pass `--json` for structured output. `--json` is a global flag and can appear anywhere on the command line.
 
 ## Commands
 
@@ -117,8 +117,9 @@ If a method has multiple overloads, you must provide one of:
 |---|---|
 | `--no-method-begin` | Skip `OnMethodBegin` handler |
 | `--no-method-end` | Skip `OnMethodEnd` handler |
-| `--async-method-end` | Generate `OnAsyncMethodEnd` handler |
 | `--no-auto-detect` | Disable smart defaults |
+
+Async methods are auto-detected: when the inspect output shows `isAsync: true`, the generator emits `OnAsyncMethodEnd` (and skips `OnMethodEnd`) without any extra flag. To force `OnAsyncMethodEnd` on a non-async method, use `--set createOnAsyncMethodEnd=true`.
 
 #### Configuration overrides
 
@@ -308,5 +309,5 @@ Applied in order (highest wins):
 
 1. **Auto-detect** from method signature (unless `--no-auto-detect`)
 2. **Base config** from `--config-file` or `--config` (replaces layer 1)
-3. **Shortcut flags** (`--no-method-begin`, `--async-method-end`, etc.)
+3. **Shortcut flags** (`--no-method-begin`, `--no-method-end`)
 4. **`--set` overrides** (applied last, highest priority)

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -205,7 +205,7 @@ partial class Build
 
            if (!string.IsNullOrEmpty(GeneratorArgs))
            {
-               appArgs.AddRange(GeneratorArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+               appArgs.AddRange(TokenizeShellArgs(GeneratorArgs));
            }
 
            var applicationArguments = string.Join(" ", appArgs.Select(a => a.Contains(' ') ? $"\"{a}\"" : a));
@@ -221,6 +221,54 @@ partial class Build
            var process = ProcessTasks.StartProcess(dotnetRunSettings);
            process.AssertZeroExitCode();
        });
+
+    /// <summary>
+    /// Splits a command-line string into tokens, respecting single and double quotes.
+    /// A naive Split(' ') corrupts values like inline JSON for --config or paths with
+    /// spaces (e.g. under "Program Files"); this honors the surrounding quotes so the
+    /// value reaches the generator intact.
+    /// </summary>
+    private static IEnumerable<string> TokenizeShellArgs(string input)
+    {
+        var current = new System.Text.StringBuilder();
+        char? quote = null;
+
+        foreach (var c in input)
+        {
+            if (quote.HasValue)
+            {
+                if (c == quote.Value)
+                {
+                    quote = null;
+                }
+                else
+                {
+                    current.Append(c);
+                }
+            }
+            else if (c == '"' || c == '\'')
+            {
+                quote = c;
+            }
+            else if (char.IsWhiteSpace(c))
+            {
+                if (current.Length > 0)
+                {
+                    yield return current.ToString();
+                    current.Clear();
+                }
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        if (current.Length > 0)
+        {
+            yield return current.ToString();
+        }
+    }
 
     Target BuildIisSampleApp => _ => _
         .Description("Rebuilds an IIS sample app")

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -119,7 +119,7 @@ partial class Build
 
            DotNetBuild(s => s
                            .SetDotnetPath(TargetPlatform)
-                           .SetFramework(TargetFramework.NET7_0)
+                           .SetFramework(TargetFramework.NET10_0)
                            .SetProjectFile(autoInstGenProj)
                            .SetConfiguration(Configuration.Release)
                            .SetNoWarnDotNetCore3());
@@ -128,11 +128,98 @@ partial class Build
            var dotnetRunSettings = new DotNetRunSettings()
                                   .SetDotnetPath(TargetPlatform)
                                   .SetNoBuild(true)
-                                  .SetFramework(TargetFramework.NET7_0)
+                                  .SetFramework(TargetFramework.NET10_0)
                                   .EnableNoLaunchProfile()
                                   .SetProjectFile(autoInstGenProj)
                                   .SetConfiguration(Configuration.Release);
            ProcessTasks.StartProcess(dotnetRunSettings);
+       });
+
+    [Parameter("Path to the assembly to generate instrumentation for")]
+    readonly string? AssemblyPath;
+
+    [Parameter("Fully qualified type name for instrumentation generation")]
+    readonly string? TypeName;
+
+    [Parameter("Method name for instrumentation generation")]
+    readonly string? MethodName;
+
+    [Parameter("Output path for the generated integration file")]
+    readonly string? OutputPath;
+
+    [Parameter("0-based overload index for method disambiguation")]
+    readonly int? OverloadIndex;
+
+    [Parameter("Parameter type full names for method disambiguation (space-separated)")]
+    readonly string? ParameterTypes;
+
+    [Parameter("Additional arguments to pass to the instrumentation generator CLI (space-separated string, e.g., '--set createDucktypeInstance=true --json')")]
+    readonly string? GeneratorArgs;
+
+    Target RunInstrumentationGeneratorCli => _ => _
+       .Description("Generates CallTarget auto-instrumentation code for a method. Usage: --assembly-path <dll> --type-name <type> --method-name <method> [--output-path <file>] [--overload-index <n>] [--generator-args <args>]")
+       .Requires(() => AssemblyPath)
+       .Requires(() => TypeName)
+       .Requires(() => MethodName)
+       .Executes(() =>
+       {
+           var autoInstGenCliProj =
+               SourceDirectory / "Datadog.AutoInstrumentation.Generator.Cli" / "Datadog.AutoInstrumentation.Generator.Cli.csproj";
+
+           DotNetRestore(s => s
+                             .SetDotnetPath(TargetPlatform)
+                             .SetProjectFile(autoInstGenCliProj)
+                             .SetNoWarnDotNetCore3());
+
+           DotNetBuild(s => s
+                           .SetDotnetPath(TargetPlatform)
+                           .SetFramework(TargetFramework.NET10_0)
+                           .SetProjectFile(autoInstGenCliProj)
+                           .SetConfiguration(Configuration.Release)
+                           .SetNoWarnDotNetCore3());
+
+           var appArgs = new List<string>
+           {
+               "generate", AssemblyPath!,
+               "--type", TypeName!,
+               "--method", MethodName!,
+           };
+
+           if (!string.IsNullOrEmpty(OutputPath))
+           {
+               appArgs.Add("--output");
+               appArgs.Add(OutputPath);
+           }
+
+           if (OverloadIndex.HasValue)
+           {
+               appArgs.Add("--overload-index");
+               appArgs.Add(OverloadIndex.Value.ToString());
+           }
+
+           if (!string.IsNullOrEmpty(ParameterTypes))
+           {
+               appArgs.Add("--parameter-types");
+               appArgs.AddRange(ParameterTypes.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+           }
+
+           if (!string.IsNullOrEmpty(GeneratorArgs))
+           {
+               appArgs.AddRange(GeneratorArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+           }
+
+           var applicationArguments = string.Join(" ", appArgs.Select(a => a.Contains(' ') ? $"\"{a}\"" : a));
+
+           var dotnetRunSettings = new DotNetRunSettings()
+                                  .SetDotnetPath(TargetPlatform)
+                                  .SetNoBuild(true)
+                                  .SetFramework(TargetFramework.NET10_0)
+                                  .EnableNoLaunchProfile()
+                                  .SetProjectFile(autoInstGenCliProj)
+                                  .SetConfiguration(Configuration.Release)
+                                  .SetApplicationArguments(applicationArguments);
+           var process = ProcessTasks.StartProcess(dotnetRunSettings);
+           process.AssertZeroExitCode();
        });
 
     Target BuildIisSampleApp => _ => _

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -208,7 +208,7 @@ partial class Build
                appArgs.AddRange(TokenizeShellArgs(GeneratorArgs));
            }
 
-           var applicationArguments = string.Join(" ", appArgs.Select(a => a.Contains(' ') ? $"\"{a}\"" : a));
+           var applicationArguments = string.Join(" ", appArgs.Select(EscapeArgForCommandLine));
 
            var dotnetRunSettings = new DotNetRunSettings()
                                   .SetDotnetPath(TargetPlatform)
@@ -221,6 +221,53 @@ partial class Build
            var process = ProcessTasks.StartProcess(dotnetRunSettings);
            process.AssertZeroExitCode();
        });
+
+    /// <summary>
+    /// Escapes a single argument so the receiving process recovers the original value via
+    /// CommandLineToArgvW rules. Naive double-quote wrapping mishandles embedded quotes and
+    /// trailing backslashes, which corrupts inline JSON for --config and paths that end in
+    /// "\". Algorithm follows the standard PasteArguments approach used in .NET's
+    /// ProcessStartInfo.ArgumentList.
+    /// </summary>
+    private static string EscapeArgForCommandLine(string arg)
+    {
+        if (arg.Length > 0
+            && arg.IndexOf(' ') < 0
+            && arg.IndexOf('\t') < 0
+            && arg.IndexOf('"') < 0
+            && arg.IndexOf('\\') < 0)
+        {
+            return arg;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        sb.Append('"');
+
+        var backslashes = 0;
+        foreach (var c in arg)
+        {
+            if (c == '\\')
+            {
+                backslashes++;
+            }
+            else if (c == '"')
+            {
+                sb.Append('\\', (backslashes * 2) + 1);
+                sb.Append('"');
+                backslashes = 0;
+            }
+            else
+            {
+                sb.Append('\\', backslashes);
+                sb.Append(c);
+                backslashes = 0;
+            }
+        }
+
+        sb.Append('\\', backslashes * 2);
+        sb.Append('"');
+        return sb.ToString();
+    }
 
     /// <summary>
     /// Splits a command-line string into tokens, respecting single and double quotes.

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -139,22 +139,22 @@ partial class Build
     readonly string AssemblyPath;
 
     [Parameter("Fully qualified type name for instrumentation generation")]
-    readonly string? TypeName;
+    readonly string TypeName;
 
     [Parameter("Method name for instrumentation generation")]
-    readonly string? MethodName;
+    readonly string MethodName;
 
     [Parameter("Output path for the generated integration file")]
-    readonly string? OutputPath;
+    readonly string OutputPath;
 
     [Parameter("0-based overload index for method disambiguation")]
     readonly int? OverloadIndex;
 
     [Parameter("Parameter type full names for method disambiguation (space-separated)")]
-    readonly string? ParameterTypes;
+    readonly string ParameterTypes;
 
     [Parameter("Additional arguments to pass to the instrumentation generator CLI (space-separated string, e.g., '--set createDucktypeInstance=true --json')")]
-    readonly string? GeneratorArgs;
+    readonly string GeneratorArgs;
 
     Target RunInstrumentationGeneratorCli => _ => _
        .Description("Generates CallTarget auto-instrumentation code for a method. Usage: --assembly-path <dll> --type-name <type> --method-name <method> [--output-path <file>] [--overload-index <n>] [--generator-args <args>]")

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -136,7 +136,7 @@ partial class Build
        });
 
     [Parameter("Path to the assembly to generate instrumentation for")]
-    readonly string? AssemblyPath;
+    readonly string AssemblyPath;
 
     [Parameter("Fully qualified type name for instrumentation generation")]
     readonly string? TypeName;

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -1,0 +1,300 @@
+// <copyright file="GenerateCommand.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.CommandLine;
+using System.IO;
+using System.Text.Json;
+using Datadog.AutoInstrumentation.Generator.Cli.Output;
+using Datadog.AutoInstrumentation.Generator.Core;
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Commands;
+
+internal class GenerateCommand : Command
+{
+    private static readonly JsonSerializerOptions ConfigDeserializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    // Arguments (validated in handler to allow --list-keys without them)
+    private readonly Argument<FileInfo?> _assemblyPathArg = new("assembly-path") { Arity = ArgumentArity.ZeroOrOne, Description = "Path to the .NET assembly (.dll) file" };
+
+    // Options (validated in handler to allow --list-keys without them)
+    private readonly Option<string?> _typeOption = new("--type") { Description = "Fully qualified type name (e.g., MyLib.MyClass)" };
+    private readonly Option<string?> _methodOption = new("--method") { Description = "Method name to instrument" };
+
+    // Method resolution
+    private readonly Option<string[]?> _parameterTypesOption = new("--parameter-types") { Description = "Parameter type full names for overload disambiguation" };
+    private readonly Option<int?> _overloadIndexOption = new("--overload-index") { Description = "0-based overload index for disambiguation" };
+
+    // Shortcut flags (3 most common toggles)
+    private readonly Option<bool> _noMethodBeginOption = new("--no-method-begin") { Description = "Skip OnMethodBegin handler generation" };
+    private readonly Option<bool> _noMethodEndOption = new("--no-method-end") { Description = "Skip OnMethodEnd handler generation" };
+    private readonly Option<bool> _asyncMethodEndOption = new("--async-method-end") { Description = "Generate OnAsyncMethodEnd handler" };
+
+    // Configuration mechanisms
+    private readonly Option<string?> _configOption = new("--config") { Description = "Inline JSON configuration object (accepts the 'configuration' block from --json output). Mutually exclusive with --config-file." };
+    private readonly Option<FileInfo?> _configFileOption = new("--config-file") { Description = "Path to a JSON configuration file. Accepts the 'configuration' block or full --json output envelope. Mutually exclusive with --config." };
+    private readonly Option<string[]> _setOption = new("--set") { Description = "Set a configuration key (repeatable, e.g., --set createDucktypeInstance=true). Use --list-keys to see available keys.", AllowMultipleArgumentsPerToken = true };
+    private readonly Option<bool> _listKeysOption = new("--list-keys") { Description = "Print available configuration keys with their default values and exit" };
+
+    // Output flags
+    private readonly Option<bool> _jsonOption = new("--json") { Description = "Output structured JSON instead of source code" };
+    private readonly Option<FileInfo?> _outputOption = new("--output") { Description = "Write output to file instead of stdout" };
+
+    // Auto-detect flag
+    private readonly Option<bool> _noAutoDetectOption = new("--no-auto-detect") { Description = "Disable smart defaults (async detection, static method handling)" };
+
+    public GenerateCommand()
+        : base("generate", "Generate CallTarget auto-instrumentation code for a method")
+    {
+        _typeOption.Aliases.Add("-t");
+        _methodOption.Aliases.Add("-m");
+        _outputOption.Aliases.Add("-o");
+
+        Add(_assemblyPathArg);
+        Add(_typeOption);
+        Add(_methodOption);
+        Add(_parameterTypesOption);
+        Add(_overloadIndexOption);
+        Add(_noMethodBeginOption);
+        Add(_noMethodEndOption);
+        Add(_asyncMethodEndOption);
+        Add(_configOption);
+        Add(_configFileOption);
+        Add(_setOption);
+        Add(_listKeysOption);
+        Add(_jsonOption);
+        Add(_outputOption);
+        Add(_noAutoDetectOption);
+
+        SetAction(Execute);
+    }
+
+    private static (GenerationConfiguration? Config, string? Error) LoadConfigFile(FileInfo configFile)
+    {
+        if (!configFile.Exists)
+        {
+            return (null, $"Error: Config file not found: {configFile.FullName}");
+        }
+
+        string fileContent;
+        try
+        {
+            fileContent = File.ReadAllText(configFile.FullName);
+        }
+        catch (Exception ex)
+        {
+            return (null, $"Error: Could not read config file: {ex.Message}");
+        }
+
+        try
+        {
+            // Try to parse as full --json output envelope (has "configuration" property)
+            using var doc = JsonDocument.Parse(fileContent);
+            if (doc.RootElement.TryGetProperty("configuration", out var configElement))
+            {
+                var config = JsonSerializer.Deserialize<GenerationConfiguration>(configElement.GetRawText(), ConfigDeserializerOptions)
+                             ?? new GenerationConfiguration();
+                return (config, null);
+            }
+
+            // Otherwise treat as a bare configuration object
+            var bareConfig = JsonSerializer.Deserialize<GenerationConfiguration>(fileContent, ConfigDeserializerOptions)
+                             ?? new GenerationConfiguration();
+            return (bareConfig, null);
+        }
+        catch (JsonException ex)
+        {
+            return (null, $"Error: Invalid JSON in config file '{configFile.Name}': {ex.Message}");
+        }
+    }
+
+    private static void PrintAvailableKeys()
+    {
+        Console.WriteLine("Available configuration keys for --set (camelCase, same as --json output):");
+        Console.WriteLine();
+        Console.WriteLine("  {0,-45} {1,-10} {2}", "Key", "Type", "Default");
+        Console.WriteLine("  {0,-45} {1,-10} {2}", new string('-', 45), new string('-', 10), new string('-', 7));
+
+        foreach (var (key, typeName, defaultValue) in ConfigurationApplier.GetAvailableKeys())
+        {
+            Console.WriteLine("  {0,-45} {1,-10} {2}", key, typeName, defaultValue);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Usage: --set key=value (repeatable)");
+        Console.WriteLine("Example: --set createDucktypeInstance=true --set ducktypeInstanceMethods=true");
+    }
+
+    private int Execute(ParseResult parseResult)
+    {
+        // Handle --list-keys: print and exit (no assembly/type/method required)
+        if (parseResult.GetValue(_listKeysOption))
+        {
+            PrintAvailableKeys();
+            return 0;
+        }
+
+        var assemblyPath = parseResult.GetValue(_assemblyPathArg);
+        var type = parseResult.GetValue(_typeOption);
+        var method = parseResult.GetValue(_methodOption);
+
+        if (assemblyPath is null || type is null || method is null)
+        {
+            Console.Error.WriteLine("Error: assembly-path, --type, and --method are required (unless using --list-keys).");
+            return 1;
+        }
+
+        if (!assemblyPath.Exists)
+        {
+            Console.Error.WriteLine($"Error: Assembly file not found: {assemblyPath.FullName}");
+            return 1;
+        }
+
+        // Validate mutual exclusivity of --config and --config-file
+        var configJson = parseResult.GetValue(_configOption);
+        var configFile = parseResult.GetValue(_configFileOption);
+        if (configJson is not null && configFile is not null)
+        {
+            Console.Error.WriteLine("Error: --config and --config-file are mutually exclusive. Use one or the other.");
+            return 1;
+        }
+
+        using var browser = new AssemblyBrowser(assemblyPath.FullName);
+        var methodDef = browser.ResolveMethod(
+            type,
+            method,
+            parseResult.GetValue(_parameterTypesOption),
+            parseResult.GetValue(_overloadIndexOption));
+
+        if (methodDef is null)
+        {
+            var overloads = browser.ListOverloads(type, method);
+            if (overloads.Count == 0)
+            {
+                Console.Error.WriteLine($"Error: Method '{method}' not found on type '{type}' in assembly '{assemblyPath.Name}'.");
+            }
+            else
+            {
+                Console.Error.WriteLine($"Error: Could not resolve method '{method}' on type '{type}'. Found {overloads.Count} overload(s):");
+                for (var i = 0; i < overloads.Count; i++)
+                {
+                    Console.Error.WriteLine($"  [{i}] {overloads[i].FullName}");
+                }
+
+                Console.Error.WriteLine("Use --parameter-types or --overload-index to disambiguate.");
+            }
+
+            return 1;
+        }
+
+        // Step 1: Start with auto-detect or blank config
+        GenerationConfiguration config;
+        if (parseResult.GetValue(_noAutoDetectOption))
+        {
+            config = new GenerationConfiguration();
+        }
+        else
+        {
+            config = GenerationConfiguration.CreateForMethod(methodDef);
+        }
+
+        // Step 2: Apply base config from --config-file or --config (replaces layer 1)
+        if (configFile is not null)
+        {
+            var loadResult = LoadConfigFile(configFile);
+            if (loadResult.Error is not null)
+            {
+                Console.Error.WriteLine(loadResult.Error);
+                return 1;
+            }
+
+            config = loadResult.Config!;
+        }
+        else if (configJson is not null)
+        {
+            try
+            {
+                config = JsonSerializer.Deserialize<GenerationConfiguration>(configJson, ConfigDeserializerOptions)
+                         ?? new GenerationConfiguration();
+            }
+            catch (JsonException ex)
+            {
+                Console.Error.WriteLine($"Error: Invalid --config JSON: {ex.Message}");
+                return 1;
+            }
+        }
+
+        // Step 3: Apply shortcut flags
+        if (parseResult.GetValue(_noMethodBeginOption))
+        {
+            config.CreateOnMethodBegin = false;
+        }
+
+        if (parseResult.GetValue(_noMethodEndOption))
+        {
+            config.CreateOnMethodEnd = false;
+        }
+
+        if (parseResult.GetValue(_asyncMethodEndOption))
+        {
+            config.CreateOnAsyncMethodEnd = true;
+        }
+
+        // Step 4: Apply --set overrides
+        var setValues = parseResult.GetValue(_setOption);
+        if (setValues is { Length: > 0 })
+        {
+            var error = ConfigurationApplier.ApplyOverrides(config, setValues);
+            if (error is not null)
+            {
+                Console.Error.WriteLine(error);
+                return 1;
+            }
+        }
+
+        // Step 5: Generate and output
+        var generator = new InstrumentationGenerator();
+        var result = generator.Generate(methodDef, config);
+
+        string outputText;
+        var json = parseResult.GetValue(_jsonOption);
+        if (json)
+        {
+            outputText = JsonOutputFormatter.Format(result, config);
+        }
+        else if (result.Success)
+        {
+            outputText = result.SourceCode!;
+        }
+        else
+        {
+            Console.Error.WriteLine($"Error: {result.ErrorMessage}");
+            return 1;
+        }
+
+        var output = parseResult.GetValue(_outputOption);
+        if (output is not null)
+        {
+            var dir = output.Directory;
+            if (dir is not null && !dir.Exists)
+            {
+                dir.Create();
+            }
+
+            File.WriteAllText(output.FullName, outputText);
+            Console.WriteLine($"Output written to: {output.FullName}");
+        }
+        else
+        {
+            Console.Write(outputText);
+        }
+
+        return 0;
+    }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -29,7 +29,7 @@ internal class GenerateCommand : Command
     private readonly Option<string?> _methodOption = new("--method") { Description = "Method name to instrument" };
 
     // Method resolution
-    private readonly Option<string[]?> _parameterTypesOption = new("--parameter-types") { Description = "Parameter type full names for overload disambiguation" };
+    private readonly Option<string[]?> _parameterTypesOption = new("--parameter-types") { Description = "Parameter type full names for overload disambiguation (space-separated, e.g., --parameter-types System.String System.Int32)", AllowMultipleArgumentsPerToken = true };
     private readonly Option<int?> _overloadIndexOption = new("--overload-index") { Description = "0-based overload index for disambiguation" };
 
     // Shortcut flags (most common toggles); async detection is automatic via auto-detect.

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -186,7 +186,21 @@ internal class GenerateCommand : Command
                 "Error: --config and --config-file are mutually exclusive. Use one or the other.");
         }
 
-        using var browser = new AssemblyBrowser(assemblyPath.FullName);
+        AssemblyBrowser browser;
+        try
+        {
+            browser = new AssemblyBrowser(assemblyPath.FullName);
+        }
+        catch (Exception ex)
+        {
+            return OutputHelper.WriteError(
+                jsonMode,
+                "generate",
+                ErrorCodes.BadAssembly,
+                $"Error: Failed to load assembly '{assemblyPath.Name}': {ex.Message}");
+        }
+
+        using var disposableBrowser = browser;
         var methodDef = browser.ResolveMethod(
             type,
             method,

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -326,16 +326,7 @@ internal class GenerateCommand : Command
         var generator = new InstrumentationGenerator();
         var result = generator.Generate(methodDef, config);
 
-        string outputText;
-        if (jsonMode)
-        {
-            outputText = JsonOutputFormatter.Format(result, config);
-        }
-        else if (result.Success)
-        {
-            outputText = result.SourceCode!;
-        }
-        else
+        if (!result.Success)
         {
             return OutputHelper.WriteError(
                 jsonMode,
@@ -343,6 +334,10 @@ internal class GenerateCommand : Command
                 ErrorCodes.GenerationError,
                 $"Error: {result.ErrorMessage}");
         }
+
+        var outputText = jsonMode
+            ? JsonOutputFormatter.Format(result, config)
+            : result.SourceCode!;
 
         var output = parseResult.GetValue(_outputOption);
         if (output is not null)

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -6,6 +6,7 @@
 using System;
 using System.CommandLine;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using Datadog.AutoInstrumentation.Generator.Cli.Output;
 using Datadog.AutoInstrumentation.Generator.Core;
@@ -43,15 +44,17 @@ internal class GenerateCommand : Command
     private readonly Option<bool> _listKeysOption = new("--list-keys") { Description = "Print available configuration keys with their default values and exit" };
 
     // Output flags
-    private readonly Option<bool> _jsonOption = new("--json") { Description = "Output structured JSON instead of source code" };
+    private readonly Option<bool> _jsonOption;
     private readonly Option<FileInfo?> _outputOption = new("--output") { Description = "Write output to file instead of stdout" };
 
     // Auto-detect flag
     private readonly Option<bool> _noAutoDetectOption = new("--no-auto-detect") { Description = "Disable smart defaults (async detection, static method handling)" };
 
-    public GenerateCommand()
+    public GenerateCommand(Option<bool> jsonOption)
         : base("generate", "Generate CallTarget auto-instrumentation code for a method")
     {
+        _jsonOption = jsonOption;
+
         _typeOption.Aliases.Add("-t");
         _methodOption.Aliases.Add("-m");
         _outputOption.Aliases.Add("-o");
@@ -68,7 +71,6 @@ internal class GenerateCommand : Command
         Add(_configFileOption);
         Add(_setOption);
         Add(_listKeysOption);
-        Add(_jsonOption);
         Add(_outputOption);
         Add(_noAutoDetectOption);
 
@@ -133,9 +135,19 @@ internal class GenerateCommand : Command
 
     private int Execute(ParseResult parseResult)
     {
+        var jsonMode = parseResult.GetValue(_jsonOption);
+
         // Handle --list-keys: print and exit (no assembly/type/method required)
         if (parseResult.GetValue(_listKeysOption))
         {
+            if (jsonMode)
+            {
+                var keys = ConfigurationApplier.GetAvailableKeys()
+                    .Select(k => new { key = k.Key, type = k.Type, defaultValue = k.DefaultValue?.ToString() })
+                    .ToList();
+                return OutputHelper.WriteSuccess(true, "generate", new { configurationKeys = keys });
+            }
+
             PrintAvailableKeys();
             return 0;
         }
@@ -146,14 +158,20 @@ internal class GenerateCommand : Command
 
         if (assemblyPath is null || type is null || method is null)
         {
-            Console.Error.WriteLine("Error: assembly-path, --type, and --method are required (unless using --list-keys).");
-            return 1;
+            return OutputHelper.WriteError(
+                jsonMode,
+                "generate",
+                ErrorCodes.InvalidArgument,
+                "Error: assembly-path, --type, and --method are required (unless using --list-keys).");
         }
 
         if (!assemblyPath.Exists)
         {
-            Console.Error.WriteLine($"Error: Assembly file not found: {assemblyPath.FullName}");
-            return 1;
+            return OutputHelper.WriteError(
+                jsonMode,
+                "generate",
+                ErrorCodes.FileNotFound,
+                $"Error: Assembly file not found: {assemblyPath.FullName}");
         }
 
         // Validate mutual exclusivity of --config and --config-file
@@ -161,8 +179,11 @@ internal class GenerateCommand : Command
         var configFile = parseResult.GetValue(_configFileOption);
         if (configJson is not null && configFile is not null)
         {
-            Console.Error.WriteLine("Error: --config and --config-file are mutually exclusive. Use one or the other.");
-            return 1;
+            return OutputHelper.WriteError(
+                jsonMode,
+                "generate",
+                ErrorCodes.InvalidArgument,
+                "Error: --config and --config-file are mutually exclusive. Use one or the other.");
         }
 
         using var browser = new AssemblyBrowser(assemblyPath.FullName);
@@ -177,20 +198,33 @@ internal class GenerateCommand : Command
             var overloads = browser.ListOverloads(type, method);
             if (overloads.Count == 0)
             {
-                Console.Error.WriteLine($"Error: Method '{method}' not found on type '{type}' in assembly '{assemblyPath.Name}'.");
+                return OutputHelper.WriteError(
+                    jsonMode,
+                    "generate",
+                    ErrorCodes.MethodNotFound,
+                    $"Error: Method '{method}' not found on type '{type}' in assembly '{assemblyPath.Name}'.");
             }
-            else
+
+            var overloadData = overloads.Select((o, i) => new
             {
-                Console.Error.WriteLine($"Error: Could not resolve method '{method}' on type '{type}'. Found {overloads.Count} overload(s):");
-                for (var i = 0; i < overloads.Count; i++)
-                {
-                    Console.Error.WriteLine($"  [{i}] {overloads[i].FullName}");
-                }
+                index = i,
+                fullName = o.FullName,
+                parameters = o.Parameters
+                    .Where(p => !p.IsHiddenThisParameter)
+                    .Select(p => new { name = p.Name, type = p.Type.FullName })
+                    .ToList(),
+            }).ToList();
 
-                Console.Error.WriteLine("Use --parameter-types or --overload-index to disambiguate.");
-            }
+            var message = $"Error: Could not resolve method '{method}' on type '{type}'. Found {overloads.Count} overload(s):\n"
+                + string.Join("\n", overloads.Select((o, i) => $"  [{i}] {o.FullName}"))
+                + "\nUse --parameter-types or --overload-index to disambiguate.";
 
-            return 1;
+            return OutputHelper.WriteError(
+                jsonMode,
+                "generate",
+                ErrorCodes.AmbiguousOverload,
+                message,
+                new { overloads = overloadData });
         }
 
         // Step 1: Start with auto-detect or blank config
@@ -210,8 +244,11 @@ internal class GenerateCommand : Command
             var loadResult = LoadConfigFile(configFile);
             if (loadResult.Error is not null)
             {
-                Console.Error.WriteLine(loadResult.Error);
-                return 1;
+                return OutputHelper.WriteError(
+                    jsonMode,
+                    "generate",
+                    ErrorCodes.InvalidConfig,
+                    loadResult.Error);
             }
 
             config = loadResult.Config!;
@@ -225,8 +262,11 @@ internal class GenerateCommand : Command
             }
             catch (JsonException ex)
             {
-                Console.Error.WriteLine($"Error: Invalid --config JSON: {ex.Message}");
-                return 1;
+                return OutputHelper.WriteError(
+                    jsonMode,
+                    "generate",
+                    ErrorCodes.InvalidConfig,
+                    $"Error: Invalid --config JSON: {ex.Message}");
             }
         }
 
@@ -253,8 +293,11 @@ internal class GenerateCommand : Command
             var error = ConfigurationApplier.ApplyOverrides(config, setValues);
             if (error is not null)
             {
-                Console.Error.WriteLine(error);
-                return 1;
+                return OutputHelper.WriteError(
+                    jsonMode,
+                    "generate",
+                    ErrorCodes.UnknownKey,
+                    error);
             }
         }
 
@@ -263,8 +306,7 @@ internal class GenerateCommand : Command
         var result = generator.Generate(methodDef, config);
 
         string outputText;
-        var json = parseResult.GetValue(_jsonOption);
-        if (json)
+        if (jsonMode)
         {
             outputText = JsonOutputFormatter.Format(result, config);
         }
@@ -274,8 +316,11 @@ internal class GenerateCommand : Command
         }
         else
         {
-            Console.Error.WriteLine($"Error: {result.ErrorMessage}");
-            return 1;
+            return OutputHelper.WriteError(
+                jsonMode,
+                "generate",
+                ErrorCodes.GenerationError,
+                $"Error: {result.ErrorMessage}");
         }
 
         var output = parseResult.GetValue(_outputOption);

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -221,6 +221,15 @@ internal class GenerateCommand : Command
 
         if (methodDef is null)
         {
+            if (!browser.TypeExists(type))
+            {
+                return OutputHelper.WriteError(
+                    jsonMode,
+                    "generate",
+                    ErrorCodes.TypeNotFound,
+                    $"Error: Type '{type}' not found in assembly '{assemblyPath.Name}'. Use `inspect --list-types` to discover types.");
+            }
+
             var overloads = browser.ListOverloads(type, method);
             if (overloads.Count == 0)
             {

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -32,10 +32,9 @@ internal class GenerateCommand : Command
     private readonly Option<string[]?> _parameterTypesOption = new("--parameter-types") { Description = "Parameter type full names for overload disambiguation" };
     private readonly Option<int?> _overloadIndexOption = new("--overload-index") { Description = "0-based overload index for disambiguation" };
 
-    // Shortcut flags (3 most common toggles)
+    // Shortcut flags (most common toggles); async detection is automatic via auto-detect.
     private readonly Option<bool> _noMethodBeginOption = new("--no-method-begin") { Description = "Skip OnMethodBegin handler generation" };
     private readonly Option<bool> _noMethodEndOption = new("--no-method-end") { Description = "Skip OnMethodEnd handler generation" };
-    private readonly Option<bool> _asyncMethodEndOption = new("--async-method-end") { Description = "Generate OnAsyncMethodEnd handler" };
 
     // Configuration mechanisms
     private readonly Option<string?> _configOption = new("--config") { Description = "Inline JSON configuration object (accepts the 'configuration' block from --json output). Mutually exclusive with --config-file." };
@@ -66,7 +65,6 @@ internal class GenerateCommand : Command
         Add(_overloadIndexOption);
         Add(_noMethodBeginOption);
         Add(_noMethodEndOption);
-        Add(_asyncMethodEndOption);
         Add(_configOption);
         Add(_configFileOption);
         Add(_setOption);
@@ -118,14 +116,28 @@ internal class GenerateCommand : Command
 
     private static void PrintAvailableKeys()
     {
+        var rows = ConfigurationApplier.GetAvailableKeys()
+            .Select(k => (Key: k.Key, Type: k.Type, Default: k.DefaultValue?.ToString() ?? string.Empty))
+            .ToList();
+
+        const string keyHeader = "Key";
+        const string typeHeader = "Type";
+        const string defaultHeader = "Default";
+
+        var keyWidth = Math.Max(keyHeader.Length, rows.Max(r => r.Key.Length));
+        var typeWidth = Math.Max(typeHeader.Length, rows.Max(r => r.Type.Length));
+        var defaultWidth = Math.Max(defaultHeader.Length, rows.Max(r => r.Default.Length));
+
+        var format = $"  {{0,-{keyWidth}}} {{1,-{typeWidth}}} {{2,-{defaultWidth}}}";
+
         Console.WriteLine("Available configuration keys for --set (camelCase, same as --json output):");
         Console.WriteLine();
-        Console.WriteLine("  {0,-45} {1,-10} {2}", "Key", "Type", "Default");
-        Console.WriteLine("  {0,-45} {1,-10} {2}", new string('-', 45), new string('-', 10), new string('-', 7));
+        Console.WriteLine(format, keyHeader, typeHeader, defaultHeader);
+        Console.WriteLine(format, new string('-', keyWidth), new string('-', typeWidth), new string('-', defaultWidth));
 
-        foreach (var (key, typeName, defaultValue) in ConfigurationApplier.GetAvailableKeys())
+        foreach (var row in rows)
         {
-            Console.WriteLine("  {0,-45} {1,-10} {2}", key, typeName, defaultValue);
+            Console.WriteLine(format, row.Key, row.Type, row.Default);
         }
 
         Console.WriteLine();
@@ -293,11 +305,6 @@ internal class GenerateCommand : Command
         if (parseResult.GetValue(_noMethodEndOption))
         {
             config.CreateOnMethodEnd = false;
-        }
-
-        if (parseResult.GetValue(_asyncMethodEndOption))
-        {
-            config.CreateOnAsyncMethodEnd = true;
         }
 
         // Step 4: Apply --set overrides

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/GenerateCommand.cs
@@ -349,7 +349,18 @@ internal class GenerateCommand : Command
             }
 
             File.WriteAllText(output.FullName, outputText);
-            Console.WriteLine($"Output written to: {output.FullName}");
+
+            // In JSON mode, stdout must remain a structured envelope (the same one written
+            // to the file) so callers honoring the --json contract can parse it. In plain
+            // mode, a human-readable confirmation is more useful.
+            if (jsonMode)
+            {
+                Console.Write(outputText);
+            }
+            else
+            {
+                Console.WriteLine($"Output written to: {output.FullName}");
+            }
         }
         else
         {

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
@@ -100,8 +100,7 @@ internal class InspectCommand : Command
                 })
                 .ToList();
 
-            var isAsync = method.ReturnType.FullName.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal)
-                       || method.ReturnType.FullName.StartsWith("System.Threading.Tasks.ValueTask", StringComparison.Ordinal);
+            var isAsync = GenerationConfiguration.IsAsyncReturnType(method.ReturnType.FullName);
 
             dtos.Add(new MethodInfoDto
             {

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
@@ -1,0 +1,180 @@
+// <copyright file="InspectCommand.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.IO;
+using System.Linq;
+using Datadog.AutoInstrumentation.Generator.Cli.Output;
+using Datadog.AutoInstrumentation.Generator.Core;
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Commands;
+
+internal class InspectCommand : Command
+{
+    private readonly Argument<FileInfo?> _assemblyPathArg = new("assembly-path") { Arity = ArgumentArity.ExactlyOne, Description = "Path to the .NET assembly (.dll) file" };
+    private readonly Option<bool> _listTypesOption = new("--list-types") { Description = "List all non-compiler-generated types in the assembly" };
+    private readonly Option<string?> _listMethodsOption = new("--list-methods") { Description = "List all instrumentable methods on the specified type" };
+    private readonly Option<bool> _jsonOption;
+
+    public InspectCommand(Option<bool> jsonOption)
+        : base("inspect", "Inspect an assembly to discover types and methods for instrumentation")
+    {
+        _jsonOption = jsonOption;
+
+        Add(_assemblyPathArg);
+        Add(_listTypesOption);
+        Add(_listMethodsOption);
+
+        SetAction(Execute);
+    }
+
+    private static int ExecuteListTypes(AssemblyBrowser browser, bool jsonMode)
+    {
+        var types = browser.ListTypes();
+        var dtos = types.Select(t => new TypeInfoDto
+        {
+            FullName = t.FullName,
+            Namespace = t.Namespace?.String ?? string.Empty,
+            Name = t.Name.String,
+            IsPublic = t.IsPublic || t.IsNestedPublic,
+            IsInterface = t.IsInterface,
+            IsAbstract = t.IsAbstract && !t.IsInterface,
+            IsSealed = t.IsSealed,
+            IsValueType = t.IsValueType,
+            MethodCount = t.Methods.Count,
+            NestedTypes = t.NestedTypes.Count,
+        }).ToList();
+
+        if (jsonMode)
+        {
+            return OutputHelper.WriteSuccess(true, "inspect", new { types = dtos });
+        }
+
+        Console.WriteLine($"{"Type",-60} {"Vis",-7} {"Kind",-12} {"Methods",7}");
+        Console.WriteLine($"{new string('-', 60)} {new string('-', 7)} {new string('-', 12)} {new string('-', 7)}");
+        foreach (var dto in dtos)
+        {
+            var vis = dto.IsPublic ? "public" : "non-pub";
+            var kind = dto.IsInterface ? "interface"
+                : dto.IsValueType ? "struct"
+                : dto.IsAbstract ? "abstract"
+                : dto.IsSealed ? "sealed"
+                : "class";
+            Console.WriteLine($"{dto.FullName,-60} {vis,-7} {kind,-12} {dto.MethodCount,7}");
+        }
+
+        return 0;
+    }
+
+    private static int ExecuteListMethods(AssemblyBrowser browser, string typeFullName, bool jsonMode)
+    {
+        var methods = browser.ListMethods(typeFullName);
+        if (methods.Count == 0)
+        {
+            return OutputHelper.WriteError(
+                jsonMode,
+                "inspect",
+                ErrorCodes.TypeNotFound,
+                $"Error: Type '{typeFullName}' not found or has no instrumentable methods.");
+        }
+
+        // Group by name to compute overload indices
+        var byName = methods.GroupBy(m => m.Name.String).ToDictionary(g => g.Key, g => g.ToList());
+
+        var dtos = new List<MethodInfoDto>();
+        foreach (var method in methods)
+        {
+            var group = byName[method.Name.String];
+            var overloadIndex = group.IndexOf(method);
+            var parameters = method.Parameters
+                .Where(p => !p.IsHiddenThisParameter)
+                .Select((p, i) => new ParameterInfoDto
+                {
+                    Name = p.Name ?? $"arg{i}",
+                    Type = p.Type.FullName,
+                    Index = i,
+                })
+                .ToList();
+
+            var isAsync = method.ReturnType.FullName.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal)
+                       || method.ReturnType.FullName.StartsWith("System.Threading.Tasks.ValueTask", StringComparison.Ordinal);
+
+            dtos.Add(new MethodInfoDto
+            {
+                Name = method.Name.String,
+                FullName = method.FullName,
+                ReturnType = method.ReturnType.FullName,
+                IsPublic = method.IsPublic,
+                IsStatic = method.IsStatic,
+                IsVirtual = method.IsVirtual,
+                IsAsync = isAsync,
+                Parameters = parameters,
+                OverloadIndex = overloadIndex,
+                OverloadCount = group.Count,
+            });
+        }
+
+        if (jsonMode)
+        {
+            return OutputHelper.WriteSuccess(true, "inspect", new { type = typeFullName, methods = dtos });
+        }
+
+        Console.WriteLine($"Methods on {typeFullName}:");
+        Console.WriteLine();
+        foreach (var dto in dtos)
+        {
+            var overloadHint = dto.OverloadCount > 1 ? $" [overload {dto.OverloadIndex}/{dto.OverloadCount}]" : string.Empty;
+            var modifiers = string.Join(" ", new[]
+            {
+                dto.IsPublic ? "public" : "non-public",
+                dto.IsStatic ? "static" : null,
+                dto.IsVirtual ? "virtual" : null,
+                dto.IsAsync ? "async" : null,
+            }.Where(s => s is not null));
+
+            var paramList = string.Join(", ", dto.Parameters.Select(p => $"{p.Type} {p.Name}"));
+            Console.WriteLine($"  {dto.ReturnType} {dto.Name}({paramList})  [{modifiers}]{overloadHint}");
+        }
+
+        return 0;
+    }
+
+    private int Execute(ParseResult parseResult)
+    {
+        var jsonMode = parseResult.GetValue(_jsonOption);
+        var assemblyPath = parseResult.GetValue(_assemblyPathArg);
+        var listTypes = parseResult.GetValue(_listTypesOption);
+        var listMethods = parseResult.GetValue(_listMethodsOption);
+
+        if (!listTypes && listMethods is null)
+        {
+            return OutputHelper.WriteError(
+                jsonMode,
+                "inspect",
+                ErrorCodes.InvalidArgument,
+                "Error: Specify --list-types or --list-methods <type>.");
+        }
+
+        if (assemblyPath is null || !assemblyPath.Exists)
+        {
+            return OutputHelper.WriteError(
+                jsonMode,
+                "inspect",
+                ErrorCodes.FileNotFound,
+                $"Error: Assembly file not found: {assemblyPath?.FullName ?? "<not specified>"}");
+        }
+
+        using var browser = new AssemblyBrowser(assemblyPath.FullName);
+
+        if (listTypes)
+        {
+            return ExecuteListTypes(browser, jsonMode);
+        }
+
+        return ExecuteListMethods(browser, listMethods!, jsonMode);
+    }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
@@ -168,7 +168,21 @@ internal class InspectCommand : Command
                 $"Error: Assembly file not found: {assemblyPath?.FullName ?? "<not specified>"}");
         }
 
-        using var browser = new AssemblyBrowser(assemblyPath.FullName);
+        AssemblyBrowser browser;
+        try
+        {
+            browser = new AssemblyBrowser(assemblyPath.FullName);
+        }
+        catch (Exception ex)
+        {
+            return OutputHelper.WriteError(
+                jsonMode,
+                "inspect",
+                ErrorCodes.BadAssembly,
+                $"Error: Failed to load assembly '{assemblyPath.Name}': {ex.Message}");
+        }
+
+        using var disposableBrowser = browser;
 
         if (listTypes)
         {

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Commands/InspectCommand.cs
@@ -75,11 +75,20 @@ internal class InspectCommand : Command
         var methods = browser.ListMethods(typeFullName);
         if (methods.Count == 0)
         {
+            if (browser.TypeExists(typeFullName))
+            {
+                return OutputHelper.WriteSuccess(
+                    jsonMode,
+                    "inspect",
+                    new { type = typeFullName, methods = Array.Empty<MethodInfoDto>() },
+                    $"No instrumentable methods on {typeFullName}.{Environment.NewLine}");
+            }
+
             return OutputHelper.WriteError(
                 jsonMode,
                 "inspect",
                 ErrorCodes.TypeNotFound,
-                $"Error: Type '{typeFullName}' not found or has no instrumentable methods.");
+                $"Error: Type '{typeFullName}' not found.");
         }
 
         // Group by name to compute overload indices

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ConfigurationApplier.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/ConfigurationApplier.cs
@@ -1,0 +1,144 @@
+// <copyright file="ConfigurationApplier.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Datadog.AutoInstrumentation.Generator.Core;
+
+namespace Datadog.AutoInstrumentation.Generator.Cli;
+
+/// <summary>
+/// Applies --set key=value overrides to a <see cref="GenerationConfiguration"/> using reflection.
+/// Keys use camelCase names matching the JSON output from --json.
+/// </summary>
+internal static class ConfigurationApplier
+{
+    private static readonly Dictionary<string, PropertyInfo> PropertyMap = BuildPropertyMap();
+
+    /// <summary>
+    /// Applies an array of "key=value" strings to the configuration.
+    /// </summary>
+    /// <returns>null on success, or an error message string.</returns>
+    public static string? ApplyOverrides(GenerationConfiguration config, string[] setValues)
+    {
+        foreach (var entry in setValues)
+        {
+            var eqIndex = entry.IndexOf('=');
+            if (eqIndex < 0)
+            {
+                return $"Error: Invalid --set format '{entry}'. Expected key=value (e.g., --set createDucktypeInstance=true).";
+            }
+
+            var key = entry[..eqIndex].Trim();
+            var value = entry[(eqIndex + 1)..].Trim();
+
+            if (!PropertyMap.TryGetValue(key.ToLowerInvariant(), out var prop))
+            {
+                var suggestion = FindClosestKey(key);
+                var suggestionText = suggestion is not null ? $" Did you mean '{suggestion}'?" : string.Empty;
+                return $"Error: Unknown configuration key '{key}'.{suggestionText} Use --list-keys to see available keys.";
+            }
+
+            if (prop.PropertyType == typeof(bool))
+            {
+                if (!bool.TryParse(value, out var boolValue))
+                {
+                    return $"Error: Invalid value '{value}' for key '{key}'. Expected true or false.";
+                }
+
+                prop.SetValue(config, boolValue);
+            }
+            else
+            {
+                return $"Error: Unsupported property type '{prop.PropertyType.Name}' for key '{key}'.";
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns all available configuration keys with their current default values.
+    /// </summary>
+    public static IEnumerable<(string Key, string Type, object? DefaultValue)> GetAvailableKeys()
+    {
+        var defaults = new GenerationConfiguration();
+        foreach (var (key, prop) in PropertyMap.OrderBy(kv => kv.Key))
+        {
+            yield return (prop.Name[..1].ToLowerInvariant() + prop.Name[1..], prop.PropertyType.Name, prop.GetValue(defaults));
+        }
+    }
+
+    private static Dictionary<string, PropertyInfo> BuildPropertyMap()
+    {
+        var map = new Dictionary<string, PropertyInfo>(StringComparer.OrdinalIgnoreCase);
+        foreach (var prop in typeof(GenerationConfiguration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!prop.CanRead || !prop.CanWrite)
+            {
+                continue;
+            }
+
+            // Use camelCase key (same as JsonNamingPolicy.CamelCase)
+            var camelKey = prop.Name[..1].ToLowerInvariant() + prop.Name[1..];
+            map[camelKey.ToLowerInvariant()] = prop;
+        }
+
+        return map;
+    }
+
+    private static string? FindClosestKey(string input)
+    {
+        var inputLower = input.ToLowerInvariant();
+        string? bestMatch = null;
+        var bestDistance = int.MaxValue;
+
+        foreach (var (key, prop) in PropertyMap)
+        {
+            var camelKey = prop.Name[..1].ToLowerInvariant() + prop.Name[1..];
+            var distance = LevenshteinDistance(inputLower, key);
+            if (distance < bestDistance && distance <= Math.Max(3, key.Length / 3))
+            {
+                bestDistance = distance;
+                bestMatch = camelKey;
+            }
+        }
+
+        return bestMatch;
+    }
+
+    private static int LevenshteinDistance(string a, string b)
+    {
+        var m = a.Length;
+        var n = b.Length;
+        var dp = new int[m + 1, n + 1];
+
+        for (var i = 0; i <= m; i++)
+        {
+            dp[i, 0] = i;
+        }
+
+        for (var j = 0; j <= n; j++)
+        {
+            dp[0, j] = j;
+        }
+
+        for (var i = 1; i <= m; i++)
+        {
+            for (var j = 1; j <= n; j++)
+            {
+                var cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                dp[i, j] = Math.Min(
+                    Math.Min(dp[i - 1, j] + 1, dp[i, j - 1] + 1),
+                    dp[i - 1, j - 1] + cost);
+            }
+        }
+
+        return dp[m, n];
+    }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Datadog.AutoInstrumentation.Generator.Cli.csproj
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Datadog.AutoInstrumentation.Generator.Cli.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <SignAssembly>false</SignAssembly>
+        <Nullable>enable</Nullable>
+        <!-- Suppress documentation warnings for internal tooling -->
+        <NoWarn>$(NoWarn);CS1591;SA1600;SA1601;SA1602;SA1611;SA1615;SA1618</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <Version>0.0.1</Version>
+        <IsPackable>true</IsPackable>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>dd-autoinstrumentation</ToolCommandName>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>dd-autoinstrumentation</PackageId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.CommandLine" Version="2.0.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Datadog.AutoInstrumentation.Generator.Core\Datadog.AutoInstrumentation.Generator.Core.csproj" />
+    </ItemGroup>
+</Project>

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/CliResult.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/CliResult.cs
@@ -1,0 +1,19 @@
+// <copyright file="CliResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Output;
+
+internal class CliResult
+{
+    public bool Success { get; init; }
+
+    public string Command { get; init; } = string.Empty;
+
+    public string? ErrorCode { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public object? Data { get; init; }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/ErrorCodes.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/ErrorCodes.cs
@@ -1,0 +1,18 @@
+// <copyright file="ErrorCodes.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Output;
+
+internal static class ErrorCodes
+{
+    public const string FileNotFound = "FILE_NOT_FOUND";
+    public const string TypeNotFound = "TYPE_NOT_FOUND";
+    public const string MethodNotFound = "METHOD_NOT_FOUND";
+    public const string AmbiguousOverload = "AMBIGUOUS_OVERLOAD";
+    public const string InvalidArgument = "INVALID_ARGUMENT";
+    public const string InvalidConfig = "INVALID_CONFIG";
+    public const string UnknownKey = "UNKNOWN_KEY";
+    public const string GenerationError = "GENERATION_ERROR";
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/ErrorCodes.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/ErrorCodes.cs
@@ -15,4 +15,5 @@ internal static class ErrorCodes
     public const string InvalidConfig = "INVALID_CONFIG";
     public const string UnknownKey = "UNKNOWN_KEY";
     public const string GenerationError = "GENERATION_ERROR";
+    public const string BadAssembly = "BAD_ASSEMBLY";
 }

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
@@ -18,16 +18,11 @@ internal static class JsonOutputFormatter
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
-    public static string Format(GenerationResult result, GenerationConfiguration config)
-    {
-        if (!result.Success)
-        {
-            return JsonSerializer.Serialize(
-                new { success = false, errorMessage = result.ErrorMessage ?? string.Empty },
-                SerializerOptions);
-        }
-
-        return JsonSerializer.Serialize(
+    // Failures are routed through OutputHelper.WriteError to emit the unified
+    // envelope (with command + errorCode) and a nonzero exit code, so this
+    // formatter only needs to handle the success case.
+    public static string Format(GenerationResult result, GenerationConfiguration config) =>
+        JsonSerializer.Serialize(
             new
             {
                 success = true,
@@ -37,7 +32,6 @@ internal static class JsonOutputFormatter
                 configuration = config,
             },
             SerializerOptions);
-    }
 
     public static string FormatResult(CliResult result) =>
         JsonSerializer.Serialize(result, SerializerOptions);

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
@@ -52,4 +52,7 @@ internal static class JsonOutputFormatter
             },
             SerializerOptions);
     }
+
+    public static string FormatResult(CliResult result) =>
+        JsonSerializer.Serialize(result, SerializerOptions);
 }

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
@@ -33,21 +33,7 @@ internal static class JsonOutputFormatter
                 success = true,
                 fileName = result.FileName ?? string.Empty,
                 sourceCode = result.SourceCode ?? string.Empty,
-                metadata = result.Metadata is { } meta
-                    ? new
-                    {
-                        meta.AssemblyName,
-                        meta.TypeName,
-                        meta.MethodName,
-                        meta.ReturnTypeName,
-                        meta.ParameterTypeNames,
-                        meta.MinimumVersion,
-                        meta.MaximumVersion,
-                        meta.IntegrationName,
-                        meta.IntegrationClassName,
-                        meta.IsInterface,
-                    }
-                    : null,
+                metadata = result.Metadata,
                 configuration = config,
             },
             SerializerOptions);

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/JsonOutputFormatter.cs
@@ -1,0 +1,55 @@
+// <copyright file="JsonOutputFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Datadog.AutoInstrumentation.Generator.Core;
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Output;
+
+internal static class JsonOutputFormatter
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static string Format(GenerationResult result, GenerationConfiguration config)
+    {
+        if (!result.Success)
+        {
+            return JsonSerializer.Serialize(
+                new { success = false, errorMessage = result.ErrorMessage ?? string.Empty },
+                SerializerOptions);
+        }
+
+        return JsonSerializer.Serialize(
+            new
+            {
+                success = true,
+                fileName = result.FileName ?? string.Empty,
+                sourceCode = result.SourceCode ?? string.Empty,
+                metadata = result.Metadata is { } meta
+                    ? new
+                    {
+                        meta.AssemblyName,
+                        meta.TypeName,
+                        meta.MethodName,
+                        meta.ReturnTypeName,
+                        meta.ParameterTypeNames,
+                        meta.MinimumVersion,
+                        meta.MaximumVersion,
+                        meta.IntegrationName,
+                        meta.IntegrationClassName,
+                        meta.IsInterface,
+                    }
+                    : null,
+                configuration = config,
+            },
+            SerializerOptions);
+    }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/MethodInfoDto.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/MethodInfoDto.cs
@@ -1,0 +1,31 @@
+// <copyright file="MethodInfoDto.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Output;
+
+internal class MethodInfoDto
+{
+    public string Name { get; init; } = string.Empty;
+
+    public string FullName { get; init; } = string.Empty;
+
+    public string ReturnType { get; init; } = string.Empty;
+
+    public bool IsPublic { get; init; }
+
+    public bool IsStatic { get; init; }
+
+    public bool IsVirtual { get; init; }
+
+    public bool IsAsync { get; init; }
+
+    public List<ParameterInfoDto> Parameters { get; init; } = [];
+
+    public int OverloadIndex { get; init; }
+
+    public int OverloadCount { get; init; }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/OutputHelper.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/OutputHelper.cs
@@ -1,0 +1,53 @@
+// <copyright file="OutputHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Output;
+
+internal static class OutputHelper
+{
+    public static int WriteSuccess(bool jsonMode, string command, object? data, string? plainText = null)
+    {
+        if (jsonMode)
+        {
+            var result = new CliResult
+            {
+                Success = true,
+                Command = command,
+                Data = data,
+            };
+            Console.Write(JsonOutputFormatter.FormatResult(result));
+        }
+        else if (plainText is not null)
+        {
+            Console.Write(plainText);
+        }
+
+        return 0;
+    }
+
+    public static int WriteError(bool jsonMode, string command, string errorCode, string errorMessage, object? data = null)
+    {
+        if (jsonMode)
+        {
+            var result = new CliResult
+            {
+                Success = false,
+                Command = command,
+                ErrorCode = errorCode,
+                ErrorMessage = errorMessage,
+                Data = data,
+            };
+            Console.Write(JsonOutputFormatter.FormatResult(result));
+        }
+        else
+        {
+            Console.Error.WriteLine(errorMessage);
+        }
+
+        return 1;
+    }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/ParameterInfoDto.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/ParameterInfoDto.cs
@@ -1,0 +1,15 @@
+// <copyright file="ParameterInfoDto.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Output;
+
+internal class ParameterInfoDto
+{
+    public string Name { get; init; } = string.Empty;
+
+    public string Type { get; init; } = string.Empty;
+
+    public int Index { get; init; }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/TypeInfoDto.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Output/TypeInfoDto.cs
@@ -1,0 +1,29 @@
+// <copyright file="TypeInfoDto.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.AutoInstrumentation.Generator.Cli.Output;
+
+internal class TypeInfoDto
+{
+    public string FullName { get; init; } = string.Empty;
+
+    public string Namespace { get; init; } = string.Empty;
+
+    public string Name { get; init; } = string.Empty;
+
+    public bool IsPublic { get; init; }
+
+    public bool IsInterface { get; init; }
+
+    public bool IsAbstract { get; init; }
+
+    public bool IsSealed { get; init; }
+
+    public bool IsValueType { get; init; }
+
+    public int MethodCount { get; init; }
+
+    public int NestedTypes { get; init; }
+}

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Program.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Program.cs
@@ -6,6 +6,10 @@
 using System.CommandLine;
 using Datadog.AutoInstrumentation.Generator.Cli.Commands;
 
+var jsonOption = new Option<bool>("--json") { Description = "Output structured JSON instead of plain text", Recursive = true };
+
 var rootCommand = new RootCommand("Datadog Auto-Instrumentation Generator CLI");
-rootCommand.Add(new GenerateCommand());
+rootCommand.Options.Add(jsonOption);
+rootCommand.Add(new GenerateCommand(jsonOption));
+rootCommand.Add(new InspectCommand(jsonOption));
 return rootCommand.Parse(args).Invoke();

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Program.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Program.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 using System.CommandLine;
+using System.Linq;
 using Datadog.AutoInstrumentation.Generator.Cli.Commands;
+using Datadog.AutoInstrumentation.Generator.Cli.Output;
 
 var jsonOption = new Option<bool>("--json") { Description = "Output structured JSON instead of plain text", Recursive = true };
 
@@ -12,4 +14,22 @@ var rootCommand = new RootCommand("Datadog Auto-Instrumentation Generator CLI");
 rootCommand.Options.Add(jsonOption);
 rootCommand.Add(new GenerateCommand(jsonOption));
 rootCommand.Add(new InspectCommand(jsonOption));
-return rootCommand.Parse(args).Invoke();
+
+var parseResult = rootCommand.Parse(args);
+
+// Honor the --json contract for parser-level errors (unknown options, missing required
+// arguments, invalid value conversions). Without this, System.CommandLine prints the
+// default help/error text to stderr and JSON-mode callers get unparseable output.
+if (parseResult.Errors.Count > 0 && parseResult.GetValue(jsonOption))
+{
+    var commandName = parseResult.CommandResult.Command.Name;
+    if (commandName == rootCommand.Name)
+    {
+        commandName = string.Empty;
+    }
+
+    var message = "Error: " + string.Join(" ", parseResult.Errors.Select(e => e.Message));
+    return OutputHelper.WriteError(jsonMode: true, commandName, ErrorCodes.InvalidArgument, message);
+}
+
+return parseResult.Invoke();

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Program.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Cli/Program.cs
@@ -1,0 +1,11 @@
+// <copyright file="Program.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.CommandLine;
+using Datadog.AutoInstrumentation.Generator.Cli.Commands;
+
+var rootCommand = new RootCommand("Datadog Auto-Instrumentation Generator CLI");
+rootCommand.Add(new GenerateCommand());
+return rootCommand.Parse(args).Invoke();

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
@@ -135,7 +135,9 @@ public class AssemblyBrowser : IDisposable
     }
 
     /// <summary>
-    /// Lists all instrumentable methods on a type (excludes compiler-generated and special-name methods).
+    /// Lists all instrumentable methods on a type (excludes only compiler-generated methods).
+    /// Special-name methods (.ctor, get_/set_ accessors, event accessors, operators) are kept
+    /// because CallTarget integrations target them.
     /// </summary>
     public IReadOnlyList<MethodDef> ListMethods(string typeFullName)
     {
@@ -155,7 +157,7 @@ public class AssemblyBrowser : IDisposable
         }
 
         return typeDef.Methods
-            .Where(m => !m.IsSpecialName && !IsCompilerGenerated(m))
+            .Where(m => !IsCompilerGenerated(m))
             .ToList();
     }
 

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
@@ -112,6 +112,53 @@ public class AssemblyBrowser : IDisposable
         return typeDef.Methods.Where(m => m.Name == methodName).ToList();
     }
 
+    /// <summary>
+    /// Lists all non-compiler-generated types in the assembly.
+    /// </summary>
+    public IReadOnlyList<TypeDef> ListTypes()
+    {
+        var result = new List<TypeDef>();
+        foreach (var module in _assemblyDef.Modules)
+        {
+            foreach (var type in module.GetTypes())
+            {
+                if (IsCompilerGenerated(type) || type.Name == "<Module>")
+                {
+                    continue;
+                }
+
+                result.Add(type);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Lists all instrumentable methods on a type (excludes compiler-generated and special-name methods).
+    /// </summary>
+    public IReadOnlyList<MethodDef> ListMethods(string typeFullName)
+    {
+        TypeDef? typeDef = null;
+        foreach (var module in _assemblyDef.Modules)
+        {
+            typeDef = FindType(module, typeFullName);
+            if (typeDef is not null)
+            {
+                break;
+            }
+        }
+
+        if (typeDef is null)
+        {
+            return Array.Empty<MethodDef>();
+        }
+
+        return typeDef.Methods
+            .Where(m => !m.IsSpecialName && !IsCompilerGenerated(m))
+            .ToList();
+    }
+
     public void Dispose()
     {
         // AssemblyDef doesn't implement IDisposable, but we free module contexts
@@ -146,6 +193,11 @@ public class AssemblyBrowser : IDisposable
         }
 
         return current;
+    }
+
+    private static bool IsCompilerGenerated(IHasCustomAttribute member)
+    {
+        return member.CustomAttributes.Any(a => a.TypeFullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
     }
 
     private static bool MatchesParameterTypes(MethodDef method, string[] parameterTypes)

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
@@ -89,6 +89,22 @@ public class AssemblyBrowser : IDisposable
     }
 
     /// <summary>
+    /// Returns true if the given fully-qualified type name resolves in the assembly.
+    /// </summary>
+    public bool TypeExists(string typeFullName)
+    {
+        foreach (var module in _assemblyDef.Modules)
+        {
+            if (FindType(module, typeFullName) is not null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Lists all available overloads for a method, useful for disambiguation.
     /// </summary>
     public IReadOnlyList<MethodDef> ListOverloads(string typeFullName, string methodName)

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Core/AssemblyBrowser.cs
@@ -215,7 +215,8 @@ public class AssemblyBrowser : IDisposable
 
     private static bool IsCompilerGenerated(IHasCustomAttribute member)
     {
-        return member.CustomAttributes.Any(a => a.TypeFullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+        return member.CustomAttributes.Any(a => a.TypeFullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+            || (member is TypeDef type && type.Name.String.StartsWith("<>", StringComparison.Ordinal));
     }
 
     private static bool MatchesParameterTypes(MethodDef method, string[] parameterTypes)

--- a/tracer/src/Datadog.AutoInstrumentation.Generator.Core/GenerationConfiguration.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator.Core/GenerationConfiguration.cs
@@ -4,8 +4,6 @@
 // </copyright>
 
 using System;
-using System.Linq;
-using System.Threading.Tasks;
 using dnlib.DotNet;
 
 namespace Datadog.AutoInstrumentation.Generator.Core;
@@ -71,6 +69,21 @@ public class GenerationConfiguration
     public bool DucktypeAsyncReturnValueDuckChaining { get; set; }
 
     /// <summary>
+    /// Returns true if the given return type full name is an async return type
+    /// that CallTarget instruments via OnAsyncMethodEnd: Task, Task&lt;T&gt;, ValueTask,
+    /// or ValueTask&lt;T&gt;. Other types under System.Threading.Tasks (TaskScheduler,
+    /// TaskCompletionSource, TaskFactory, etc.) are not async return shapes.
+    /// dnlib formats generic full names as `System.Threading.Tasks.Task`1&lt;T&gt;`.
+    /// </summary>
+    public static bool IsAsyncReturnType(string returnTypeFullName)
+    {
+        return returnTypeFullName == "System.Threading.Tasks.Task"
+            || returnTypeFullName == "System.Threading.Tasks.ValueTask"
+            || returnTypeFullName.StartsWith("System.Threading.Tasks.Task`1<", StringComparison.Ordinal)
+            || returnTypeFullName.StartsWith("System.Threading.Tasks.ValueTask`1<", StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Creates a configuration with smart defaults based on the method being instrumented.
     /// Mirrors the GUI auto-detection logic from MainViewModel.Configuration.cs.
     /// </summary>
@@ -78,8 +91,7 @@ public class GenerationConfiguration
     {
         var config = new GenerationConfiguration();
 
-        var isAsync = methodDef.ReturnType.FullName.StartsWith(typeof(Task).FullName!, StringComparison.Ordinal) ||
-                      methodDef.ReturnType.FullName.StartsWith(typeof(ValueTask).FullName!, StringComparison.Ordinal);
+        var isAsync = IsAsyncReturnType(methodDef.ReturnType.FullName);
 
         if (isAsync)
         {


### PR DESCRIPTION
 ## Summary of changes

  Adds a new CLI tool (`dd-autoinstrumentation`) for auto-instrumentation code generation, designed
  for scriptable and AI-agent-driven workflows with structured JSON output.

  ## Reason for change

  Creating integrations currently requires either the GUI or manual boilerplate. A CLI with structured
   JSON output enables LLM agents to autonomously discover types/methods in an assembly, generate
  instrumentation code, and recover from errors — all without human intervention.

  ## Implementation details

  New `Datadog.AutoInstrumentation.Generator.Cli` project with two commands:

  **`inspect`** — assembly discovery
  - `--list-types`: lists all non-compiler-generated types with visibility, kind, method count
  - `--list-methods <type>`: lists instrumentable methods with parameters, async detection, overload
  index/count

  **`generate`** — code generation
  - Resolves method from assembly/type/method with overload disambiguation (`--overload-index`,
  `--parameter-types`)
  - Smart defaults auto-detect async/static/void methods (disable with `--no-auto-detect`)
  - Configuration via `--set key=value`, `--config '{json}'`, or `--config-file path.json`
  - Shortcut flags: `--no-method-begin`, `--no-method-end`, `--async-method-end`

  **`--json` flag** (global) — all output (success and error) as structured JSON on stdout with:
  - Machine-readable error codes (`FILE_NOT_FOUND`, `TYPE_NOT_FOUND`, `AMBIGUOUS_OVERLOAD`,
  `BAD_ASSEMBLY`, etc.)
  - `AMBIGUOUS_OVERLOAD` includes full overload list in response data for immediate retry
  - `inspect` output includes `overloadIndex`/`overloadCount` so agents know upfront if disambiguation
   is needed

  **Nuke integration** — `RunInstrumentationGeneratorCli` target with direct parameters and
  `--generator-args` passthrough.

  **Documentation:**
  - `docs/development/InstrumentationGenerator.md` — comprehensive reference for both GUI and CLI
  - `docs/development/for-ai/InstrumentationGenerator-CLI.md` — LLM-focused reference with full JSON
  schemas, error recovery patterns, and recommended autonomous workflow

  ## Test coverage

  No automated tests in this PR — this is a developer/AI tooling utility, not a production code path.
  Manual testing performed against real assemblies for all commands, error paths, and JSON output.

  ## Other details

https://github.com/DataDog/dd-trace-dotnet/pull/8312

 🤖 Generated with [Claude Code](https://claude.com/claude-code)