### PR TITLE
Fix `CA1872` - Prefer `Convert.ToHexString` over `BitConverter.ToString`

### DIFF
--- a/tracer/src/Datadog.Trace/.editorconfig
+++ b/tracer/src/Datadog.Trace/.editorconfig
@@ -64,5 +64,5 @@ dotnet_diagnostic.CA1868.severity = error # Unnecessary call to Contains for set
 dotnet_diagnostic.CA1869.severity = error # Cache and reuse JsonSerializerOptions instances
 dotnet_diagnostic.CA1870.severity = error # Use a cached SearchValues instance
 dotnet_diagnostic.CA1871.severity = error # Do not pass a nullable struct to ArgumentNullException.ThrowIfNull.
-# dotnet_diagnostic.CA1872.severity = error # Prefer Convert.ToHexString over BitConverter.ToString
+dotnet_diagnostic.CA1872.severity = error # Prefer Convert.ToHexString over BitConverter.ToString
 

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -368,8 +368,12 @@ namespace Datadog.Trace.DuckTyping
                 // Include target assembly name and public token.
                 AssemblyName asmName = typeToDelegateTo.Assembly.GetName();
                 assembly = asmName.Name ?? string.Empty;
-                byte[] pbToken = asmName.GetPublicKeyToken() ?? Array.Empty<byte>();
-                assembly += "__" + BitConverter.ToString(pbToken).Replace("-", string.Empty);
+                var pbToken = asmName.GetPublicKeyToken();
+#if NET6_0_OR_GREATER
+                assembly += "__" + (pbToken is null ? string.Empty : Convert.ToHexString(pbToken));
+#else
+                assembly += "__" + (pbToken is null ? string.Empty : HexConverter.ToString(pbToken));
+#endif
                 assembly = assembly.Replace(".", "_").Replace("+", "__");
             }
 


### PR DESCRIPTION
## Summary of changes

Stop using `BitConverter.ToString` to convert a `byte[]` into a `string`

## Reason for change

The `CA1872` analyzer suggests to use `Convert.ToHexString` instead. That's not available in <.NET 6, but ultimately it just calls `HexConverter.ToString(bytes, HexConverter.Casing.Upper)` which we have vendored, so we can just use that instead in that case.

## Implementation details

- Enable the analyzer
- Fix the one violation

## Test coverage

Covered by existing

## Other details

https://datadoghq.atlassian.net/browse/LANGPLAT-813

We could argue whether it's worth having the `#if`, but it feels like we should generally use the built-in types where they're available. But _maybe_ that means we should make `HexConverter.ToString()` delegate to the built-in `Convert.ToHexString()` method? i.e. move the `#if` to be an implementation detail of our vendored `HexConverter`? I'm undecided. 