### PR TITLE
Fix macOS CI build: only build static re2 library

### DIFF
--- a/build/cmake/FindRe2.cmake
+++ b/build/cmake/FindRe2.cmake
@@ -8,11 +8,11 @@ if (ISMACOS)
     SET (OSXRE2BUILDCOMMAND
             echo "Building Re2 Arm64" &&
             rm -f -r ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj &&
-            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ arm64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ arm64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j &&
+            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ arm64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ arm64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j obj/libre2.a &&
             mv ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.arm64.a &&
             echo "Building Re2 X86_64" &&
             rm -f -r ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj &&
-            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ x86_64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ x86_64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j &&
+            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ x86_64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ x86_64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j obj/libre2.a &&
             mv ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.x86_64.a &&
             echo "Creating Re2 universal binary" &&
             lipo ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.arm64.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.x86_64.a -create -output ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a


### PR DESCRIPTION
## Summary

Our CI is broken on `master` as building on macos is failing due to a runner update.
Build only the static re2 library (obj/libre2.a) on macOS instead of the default all target which also builds the shared library (libre2.dylib).

## Reason for change

CI is broken.

## Implementation details

Some of the related issues associated with this suggested some workarounds, I just instructed Claude to fix, I didn't test it figure if the build works we are good.

### Related issues
- https://github.com/actions/runner-images/issues/13827
- https://github.com/actions/runner-images/issues/13816
- https://github.com/llvm/llvm-project/pull/187541#issuecomment-4092605947

## Test coverage

If the CI passes then we should hopefully be good? 

Generated by Claude