### PR TITLE
[Analyzers] Add analyzer and code fix for throw in inlined methods

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/Datadog.Trace.Tools.Analyzers.CodeFixes.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/Datadog.Trace.Tools.Analyzers.CodeFixes.csproj
@@ -20,6 +20,7 @@
     <Compile Include="..\Datadog.Trace.Tools.Analyzers\LogAnalyzer\Diagnostics.cs" Link="LogAnalyzer\Diagnostics.cs" />
     <Compile Include="..\Datadog.Trace.Tools.Analyzers\ThreadAbortAnalyzer\Diagnostics.cs" Link="ThreadAbortAnalyzer\Diagnostics.cs" />
     <Compile Include="..\Datadog.Trace.Tools.Analyzers\SealedAnalyzer\Diagnostics.cs" Link="SealedAnalyzer\Diagnostics.cs" />
+    <Compile Include="..\Datadog.Trace.Tools.Analyzers\ThrowInInlinedMethodAnalyzer\Diagnostics.cs" Link="ThrowInInlinedMethodAnalyzer\Diagnostics.cs" />
     <Compile Include="..\Datadog.Trace\Util\System.Diagnostics.CodeAnalysis.Attributes.cs" Link="Helpers\System.Diagnostics.CodeAnalysis.Attributes.cs" />
     <Compile Include="..\Datadog.Trace\Util\System.Runtime.CompilerServices.Attributes.cs" Link="Helpers\System.Runtime.CompilerServices.Attributes.cs" />
     <Compile Update="LogAnalyzer\ConstantMessageTemplateCodeFixProvider.*.cs">

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
@@ -29,20 +29,20 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
     {
         private const string ThrowHelperUsingNamespace = "Datadog.Trace.Util";
 
-        private static readonly Dictionary<string, (string MethodName, int MaxArgs)> SupportedExceptions
-            = new Dictionary<string, (string, int)>
+        private static readonly Dictionary<string, (string MethodName, int MinArgs, int MaxArgs)> SupportedExceptions
+            = new Dictionary<string, (string, int, int)>
             {
-                ["System.ArgumentNullException"] = ("ThrowArgumentNullException", 1),
-                ["System.ArgumentOutOfRangeException"] = ("ThrowArgumentOutOfRangeException", 3),
-                ["System.ArgumentException"] = ("ThrowArgumentException", 2),
-                ["System.InvalidOperationException"] = ("ThrowInvalidOperationException", 1),
-                ["System.Exception"] = ("ThrowException", 1),
-                ["System.InvalidCastException"] = ("ThrowInvalidCastException", 1),
-                ["System.IndexOutOfRangeException"] = ("ThrowIndexOutOfRangeException", 1),
-                ["System.NotSupportedException"] = ("ThrowNotSupportedException", 1),
-                ["System.Collections.Generic.KeyNotFoundException"] = ("ThrowKeyNotFoundException", 1),
-                ["System.NullReferenceException"] = ("ThrowNullReferenceException", 1),
-                ["System.ObjectDisposedException"] = ("ThrowObjectDisposedException", 1),
+                ["System.ArgumentNullException"] = ("ThrowArgumentNullException", 1, 1),
+                ["System.ArgumentOutOfRangeException"] = ("ThrowArgumentOutOfRangeException", 1, 3),
+                ["System.ArgumentException"] = ("ThrowArgumentException", 1, 2),
+                ["System.InvalidOperationException"] = ("ThrowInvalidOperationException", 1, 1),
+                ["System.Exception"] = ("ThrowException", 1, 1),
+                ["System.InvalidCastException"] = ("ThrowInvalidCastException", 1, 1),
+                ["System.IndexOutOfRangeException"] = ("ThrowIndexOutOfRangeException", 1, 1),
+                ["System.NotSupportedException"] = ("ThrowNotSupportedException", 1, 1),
+                ["System.Collections.Generic.KeyNotFoundException"] = ("ThrowKeyNotFoundException", 1, 1),
+                ["System.NullReferenceException"] = ("ThrowNullReferenceException", 1, 1),
+                ["System.ObjectDisposedException"] = ("ThrowObjectDisposedException", 1, 1),
             };
 
         /// <inheritdoc />
@@ -112,7 +112,7 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
             }
 
             var argCount = creation.ArgumentList?.Arguments.Count ?? 0;
-            if (argCount > entry.MaxArgs)
+            if (argCount < entry.MinArgs || argCount > entry.MaxArgs)
             {
                 return false;
             }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
@@ -1,0 +1,183 @@
+// <copyright file="ThrowInInlinedMethodCodeFixProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
+{
+    /// <summary>
+    /// A CodeFixProvider for <see cref="ThrowInInlinedMethodAnalyzer"/> that replaces
+    /// throw statements with ThrowHelper method calls.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ThrowInInlinedMethodCodeFixProvider))]
+    [Shared]
+    public class ThrowInInlinedMethodCodeFixProvider : CodeFixProvider
+    {
+        private const string ThrowHelperUsingNamespace = "Datadog.Trace.Util";
+
+        private static readonly int[] OneArg = { 1 };
+        private static readonly int[] OneOrTwoArgs = { 1, 2 };
+        private static readonly int[] OneToThreeArgs = { 1, 2, 3 };
+
+        private static readonly Dictionary<string, (string MethodName, int[] ValidArgCounts)> SupportedExceptions
+            = new Dictionary<string, (string, int[])>
+            {
+                ["System.ArgumentNullException"] = ("ThrowArgumentNullException", OneArg),
+                ["System.ArgumentOutOfRangeException"] = ("ThrowArgumentOutOfRangeException", OneToThreeArgs),
+                ["System.ArgumentException"] = ("ThrowArgumentException", OneOrTwoArgs),
+                ["System.InvalidOperationException"] = ("ThrowInvalidOperationException", OneArg),
+                ["System.Exception"] = ("ThrowException", OneArg),
+                ["System.InvalidCastException"] = ("ThrowInvalidCastException", OneArg),
+                ["System.IndexOutOfRangeException"] = ("ThrowIndexOutOfRangeException", OneArg),
+                ["System.NotSupportedException"] = ("ThrowNotSupportedException", OneArg),
+                ["System.Collections.Generic.KeyNotFoundException"] = ("ThrowKeyNotFoundException", OneArg),
+                ["System.NullReferenceException"] = ("ThrowNullReferenceException", OneArg),
+            };
+
+        /// <inheritdoc />
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(Diagnostics.DiagnosticId);
+
+        /// <inheritdoc />
+        public sealed override FixAllProvider GetFixAllProvider()
+            => WellKnownFixAllProviders.BatchFixer;
+
+        /// <inheritdoc />
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return;
+            }
+
+            var diagnostic = context.Diagnostics.First();
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+
+            // Only handle throw statements with object creation expressions (not throw expressions or bare throw;)
+            if (node is not ThrowStatementSyntax throwStatement
+                || throwStatement.Expression is not ObjectCreationExpressionSyntax creation)
+            {
+                return;
+            }
+
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (semanticModel is null)
+            {
+                return;
+            }
+
+            var typeInfo = semanticModel.GetTypeInfo(creation, context.CancellationToken);
+            var typeName = typeInfo.Type?.ToDisplayString();
+
+            if (typeName is null || !SupportedExceptions.TryGetValue(typeName, out var entry))
+            {
+                return;
+            }
+
+            var argCount = creation.ArgumentList?.Arguments.Count ?? 0;
+            if (!entry.ValidArgCounts.Contains(argCount))
+            {
+                return;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Replace with ThrowHelper.{entry.MethodName}",
+                    createChangedDocument: c => ReplaceWithThrowHelperAsync(context.Document, throwStatement, entry.MethodName, c),
+                    equivalenceKey: nameof(ThrowInInlinedMethodCodeFixProvider)),
+                diagnostic);
+        }
+
+        private static async Task<Document> ReplaceWithThrowHelperAsync(
+            Document document,
+            ThrowStatementSyntax throwStatement,
+            string methodName,
+            CancellationToken cancellationToken)
+        {
+            var creation = (ObjectCreationExpressionSyntax)throwStatement.Expression!;
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return document;
+            }
+
+            // Build: ThrowHelper.MethodName(args)
+            var invocation = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("ThrowHelper"),
+                    SyntaxFactory.IdentifierName(methodName)),
+                creation.ArgumentList ?? SyntaxFactory.ArgumentList());
+
+            var expressionStatement = SyntaxFactory.ExpressionStatement(invocation)
+                .WithLeadingTrivia(throwStatement.GetLeadingTrivia())
+                .WithTrailingTrivia(throwStatement.GetTrailingTrivia());
+
+            root = root.ReplaceNode(throwStatement, expressionStatement);
+
+            // Add using directive if not already present
+            if (root is CompilationUnitSyntax compilationUnit && !HasUsingDirective(compilationUnit))
+            {
+                // Match the document's existing line ending style
+                var eolTrivia = compilationUnit.Usings.Count > 0
+                    ? GetTrailingEndOfLine(compilationUnit.Usings.Last())
+                    : SyntaxFactory.ElasticCarriageReturnLineFeed;
+
+                var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(ThrowHelperUsingNamespace))
+                    .WithTrailingTrivia(eolTrivia);
+                root = compilationUnit.AddUsings(usingDirective);
+            }
+
+            return document.WithSyntaxRoot(root);
+        }
+
+        private static SyntaxTrivia GetTrailingEndOfLine(UsingDirectiveSyntax usingDirective)
+        {
+            foreach (var trivia in usingDirective.GetTrailingTrivia())
+            {
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    return trivia;
+                }
+            }
+
+            return SyntaxFactory.ElasticCarriageReturnLineFeed;
+        }
+
+        private static bool HasUsingDirective(CompilationUnitSyntax compilationUnit)
+        {
+            // Check top-level usings
+            if (compilationUnit.Usings.Any(u => u.Name?.ToString() == ThrowHelperUsingNamespace))
+            {
+                return true;
+            }
+
+            // Check usings inside namespace declarations
+            foreach (var member in compilationUnit.Members)
+            {
+                if (member is BaseNamespaceDeclarationSyntax ns
+                    && ns.Usings.Any(u => u.Name?.ToString() == ThrowHelperUsingNamespace))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
@@ -181,7 +181,6 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
             {
                 IdentifierNameSyntax => true,
                 ThisExpressionSyntax => true,
-                MemberAccessExpressionSyntax ma => IsSimpleExpression(ma.Expression),
                 _ => false,
             };
         }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
 {
     /// <summary>
     /// A CodeFixProvider for <see cref="ThrowInInlinedMethodAnalyzer"/> that replaces
-    /// throw statements with ThrowHelper method calls.
+    /// throw statements and throw expressions with ThrowHelper method calls.
     /// </summary>
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ThrowInInlinedMethodCodeFixProvider))]
     [Shared]
