### PR TITLE
Wrap ContainerTagsHash around !NETFRAMEWORK

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -306,14 +306,12 @@ namespace Datadog.Trace.Agent.DiscoveryService
 
         private async Task ProcessDiscoveryResponse(IApiResponse response)
         {
-#if !NETFRAMEWORK
             // Extract and store container tags hash from response headers
             var containerTagsHash = response.GetHeader(AgentHttpHeaderNames.ContainerTagsHash);
             if (containerTagsHash != null)
             {
                 _containerMetadata.ContainerTagsHash = containerTagsHash;
             }
-#endif
 
             // Grab the original stream
             var stream = await response.GetStreamAsync().ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.NetFramework.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.NetFramework.cs
@@ -5,9 +5,6 @@
 
 #nullable enable
 
-using System.Threading;
-using Datadog.Trace.Logging;
-
 #if NETFRAMEWORK
 
 namespace Datadog.Trace.PlatformHelpers;
@@ -17,9 +14,6 @@ namespace Datadog.Trace.PlatformHelpers;
 /// </summary>
 internal sealed class ContainerMetadata
 {
-    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ContainerMetadata));
-    private static bool _warnedOnSet; // to log only once
-
     public static readonly ContainerMetadata Instance = new();
 
     private ContainerMetadata()
@@ -36,14 +30,7 @@ internal sealed class ContainerMetadata
     public string? ContainerTagsHash
     {
         get => null;
-        set
-        {
-            if (!_warnedOnSet)
-            {
-                _warnedOnSet = true;
-                Log.Error("The code is trying to set the value '{Value}' to {Prop}, but this has no effect in .NET Framework.", value, nameof(ContainerTagsHash));
-            }
-        }
+        set { }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary of changes

It appears that this isn't supposed to be set on .NET Framework and we have a `Log.Error` for whenever `ContainerTagsHash` is set.

This was intended from what I can tell to be to see if customers were setting this while on .NET Framework, but we set it ourselves on .NET Framework in` DiscoveryService`

## Reason for change

Identified by Error Tracking with a large number of errors from the latest release, realistically these are harmless errors and were supposed to indicate to customers that this functionality isn't available on .NET Framework, but instead we are the ones calling it.

## Implementation details

Added `!NETFRAMEWORK`

## Test coverage

Used Visual Studio and did a Find all References on it, I think this is it😅 

## Other details
<!-- Fixes #{issue} -->

Fixes [APMLP-1140](https://datadoghq.atlassian.net/browse/APMLP-1140)


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
