### PR TITLE
Pin floating pre-release versions of SQLitePCLRaw.* dependencies in samples

### DIFF
--- a/tracer/test/test-applications/debugger/Samples.Debugger.AspNetCore5/Samples.Debugger.AspNetCore5.csproj
+++ b/tracer/test/test-applications/debugger/Samples.Debugger.AspNetCore5/Samples.Debugger.AspNetCore5.csproj
@@ -116,8 +116,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.0" />
     <PackageReference Update="Microsoft.Data.Sqlite.Core" Version="8.0.0" />
-    <PackageReference Update="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.6-*" />
-    <PackageReference Update="SQLitePCLRaw.core" Version="2.1.6-*" />
+    <PackageReference Update="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.6" />
+    <PackageReference Update="SQLitePCLRaw.core" Version="2.1.6" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
@@ -104,8 +104,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.0" />
     <PackageReference Update="Microsoft.Data.Sqlite.Core" Version="8.0.0" />
-    <PackageReference Update="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.6-*" />
-    <PackageReference Update="SQLitePCLRaw.core" Version="2.1.6-*" />
+    <PackageReference Update="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.6" />
+    <PackageReference Update="SQLitePCLRaw.core" Version="2.1.6" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">


### PR DESCRIPTION
## Summary of changes

Pins two different projects that were using floating versions of PackageReferences to `SQLitePCLRaw.bundle_e_sqlite3` and `SQLitePCLRaw.core`.

These appeared to link to these versions, I bumped them to be stable

- https://www.nuget.org/packages/SQLitePCLRaw.core/2.1.6-pre20230809203314
- https://www.nuget.org/packages/SQLitePCLRaw.bundle_e_sqlite3/2.1.6-pre20230809203314

## Reason for change

We don't want any floating dependencies

## Implementation details

Searched here: https://github.com/search?q=repo%3ADataDog%2Fdd-trace-dotnet%20%2FVersion%3D%22%5B%5E%22%5D*%5C*%2F&type=code

## Test coverage

This is the test, hopefully this works

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
