### PR TITLE
Split IDuckTypeTask into separate Task and ValueTask duck types

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration.Schema;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DataStreamsMonitoring.TransactionTracking;
@@ -530,6 +531,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             options.DuckCast<IDescribeClusterOptions>().RequestTimeout = TimeSpan.FromSeconds(2);
 
             var duckTask = adminClient.DescribeClusterAsync(options);
+
+            if (duckTask.Status == TaskStatus.RanToCompletion)
+            {
+                return duckTask.Result?.ClusterId;
+            }
 
             var originalContext = SynchronizationContext.Current;
             try

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/V3/IXunitTestMethodRunnerV3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/V3/IXunitTestMethodRunnerV3.cs
@@ -17,5 +17,5 @@ internal interface IXunitTestMethodRunnerV3
     /// </summary>
     /// <param name="context">Test context</param>
     /// <param name="testCase">Test case</param>
-    IDuckTypeTask<object> RunTestCase(object context, object testCase);
+    IDuckTypeValueTask<object> RunTestCase(object context, object testCase);
 }

--- a/tracer/src/Datadog.Trace/DuckTyping/IDuckTypeValueTask.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/IDuckTypeValueTask.cs
@@ -1,49 +1,46 @@
-// <copyright file="IDuckTypeTask.cs" company="Datadog">
+// <copyright file="IDuckTypeValueTask.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 #nullable enable
-
-using System.Threading.Tasks;
-
 namespace Datadog.Trace.DuckTyping;
 
 /// <summary>
-/// Duck type task interface
+/// Duck type value task interface
 /// </summary>
 /// <typeparam name="T">Type of the result</typeparam>
-public interface IDuckTypeTask<out T> : IDuckType
+public interface IDuckTypeValueTask<out T> : IDuckType
 {
     /// <summary>
-    /// Gets the status of the task
+    /// Gets a value indicating whether the value task completed successfully
     /// </summary>
-    TaskStatus Status { get; }
+    bool IsCompletedSuccessfully { get; }
 
     /// <summary>
-    /// Gets the result of the task
+    /// Gets the result of the value task
     /// </summary>
     T? Result { get; }
 
     /// <summary>
-    /// Gets the awaiter for the task
+    /// Gets the awaiter for the value task
     /// </summary>
     /// <returns>Awaiter instance</returns>
     IDuckTypeAwaiter<T> GetAwaiter();
 }
 
 /// <summary>
-/// Duck type task interface
+/// Duck type value task interface
 /// </summary>
-public interface IDuckTypeTask : IDuckType
+public interface IDuckTypeValueTask : IDuckType
 {
     /// <summary>
-    /// Gets the status of the task
+    /// Gets a value indicating whether the value task completed successfully
     /// </summary>
-    TaskStatus Status { get; }
+    bool IsCompletedSuccessfully { get; }
 
     /// <summary>
-    /// Gets the awaiter for the task
+    /// Gets the awaiter for the value task
     /// </summary>
     /// <returns>Awaiter instance</returns>
     IDuckTypeAwaiter GetAwaiter();


### PR DESCRIPTION
## Summary of changes

Create `IDuckTypeValueTask<T>` / `IDuckTypeValueTask` for `ValueTask` targets, and re-add `TaskStatus Status` to `IDuckTypeTask` for Task targets. Update XUnit V3 to use the ValueTask variant.

## Reason for change

This is a follow up to https://github.com/DataDog/dd-trace-dotnet/pull/8366 in which Kafka was failing on .NET Framework due to not having access to the `IsCompletedSuccessfully` property on the Task. Initially, I attempted to swap to use a `TaskStatus Status` instead, but that then caused the xUnit integration tests to start failing as they are actually `ValueTask` and not `Task` which `ValueTask` lack the `TaskStatus`

## Implementation details

- Add `TaskStatus` to the `IDuckTask`/`IDuckTask<T>`
- Create `IValueTaskDuck`/`IValueTaskDuck<T>` with `IsCompletedSuccessfully`
- Update the xUnit (V3) integration to use `IValueTaskDuck`
- Update the `KafkaHelper` to use `TaskStatus`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

https://github.com/DataDog/dd-trace-dotnet/pull/8366

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