@@ -29,23 +29,19 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
     {
         private const string ThrowHelperUsingNamespace = "Datadog.Trace.Util";
 
-        private static readonly int[] OneArg = { 1 };
-        private static readonly int[] OneOrTwoArgs = { 1, 2 };
-        private static readonly int[] OneToThreeArgs = { 1, 2, 3 };
-
-        private static readonly Dictionary<string, (string MethodName, int[] ValidArgCounts)> SupportedExceptions
-            = new Dictionary<string, (string, int[])>
+        private static readonly Dictionary<string, (string MethodName, int MaxArgs)> SupportedExceptions
+            = new Dictionary<string, (string, int)>
             {
-                ["System.ArgumentNullException"] = ("ThrowArgumentNullException", OneArg),
-                ["System.ArgumentOutOfRangeException"] = ("ThrowArgumentOutOfRangeException", OneToThreeArgs),
-                ["System.ArgumentException"] = ("ThrowArgumentException", OneOrTwoArgs),
-                ["System.InvalidOperationException"] = ("ThrowInvalidOperationException", OneArg),
-                ["System.Exception"] = ("ThrowException", OneArg),
-                ["System.InvalidCastException"] = ("ThrowInvalidCastException", OneArg),
-                ["System.IndexOutOfRangeException"] = ("ThrowIndexOutOfRangeException", OneArg),
-                ["System.NotSupportedException"] = ("ThrowNotSupportedException", OneArg),
-                ["System.Collections.Generic.KeyNotFoundException"] = ("ThrowKeyNotFoundException", OneArg),
-                ["System.NullReferenceException"] = ("ThrowNullReferenceException", OneArg),
+                ["System.ArgumentNullException"] = ("ThrowArgumentNullException", 1),
+                ["System.ArgumentOutOfRangeException"] = ("ThrowArgumentOutOfRangeException", 3),
+                ["System.ArgumentException"] = ("ThrowArgumentException", 2),
+                ["System.InvalidOperationException"] = ("ThrowInvalidOperationException", 1),
+                ["System.Exception"] = ("ThrowException", 1),
+                ["System.InvalidCastException"] = ("ThrowInvalidCastException", 1),
+                ["System.IndexOutOfRangeException"] = ("ThrowIndexOutOfRangeException", 1),
+                ["System.NotSupportedException"] = ("ThrowNotSupportedException", 1),
+                ["System.Collections.Generic.KeyNotFoundException"] = ("ThrowKeyNotFoundException", 1),
+                ["System.NullReferenceException"] = ("ThrowNullReferenceException", 1),
             };
 
         /// <inheritdoc />
@@ -68,42 +64,136 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
             var diagnostic = context.Diagnostics.First();
             var node = root.FindNode(diagnostic.Location.SourceSpan);
 
-            // Only handle throw statements with object creation expressions (not throw expressions or bare throw;)
-            if (node is not ThrowStatementSyntax throwStatement
-                || throwStatement.Expression is not ObjectCreationExpressionSyntax creation)
-            {
-                return;
-            }
-
             var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             if (semanticModel is null)
             {
                 return;
             }
 
-            var typeInfo = semanticModel.GetTypeInfo(creation, context.CancellationToken);
+            if (node is ThrowStatementSyntax throwStatement
+                && throwStatement.Expression is ObjectCreationExpressionSyntax creation1
+                && TryGetThrowHelperMethod(semanticModel, creation1, context.CancellationToken, out var methodName1))
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: $"Replace with ThrowHelper.{methodName1}",
+                        createChangedDocument: c => ReplaceThrowStatementAsync(context.Document, throwStatement, methodName1, c),
+                        equivalenceKey: nameof(ThrowInInlinedMethodCodeFixProvider)),
+                    diagnostic);
+            }
+            else if (node is ThrowExpressionSyntax throwExpression
+                     && throwExpression.Expression is ObjectCreationExpressionSyntax creation2
+                     && TryGetThrowHelperMethod(semanticModel, creation2, context.CancellationToken, out var methodName2)
+                     && CanConvertThrowExpression(throwExpression))
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: $"Replace with ThrowHelper.{methodName2}",
+                        createChangedDocument: c => ReplaceThrowExpressionAsync(context.Document, throwExpression, methodName2, c),
+                        equivalenceKey: nameof(ThrowInInlinedMethodCodeFixProvider)),
+                    diagnostic);
+            }
+        }
+
+        private static bool TryGetThrowHelperMethod(
+            SemanticModel semanticModel,
+            ObjectCreationExpressionSyntax creation,
+            CancellationToken cancellationToken,
+            out string methodName)
+        {
+            methodName = string.Empty;
+            var typeInfo = semanticModel.GetTypeInfo(creation, cancellationToken);
             var typeName = typeInfo.Type?.ToDisplayString();
 
             if (typeName is null || !SupportedExceptions.TryGetValue(typeName, out var entry))
             {
-                return;
+                return false;
             }
 
             var argCount = creation.ArgumentList?.Arguments.Count ?? 0;
-            if (!entry.ValidArgCounts.Contains(argCount))
+            if (argCount > entry.MaxArgs)
             {
-                return;
+                return false;
             }
 
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    title: $"Replace with ThrowHelper.{entry.MethodName}",
-                    createChangedDocument: c => ReplaceWithThrowHelperAsync(context.Document, throwStatement, entry.MethodName, c),
-                    equivalenceKey: nameof(ThrowInInlinedMethodCodeFixProvider)),
-                diagnostic);
+            methodName = entry.MethodName;
+            return true;
         }
 
