### PR TITLE
Add OTEL_RESOURCE_ATTRIBUTES to claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "repo.owner=DataDog,repo.name=dd-trace-dotnet"
+  },
   "extraKnownMarketplaces": {
     "datadog-claude-plugins": {
       "source": {


### PR DESCRIPTION
## Summary of changes

This adds `"OTEL_RESOURCE_ATTRIBUTES": "repo.owner=DataDog,repo.name=dd-trace-dotnet"` to our claude settings

## Reason for change

This will make it so that our telemetry marks that if we are working on the repo with Claude that it will report our repository.

I don't think there is any functional change here besides the fact that I want to make my telemetry go from `N/A` to `dd-trace-dotnet` 

## Implementation details

Followed https://datadoghq.atlassian.net/wiki/spaces/AIDEVX/pages/5689508824/Repo+Config#Repo-Tags-in-Telemetry

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
