### PR TITLE
[AI Agents] Remove plugin settings from shared Claude Code config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,20 +6,5 @@
         "repo": "DataDog/claude-marketplace"
       }
     }
-  },
-  "enabledPlugins": {
-    "marketplace-auto-update@datadog-claude-plugins": true,
-    "dd@datadog-claude-plugins": true
-  },
-  "permissions": {
-    "deny": [
-      "Skill(dd:conductor *)",
-      "Skill(dd:trebuchet *)",
-      "Skill(dd:render-helm *)",
-      "Skill(dd:deploy-yaml-local-dev *)",
-      "Skill(dd:integrate *)",
-      "Skill(dd:live-test-api *)",
-      "Skill(dd:debug-ddci-request *)"
-    ]
   }
 }


### PR DESCRIPTION
## Summary of changes

Remove plugin settings (`enabledPlugins` and `permissions.deny`) from the shared `.claude/settings.json` configuration file.

## Reason for change

Plugin preferences and permission overrides are user-specific and should not be committed to the shared repository configuration. Having them in `.claude/settings.json` forces these settings on all contributors.

## Implementation details

- Removed the `enabledPlugins` block that auto-enabled `marketplace-auto-update` and `dd` plugins from `datadog-claude-plugins`
- Removed the `permissions.deny` block that blocked several `dd:*` skills (conductor, trebuchet, render-helm, deploy-yaml-local-dev, integrate, live-test-api, debug-ddci-request)

## Test coverage

N/A — configuration-only change.

## Other details

These settings can be configured per-user in their local/user-level Claude Code settings instead.

> *"I'm not saying those plugins were bad, but even my settings.json needed a detox."* — Claude 🤖