-        private static async Task<Document> ReplaceWithThrowHelperAsync(
+        private static bool CanConvertThrowExpression(ThrowExpressionSyntax throwExpression)
+        {
+            var parent = throwExpression.Parent;
+
+            if (parent is BinaryExpressionSyntax coalesce && coalesce.IsKind(SyntaxKind.CoalesceExpression))
+            {
+                // Only offer fix when left side has no side effects (won't be evaluated twice)
+                if (!IsSimpleExpression(coalesce.Left))
+                {
+                    return false;
+                }
+
+                // Must be a direct expression of a statement (not nested in another expression)
+                if (!IsDirectStatementExpression(coalesce))
+                {
+                    return false;
+                }
+            }
+            else if (parent is ConditionalExpressionSyntax conditional)
+            {
+                if (!IsDirectStatementExpression(conditional))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+
+            // Must be inside a statement within a block (so we can insert the if-statement)
+            var statement = parent.FirstAncestorOrSelf<StatementSyntax>();
+            return statement?.Parent is BlockSyntax;
+        }
+
+        private static bool IsSimpleExpression(ExpressionSyntax expression)
+        {
+            return expression switch
+            {
+                IdentifierNameSyntax => true,
+                ThisExpressionSyntax => true,
+                MemberAccessExpressionSyntax ma => IsSimpleExpression(ma.Expression),
+                _ => false,
+            };
+        }
+
+        private static bool IsDirectStatementExpression(ExpressionSyntax expression)
+        {
+            var parent = expression.Parent;
+
+            // return expr;
+            if (parent is ReturnStatementSyntax)
+            {
+                return true;
+            }
+
+            // var x = expr; or T x = expr;
+            if (parent is EqualsValueClauseSyntax)
+            {
+                return true;
+            }
+
+            // x = expr; (where the assignment is the entire expression statement)
+            if (parent is AssignmentExpressionSyntax assignment
+                && assignment.Right == expression
+                && assignment.Parent is ExpressionStatementSyntax)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static async Task<Document> ReplaceThrowStatementAsync(
             Document document,
             ThrowStatementSyntax throwStatement,
             string methodName,
@@ -116,34 +206,187 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
                 return document;
             }
 
-            // Build: ThrowHelper.MethodName(args)
-            var invocation = SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.IdentifierName("ThrowHelper"),
-                    SyntaxFactory.IdentifierName(methodName)),
-                creation.ArgumentList ?? SyntaxFactory.ArgumentList());
-
+            var invocation = BuildThrowHelperInvocation(methodName, creation.ArgumentList);
             var expressionStatement = SyntaxFactory.ExpressionStatement(invocation)
                 .WithLeadingTrivia(throwStatement.GetLeadingTrivia())
                 .WithTrailingTrivia(throwStatement.GetTrailingTrivia());
 
             root = root.ReplaceNode(throwStatement, expressionStatement);
+            root = AddUsingDirectiveIfNeeded(root);
+            return document.WithSyntaxRoot(root);
+        }
 
-            // Add using directive if not already present
+        private static async Task<Document> ReplaceThrowExpressionAsync(
+            Document document,
+            ThrowExpressionSyntax throwExpression,
+            string methodName,
+            CancellationToken cancellationToken)
+        {
+            var creation = (ObjectCreationExpressionSyntax)throwExpression.Expression;
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return document;
+            }
+
+            var parent = throwExpression.Parent!;
+            var containingStatement = parent.FirstAncestorOrSelf<StatementSyntax>()!;
+            var block = (BlockSyntax)containingStatement.Parent!;
+
+            var throwHelperInvocation = BuildThrowHelperInvocation(methodName, creation.ArgumentList);
+
+            ExpressionSyntax condition;
+            ExpressionSyntax valueExpression;
+
+            if (parent is BinaryExpressionSyntax coalesce && coalesce.IsKind(SyntaxKind.CoalesceExpression))
+            {
+                // x ?? throw new Ex(args)  →  if (x is null) { ThrowHelper.ThrowEx(args); }
+                condition = SyntaxFactory.IsPatternExpression(
+                    coalesce.Left.WithoutTrivia(),
+                    SyntaxFactory.ConstantPattern(
+                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)));
+                valueExpression = coalesce.Left.WithoutTrivia();
+            }
+            else if (parent is ConditionalExpressionSyntax conditional)
+            {
+                if (conditional.WhenFalse == throwExpression)
+                {
+                    // cond ? val : throw  →  if (negated-cond) { ThrowHelper; }; use val
+                    condition = NegateExpression(conditional.Condition.WithoutTrivia());
+                    valueExpression = conditional.WhenTrue.WithoutTrivia();
+                }
+                else
+                {
+                    // cond ? throw : val  →  if (cond) { ThrowHelper; }; use val
+                    condition = conditional.Condition.WithoutTrivia();
+                    valueExpression = conditional.WhenFalse.WithoutTrivia();
+                }
+            }
+            else
+            {
+                return document;
+            }
+
+            // Build the if statement with proper formatting
+            var indentation = GetIndentation(containingStatement);
+            var eol = GetEndOfLine(containingStatement);
+            var ifStatement = BuildIfStatement(indentation, eol, condition, throwHelperInvocation);
+
+            // Replace the parent expression (coalesce/conditional) with just the value expression
+            var modifiedStatement = containingStatement.ReplaceNode(parent, valueExpression);
+
+            // Replace the single statement with if + modified statement in the block
+            var newStatements = new List<StatementSyntax>(block.Statements.Count + 1);
+            foreach (var stmt in block.Statements)
+            {
+                if (stmt == containingStatement)
+                {
+                    newStatements.Add(ifStatement);
+                    newStatements.Add(modifiedStatement);
+                }
+                else
+                {
+                    newStatements.Add(stmt);
+                }
+            }
+
+            root = root.ReplaceNode(block, block.WithStatements(SyntaxFactory.List(newStatements)));
+            root = AddUsingDirectiveIfNeeded(root);
+            return document.WithSyntaxRoot(root);
+        }
+
+        private static StatementSyntax BuildIfStatement(
+            string indentation,
+            string eol,
+            ExpressionSyntax condition,
+            InvocationExpressionSyntax throwHelperInvocation)
+        {
+            var conditionText = condition.NormalizeWhitespace().ToFullString();
+            var invocationText = throwHelperInvocation.NormalizeWhitespace().ToFullString();
+            var innerIndent = indentation + "    ";
+
+            var text = $"if ({conditionText}){eol}{indentation}{{{eol}{innerIndent}{invocationText};{eol}{indentation}}}";
+            return SyntaxFactory.ParseStatement(text)
+                .WithLeadingTrivia(SyntaxFactory.Whitespace(indentation))
+                .WithTrailingTrivia(SyntaxFactory.EndOfLine(eol));
+        }
+
+        private static ExpressionSyntax NegateExpression(ExpressionSyntax expression)
+        {
+            // Already negated with !: unwrap
+            if (expression is PrefixUnaryExpressionSyntax prefix
+                && prefix.IsKind(SyntaxKind.LogicalNotExpression))
+            {
+                return prefix.Operand is ParenthesizedExpressionSyntax paren
+                    ? paren.Expression
+                    : prefix.Operand;
+            }
+
+            // Simple expressions don't need parentheses: !expr
+            if (expression is IdentifierNameSyntax or MemberAccessExpressionSyntax
+                or InvocationExpressionSyntax or ParenthesizedExpressionSyntax)
+            {
+                return SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, expression);
+            }
+
+            // Complex expressions: !(expr)
+            return SyntaxFactory.PrefixUnaryExpression(
+                SyntaxKind.LogicalNotExpression,
+                SyntaxFactory.ParenthesizedExpression(expression));
+        }
+
+        private static InvocationExpressionSyntax BuildThrowHelperInvocation(
+            string methodName,
+            ArgumentListSyntax? argumentList)
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("ThrowHelper"),
+                    SyntaxFactory.IdentifierName(methodName)),
+                argumentList ?? SyntaxFactory.ArgumentList());
+        }
+
+        private static SyntaxNode AddUsingDirectiveIfNeeded(SyntaxNode root)
+        {
             if (root is CompilationUnitSyntax compilationUnit && !HasUsingDirective(compilationUnit))
             {
-                // Match the document's existing line ending style
                 var eolTrivia = compilationUnit.Usings.Count > 0
                     ? GetTrailingEndOfLine(compilationUnit.Usings.Last())
                     : SyntaxFactory.ElasticCarriageReturnLineFeed;
 
                 var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(ThrowHelperUsingNamespace))
                     .WithTrailingTrivia(eolTrivia);
-                root = compilationUnit.AddUsings(usingDirective);
+                return compilationUnit.AddUsings(usingDirective);
             }
 
