### PR TITLE
Specify AGENTS.md to not edit generated files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Auto-instrumentation comes from the tracer "monitoring home" deployed separately
 - Prefer modern collection expressions (`[]`)
 - Use `StringUtil.IsNullOrEmpty()` instead of `string.IsNullOrEmpty()` for compatibility across all supported runtimes
 - StyleCop: see `tracer/stylecop.json`; address warnings before pushing
+- Never manually edit generated files (`.g.` in the file extension). Read the file header for regeneration instructions instead.
 
 **C/C++ style:**
 - See `.clang-format`; keep consistent naming


### PR DESCRIPTION
## Summary of changes

Adds a line to AGENTS.md to stop it from touching generated files.

## Reason for change

Do not want these files edited by LLMs and instead should be updated by correct tooling.

Note that I'm not directing _how_ to update the generated files, I figure we can do that manually?


## Implementation details

Added a line underneath the coding section

## Test coverage

Super simple test where I just opted to directly ask the LLM to update a `.g.` file - much fewer token usage and much quicker (and the LLMs might not edit the generated files in the future)

> Before

```
❯ Edit PackageVersionsLatestMinors.g.cs to include the latest version of Hangfire

  Searched for 2 patterns, read 1 file (ctrl+o to expand)

● Now let me check NuGet for the latest Hangfire version to know what to add.

● Agent(Check latest Hangfire version)
  ⎿  Done (1 tool use · 16.3k tokens · 22s)
  (ctrl+o to expand)

  Searched for 2 patterns (ctrl+o to expand)

● The file already contains 1.8.23 which appears to be the latest stable Hangfire version on NuGet. Let me check if there's a newer version or if the generation source has a newer one.

  Searched for 5 patterns, read 1 file (ctrl+o to expand)

● Now let me check the NuGet cache to see what versions are known.

  Searched for 2 patterns, read 1 file (ctrl+o to expand)

● The NuGet version cache tops out at 1.8.23, and the generated file already includes that version. Let me check NuGet directly for any newer versions.

● Bash(curl -s "https://api.nuget.org/v3-flatcontainer/hangfire.core/index.json" 2>&1 | tail -20)
  ⎿      "1.8.6",
         "1.8.7",
         "1.8.8",
     … +17 lines (ctrl+o to expand)

● The file already contains 1.8.23, which is the latest version of Hangfire.Core on NuGet. The PackageVersionsLatestMinors.g.cs file is already up to date -- there's no newer version to add.

  Is there a specific version you had in mind, or were you expecting a newer release to exist?
```

> After

```
❯  Edit PackageVersionsLatestMinors.g.cs to include the latest version of Hangfire

● The AGENTS.md says never to manually edit generated files (.g. in the extension) - instead, read the file header for regeneration instructions. Let me find the file and check how to properly update it.

  Searched for 2 patterns, read 1 file (ctrl+o to expand)

● This is a generated file. Per the header, the correct approach is:

  1. Edit PackageVersionsGeneratorDefinitions.json
  2. Re-run the GeneratePackageVersions project

  Let me find the definitions file and the current Hangfire entry.

  Searched for 2 patterns, read 1 file (ctrl+o to expand)

● This is a generated file -- you should edit PackageVersionsGeneratorDefinitions.json instead, then re-run the generator. The current Hangfire definition (lines 2-12) covers versions 1.7.* and 1.8.* with
  MaxVersionExclusive of 2.0.0.

  What change do you want to make? For example:
  - Add a new version pattern like 1.9.*?
  - Bump MaxVersionExclusive to include a newer major version?
  - Something else?

  Let me know the specific Hangfire version you want to include and I'll update the definitions file accordingly.
```

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
