### PR TITLE
Set .Net-specific injection package size ratchet

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,10 @@ variables:
   CI_IDENTITIES_CLIENT_URL: s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/v0.2.0/ci-identities-gitlab-job-client-windows-amd64.exe
   SUPPORTED_CONFIG_PATH: "tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml"
 
+  # One pipeline injection package size ratchet
+  OCI_PACKAGE_MAX_SIZE_BYTES: 50_000_000
+  LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 50_000_000
+
 build:
   except:
     variables:


### PR DESCRIPTION
## Summary of changes

Introduce language-specific thresholds for the ratchet.

## Reason for change

Due to [a change PHP-side](https://github.com/DataDog/dd-trace-php/pull/3573) libdatadog was bumped to v29. This version bump caused PHP images to blow past their previous limit. 

Simultaneously, [changes to the `datadog-package`](https://github.com/DataDog/datadog-packages/commit/2e178346124a3a88edd4e055ef5ca60d1a610b8c#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L82-R79) binary were picked up. Notably the `github.com/klauspost/compress/zstd` dependency was bumped from 1.17.4 to 1.18.1. This bump included in 1.17.5 a default value change for the compression context size, [downscaled from 32MB to 8MB](https://github.com/klauspost/compress/pull/913) (fixing compatibility with browsers like Chrome), causing drastic changes in compression results.

Unbeknownst to the second change, PHP therefore updated the global limits, attributing the size change to the libdatadog bump (which was true, but not for the whole of it):
- Container image limit [changed from 190MB to 250MB](https://github.com/DataDog/libdatadog-build/pull/186)
- OCI package limit [changed from 130MB to 160MB](https://github.com/DataDog/libdatadog-build/pull/187)

This allowed a change to slip through to other languages, where the new `datadog-package` binary caused regressions in package size _without_ change to the inputs. Due to the wildly differing sizes of packages across languages the regression is silent, rendering the size threshold ratchet moot.

To combat such silently creeping regressions, this PR introduces language-specific thresholds for the ratchet.

## Implementation details

Overrides variables in [one pipeline](https://github.com/DataDog/libdatadog-build/blob/09c7352ba84397d1c5b624608c7f6cd93905d6fa/templates/one-pipeline.yml#L47-L53) 

## Test coverage

## Other details
<!-- Fixes #{issue} -->

`datadog-package` was fixed in https://github.com/DataDog/datadog-packages/pull/64 which may take some time to trickle down.

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