-            return document.WithSyntaxRoot(root);
+            return root;
+        }
+
+        private static string GetIndentation(SyntaxNode node)
+        {
+            foreach (var trivia in node.GetLeadingTrivia())
+            {
+                if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                {
+                    return trivia.ToString();
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static string GetEndOfLine(SyntaxNode node)
+        {
+            foreach (var trivia in node.DescendantTrivia())
+            {
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    return trivia.ToString();
+                }
+            }
+
+            return "\r\n";
         }
 
         private static SyntaxTrivia GetTrailingEndOfLine(UsingDirectiveSyntax usingDirective)
@@ -161,13 +404,11 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
 
         private static bool HasUsingDirective(CompilationUnitSyntax compilationUnit)
         {
-            // Check top-level usings
             if (compilationUnit.Usings.Any(u => u.Name?.ToString() == ThrowHelperUsingNamespace))
             {
                 return true;
             }
 
-            // Check usings inside namespace declarations
             foreach (var member in compilationUnit.Members)
             {
                 if (member is BaseNamespaceDeclarationSyntax ns

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
@@ -42,6 +42,7 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
                 ["System.NotSupportedException"] = ("ThrowNotSupportedException", 1),
                 ["System.Collections.Generic.KeyNotFoundException"] = ("ThrowKeyNotFoundException", 1),
                 ["System.NullReferenceException"] = ("ThrowNullReferenceException", 1),
+                ["System.ObjectDisposedException"] = ("ThrowObjectDisposedException", 1),
             };
 
         /// <inheritdoc />

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProvider.cs
@@ -85,7 +85,8 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
             else if (node is ThrowExpressionSyntax throwExpression
                      && throwExpression.Expression is ObjectCreationExpressionSyntax creation2
                      && TryGetThrowHelperMethod(semanticModel, creation2, context.CancellationToken, out var methodName2)
-                     && CanConvertThrowExpression(throwExpression))
+                     && CanConvertThrowExpression(throwExpression)
+                     && !IsNullableValueTypeCoalesce(semanticModel, throwExpression, context.CancellationToken))
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(
@@ -154,6 +155,24 @@ namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer
             // Must be inside a statement within a block (so we can insert the if-statement)
             var statement = parent.FirstAncestorOrSelf<StatementSyntax>();
             return statement?.Parent is BlockSyntax;
+        }
+
+        private static bool IsNullableValueTypeCoalesce(
+            SemanticModel semanticModel,
+            ThrowExpressionSyntax throwExpression,
+            CancellationToken cancellationToken)
+        {
+            if (throwExpression.Parent is BinaryExpressionSyntax coalesce
+                && coalesce.IsKind(SyntaxKind.CoalesceExpression))
+            {
+                var typeInfo = semanticModel.GetTypeInfo(coalesce.Left, cancellationToken);
+                if (typeInfo.Type is INamedTypeSymbol { IsValueType: true, OriginalDefinition.SpecialType: SpecialType.System_Nullable_T })
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool IsSimpleExpression(ExpressionSyntax expression)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
@@ -1,0 +1,31 @@
+// <copyright file="Diagnostics.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Microsoft.CodeAnalysis;
+
+namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer;
+
+/// <summary>
+/// Diagnostic definitions for <see cref="ThrowInInlinedMethodAnalyzer"/>
+/// </summary>
+public static class Diagnostics
+{
+    /// <summary>
+    /// The diagnostic ID for throw statements in AggressiveInlining methods
+    /// </summary>
+    public const string DiagnosticId = "DDALLOC007";
+
+#pragma warning disable RS2008 // Enable analyzer release tracking
+    internal static readonly DiagnosticDescriptor ThrowInAggressiveInliningRule = new(
+        DiagnosticId,
+        title: "Avoid throw in AggressiveInlining method",
+        messageFormat: "Method '{0}' is marked [AggressiveInlining] but contains a throw statement, which prevents inlining. Extract the throw to a ThrowHelper method with [DoesNotReturn] and [MethodImpl(MethodImplOptions.NoInlining)].",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "throw statements prevent the JIT from inlining a method. Move the throw to a separate helper method marked with [MethodImpl(MethodImplOptions.NoInlining)] and [DoesNotReturn].");
+#pragma warning restore RS2008
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
@@ -16,7 +16,7 @@ public static class Diagnostics
     /// <summary>
     /// The diagnostic ID for throw statements in AggressiveInlining methods
     /// </summary>
-    public const string DiagnosticId = "DDALLOC007";
+    public const string DiagnosticId = "DD0011";
 
 #pragma warning disable RS2008 // Enable analyzer release tracking
     internal static readonly DiagnosticDescriptor ThrowInAggressiveInliningRule = new(

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
@@ -27,5 +27,14 @@ public static class Diagnostics
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: false,
         description: "throw statements prevent the JIT from inlining a method. Move the throw to a separate helper method marked with [MethodImpl(MethodImplOptions.NoInlining)] and [DoesNotReturn].");
+
+    internal static readonly DiagnosticDescriptor RethrowInAggressiveInliningRule = new(
+        DiagnosticId,
+        title: "Avoid throw in AggressiveInlining method",
+        messageFormat: "Method '{0}' is marked [AggressiveInlining] but contains a rethrow statement, which prevents inlining. Extract the try/catch block to a separate non-inlined method.",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "throw statements (including rethrows) prevent the JIT from inlining a method. Move the try/catch block to a separate method marked with [MethodImpl(MethodImplOptions.NoInlining)].");
 #pragma warning restore RS2008
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/Diagnostics.cs
@@ -25,7 +25,7 @@ public static class Diagnostics
         messageFormat: "Method '{0}' is marked [AggressiveInlining] but contains a throw statement, which prevents inlining. Extract the throw to a ThrowHelper method with [DoesNotReturn] and [MethodImpl(MethodImplOptions.NoInlining)].",
         category: "Performance",
         defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
+        isEnabledByDefault: false,
         description: "throw statements prevent the JIT from inlining a method. Move the throw to a separate helper method marked with [MethodImpl(MethodImplOptions.NoInlining)] and [DoesNotReturn].");
 #pragma warning restore RS2008
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzer.cs
@@ -1,0 +1,145 @@
+// <copyright file="ThrowInInlinedMethodAnalyzer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer;
+
+/// <summary>
+/// Detects throw statements inside methods marked with [MethodImpl(MethodImplOptions.AggressiveInlining)].
+/// throw prevents the JIT from inlining the method, defeating the attribute's purpose.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ThrowInInlinedMethodAnalyzer : DiagnosticAnalyzer
+{
+    private const int AggressiveInliningValue = (int)MethodImplOptions.AggressiveInlining; // 256
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Diagnostics.ThrowInAggressiveInliningRule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeThrow, SyntaxKind.ThrowStatement, SyntaxKind.ThrowExpression);
+    }
+
+    private static void AnalyzeThrow(SyntaxNodeAnalysisContext context)
+    {
+        var throwNode = context.Node;
+
+        // Walk up to find the containing method, property accessor, or constructor
+        var containingMember = GetContainingMember(throwNode);
+        if (containingMember is null)
+        {
+            return;
+        }
+
+        // Check if the member has [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        var declaredSymbol = context.SemanticModel.GetDeclaredSymbol(containingMember, context.CancellationToken);
+        if (declaredSymbol is not IMethodSymbol methodSymbol)
+        {
+            return;
+        }
+
+        if (HasAggressiveInlining(methodSymbol))
+        {
+            var memberName = GetMemberDisplayName(containingMember);
+            var diagnostic = Diagnostic.Create(
+                Diagnostics.ThrowInAggressiveInliningRule,
+                throwNode.GetLocation(),
+                memberName);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    private static SyntaxNode? GetContainingMember(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case MethodDeclarationSyntax:
+                case ConstructorDeclarationSyntax:
+                case DestructorDeclarationSyntax:
+                case OperatorDeclarationSyntax:
+                case ConversionOperatorDeclarationSyntax:
+                case AccessorDeclarationSyntax:
+                case LocalFunctionStatementSyntax:
+                    return current;
+                // Stop at type boundary — lambdas/anonymous methods create their own scope
+                case AnonymousFunctionExpressionSyntax:
+                case TypeDeclarationSyntax:
+                    return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasAggressiveInlining(IMethodSymbol methodSymbol)
+    {
+        foreach (var attribute in methodSymbol.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString() != "System.Runtime.CompilerServices.MethodImplAttribute")
+            {
+                continue;
+            }
+
+            // Check constructor argument: [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            if (attribute.ConstructorArguments.Length > 0)
+            {
+                var arg = attribute.ConstructorArguments[0];
+                if (arg.Value is int intValue && (intValue & AggressiveInliningValue) != 0)
+                {
+                    return true;
+                }
+
+                // The constructor also accepts MethodImplOptions (short) cast scenarios
+                if (arg.Value is short shortValue && (shortValue & AggressiveInliningValue) != 0)
+                {
+                    return true;
+                }
+            }
+
+            // Check named argument: [MethodImpl(Value = MethodImplOptions.AggressiveInlining)]
+            foreach (var namedArg in attribute.NamedArguments)
+            {
+                if (namedArg.Key == "Value" &&
+                    namedArg.Value.Value is int namedIntValue &&
+                    (namedIntValue & AggressiveInliningValue) != 0)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetMemberDisplayName(SyntaxNode member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax m => m.Identifier.Text,
+            ConstructorDeclarationSyntax c => c.Identifier.Text,
+            DestructorDeclarationSyntax d => "~" + d.Identifier.Text,
+            OperatorDeclarationSyntax o => "operator " + o.OperatorToken.Text,
+            ConversionOperatorDeclarationSyntax co => co.ImplicitOrExplicitKeyword.Text + " operator " + co.Type,
+            AccessorDeclarationSyntax a => a.Keyword.Text,
+            LocalFunctionStatementSyntax l => l.Identifier.Text,
+            _ => "unknown",
+        };
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzer.cs
@@ -25,7 +25,7 @@ public class ThrowInInlinedMethodAnalyzer : DiagnosticAnalyzer
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => ImmutableArray.Create(Diagnostics.ThrowInAggressiveInliningRule);
+        => ImmutableArray.Create(Diagnostics.ThrowInAggressiveInliningRule, Diagnostics.RethrowInAggressiveInliningRule);
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -56,13 +56,16 @@ public class ThrowInInlinedMethodAnalyzer : DiagnosticAnalyzer
         if (HasAggressiveInlining(methodSymbol))
         {
             var memberName = GetMemberDisplayName(containingMember);
-            var diagnostic = Diagnostic.Create(
-                Diagnostics.ThrowInAggressiveInliningRule,
-                throwNode.GetLocation(),
-                memberName);
+            var rule = IsRethrow(throwNode)
+                ? Diagnostics.RethrowInAggressiveInliningRule
+                : Diagnostics.ThrowInAggressiveInliningRule;
+            var diagnostic = Diagnostic.Create(rule, throwNode.GetLocation(), memberName);
             context.ReportDiagnostic(diagnostic);
         }
     }
+
+    private static bool IsRethrow(SyntaxNode throwNode)
+        => throwNode is ThrowStatementSyntax { Expression: null };
 
     private static SyntaxNode? GetContainingMember(SyntaxNode node)
     {

--- a/tracer/src/Datadog.Trace/.editorconfig
+++ b/tracer/src/Datadog.Trace/.editorconfig
@@ -2,6 +2,7 @@
 
 [*.{cs,vb}]
 dotnet_diagnostic.DDSEAL001.severity = error # types should be sealed
+dotnet_diagnostic.DDALLOC007.severity = none # throw in AggressiveInlining methods - disabled until existing usages are migrated
 
 # Microsoft performance analyzers
 dotnet_diagnostic.CA1802.severity = error # Use Literals Where Appropriate

--- a/tracer/src/Datadog.Trace/.editorconfig
+++ b/tracer/src/Datadog.Trace/.editorconfig
@@ -2,7 +2,7 @@
 
 [*.{cs,vb}]
 dotnet_diagnostic.DDSEAL001.severity = error # types should be sealed
-dotnet_diagnostic.DDALLOC007.severity = error # throw in AggressiveInlining methods
+dotnet_diagnostic.DD0011.severity = error # throw in AggressiveInlining methods
 
 # Microsoft performance analyzers
 dotnet_diagnostic.CA1802.severity = error # Use Literals Where Appropriate

--- a/tracer/src/Datadog.Trace/.editorconfig
+++ b/tracer/src/Datadog.Trace/.editorconfig
@@ -2,7 +2,7 @@
 
 [*.{cs,vb}]
 dotnet_diagnostic.DDSEAL001.severity = error # types should be sealed
-dotnet_diagnostic.DDALLOC007.severity = none # throw in AggressiveInlining methods - disabled until existing usages are migrated
+dotnet_diagnostic.DDALLOC007.severity = error # throw in AggressiveInlining methods
 
 # Microsoft performance analyzers
 dotnet_diagnostic.CA1802.severity = error # Use Literals Where Appropriate

--- a/tracer/src/Datadog.Trace/Ci/Coverage/CoverageReporter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/CoverageReporter.cs
@@ -29,7 +29,15 @@ public static class CoverageReporter
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => _handler;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => _handler = value ?? throw new ArgumentNullException(nameof(value));
+        set
+        {
+            if (value == null!)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(value));
+            }
+
+            _handler = value;
+        }
     }
 
     internal static CoverageContextContainer? Container => _handler.Container;

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionNormalizer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionNormalizer.cs
@@ -30,7 +30,8 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         {
             if (string.IsNullOrEmpty(exceptionString))
             {
-                throw new ArgumentException(@"Exception string cannot be null or empty", nameof(exceptionString));
+                ThrowHelper.ThrowArgumentException(@"Exception string cannot be null or empty", nameof(exceptionString));
+                return 0; // code never reached
             }
 
             var fnvHashCode = HashLine(outerExceptionType.AsSpan(), Fnv1aHash.FnvOffsetBias);
@@ -104,7 +105,8 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         {
             if (string.IsNullOrEmpty(exceptionString))
             {
-                throw new ArgumentException(@"Exception string cannot be null or empty", nameof(exceptionString));
+                ThrowHelper.ThrowArgumentException(@"Exception string cannot be null or empty", nameof(exceptionString));
+                return null; // code never reached
             }
 
             var results = new List<string>();

--- a/tracer/src/Datadog.Trace/Util/FixedSizeArrayPool.cs
+++ b/tracer/src/Datadog.Trace/Util/FixedSizeArrayPool.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -115,7 +114,7 @@ internal sealed class FixedSizeArrayPool<T>
 #if DEBUG
                 if (_array is null)
                 {
-                    throw new ObjectDisposedException(nameof(ArrayPoolItem));
+                    ThrowHelper.ThrowObjectDisposedException(nameof(ArrayPoolItem));
                 }
 #endif
                 return _array ?? [];

--- a/tracer/src/Datadog.Trace/Util/SpanCharSplitter.cs
+++ b/tracer/src/Datadog.Trace/Util/SpanCharSplitter.cs
@@ -19,7 +19,12 @@ internal readonly ref struct SpanCharSplitter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public SpanCharSplitter(string source, char separator, int count)
     {
-        _source = source ?? throw new ArgumentNullException(nameof(source));
+        if (source == null!)
+        {
+            ThrowHelper.ThrowArgumentNullException(nameof(source));
+        }
+
+        _source = source;
         _separator = separator;
         _count = count;
     }

--- a/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
@@ -77,5 +77,10 @@ namespace Datadog.Trace.Util
         [DebuggerHidden]
         [DoesNotReturn]
         internal static void ThrowNullReferenceException(string message) => throw new NullReferenceException(message);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [DebuggerHidden]
+        [DoesNotReturn]
+        internal static void ThrowObjectDisposedException(string objectName) => throw new ObjectDisposedException(objectName);
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzerTests.cs
@@ -191,7 +191,7 @@ public class ThrowInInlinedMethodAnalyzerTests
 
             class TestClass
             {
-                [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+                [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.NoOptimization)]
                 void TestMethod()
                 {
                     {|#0:throw new InvalidOperationException();|}
@@ -258,6 +258,37 @@ public class ThrowInInlinedMethodAnalyzerTests
         var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
             .WithLocation(0)
             .WithArguments("TestMethod");
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagThrowInAggressiveInliningLocalFunction()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                void OuterMethod()
+                {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    int LocalFunc(int value)
+                    {
+                        if (value < 0)
+                        {
+                            {|#0:throw new ArgumentOutOfRangeException(nameof(value));|}
+                        }
+
+                        return value;
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("LocalFunc");
         await Verifier.VerifyAnalyzerAsync(source, expected);
     }
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodAnalyzerTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="ThrowInInlinedMethodAnalyzerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer.ThrowInInlinedMethodAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests.ThrowInInlinedMethodAnalyzer;
+
+public class ThrowInInlinedMethodAnalyzerTests
+{
+    private const string DiagnosticId = Analyzers.ThrowInInlinedMethodAnalyzer.Diagnostics.DiagnosticId;
+
+    [Fact]
+    public async Task EmptySourceShouldNotHaveDiagnostics()
+    {
+        await Verifier.VerifyAnalyzerAsync(string.Empty);
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagThrowInRegularMethod()
+    {
+        const string source = """
+            using System;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagThrowInNoInliningMethod()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                void TestMethod()
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagAggressiveInliningMethodWithoutThrow()
+    {
+        const string source = """
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                int Add(int a, int b) => a + b;
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagThrowInLambdaInsideAggressiveInliningMethod()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    Action a = () => throw new InvalidOperationException();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ShouldFlagThrowNewInAggressiveInliningMethod()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        {|#0:throw new ArgumentNullException(nameof(arg));|}
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagThrowExpressionInAggressiveInliningMethod()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                object TestMethod(object? arg)
+                {
+                    return arg ?? {|#0:throw new ArgumentNullException(nameof(arg))|};
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMultipleThrowsInAggressiveInliningMethod()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg1, object? arg2)
+                {
+                    if (arg1 is null)
+                    {
+                        {|#0:throw new ArgumentNullException(nameof(arg1));|}
+                    }
+
+                    if (arg2 is null)
+                    {
+                        {|#1:throw new ArgumentNullException(nameof(arg2));|}
+                    }
+                }
+            }
+            """;
+
+        var expected1 = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        var expected2 = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(1)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyAnalyzerAsync(source, expected1, expected2);
+    }
+
+    [Fact]
+    public async Task ShouldFlagAggressiveInliningWithCombinedFlags()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+                void TestMethod()
+                {
+                    {|#0:throw new InvalidOperationException();|}
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagThrowInAggressiveInliningConstructor()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public TestClass(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        {|#0:throw new ArgumentNullException(nameof(arg));|}
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestClass");
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagRethrowInAggressiveInliningMethod()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    try
+                    {
+                        Console.WriteLine();
+                    }
+                    catch
+                    {
+                        {|#0:throw;|}
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagThrowInAggressiveInliningPropertyGetter()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                private object? _value;
+
+                object Value
+                {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    get
+                    {
+                        {|#0:throw new InvalidOperationException();|}
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("get");
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
@@ -309,49 +309,6 @@ public class ThrowInInlinedMethodCodeFixProviderTests
     }
 
     [Fact]
-    public async Task ShouldFixThrowExpression()
-    {
-        // Throw expressions in null-coalescing are converted to if-statements
-        const string source = """
-            using System;
-            using System.Runtime.CompilerServices;
-
-            class TestClass
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                object TestMethod(object? arg)
-                {
-                    return arg ?? {|#0:throw new ArgumentNullException(nameof(arg))|};
-                }
-            }
-            """;
-
-        const string fix = """
-            using System;
-            using System.Runtime.CompilerServices;
-            using Datadog.Trace.Util;
-
-            class TestClass
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                object TestMethod(object? arg)
-                {
-                    if (arg is null)
-                    {
-                        ThrowHelper.ThrowArgumentNullException(nameof(arg));
-                    }
-                    return arg;
-                }
-            }
-            """;
-
-        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
-            .WithLocation(0)
-            .WithArguments("TestMethod");
-        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
-    }
-
-    [Fact]
     public async Task ShouldNotFixBareThrow()
     {
         // bare throw; (rethrow) has no exception constructor to map

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
@@ -558,4 +558,29 @@ public class ThrowInInlinedMethodCodeFixProviderTests
             .WithArguments("TestMethod");
         await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
     }
+
+    [Fact]
+    public async Task ShouldNotFixNullCoalesceWithNullableValueType()
+    {
+        // int? ?? throw produces int, but the fix would produce int? — skip the fix
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                int TestMethod(int? value)
+                {
+                    return value ?? {|#0:throw new ArgumentNullException(nameof(value))|};
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
@@ -22,35 +22,25 @@ public class ThrowInInlinedMethodCodeFixProviderTests
 {
     private const string DiagnosticId = Analyzers.ThrowInInlinedMethodAnalyzer.Diagnostics.DiagnosticId;
 
-    // Minimal ThrowHelper stub so the fixed code compiles in the test harness
+    // Minimal ThrowHelper stub matching real signatures so the fixed code compiles in the test harness
     private const string ThrowHelperStub = """
 
         namespace Datadog.Trace.Util
         {
             internal static class ThrowHelper
             {
-                internal static void ThrowArgumentNullException() => throw new System.ArgumentNullException();
                 internal static void ThrowArgumentNullException(string paramName) => throw new System.ArgumentNullException(paramName);
-                internal static void ThrowArgumentOutOfRangeException() => throw new System.ArgumentOutOfRangeException();
                 internal static void ThrowArgumentOutOfRangeException(string paramName) => throw new System.ArgumentOutOfRangeException(paramName);
                 internal static void ThrowArgumentOutOfRangeException(string paramName, string message) => throw new System.ArgumentOutOfRangeException(paramName, message);
                 internal static void ThrowArgumentOutOfRangeException(string paramName, object actualValue, string message) => throw new System.ArgumentOutOfRangeException(paramName, actualValue, message);
-                internal static void ThrowArgumentException() => throw new System.ArgumentException();
                 internal static void ThrowArgumentException(string message) => throw new System.ArgumentException(message);
                 internal static void ThrowArgumentException(string message, string paramName) => throw new System.ArgumentException(message, paramName);
-                internal static void ThrowInvalidOperationException() => throw new System.InvalidOperationException();
                 internal static void ThrowInvalidOperationException(string message) => throw new System.InvalidOperationException(message);
-                internal static void ThrowException() => throw new System.Exception();
                 internal static void ThrowException(string message) => throw new System.Exception(message);
-                internal static void ThrowInvalidCastException() => throw new System.InvalidCastException();
                 internal static void ThrowInvalidCastException(string message) => throw new System.InvalidCastException(message);
-                internal static void ThrowIndexOutOfRangeException() => throw new System.IndexOutOfRangeException();
                 internal static void ThrowIndexOutOfRangeException(string message) => throw new System.IndexOutOfRangeException(message);
-                internal static void ThrowNotSupportedException() => throw new System.NotSupportedException();
                 internal static void ThrowNotSupportedException(string message) => throw new System.NotSupportedException(message);
-                internal static void ThrowKeyNotFoundException() => throw new System.Collections.Generic.KeyNotFoundException();
                 internal static void ThrowKeyNotFoundException(string message) => throw new System.Collections.Generic.KeyNotFoundException(message);
-                internal static void ThrowNullReferenceException() => throw new System.NullReferenceException();
                 internal static void ThrowNullReferenceException(string message) => throw new System.NullReferenceException(message);
             }
         }
@@ -271,8 +261,10 @@ public class ThrowInInlinedMethodCodeFixProviderTests
     }
 
     [Fact]
-    public async Task ShouldFixZeroArgConstructor()
+    public async Task ShouldNotFixZeroArgConstructor()
     {
+        // Zero-arg constructors have no matching ThrowHelper overload, so no fix should be offered.
+        // The diagnostic is still reported, but the source is unchanged.
         const string source = """
             using System;
             using System.Runtime.CompilerServices;
@@ -287,25 +279,11 @@ public class ThrowInInlinedMethodCodeFixProviderTests
             }
             """;
 
-        const string fix = """
-            using System;
-            using System.Runtime.CompilerServices;
-            using Datadog.Trace.Util;
-
-            class TestClass
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                void TestMethod()
-                {
-                    ThrowHelper.ThrowInvalidOperationException();
-                }
-            }
-            """;
-
         var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
             .WithLocation(0)
             .WithArguments("TestMethod");
-        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
@@ -515,6 +515,35 @@ public class ThrowInInlinedMethodCodeFixProviderTests
     }
 
     [Fact]
+    public async Task ShouldNotFixNullCoalesceWithMemberAccessLeftSide()
+    {
+        // obj.Value could be a property with side effects — can't be evaluated twice safely
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                private object? _inner;
+
+                object Inner => _inner;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                object TestMethod()
+                {
+                    return this.Inner ?? {|#0:throw new InvalidOperationException("no value")|};
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
+    }
+
+    [Fact]
     public async Task ShouldNotAddDuplicateUsingDirective()
     {
         const string source = """

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
@@ -29,18 +29,28 @@ public class ThrowInInlinedMethodCodeFixProviderTests
         {
             internal static class ThrowHelper
             {
+                internal static void ThrowArgumentNullException() => throw new System.ArgumentNullException();
                 internal static void ThrowArgumentNullException(string paramName) => throw new System.ArgumentNullException(paramName);
+                internal static void ThrowArgumentOutOfRangeException() => throw new System.ArgumentOutOfRangeException();
                 internal static void ThrowArgumentOutOfRangeException(string paramName) => throw new System.ArgumentOutOfRangeException(paramName);
                 internal static void ThrowArgumentOutOfRangeException(string paramName, string message) => throw new System.ArgumentOutOfRangeException(paramName, message);
                 internal static void ThrowArgumentOutOfRangeException(string paramName, object actualValue, string message) => throw new System.ArgumentOutOfRangeException(paramName, actualValue, message);
+                internal static void ThrowArgumentException() => throw new System.ArgumentException();
                 internal static void ThrowArgumentException(string message) => throw new System.ArgumentException(message);
                 internal static void ThrowArgumentException(string message, string paramName) => throw new System.ArgumentException(message, paramName);
+                internal static void ThrowInvalidOperationException() => throw new System.InvalidOperationException();
                 internal static void ThrowInvalidOperationException(string message) => throw new System.InvalidOperationException(message);
+                internal static void ThrowException() => throw new System.Exception();
                 internal static void ThrowException(string message) => throw new System.Exception(message);
+                internal static void ThrowInvalidCastException() => throw new System.InvalidCastException();
                 internal static void ThrowInvalidCastException(string message) => throw new System.InvalidCastException(message);
+                internal static void ThrowIndexOutOfRangeException() => throw new System.IndexOutOfRangeException();
                 internal static void ThrowIndexOutOfRangeException(string message) => throw new System.IndexOutOfRangeException(message);
+                internal static void ThrowNotSupportedException() => throw new System.NotSupportedException();
                 internal static void ThrowNotSupportedException(string message) => throw new System.NotSupportedException(message);
+                internal static void ThrowKeyNotFoundException() => throw new System.Collections.Generic.KeyNotFoundException();
                 internal static void ThrowKeyNotFoundException(string message) => throw new System.Collections.Generic.KeyNotFoundException(message);
+                internal static void ThrowNullReferenceException() => throw new System.NullReferenceException();
                 internal static void ThrowNullReferenceException(string message) => throw new System.NullReferenceException(message);
             }
         }
@@ -261,9 +271,8 @@ public class ThrowInInlinedMethodCodeFixProviderTests
     }
 
     [Fact]
-    public async Task ShouldNotFixZeroArgConstructor()
+    public async Task ShouldFixZeroArgConstructor()
     {
-        // throw new InvalidOperationException() has 0 args, ThrowHelper requires 1
         const string source = """
             using System;
             using System.Runtime.CompilerServices;
@@ -278,17 +287,31 @@ public class ThrowInInlinedMethodCodeFixProviderTests
             }
             """;
 
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    ThrowHelper.ThrowInvalidOperationException();
+                }
+            }
+            """;
+
         var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
             .WithLocation(0)
             .WithArguments("TestMethod");
-
-        await Verifier.VerifyCodeFixAsync(source, expected, source);
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
     }
 
     [Fact]
-    public async Task ShouldNotFixThrowExpression()
+    public async Task ShouldFixThrowExpression()
     {
-        // Throw expressions can't be replaced with void ThrowHelper calls
+        // Throw expressions in null-coalescing are converted to if-statements
         const string source = """
             using System;
             using System.Runtime.CompilerServices;
@@ -303,11 +326,29 @@ public class ThrowInInlinedMethodCodeFixProviderTests
             }
             """;
 
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                object TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        ThrowHelper.ThrowArgumentNullException(nameof(arg));
+                    }
+                    return arg;
+                }
+            }
+            """;
+
         var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
             .WithLocation(0)
             .WithArguments("TestMethod");
-
-        await Verifier.VerifyCodeFixAsync(source, expected, source);
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
     }
 
     [Fact]
@@ -332,6 +373,201 @@ public class ThrowInInlinedMethodCodeFixProviderTests
                         {|#0:throw;|}
                     }
                 }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
+    }
+
+    [Fact]
+    public async Task ShouldFixNullCoalesceThrowExpressionInReturn()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                object TestMethod(object? arg)
+                {
+                    return arg ?? {|#0:throw new ArgumentNullException(nameof(arg))|};
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                object TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        ThrowHelper.ThrowArgumentNullException(nameof(arg));
+                    }
+                    return arg;
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldFixNullCoalesceThrowExpressionInAssignment()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg)
+                {
+                    var value = arg ?? {|#0:throw new ArgumentNullException(nameof(arg))|};
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        ThrowHelper.ThrowArgumentNullException(nameof(arg));
+                    }
+                    var value = arg;
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldFixConditionalThrowExpressionInFalseBranch()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                string TestMethod(bool isValid, string value)
+                {
+                    return isValid ? value : {|#0:throw new InvalidOperationException("invalid")|};
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                string TestMethod(bool isValid, string value)
+                {
+                    if (!isValid)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException("invalid");
+                    }
+                    return value;
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldFixConditionalThrowExpressionInTrueBranch()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                string TestMethod(bool isError, string value)
+                {
+                    return isError ? {|#0:throw new InvalidOperationException("error")|} : value;
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                string TestMethod(bool isError, string value)
+                {
+                    if (isError)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException("error");
+                    }
+                    return value;
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldNotFixNullCoalesceWithMethodCallLeftSide()
+    {
+        // GetValue() has side effects — can't be evaluated twice safely
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                object TestMethod()
+                {
+                    return GetValue() ?? {|#0:throw new InvalidOperationException("no value")|};
+                }
+
+                object? GetValue() => null;
             }
             """;
 

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
@@ -42,6 +42,7 @@ public class ThrowInInlinedMethodCodeFixProviderTests
                 internal static void ThrowNotSupportedException(string message) => throw new System.NotSupportedException(message);
                 internal static void ThrowKeyNotFoundException(string message) => throw new System.Collections.Generic.KeyNotFoundException(message);
                 internal static void ThrowNullReferenceException(string message) => throw new System.NullReferenceException(message);
+                internal static void ThrowObjectDisposedException(string objectName) => throw new System.ObjectDisposedException(objectName);
             }
         }
         """;

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/ThrowInInlinedMethodAnalyzer/ThrowInInlinedMethodCodeFixProviderTests.cs
@@ -1,0 +1,389 @@
+// <copyright file="ThrowInInlinedMethodCodeFixProviderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+extern alias AnalyzerCodeFixes;
+
+#nullable enable
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
+    Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer.ThrowInInlinedMethodAnalyzer,
+    AnalyzerCodeFixes::Datadog.Trace.Tools.Analyzers.ThrowInInlinedMethodAnalyzer.ThrowInInlinedMethodCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests.ThrowInInlinedMethodAnalyzer;
+
+public class ThrowInInlinedMethodCodeFixProviderTests
+{
+    private const string DiagnosticId = Analyzers.ThrowInInlinedMethodAnalyzer.Diagnostics.DiagnosticId;
+
+    // Minimal ThrowHelper stub so the fixed code compiles in the test harness
+    private const string ThrowHelperStub = """
+
+        namespace Datadog.Trace.Util
+        {
+            internal static class ThrowHelper
+            {
+                internal static void ThrowArgumentNullException(string paramName) => throw new System.ArgumentNullException(paramName);
+                internal static void ThrowArgumentOutOfRangeException(string paramName) => throw new System.ArgumentOutOfRangeException(paramName);
+                internal static void ThrowArgumentOutOfRangeException(string paramName, string message) => throw new System.ArgumentOutOfRangeException(paramName, message);
+                internal static void ThrowArgumentOutOfRangeException(string paramName, object actualValue, string message) => throw new System.ArgumentOutOfRangeException(paramName, actualValue, message);
+                internal static void ThrowArgumentException(string message) => throw new System.ArgumentException(message);
+                internal static void ThrowArgumentException(string message, string paramName) => throw new System.ArgumentException(message, paramName);
+                internal static void ThrowInvalidOperationException(string message) => throw new System.InvalidOperationException(message);
+                internal static void ThrowException(string message) => throw new System.Exception(message);
+                internal static void ThrowInvalidCastException(string message) => throw new System.InvalidCastException(message);
+                internal static void ThrowIndexOutOfRangeException(string message) => throw new System.IndexOutOfRangeException(message);
+                internal static void ThrowNotSupportedException(string message) => throw new System.NotSupportedException(message);
+                internal static void ThrowKeyNotFoundException(string message) => throw new System.Collections.Generic.KeyNotFoundException(message);
+                internal static void ThrowNullReferenceException(string message) => throw new System.NullReferenceException(message);
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task ShouldFixThrowArgumentNullException()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        {|#0:throw new ArgumentNullException(nameof(arg));|}
+                    }
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        ThrowHelper.ThrowArgumentNullException(nameof(arg));
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldFixThrowInvalidOperationException()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    {|#0:throw new InvalidOperationException("something went wrong");|}
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    ThrowHelper.ThrowInvalidOperationException("something went wrong");
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldFixThrowArgumentOutOfRangeExceptionWithThreeArgs()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(int value)
+                {
+                    if (value < 0)
+                    {
+                        {|#0:throw new ArgumentOutOfRangeException(nameof(value), value, "must be non-negative");|}
+                    }
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(int value)
+                {
+                    if (value < 0)
+                    {
+                        ThrowHelper.ThrowArgumentOutOfRangeException(nameof(value), value, "must be non-negative");
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldFixMultipleThrowsInSameMethod()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg1, object? arg2)
+                {
+                    if (arg1 is null)
+                    {
+                        {|#0:throw new ArgumentNullException(nameof(arg1));|}
+                    }
+
+                    if (arg2 is null)
+                    {
+                        {|#1:throw new ArgumentNullException(nameof(arg2));|}
+                    }
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg1, object? arg2)
+                {
+                    if (arg1 is null)
+                    {
+                        ThrowHelper.ThrowArgumentNullException(nameof(arg1));
+                    }
+
+                    if (arg2 is null)
+                    {
+                        ThrowHelper.ThrowArgumentNullException(nameof(arg2));
+                    }
+                }
+            }
+            """;
+
+        var expected = new[]
+        {
+            new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("TestMethod"),
+            new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+                .WithLocation(1)
+                .WithArguments("TestMethod"),
+        };
+
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+
+    [Fact]
+    public async Task ShouldNotFixUnsupportedExceptionType()
+    {
+        // NotImplementedException is not in ThrowHelper, so no fix should be offered.
+        // The diagnostic is still reported, but the verifier accepts no code fix.
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    {|#0:throw new NotImplementedException();|}
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+
+        // Verify the diagnostic is reported but the source is unchanged (no fix applied)
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
+    }
+
+    [Fact]
+    public async Task ShouldNotFixZeroArgConstructor()
+    {
+        // throw new InvalidOperationException() has 0 args, ThrowHelper requires 1
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    {|#0:throw new InvalidOperationException();|}
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
+    }
+
+    [Fact]
+    public async Task ShouldNotFixThrowExpression()
+    {
+        // Throw expressions can't be replaced with void ThrowHelper calls
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                object TestMethod(object? arg)
+                {
+                    return arg ?? {|#0:throw new ArgumentNullException(nameof(arg))|};
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
+    }
+
+    [Fact]
+    public async Task ShouldNotFixBareThrow()
+    {
+        // bare throw; (rethrow) has no exception constructor to map
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod()
+                {
+                    try
+                    {
+                        Console.WriteLine();
+                    }
+                    catch
+                    {
+                        {|#0:throw;|}
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+
+        await Verifier.VerifyCodeFixAsync(source, expected, source);
+    }
+
+    [Fact]
+    public async Task ShouldNotAddDuplicateUsingDirective()
+    {
+        const string source = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        {|#0:throw new ArgumentNullException(nameof(arg));|}
+                    }
+                }
+            }
+            """;
+
+        const string fix = """
+            using System;
+            using System.Runtime.CompilerServices;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void TestMethod(object? arg)
+                {
+                    if (arg is null)
+                    {
+                        ThrowHelper.ThrowArgumentNullException(nameof(arg));
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("TestMethod");
+        await Verifier.VerifyCodeFixAsync(source + ThrowHelperStub, expected, fix + ThrowHelperStub);
+    }
+}


### PR DESCRIPTION
## Summary of changes

Add new Roslyn analyzer `DD0011` that detects `throw` statements inside methods marked with `[MethodImpl(MethodImplOptions.AggressiveInlining)]`, plus a code fix that replaces `throw new <ExceptionType>(args)` with the corresponding `ThrowHelper` method call. The JIT compiler refuses to inline methods containing `throw`, making the attribute ineffective.

## Reason for change

When a method is marked `[AggressiveInlining]` but contains a `throw` statement, the JIT silently ignores the inlining hint. This is a subtle performance pitfall — the developer intended the method to be inlined, but the `throw` prevents it. Extracting the throw to a `[DoesNotReturn]` + `[NoInlining]` helper method restores inlining eligibility.

## Implementation details

- New analyzer: `ThrowInInlinedMethodAnalyzer` under `Datadog.Trace.Tools.Analyzers`
- Diagnostic ID: `DD0011` (category: Performance, severity: Warning)
- Detects both `throw` statements and `throw` expressions (e.g., `?? throw new ...`)
- Separate diagnostic message for bare rethrows (`throw;`) advising to extract the try/catch block
- `isEnabledByDefault: false` — enabled as `error` via `.editorconfig` in `Datadog.Trace` project only
- 4 existing violations fixed: `CoverageReporter`, `ExceptionNormalizer`, `FixedSizeArrayPool`, `SpanCharSplitter`
- New code fix: `ThrowInInlinedMethodCodeFixProvider` under `Datadog.Trace.Tools.Analyzers.CodeFixes`
- Replaces `throw new <ExceptionType>(args)` with `ThrowHelper.Throw<ExceptionType>(args)` for 11 exception types in `ThrowHelper.cs`
- Handles throw statements and throw expressions in null-coalescing (`??`) and ternary (`? :`) contexts
- No fix offered for bare rethrows (`throw;`), unsupported exception types, or zero-arg constructors (no matching ThrowHelper overload)
- No fix offered for nullable value type coalesce (`int? ?? throw`) — the fix would lose the unwrapping semantics
- No fix offered for member-access or method-call coalesce (`obj.Prop ?? throw`, `GetValue() ?? throw`) — potential side effects or double evaluation
- Adds `using Datadog.Trace.Util;` if not already present
- Added `ThrowHelper.ThrowObjectDisposedException(string)` overload

## Test coverage

Unit tests in `ThrowInInlinedMethodAnalyzerTests.cs` covering:
- Methods with `[AggressiveInlining]` containing throw statements (flagged)
- Methods with `[AggressiveInlining]` containing throw expressions (flagged)
- Methods without the attribute (not flagged)
- Methods with the attribute but no throw (not flagged)

Unit tests in `ThrowInInlinedMethodCodeFixProviderTests.cs` covering:
- Fix replaces supported exception types (`ArgumentNullException`, `InvalidOperationException`, `ArgumentOutOfRangeException` with 3 args)
- Fix handles multiple throws in the same method (FixAll)
- Fix converts null-coalescing throw expressions to if-statement + ThrowHelper (return and assignment contexts)
- Fix converts ternary throw expressions to if-statement + ThrowHelper (true and false branches)
- No fix offered for unsupported exception types (e.g., `NotImplementedException`)
- No fix offered for zero-arg constructors (no matching ThrowHelper overload)
- No fix offered for bare `throw;` (rethrow)
- No fix offered for null-coalescing with method call on left side (side effects)
- No fix offered for null-coalescing with member-access on left side (potential side effects)
- No fix offered for nullable value type coalesce (would lose unwrapping)
- No duplicate `using` directive when already present

## Other details

Stacked on #8421

> *"I throw exceptions at code that throws exceptions — it's throws all the way down."* — Claude 🤖



