### PR TITLE
fix(dsm): Grab correct span in RabbitMQ/OTel for DSM checkpoints

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/PopulateBasicPropertiesHeadersIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/PopulateBasicPropertiesHeadersIntegration.cs
@@ -43,10 +43,9 @@ public sealed class PopulateBasicPropertiesHeadersIntegration
     {
         var tracer = Tracer.Instance;
 
-        // Walk the internal scope chain to find the dd-trace RabbitMQ producer span.
         Span? span = null;
         RabbitMQTags? tags = null;
-        var scope = tracer.InternalActiveScope;
+        var scope = tracer.ActiveScope as Scope;
         while (scope is not null)
         {
             if (scope.Span is Span { Tags: RabbitMQTags candidateTags } candidateSpan


### PR DESCRIPTION
## Summary of changes
Fix DSM header injection for RabbitMQ / OTel. OTel emits a span which causes us to skip DSM checkpoint logic.

## Reason for change
Customer issue

## Implementation details
OnMethodEnd used `tracer.ActiveScope?.Span` to find the RabbitMQ producer span. When
  DD_TRACE_OTEL_ENABLED=true, RabbitMQ.Client v7 emits its own OTel Activity which gets converted to a
  scope with OpenTelemetryTags that sits on top of the dd-trace RabbitMQ scope (RabbitMQTags). The
  pattern match `activeSpan is not Span { Tags: RabbitMQTags }` fails on the OTel span, so the method
  bails out, skipping both DSM checkpoint and header injection.

OTel generated span from [here](https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs#L217-L228)
RabbitMQ span created from [here](https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs#L229)

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
