### PR TITLE
[Analyzers] Add analyzer and code fix for `StringBuilderCache`

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/Datadog.Trace.Tools.Analyzers.CodeFixes.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/Datadog.Trace.Tools.Analyzers.CodeFixes.csproj
@@ -20,6 +20,7 @@
     <Compile Include="..\Datadog.Trace.Tools.Analyzers\LogAnalyzer\Diagnostics.cs" Link="LogAnalyzer\Diagnostics.cs" />
     <Compile Include="..\Datadog.Trace.Tools.Analyzers\ThreadAbortAnalyzer\Diagnostics.cs" Link="ThreadAbortAnalyzer\Diagnostics.cs" />
     <Compile Include="..\Datadog.Trace.Tools.Analyzers\SealedAnalyzer\Diagnostics.cs" Link="SealedAnalyzer\Diagnostics.cs" />
+    <Compile Include="..\Datadog.Trace.Tools.Analyzers\StringBuilderCacheAnalyzer\Diagnostics.cs" Link="StringBuilderCacheAnalyzer\Diagnostics.cs" />
     <Compile Include="..\Datadog.Trace\Util\System.Diagnostics.CodeAnalysis.Attributes.cs" Link="Helpers\System.Diagnostics.CodeAnalysis.Attributes.cs" />
     <Compile Include="..\Datadog.Trace\Util\System.Runtime.CompilerServices.Attributes.cs" Link="Helpers\System.Runtime.CompilerServices.Attributes.cs" />
     <Compile Update="LogAnalyzer\ConstantMessageTemplateCodeFixProvider.*.cs">

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -505,7 +505,8 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         {
             if (arg.NameColon?.Name.Identifier.Text == paramName)
             {
-                return arg;
+                // Strip the NameColon so the arg is passed positionally in the rewritten call
+                return arg.WithNameColon(null);
             }
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -1,0 +1,213 @@
+// <copyright file="StringBuilderCacheCodeFixProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer;
+
+/// <summary>
+/// Code fix provider that replaces <c>new StringBuilder()</c> with
+/// <c>StringBuilderCache.Acquire()</c> and rewrites <c>.ToString()</c>
+/// to <c>StringBuilderCache.GetStringAndRelease()</c>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(StringBuilderCacheCodeFixProvider))]
+[Shared]
+public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
+{
+    private const string Title = "Use StringBuilderCache";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds { get; }
+        = ImmutableArray.Create(Diagnostics.DiagnosticId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics.First();
+        var node = root.FindNode(diagnostic.Location.SourceSpan);
+
+        if (node is not (ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Title,
+                createChangedDocument: ct => ApplyFixAsync(context.Document, node, ct),
+                equivalenceKey: Title),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, SyntaxNode creationNode, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return document;
+        }
+
+        var variableName = GetAssignedVariableName(creationNode);
+
+        // Collect all .ToString() invocations on the variable in the enclosing scope
+        var toStringInvocations = ImmutableArray<InvocationExpressionSyntax>.Empty;
+        if (variableName is not null)
+        {
+            var enclosingFunction = GetEnclosingFunction(creationNode);
+            if (enclosingFunction is not null)
+            {
+                toStringInvocations = enclosingFunction
+                    .DescendantNodes()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Where(inv =>
+                        inv.Expression is MemberAccessExpressionSyntax memberAccess
+                        && memberAccess.Name.Identifier.Text == "ToString"
+                        && memberAccess.Expression is IdentifierNameSyntax id
+                        && id.Identifier.Text == variableName
+                        && inv.ArgumentList.Arguments.Count == 0)
+                    .ToImmutableArray();
+            }
+        }
+
+        // Replace all nodes in a single pass to avoid span invalidation
+        var newRoot = root.ReplaceNodes(
+            toStringInvocations.Cast<SyntaxNode>().Append(creationNode),
+            (original, _) =>
+            {
+                if (original == creationNode)
+                {
+                    return BuildAcquireCall(original);
+                }
+
+                // Must be a .ToString() invocation — replace with GetStringAndRelease
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("StringBuilderCache"),
+                        SyntaxFactory.IdentifierName("GetStringAndRelease")),
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(SyntaxFactory.IdentifierName(variableName!)))))
+                    .WithTriviaFrom(original);
+            });
+
+        // Add using directive for Datadog.Trace.Util
+        newRoot = AddUsingDirectiveIfMissing(newRoot);
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static InvocationExpressionSyntax BuildAcquireCall(SyntaxNode creationNode)
+    {
+        var memberAccess = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxFactory.IdentifierName("StringBuilderCache"),
+            SyntaxFactory.IdentifierName("Acquire"));
+
+        // Forward constructor arguments (e.g., capacity) to Acquire()
+        ArgumentListSyntax? originalArgs = creationNode switch
+        {
+            ObjectCreationExpressionSyntax objectCreation => objectCreation.ArgumentList,
+            ImplicitObjectCreationExpressionSyntax implicitCreation => implicitCreation.ArgumentList,
+            _ => null,
+        };
+
+        var args = originalArgs is not null && originalArgs.Arguments.Count > 0
+            ? originalArgs
+            : SyntaxFactory.ArgumentList();
+
+        return SyntaxFactory.InvocationExpression(memberAccess, args)
+            .WithTriviaFrom(creationNode);
+    }
+
+    private static string? GetAssignedVariableName(SyntaxNode creationNode)
+    {
+        var parent = creationNode.Parent;
+
+        // var sb = new StringBuilder();
+        if (parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator })
+        {
+            return declarator.Identifier.Text;
+        }
+
+        // sb = new StringBuilder();
+        if (parent is AssignmentExpressionSyntax assignment
+            && assignment.Left is IdentifierNameSyntax identifier)
+        {
+            return identifier.Identifier.Text;
+        }
+
+        return null;
+    }
+
+    private static SyntaxNode? GetEnclosingFunction(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case MethodDeclarationSyntax:
+                case LocalFunctionStatementSyntax:
+                case AnonymousFunctionExpressionSyntax:
+                case AccessorDeclarationSyntax:
+                    return current;
+            }
+        }
+
+        return null;
+    }
+
+    private static SyntaxNode AddUsingDirectiveIfMissing(SyntaxNode root)
+    {
+        if (root is not CompilationUnitSyntax compilationUnit)
+        {
+            return root;
+        }
+
+        const string targetNamespace = "Datadog.Trace.Util";
+
+        // Check if the using already exists
+        var hasUsing = compilationUnit.Usings
+            .Any(u => u.Name?.ToString() == targetNamespace);
+
+        if (hasUsing)
+        {
+            return root;
+        }
+
+        // Match the line ending style of the existing using directives
+        var existingTrailingTrivia = compilationUnit.Usings.LastOrDefault()?.GetTrailingTrivia();
+        var trailingTrivia = existingTrailingTrivia?.Count > 0
+            ? existingTrailingTrivia.Value
+            : SyntaxFactory.TriviaList(SyntaxFactory.ElasticLineFeed);
+
+        var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(targetNamespace))
+            .WithTrailingTrivia(trailingTrivia)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        return compilationUnit.AddUsings(usingDirective);
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -98,12 +98,13 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
     {
         var enclosingFunction = GetEnclosingFunction(creationNode);
 
-        // Collect all .ToString() invocations on the variable in the enclosing scope
+        // Collect all .ToString() invocations on the variable in the enclosing scope,
+        // skipping nested lambdas/local functions that may shadow the variable name
         var toStringInvocations = ImmutableArray<InvocationExpressionSyntax>.Empty;
         if (enclosingFunction is not null)
         {
             toStringInvocations = enclosingFunction
-                .DescendantNodes()
+                .DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == enclosingFunction)
                 .OfType<InvocationExpressionSyntax>()
                 .Where(inv =>
                     inv.Expression is MemberAccessExpressionSyntax memberAccess
@@ -324,7 +325,8 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         var firstSpanEnd = firstToString.Span.End;
         var lastSpanStart = lastToString.SpanStart;
 
-        foreach (var invocation in enclosingFunction.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        // Skip nested lambdas/local functions that may shadow the variable name
+        foreach (var invocation in enclosingFunction.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == enclosingFunction).OfType<InvocationExpressionSyntax>())
         {
             if (invocation.SpanStart <= firstSpanEnd || invocation.SpanStart >= lastSpanStart)
             {
@@ -341,7 +343,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         }
 
         // Also check for element access (sb[i] = ...)
-        foreach (var elementAccess in enclosingFunction.DescendantNodes().OfType<ElementAccessExpressionSyntax>())
+        foreach (var elementAccess in enclosingFunction.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == enclosingFunction).OfType<ElementAccessExpressionSyntax>())
         {
             if (elementAccess.SpanStart <= firstSpanEnd || elementAccess.SpanStart >= lastSpanStart)
             {

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -76,6 +76,13 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
             return document;
         }
 
+        // Bail out for unsupported constructor overloads (e.g., (capacity, maxCapacity)) where
+        // rewriting would silently change runtime semantics.
+        if (AnalyzeConstructorArgs(creationNode, semanticModel, cancellationToken) is null)
+        {
+            return document;
+        }
+
         var variableName = GetAssignedVariableName(creationNode);
 
         SyntaxNode newRoot;
@@ -365,7 +372,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        var (capacityArg, appendArgs) = AnalyzeConstructorArgs(creationNode, semanticModel, cancellationToken);
+        var (capacityArg, appendArgs) = AnalyzeConstructorArgs(creationNode, semanticModel, cancellationToken)!.Value;
 
         var acquireAccess = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
@@ -392,7 +399,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         return result.WithTriviaFrom(creationNode);
     }
 
-    private static (ArgumentSyntax? CapacityArg, ImmutableArray<ArgumentSyntax> AppendArgs) AnalyzeConstructorArgs(
+    private static (ArgumentSyntax? CapacityArg, ImmutableArray<ArgumentSyntax> AppendArgs)? AnalyzeConstructorArgs(
         SyntaxNode creationNode,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
@@ -440,11 +447,13 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         }
 
         // StringBuilder(int capacity, int maxCapacity)
+        // StringBuilderCache.Acquire() has no maxCapacity parameter — rewriting would silently
+        // drop the capacity bound and change runtime semantics, so skip the code fix for this overload.
         if (paramCount == 2
             && constructor.Parameters[0].Type.SpecialType == SpecialType.System_Int32
             && constructor.Parameters[1].Type.SpecialType == SpecialType.System_Int32)
         {
-            return (args[0], ImmutableArray<ArgumentSyntax>.Empty);
+            return null;
         }
 
         // StringBuilder(string? value, int startIndex, int length, int capacity)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -364,6 +364,31 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
             }
         }
 
+        // Also check for assignment expressions targeting the variable or its properties/fields
+        // e.g. sb.Length = 0 or sb = other
+        foreach (var assignment in enclosingFunction.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == enclosingFunction).OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.SpanStart <= firstSpanEnd || assignment.SpanStart >= lastSpanStart)
+            {
+                continue;
+            }
+
+            // sb = other  (reassignment of the variable itself)
+            if (assignment.Left is IdentifierNameSyntax leftId
+                && leftId.Identifier.Text == variableName)
+            {
+                return true;
+            }
+
+            // sb.Length = 0  (property/field assignment on the variable)
+            if (assignment.Left is MemberAccessExpressionSyntax leftMember
+                && leftMember.Expression is IdentifierNameSyntax memberId
+                && memberId.Identifier.Text == variableName)
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -70,17 +70,23 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
             return document;
         }
 
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return document;
+        }
+
         var variableName = GetAssignedVariableName(creationNode);
 
         SyntaxNode newRoot;
 
         if (variableName is not null)
         {
-            newRoot = ApplyVariableFix(root, creationNode, variableName);
+            newRoot = ApplyVariableFix(root, creationNode, variableName, semanticModel, cancellationToken);
         }
         else
         {
-            newRoot = ApplyInlineFix(root, creationNode);
+            newRoot = ApplyInlineFix(root, creationNode, semanticModel, cancellationToken);
         }
 
         newRoot = AddUsingDirectiveIfMissing(newRoot);
@@ -88,7 +94,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         return document.WithSyntaxRoot(newRoot);
     }
 
-    private static SyntaxNode ApplyVariableFix(SyntaxNode root, SyntaxNode creationNode, string variableName)
+    private static SyntaxNode ApplyVariableFix(SyntaxNode root, SyntaxNode creationNode, string variableName, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         var enclosingFunction = GetEnclosingFunction(creationNode);
 
@@ -117,7 +123,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
                 {
                     if (original == creationNode)
                     {
-                        return BuildAcquireCall(original);
+                        return BuildAcquireCall(original, semanticModel, cancellationToken);
                     }
 
                     return BuildGetStringAndReleaseCall(variableName)
@@ -139,7 +145,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
                 {
                     if (original == creationNode)
                     {
-                        return BuildAcquireCall(original);
+                        return BuildAcquireCall(original, semanticModel, cancellationToken);
                     }
 
                     return BuildGetStringAndReleaseCall(variableName)
@@ -148,14 +154,16 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         }
 
         // Case A: no mutations — use single GetStringAndRelease() + local variable
-        return ApplyNoMutationFix(root, creationNode, variableName, toStringInvocations);
+        return ApplyNoMutationFix(root, creationNode, variableName, toStringInvocations, semanticModel, cancellationToken);
     }
 
     private static SyntaxNode ApplyNoMutationFix(
         SyntaxNode root,
         SyntaxNode creationNode,
         string variableName,
-        ImmutableArray<InvocationExpressionSyntax> toStringInvocations)
+        ImmutableArray<InvocationExpressionSyntax> toStringInvocations,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         var resultVarName = variableName + "Result";
 
@@ -189,7 +197,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
             {
                 if (original == creationNode)
                 {
-                    return BuildAcquireCall(original);
+                    return BuildAcquireCall(original, semanticModel, cancellationToken);
                 }
 
                 // All .ToString() calls become the result variable reference
@@ -234,7 +242,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         return newRoot;
     }
 
-    private static SyntaxNode ApplyInlineFix(SyntaxNode root, SyntaxNode creationNode)
+    private static SyntaxNode ApplyInlineFix(SyntaxNode root, SyntaxNode creationNode, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         // Walk up the fluent chain to find a trailing .ToString() call
         var toStringInvocation = FindChainedToString(creationNode);
@@ -242,7 +250,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         if (toStringInvocation is null)
         {
             // No .ToString() in the chain — just replace new StringBuilder() with Acquire()
-            return root.ReplaceNode(creationNode, BuildAcquireCall(creationNode));
+            return root.ReplaceNode(creationNode, BuildAcquireCall(creationNode, semanticModel, cancellationToken));
         }
 
         // Replace the outer .ToString() invocation with GetStringAndRelease(<inner chain>)
@@ -260,7 +268,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
             {
                 if (original == creationNode)
                 {
-                    return BuildAcquireCall(original);
+                    return BuildAcquireCall(original, semanticModel, cancellationToken);
                 }
 
                 // This is the .ToString() invocation — wrap inner chain with GetStringAndRelease
@@ -350,27 +358,101 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         return false;
     }
 
-    private static InvocationExpressionSyntax BuildAcquireCall(SyntaxNode creationNode)
+    private static ExpressionSyntax BuildAcquireCall(
+        SyntaxNode creationNode,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
-        var memberAccess = SyntaxFactory.MemberAccessExpression(
+        var (capacityArg, appendArgs) = AnalyzeConstructorArgs(creationNode, semanticModel, cancellationToken);
+
+        var acquireAccess = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             SyntaxFactory.IdentifierName("StringBuilderCache"),
             SyntaxFactory.IdentifierName("Acquire"));
 
-        // Forward constructor arguments (e.g., capacity) to Acquire()
-        ArgumentListSyntax? originalArgs = creationNode switch
+        var acquireArgList = capacityArg is not null
+            ? SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(capacityArg))
+            : SyntaxFactory.ArgumentList();
+
+        ExpressionSyntax result = SyntaxFactory.InvocationExpression(acquireAccess, acquireArgList);
+
+        if (appendArgs.Length > 0)
         {
-            ObjectCreationExpressionSyntax objectCreation => objectCreation.ArgumentList,
-            ImplicitObjectCreationExpressionSyntax implicitCreation => implicitCreation.ArgumentList,
+            // Chain .Append(value[, startIndex, length]) after Acquire()
+            result = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    result,
+                    SyntaxFactory.IdentifierName("Append")),
+                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(appendArgs)));
+        }
+
+        return result.WithTriviaFrom(creationNode);
+    }
+
+    private static (ArgumentSyntax? CapacityArg, ImmutableArray<ArgumentSyntax> AppendArgs) AnalyzeConstructorArgs(
+        SyntaxNode creationNode,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        ArgumentListSyntax? argList = creationNode switch
+        {
+            ObjectCreationExpressionSyntax oc => oc.ArgumentList,
+            ImplicitObjectCreationExpressionSyntax ic => ic.ArgumentList,
             _ => null,
         };
 
-        var args = originalArgs is not null && originalArgs.Arguments.Count > 0
-            ? originalArgs
-            : SyntaxFactory.ArgumentList();
+        if (argList is null || argList.Arguments.Count == 0)
+        {
+            return (null, ImmutableArray<ArgumentSyntax>.Empty);
+        }
 
-        return SyntaxFactory.InvocationExpression(memberAccess, args)
-            .WithTriviaFrom(creationNode);
+        var symbolInfo = semanticModel.GetSymbolInfo(creationNode, cancellationToken);
+        if (symbolInfo.Symbol is not IMethodSymbol constructor)
+        {
+            // Can't resolve constructor — don't forward args to be safe
+            return (null, ImmutableArray<ArgumentSyntax>.Empty);
+        }
+
+        var args = argList.Arguments;
+        var paramCount = constructor.Parameters.Length;
+
+        // StringBuilder(int capacity)
+        if (paramCount == 1 && constructor.Parameters[0].Type.SpecialType == SpecialType.System_Int32)
+        {
+            return (args[0], ImmutableArray<ArgumentSyntax>.Empty);
+        }
+
+        // StringBuilder(string? value)
+        if (paramCount == 1 && constructor.Parameters[0].Type.SpecialType == SpecialType.System_String)
+        {
+            return (null, ImmutableArray.Create(args[0]));
+        }
+
+        // StringBuilder(string? value, int capacity)
+        if (paramCount == 2
+            && constructor.Parameters[0].Type.SpecialType == SpecialType.System_String
+            && constructor.Parameters[1].Type.SpecialType == SpecialType.System_Int32)
+        {
+            return (args[1], ImmutableArray.Create(args[0]));
+        }
+
+        // StringBuilder(int capacity, int maxCapacity)
+        if (paramCount == 2
+            && constructor.Parameters[0].Type.SpecialType == SpecialType.System_Int32
+            && constructor.Parameters[1].Type.SpecialType == SpecialType.System_Int32)
+        {
+            return (args[0], ImmutableArray<ArgumentSyntax>.Empty);
+        }
+
+        // StringBuilder(string? value, int startIndex, int length, int capacity)
+        if (paramCount == 4 && constructor.Parameters[0].Type.SpecialType == SpecialType.System_String)
+        {
+            return (args[3], ImmutableArray.Create(args[0], args[1], args[2]));
+        }
+
+        // Unknown overload — don't forward args
+        return (null, ImmutableArray<ArgumentSyntax>.Empty);
     }
 
     private static InvocationExpressionSyntax BuildGetStringAndReleaseCall(string variableName)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -72,27 +72,117 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
 
         var variableName = GetAssignedVariableName(creationNode);
 
-        // Collect all .ToString() invocations on the variable in the enclosing scope
-        var toStringInvocations = ImmutableArray<InvocationExpressionSyntax>.Empty;
+        SyntaxNode newRoot;
+
         if (variableName is not null)
         {
-            var enclosingFunction = GetEnclosingFunction(creationNode);
-            if (enclosingFunction is not null)
-            {
-                toStringInvocations = enclosingFunction
-                    .DescendantNodes()
-                    .OfType<InvocationExpressionSyntax>()
-                    .Where(inv =>
-                        inv.Expression is MemberAccessExpressionSyntax memberAccess
-                        && memberAccess.Name.Identifier.Text == "ToString"
-                        && memberAccess.Expression is IdentifierNameSyntax id
-                        && id.Identifier.Text == variableName
-                        && inv.ArgumentList.Arguments.Count == 0)
-                    .ToImmutableArray();
-            }
+            newRoot = ApplyVariableFix(root, creationNode, variableName);
+        }
+        else
+        {
+            newRoot = ApplyInlineFix(root, creationNode);
         }
 
-        // Replace all nodes in a single pass to avoid span invalidation
+        newRoot = AddUsingDirectiveIfMissing(newRoot);
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static SyntaxNode ApplyVariableFix(SyntaxNode root, SyntaxNode creationNode, string variableName)
+    {
+        var enclosingFunction = GetEnclosingFunction(creationNode);
+
+        // Collect all .ToString() invocations on the variable in the enclosing scope
+        var toStringInvocations = ImmutableArray<InvocationExpressionSyntax>.Empty;
+        if (enclosingFunction is not null)
+        {
+            toStringInvocations = enclosingFunction
+                .DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Where(inv =>
+                    inv.Expression is MemberAccessExpressionSyntax memberAccess
+                    && memberAccess.Name.Identifier.Text == "ToString"
+                    && memberAccess.Expression is IdentifierNameSyntax id
+                    && id.Identifier.Text == variableName
+                    && inv.ArgumentList.Arguments.Count == 0)
+                .ToImmutableArray();
+        }
+
+        if (toStringInvocations.Length <= 1)
+        {
+            // Single or zero .ToString() — replace creation + that one call
+            return root.ReplaceNodes(
+                toStringInvocations.Cast<SyntaxNode>().Append(creationNode),
+                (original, _) =>
+                {
+                    if (original == creationNode)
+                    {
+                        return BuildAcquireCall(original);
+                    }
+
+                    return BuildGetStringAndReleaseCall(variableName)
+                        .WithTriviaFrom(original);
+                });
+        }
+
+        // Multiple .ToString() calls — check for mutations between first and last
+        if (enclosingFunction is not null && HasMutationsBetween(enclosingFunction, variableName, toStringInvocations.First(), toStringInvocations.Last()))
+        {
+            // Case B: mutations exist — only replace the last .ToString()
+            return root.ReplaceNodes(
+                new SyntaxNode[]
+                {
+                    creationNode,
+                    toStringInvocations.Last(),
+                },
+                (original, _) =>
+                {
+                    if (original == creationNode)
+                    {
+                        return BuildAcquireCall(original);
+                    }
+
+                    return BuildGetStringAndReleaseCall(variableName)
+                        .WithTriviaFrom(original);
+                });
+        }
+
+        // Case A: no mutations — use single GetStringAndRelease() + local variable
+        return ApplyNoMutationFix(root, creationNode, variableName, toStringInvocations);
+    }
+
+    private static SyntaxNode ApplyNoMutationFix(
+        SyntaxNode root,
+        SyntaxNode creationNode,
+        string variableName,
+        ImmutableArray<InvocationExpressionSyntax> toStringInvocations)
+    {
+        var resultVarName = variableName + "Result";
+
+        // The first .ToString() becomes: var sbResult = StringBuilderCache.GetStringAndRelease(sb);
+        // Remaining .ToString() calls become: sbResult
+        var firstToString = toStringInvocations[0];
+
+        // We need to:
+        // 1. Replace the creation node with Acquire()
+        // 2. Replace the first .ToString() statement with a GetStringAndRelease() + local var
+        // 3. Replace remaining .ToString() calls with the result variable
+
+        // Find the statement containing the first .ToString()
+        var firstToStringStatement = firstToString.FirstAncestorOrSelf<StatementSyntax>();
+
+        // Build the GetStringAndRelease local declaration:
+        // var sbResult = StringBuilderCache.GetStringAndRelease(sb);
+        var getStringAndReleaseStatement = SyntaxFactory.LocalDeclarationStatement(
+            SyntaxFactory.VariableDeclaration(
+                SyntaxFactory.IdentifierName("var"),
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.VariableDeclarator(resultVarName)
+                        .WithInitializer(
+                            SyntaxFactory.EqualsValueClause(
+                                BuildGetStringAndReleaseCall(variableName))))));
+
+        // First pass: replace creation + all .ToString() calls
         var newRoot = root.ReplaceNodes(
             toStringInvocations.Cast<SyntaxNode>().Append(creationNode),
             (original, _) =>
@@ -102,7 +192,84 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
                     return BuildAcquireCall(original);
                 }
 
-                // Must be a .ToString() invocation — replace with GetStringAndRelease
+                // All .ToString() calls become the result variable reference
+                return SyntaxFactory.IdentifierName(resultVarName)
+                    .WithTriviaFrom(original);
+            });
+
+        // Second pass: insert the GetStringAndRelease statement before the first .ToString() statement
+        // We need to find the updated version of the statement
+        var updatedFirstToStringStatement = newRoot.DescendantNodes()
+            .OfType<StatementSyntax>()
+            .FirstOrDefault(s => s.Span.Start == firstToStringStatement!.Span.Start
+                && s.Span.Length == firstToStringStatement.Span.Length);
+
+        // Fallback: find statement containing the resultVarName identifier that was the first replacement
+        if (updatedFirstToStringStatement is null)
+        {
+            // After ReplaceNodes, spans may shift. Find the first statement containing our result variable.
+            var firstResultRef = newRoot.DescendantNodes()
+                .OfType<IdentifierNameSyntax>()
+                .FirstOrDefault(id => id.Identifier.Text == resultVarName);
+
+            updatedFirstToStringStatement = firstResultRef?.FirstAncestorOrSelf<StatementSyntax>();
+        }
+
+        if (updatedFirstToStringStatement?.Parent is BlockSyntax block)
+        {
+            var stmtIndex = block.Statements.IndexOf(updatedFirstToStringStatement);
+            if (stmtIndex >= 0)
+            {
+                var releaseStmt = getStringAndReleaseStatement
+                    .WithLeadingTrivia(updatedFirstToStringStatement.GetLeadingTrivia())
+                    .WithTrailingTrivia(updatedFirstToStringStatement.GetTrailingTrivia())
+                    .WithAdditionalAnnotations(Formatter.Annotation);
+
+                var newStatements = block.Statements.Insert(stmtIndex, releaseStmt);
+                var newBlock = block.WithStatements(newStatements);
+                newRoot = newRoot.ReplaceNode(block, newBlock);
+            }
+        }
+
+        return newRoot;
+    }
+
+    private static SyntaxNode ApplyInlineFix(SyntaxNode root, SyntaxNode creationNode)
+    {
+        // Walk up the fluent chain to find a trailing .ToString() call
+        var toStringInvocation = FindChainedToString(creationNode);
+
+        if (toStringInvocation is null)
+        {
+            // No .ToString() in the chain — just replace new StringBuilder() with Acquire()
+            return root.ReplaceNode(creationNode, BuildAcquireCall(creationNode));
+        }
+
+        // Replace the outer .ToString() invocation with GetStringAndRelease(<inner chain>)
+        // and the creation node with Acquire() in one pass
+        var memberAccess = (MemberAccessExpressionSyntax)toStringInvocation.Expression;
+        var innerChain = memberAccess.Expression; // everything before .ToString()
+
+        return root.ReplaceNodes(
+            new SyntaxNode[]
+            {
+                creationNode,
+                toStringInvocation,
+            },
+            (original, rewritten) =>
+            {
+                if (original == creationNode)
+                {
+                    return BuildAcquireCall(original);
+                }
+
+                // This is the .ToString() invocation — wrap inner chain with GetStringAndRelease
+                // At this point, the creationNode inside the chain has already been replaced with Acquire()
+                // by ReplaceNodes, so we need to use the rewritten version of the inner chain
+                var rewrittenInvocation = (InvocationExpressionSyntax)rewritten;
+                var rewrittenMemberAccess = (MemberAccessExpressionSyntax)rewrittenInvocation.Expression;
+                var rewrittenInnerChain = rewrittenMemberAccess.Expression;
+
                 return SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
@@ -110,14 +277,77 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
                         SyntaxFactory.IdentifierName("GetStringAndRelease")),
                     SyntaxFactory.ArgumentList(
                         SyntaxFactory.SingletonSeparatedList(
-                            SyntaxFactory.Argument(SyntaxFactory.IdentifierName(variableName!)))))
+                            SyntaxFactory.Argument(rewrittenInnerChain))))
                     .WithTriviaFrom(original);
             });
+    }
 
-        // Add using directive for Datadog.Trace.Util
-        newRoot = AddUsingDirectiveIfMissing(newRoot);
+    private static InvocationExpressionSyntax? FindChainedToString(SyntaxNode creationNode)
+    {
+        // Walk up through the fluent method chain looking for .ToString()
+        // Pattern: new StringBuilder().Append("x").ToString()
+        // AST: InvocationExpression(MemberAccess(InvocationExpression(MemberAccess(ObjectCreation, Append)), ToString))
+        for (var current = creationNode.Parent; current is not null; current = current.Parent)
+        {
+            if (current is InvocationExpressionSyntax invocation
+                && invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Name.Identifier.Text == "ToString"
+                && invocation.ArgumentList.Arguments.Count == 0)
+            {
+                return invocation;
+            }
 
-        return document.WithSyntaxRoot(newRoot);
+            // Only continue walking if we're still in a fluent chain
+            if (current is not (MemberAccessExpressionSyntax or InvocationExpressionSyntax or ArgumentListSyntax))
+            {
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasMutationsBetween(
+        SyntaxNode enclosingFunction,
+        string variableName,
+        InvocationExpressionSyntax firstToString,
+        InvocationExpressionSyntax lastToString)
+    {
+        var firstSpanEnd = firstToString.Span.End;
+        var lastSpanStart = lastToString.SpanStart;
+
+        foreach (var invocation in enclosingFunction.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.SpanStart <= firstSpanEnd || invocation.SpanStart >= lastSpanStart)
+            {
+                continue;
+            }
+
+            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Expression is IdentifierNameSyntax id
+                && id.Identifier.Text == variableName
+                && memberAccess.Name.Identifier.Text != "ToString")
+            {
+                return true;
+            }
+        }
+
+        // Also check for element access (sb[i] = ...)
+        foreach (var elementAccess in enclosingFunction.DescendantNodes().OfType<ElementAccessExpressionSyntax>())
+        {
+            if (elementAccess.SpanStart <= firstSpanEnd || elementAccess.SpanStart >= lastSpanStart)
+            {
+                continue;
+            }
+
+            if (elementAccess.Expression is IdentifierNameSyntax id
+                && id.Identifier.Text == variableName)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static InvocationExpressionSyntax BuildAcquireCall(SyntaxNode creationNode)
@@ -141,6 +371,18 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
 
         return SyntaxFactory.InvocationExpression(memberAccess, args)
             .WithTriviaFrom(creationNode);
+    }
+
+    private static InvocationExpressionSyntax BuildGetStringAndReleaseCall(string variableName)
+    {
+        return SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName("StringBuilderCache"),
+                SyntaxFactory.IdentifierName("GetStringAndRelease")),
+            SyntaxFactory.ArgumentList(
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.Argument(SyntaxFactory.IdentifierName(variableName)))));
     }
 
     private static string? GetAssignedVariableName(SyntaxNode creationNode)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers.CodeFixes/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixProvider.cs
@@ -448,19 +448,18 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
             return (null, ImmutableArray<ArgumentSyntax>.Empty);
         }
 
-        var args = argList.Arguments;
         var paramCount = constructor.Parameters.Length;
 
         // StringBuilder(int capacity)
         if (paramCount == 1 && constructor.Parameters[0].Type.SpecialType == SpecialType.System_Int32)
         {
-            return (args[0], ImmutableArray<ArgumentSyntax>.Empty);
+            return (GetArgByName(argList, constructor, "capacity"), ImmutableArray<ArgumentSyntax>.Empty);
         }
 
         // StringBuilder(string? value)
         if (paramCount == 1 && constructor.Parameters[0].Type.SpecialType == SpecialType.System_String)
         {
-            return (null, ImmutableArray.Create(args[0]));
+            return (null, ImmutableArray.Create(GetArgByName(argList, constructor, "value")));
         }
 
         // StringBuilder(string? value, int capacity)
@@ -468,7 +467,7 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
             && constructor.Parameters[0].Type.SpecialType == SpecialType.System_String
             && constructor.Parameters[1].Type.SpecialType == SpecialType.System_Int32)
         {
-            return (args[1], ImmutableArray.Create(args[0]));
+            return (GetArgByName(argList, constructor, "capacity"), ImmutableArray.Create(GetArgByName(argList, constructor, "value")));
         }
 
         // StringBuilder(int capacity, int maxCapacity)
@@ -484,11 +483,43 @@ public sealed class StringBuilderCacheCodeFixProvider : CodeFixProvider
         // StringBuilder(string? value, int startIndex, int length, int capacity)
         if (paramCount == 4 && constructor.Parameters[0].Type.SpecialType == SpecialType.System_String)
         {
-            return (args[3], ImmutableArray.Create(args[0], args[1], args[2]));
+            return (GetArgByName(argList, constructor, "capacity"),
+                    ImmutableArray.Create(
+                        GetArgByName(argList, constructor, "value"),
+                        GetArgByName(argList, constructor, "startIndex"),
+                        GetArgByName(argList, constructor, "length")));
         }
 
         // Unknown overload — don't forward args
         return (null, ImmutableArray<ArgumentSyntax>.Empty);
+    }
+
+    /// <summary>
+    /// Returns the <see cref="ArgumentSyntax"/> for the parameter with the given name,
+    /// handling both positional and named arguments.
+    /// </summary>
+    private static ArgumentSyntax GetArgByName(ArgumentListSyntax argList, IMethodSymbol method, string paramName)
+    {
+        // Named argument: caller wrote e.g. new StringBuilder(capacity: 128, value: "x")
+        foreach (var arg in argList.Arguments)
+        {
+            if (arg.NameColon?.Name.Identifier.Text == paramName)
+            {
+                return arg;
+            }
+        }
+
+        // Positional argument: find the parameter index and return args[index]
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            if (method.Parameters[i].Name == paramName)
+            {
+                return argList.Arguments[i];
+            }
+        }
+
+        // Fallback — should not happen for known overloads
+        return argList.Arguments[0];
     }
 
     private static InvocationExpressionSyntax BuildGetStringAndReleaseCall(string variableName)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
@@ -24,6 +24,6 @@ public sealed class Diagnostics
         messageFormat: "Use StringBuilderCache.Acquire() instead of new StringBuilder() to avoid heap allocation. Call StringBuilderCache.GetStringAndRelease() when done.",
         category: "Performance",
         defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: false,
+        isEnabledByDefault: true,
         description: "StringBuilderCache uses a [ThreadStatic] cached instance to avoid allocating a new StringBuilder per call.");
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
@@ -1,0 +1,29 @@
+// <copyright file="Diagnostics.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Microsoft.CodeAnalysis;
+
+namespace Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer;
+
+/// <summary>
+/// Diagnostic descriptors for the StringBuilderCache analyzer.
+/// </summary>
+public sealed class Diagnostics
+{
+    /// <summary>
+    /// The diagnostic ID for <see cref="UseStringBuilderCacheRule"/>.
+    /// </summary>
+    public const string DiagnosticId = "DDALLOC003";
+
+    internal static readonly DiagnosticDescriptor UseStringBuilderCacheRule = new(
+        DiagnosticId,
+        title: "Use StringBuilderCache instead of new StringBuilder()",
+        messageFormat: "Use StringBuilderCache.Acquire() instead of new StringBuilder() to avoid heap allocation. Call StringBuilderCache.GetStringAndRelease() when done.",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "StringBuilderCache uses a [ThreadStatic] cached instance to avoid allocating a new StringBuilder per call.");
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
@@ -24,6 +24,6 @@ public sealed class Diagnostics
         messageFormat: "Use StringBuilderCache.Acquire() instead of new StringBuilder() to avoid heap allocation. Call StringBuilderCache.GetStringAndRelease() when done.",
         category: "Performance",
         defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
+        isEnabledByDefault: false,
         description: "StringBuilderCache uses a [ThreadStatic] cached instance to avoid allocating a new StringBuilder per call.");
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/Diagnostics.cs
@@ -23,7 +23,7 @@ public sealed class Diagnostics
         title: "Use StringBuilderCache instead of new StringBuilder()",
         messageFormat: "Use StringBuilderCache.Acquire() instead of new StringBuilder() to avoid heap allocation. Call StringBuilderCache.GetStringAndRelease() when done.",
         category: "Performance",
-        defaultSeverity: DiagnosticSeverity.Info,
-        isEnabledByDefault: true,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
         description: "StringBuilderCache uses a [ThreadStatic] cached instance to avoid allocating a new StringBuilder per call.");
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
@@ -1,0 +1,127 @@
+// <copyright file="StringBuilderCacheAnalyzer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer;
+
+/// <summary>
+/// An analyzer that detects <c>new StringBuilder()</c> allocations and suggests
+/// using <c>StringBuilderCache.Acquire()</c> instead.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+        = ImmutableArray.Create(Diagnostics.UseStringBuilderCacheRule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var stringBuilderType = context.Compilation.GetTypeByMetadataName("System.Text.StringBuilder");
+        if (stringBuilderType is null)
+        {
+            return;
+        }
+
+        context.RegisterSyntaxNodeAction(
+            ctx => AnalyzeObjectCreation(ctx, stringBuilderType),
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.ImplicitObjectCreationExpression);
+    }
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context, INamedTypeSymbol stringBuilderType)
+    {
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(context.Node, context.CancellationToken);
+        if (symbolInfo.Symbol is not IMethodSymbol constructorSymbol)
+        {
+            return;
+        }
+
+        // Check that this is a StringBuilder constructor
+        if (!SymbolEqualityComparer.Default.Equals(constructorSymbol.ContainingType, stringBuilderType))
+        {
+            return;
+        }
+
+        // Suppress if inside the StringBuilderCache class itself
+        var containingType = GetContainingTypeSymbol(context);
+        if (containingType is not null && containingType.Name == "StringBuilderCache")
+        {
+            return;
+        }
+
+        // Suppress if the enclosing function-like scope already calls StringBuilderCache.Acquire()
+        var enclosingFunction = GetEnclosingFunction(context.Node);
+        if (enclosingFunction is not null && ContainsStringBuilderCacheAcquireCall(enclosingFunction))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Diagnostics.UseStringBuilderCacheRule,
+                context.Node.GetLocation()));
+    }
+
+    private static INamedTypeSymbol? GetContainingTypeSymbol(SyntaxNodeAnalysisContext context)
+    {
+        var typeDeclaration = context.Node.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (typeDeclaration is null)
+        {
+            return null;
+        }
+
+        return context.SemanticModel.GetDeclaredSymbol(typeDeclaration, context.CancellationToken) as INamedTypeSymbol;
+    }
+
+    private static SyntaxNode? GetEnclosingFunction(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case MethodDeclarationSyntax:
+                case LocalFunctionStatementSyntax:
+                case AnonymousFunctionExpressionSyntax:
+                case AccessorDeclarationSyntax:
+                    return current;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ContainsStringBuilderCacheAcquireCall(SyntaxNode functionNode)
+    {
+        foreach (var invocation in functionNode.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Name.Identifier.Text == "Acquire"
+                && memberAccess.Expression is IdentifierNameSyntax identifier
+                && identifier.Identifier.Text == "StringBuilderCache")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
@@ -68,6 +68,12 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // Suppress if assigned to a field or property (long-lived, not method-scoped)
+        if (IsAssignedToFieldOrProperty(context))
+        {
+            return;
+        }
+
         // Suppress if the enclosing function-like scope already calls StringBuilderCache.Acquire()
         var enclosingFunction = GetEnclosingFunction(context.Node);
         if (enclosingFunction is not null && ContainsStringBuilderCacheAcquireCall(enclosingFunction))
@@ -107,6 +113,40 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    private static bool IsAssignedToFieldOrProperty(SyntaxNodeAnalysisContext context)
+    {
+        var node = context.Node;
+
+        // Case 1: Field initializer — e.g., StringBuilder _sb = new(...);
+        // Walk up: ObjectCreation -> EqualsValueClause -> VariableDeclarator -> VariableDeclaration -> FieldDeclaration/PropertyDeclaration
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is FieldDeclarationSyntax or PropertyDeclarationSyntax)
+            {
+                return true;
+            }
+
+            // Stop walking if we hit a statement or member boundary
+            if (current is StatementSyntax or MemberDeclarationSyntax)
+            {
+                break;
+            }
+        }
+
+        // Case 2: Constructor assignment to field — e.g., _sb = new StringBuilder(...);
+        if (node.Parent is AssignmentExpressionSyntax assignment
+            && assignment.Right == node)
+        {
+            var symbol = context.SemanticModel.GetSymbolInfo(assignment.Left, context.CancellationToken).Symbol;
+            if (symbol is IFieldSymbol or IPropertySymbol)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ContainsStringBuilderCacheAcquireCall(SyntaxNode functionNode)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
@@ -7,6 +7,8 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -84,7 +86,7 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
 
         // Suppress if there are multiple StringBuilder allocations in the same scope
         // (StringBuilderCache only caches one instance per thread)
-        if (enclosingFunction is not null && CountStringBuilderCreations(enclosingFunction) > 1)
+        if (enclosingFunction is not null && CountStringBuilderCreations(enclosingFunction, context.SemanticModel, stringBuilderType, context.CancellationToken) > 1)
         {
             return;
         }
@@ -124,11 +126,43 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool IsAssignedToFieldOrProperty(SyntaxNodeAnalysisContext context)
-    {
-        var node = context.Node;
+        => IsAssignedToFieldOrProperty(context.Node, context.SemanticModel, context.CancellationToken);
 
-        // Case 1: Field initializer — e.g., StringBuilder _sb = new(...);
-        // Walk up: ObjectCreation -> EqualsValueClause -> VariableDeclarator -> VariableDeclaration -> FieldDeclaration/PropertyDeclaration
+    private static int CountStringBuilderCreations(
+        SyntaxNode functionNode,
+        SemanticModel semanticModel,
+        INamedTypeSymbol stringBuilderType,
+        CancellationToken cancellationToken)
+    {
+        var count = 0;
+
+        // Use descendIntoChildren to skip nested function scopes — they are analyzed independently
+        foreach (var node in functionNode.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == functionNode))
+        {
+            ITypeSymbol? createdType = node switch
+            {
+                ObjectCreationExpressionSyntax creation => semanticModel.GetTypeInfo(creation, cancellationToken).Type,
+                ImplicitObjectCreationExpressionSyntax creation => semanticModel.GetTypeInfo(creation, cancellationToken).Type,
+                _ => null,
+            };
+
+            if (createdType is not null
+                && SymbolEqualityComparer.Default.Equals(createdType, stringBuilderType)
+                && !IsAssignedToFieldOrProperty(node, semanticModel, cancellationToken))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static bool IsAssignedToFieldOrProperty(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        // Case 1: Field/property initializer
         for (var current = node.Parent; current is not null; current = current.Parent)
         {
             if (current is FieldDeclarationSyntax or PropertyDeclarationSyntax)
@@ -136,7 +170,6 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
                 return true;
             }
 
-            // Stop walking if we hit a statement or member boundary
             if (current is StatementSyntax or MemberDeclarationSyntax)
             {
                 break;
@@ -147,7 +180,7 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
         if (node.Parent is AssignmentExpressionSyntax assignment
             && assignment.Right == node)
         {
-            var symbol = context.SemanticModel.GetSymbolInfo(assignment.Left, context.CancellationToken).Symbol;
+            var symbol = semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol;
             if (symbol is IFieldSymbol or IPropertySymbol)
             {
                 return true;
@@ -157,37 +190,29 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static int CountStringBuilderCreations(SyntaxNode functionNode)
-    {
-        var count = 0;
-
-        // Use descendIntoChildren to skip nested function scopes — they are analyzed independently
-        foreach (var node in functionNode.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == functionNode))
-        {
-            if (node is ObjectCreationExpressionSyntax creation
-                && creation.Type is IdentifierNameSyntax { Identifier.Text: "StringBuilder" } or
-                    QualifiedNameSyntax { Right.Identifier.Text: "StringBuilder" })
-            {
-                count++;
-            }
-        }
-
-        return count;
-    }
-
     private static bool ContainsStringBuilderCacheAcquireCall(SyntaxNode functionNode)
     {
-        foreach (var invocation in functionNode.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        // Use descendIntoChildren to skip nested function scopes — they are analyzed independently
+        foreach (var invocation in functionNode.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == functionNode).OfType<InvocationExpressionSyntax>())
         {
             if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
                 && memberAccess.Name.Identifier.Text == "Acquire"
-                && memberAccess.Expression is IdentifierNameSyntax identifier
-                && identifier.Identifier.Text == "StringBuilderCache")
+                && ExpressionEndsWithStringBuilderCache(memberAccess.Expression))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private static bool ExpressionEndsWithStringBuilderCache(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax { Identifier.Text: "StringBuilderCache" } => true,
+            MemberAccessExpressionSyntax { Name.Identifier.Text: "StringBuilderCache" } => true,
+            _ => false,
+        };
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
@@ -76,6 +76,14 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // Suppress if the capacity exceeds StringBuilderCache.MaxBuilderSize (360).
+        // StringBuilderCache won't cache builders larger than this, so using it
+        // would add overhead without any caching benefit.
+        if (HasCapacityExceedingMaxBuilderSize(constructorSymbol, context))
+        {
+            return;
+        }
+
         var enclosingFunction = GetEnclosingFunction(context.Node);
 
         // Suppress if the enclosing function-like scope already calls StringBuilderCache.Acquire()
@@ -188,6 +196,55 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool HasCapacityExceedingMaxBuilderSize(IMethodSymbol constructorSymbol, SyntaxNodeAnalysisContext context)
+    {
+        const int maxBuilderSize = 360; // StringBuilderCache.MaxBuilderSize
+
+        // Find the capacity parameter index
+        int capacityIndex = -1;
+        for (var i = 0; i < constructorSymbol.Parameters.Length; i++)
+        {
+            if (constructorSymbol.Parameters[i].Type.SpecialType == SpecialType.System_Int32)
+            {
+                capacityIndex = i;
+                // For StringBuilder(string, int) the int is capacity
+                // For StringBuilder(int) the int is capacity
+                // For StringBuilder(int, int) the first int is capacity
+                // For StringBuilder(string, int, int, int) the last int is capacity
+                // In all overloads, we check the first int parameter found — except the 4-arg overload
+                if (constructorSymbol.Parameters.Length == 4)
+                {
+                    // StringBuilder(string, int startIndex, int length, int capacity) — capacity is last
+                    capacityIndex = 3;
+                }
+
+                break;
+            }
+        }
+
+        if (capacityIndex < 0)
+        {
+            return false;
+        }
+
+        ArgumentListSyntax? argList = context.Node switch
+        {
+            ObjectCreationExpressionSyntax oc => oc.ArgumentList,
+            ImplicitObjectCreationExpressionSyntax ic => ic.ArgumentList,
+            _ => null,
+        };
+
+        if (argList is null || capacityIndex >= argList.Arguments.Count)
+        {
+            return false;
+        }
+
+        var capacityArg = argList.Arguments[capacityIndex].Expression;
+        var constantValue = context.SemanticModel.GetConstantValue(capacityArg, context.CancellationToken);
+
+        return constantValue is { HasValue: true, Value: int capacity } && capacity > maxBuilderSize;
     }
 
     private static bool ContainsStringBuilderCacheAcquireCall(SyntaxNode functionNode)

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
@@ -43,13 +43,17 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        // May be null in projects that don't reference Datadog.Trace.Util — the
+        // "scope already uses Acquire" suppression simply won't fire in that case.
+        var stringBuilderCacheType = context.Compilation.GetTypeByMetadataName("Datadog.Trace.Util.StringBuilderCache");
+
         context.RegisterSyntaxNodeAction(
-            ctx => AnalyzeObjectCreation(ctx, stringBuilderType),
+            ctx => AnalyzeObjectCreation(ctx, stringBuilderType, stringBuilderCacheType),
             SyntaxKind.ObjectCreationExpression,
             SyntaxKind.ImplicitObjectCreationExpression);
     }
 
-    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context, INamedTypeSymbol stringBuilderType)
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context, INamedTypeSymbol stringBuilderType, INamedTypeSymbol? stringBuilderCacheType)
     {
         var symbolInfo = context.SemanticModel.GetSymbolInfo(context.Node, context.CancellationToken);
         if (symbolInfo.Symbol is not IMethodSymbol constructorSymbol)
@@ -87,7 +91,7 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
         var enclosingFunction = GetEnclosingFunction(context.Node);
 
         // Suppress if the enclosing function-like scope already calls StringBuilderCache.Acquire()
-        if (enclosingFunction is not null && ContainsStringBuilderCacheAcquireCall(enclosingFunction))
+        if (enclosingFunction is not null && ContainsStringBuilderCacheAcquireCall(enclosingFunction, stringBuilderCacheType, context.SemanticModel, context.CancellationToken))
         {
             return;
         }
@@ -247,29 +251,28 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
         return constantValue is { HasValue: true, Value: int capacity } && capacity > maxBuilderSize;
     }
 
-    private static bool ContainsStringBuilderCacheAcquireCall(SyntaxNode functionNode)
+    private static bool ContainsStringBuilderCacheAcquireCall(
+        SyntaxNode functionNode,
+        INamedTypeSymbol? stringBuilderCacheType,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
+        if (stringBuilderCacheType is null)
+        {
+            return false;
+        }
+
         // Use descendIntoChildren to skip nested function scopes — they are analyzed independently
         foreach (var invocation in functionNode.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == functionNode).OfType<InvocationExpressionSyntax>())
         {
-            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
-                && memberAccess.Name.Identifier.Text == "Acquire"
-                && ExpressionEndsWithStringBuilderCache(memberAccess.Expression))
+            var symbol = semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol;
+            if (symbol is IMethodSymbol { Name: "Acquire" } method
+                && SymbolEqualityComparer.Default.Equals(method.ContainingType, stringBuilderCacheType))
             {
                 return true;
             }
         }
 
         return false;
-    }
-
-    private static bool ExpressionEndsWithStringBuilderCache(ExpressionSyntax expression)
-    {
-        return expression switch
-        {
-            IdentifierNameSyntax { Identifier.Text: "StringBuilderCache" } => true,
-            MemberAccessExpressionSyntax { Name.Identifier.Text: "StringBuilderCache" } => true,
-            _ => false,
-        };
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzer.cs
@@ -74,9 +74,17 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Suppress if the enclosing function-like scope already calls StringBuilderCache.Acquire()
         var enclosingFunction = GetEnclosingFunction(context.Node);
+
+        // Suppress if the enclosing function-like scope already calls StringBuilderCache.Acquire()
         if (enclosingFunction is not null && ContainsStringBuilderCacheAcquireCall(enclosingFunction))
+        {
+            return;
+        }
+
+        // Suppress if there are multiple StringBuilder allocations in the same scope
+        // (StringBuilderCache only caches one instance per thread)
+        if (enclosingFunction is not null && CountStringBuilderCreations(enclosingFunction) > 1)
         {
             return;
         }
@@ -147,6 +155,24 @@ public class StringBuilderCacheAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static int CountStringBuilderCreations(SyntaxNode functionNode)
+    {
+        var count = 0;
+
+        // Use descendIntoChildren to skip nested function scopes — they are analyzed independently
+        foreach (var node in functionNode.DescendantNodes(descendIntoChildren: n => n is not (LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax) || n == functionNode))
+        {
+            if (node is ObjectCreationExpressionSyntax creation
+                && creation.Type is IdentifierNameSyntax { Identifier.Text: "StringBuilder" } or
+                    QualifiedNameSyntax { Right.Identifier.Text: "StringBuilder" })
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     private static bool ContainsStringBuilderCacheAcquireCall(SyntaxNode functionNode)

--- a/tracer/src/Datadog.Trace/.editorconfig
+++ b/tracer/src/Datadog.Trace/.editorconfig
@@ -2,7 +2,7 @@
 
 [*.{cs,vb}]
 dotnet_diagnostic.DDSEAL001.severity = error # types should be sealed
-dotnet_diagnostic.DDALLOC003.severity = none # use StringBuilderCache instead of new StringBuilder(), TODO: disabled until existing usages are migrated
+dotnet_diagnostic.DDALLOC003.severity = error # use StringBuilderCache instead of new StringBuilder()
 
 # Microsoft performance analyzers
 dotnet_diagnostic.CA1802.severity = error # Use Literals Where Appropriate

--- a/tracer/src/Datadog.Trace/.editorconfig
+++ b/tracer/src/Datadog.Trace/.editorconfig
@@ -2,6 +2,7 @@
 
 [*.{cs,vb}]
 dotnet_diagnostic.DDSEAL001.severity = error # types should be sealed
+dotnet_diagnostic.DDALLOC003.severity = warning # use StringBuilderCache instead of new StringBuilder()
 
 # Microsoft performance analyzers
 dotnet_diagnostic.CA1802.severity = error # Use Literals Where Appropriate

--- a/tracer/src/Datadog.Trace/.editorconfig
+++ b/tracer/src/Datadog.Trace/.editorconfig
@@ -2,7 +2,7 @@
 
 [*.{cs,vb}]
 dotnet_diagnostic.DDSEAL001.severity = error # types should be sealed
-dotnet_diagnostic.DDALLOC003.severity = warning # use StringBuilderCache instead of new StringBuilder()
+dotnet_diagnostic.DDALLOC003.severity = none # use StringBuilderCache instead of new StringBuilder(), TODO: disabled until existing usages are migrated
 
 # Microsoft performance analyzers
 dotnet_diagnostic.CA1802.severity = error # Use Literals Where Appropriate

--- a/tracer/src/Datadog.Trace/AppSec/ApiSec/MapEndpointsCollection.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ApiSec/MapEndpointsCollection.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.AppSec;
 
@@ -46,7 +47,7 @@ internal static class MapEndpointsCollection
                 return;
             }
 
-            var sb = new StringBuilder();
+            var sb = StringBuilderCache.Acquire();
 
             for (var i = _buildingMapEndpoints.Count - 1; i >= 0; i--)
             {
@@ -60,7 +61,8 @@ internal static class MapEndpointsCollection
                 }
             }
 
-            _mapEndpoints?.Add(sb.ToString());
+            var endpoint = StringBuilderCache.GetStringAndRelease(sb);
+            _mapEndpoints?.Add(endpoint);
         }
     }
 

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Util/FileBitmap.cs
@@ -12,6 +12,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Datadog.Trace.Util;
 
 #if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.Intrinsics;
@@ -932,13 +933,14 @@ internal readonly unsafe ref struct FileBitmap
     /// <returns>A string showing the bitmap in binary form.</returns>
     public override string ToString()
     {
-        var sb = new StringBuilder();
+        var sb = StringBuilderCache.Acquire();
+
         for (var i = 0; i < _size; i++)
         {
             sb.Append(Convert.ToString(_bitmap[i], 2).PadLeft(8, '0'));
         }
 
-        return sb.ToString();
+        return StringBuilderCache.GetStringAndRelease(sb);
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/BsonSerialization/BsonSerializationHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/BsonSerialization/BsonSerializationHelper.cs
@@ -261,7 +261,10 @@ internal static class BsonSerializationHelper
             // so we do it once here, just to confirm that it will work later
             try
             {
+                // StringBuilder is passed to external MongoDB BsonWriter — cannot use StringBuilderCache
+#pragma warning disable DDALLOC003
                 SerializeWithCustomWriter(string.Empty, new StringBuilder(1), helper);
+#pragma warning restore DDALLOC003
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/VendoredSqlHelpers.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/VendoredSqlHelpers.cs
@@ -61,16 +61,16 @@ namespace Datadog.Trace.DatabaseMonitoring
             //  with all parts except trimming separators for leading empty names (null or empty strings,
             //  but not whitespace). Separators in the middle should be added, even if the name part is
             //  null/empty, to maintain proper location of the parts.
-            for (int i = 0; i < strings.Length; i++)
+            foreach (var s in strings)
             {
-                if (0 < sb.Length)
+                if (sb.Length > 0)
                 {
                     sb.Append('.');
                 }
 
-                if (strings[i] != null && 0 != strings[i].Length)
+                if (!string.IsNullOrEmpty(s))
                 {
-                    AppendQuotedString(sb, "[", "]", strings[i]);
+                    AppendQuotedString(sb, "[", "]", s);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/VendoredSqlHelpers.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/VendoredSqlHelpers.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Text;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.DatabaseMonitoring
 {
@@ -54,7 +55,7 @@ namespace Datadog.Trace.DatabaseMonitoring
         // https://github.com/dotnet/SqlClient/blob/414f016540932d339054c61abc5ae838401cdb06/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs#L6502
         private static string QuoteIdentifier(ReadOnlySpan<string> strings)
         {
-            StringBuilder bld = new StringBuilder();
+            var sb = StringBuilderCache.Acquire();
 
             // Stitching back together is a little tricky. Assume we want to build a full multi-part name
             //  with all parts except trimming separators for leading empty names (null or empty strings,
@@ -62,18 +63,18 @@ namespace Datadog.Trace.DatabaseMonitoring
             //  null/empty, to maintain proper location of the parts.
             for (int i = 0; i < strings.Length; i++)
             {
-                if (0 < bld.Length)
+                if (0 < sb.Length)
                 {
-                    bld.Append('.');
+                    sb.Append('.');
                 }
 
                 if (strings[i] != null && 0 != strings[i].Length)
                 {
-                    AppendQuotedString(bld, "[", "]", strings[i]);
+                    AppendQuotedString(sb, "[", "]", strings[i]);
                 }
             }
 
-            return bld.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         // https://github.com/dotnet/SqlClient/blob/414f016540932d339054c61abc5ae838401cdb06/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs#L547

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/VendoredSqlHelpers.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/VendoredSqlHelpers.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.DatabaseMonitoring
 {
     internal static class VendoredSqlHelpers
     {
-        // parse an string of the form db.schema.name where any of the three components
+        // parse a string of the form db.schema.name where any of the three components
         // might have "[" "]" and dots within it.
         // returns:
         //   [0] dbname (or null)
@@ -22,7 +22,7 @@ namespace Datadog.Trace.DatabaseMonitoring
         // NOTE: if perf/space implications of Regex is not a problem, we can get rid
         // of this and use a simple regex to do the parsing
         // https://github.com/dotnet/SqlClient/blob/414f016540932d339054c61abc5ae838401cdb06/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs#L2433
-        internal static string[] ParseTypeName(string typeName, bool isUdtTypeName)
+        private static string[] ParseTypeName(string typeName)
         {
             try
             {
@@ -40,7 +40,7 @@ namespace Datadog.Trace.DatabaseMonitoring
         //  the result as a single composite name.
         internal static string ParseAndQuoteIdentifier(string identifier, bool isUdtTypeName)
         {
-            string[] strings = ParseTypeName(identifier, isUdtTypeName);
+            string[] strings = ParseTypeName(identifier);
 
             if (strings.Length == 0)
             {
@@ -77,7 +77,7 @@ namespace Datadog.Trace.DatabaseMonitoring
         }
 
         // https://github.com/dotnet/SqlClient/blob/414f016540932d339054c61abc5ae838401cdb06/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs#L547
-        internal static string AppendQuotedString(StringBuilder buffer, string quotePrefix, string quoteSuffix, string unQuotedString)
+        private static void AppendQuotedString(StringBuilder buffer, string quotePrefix, string quoteSuffix, string unQuotedString)
         {
             if (!string.IsNullOrEmpty(quotePrefix))
             {
@@ -96,8 +96,6 @@ namespace Datadog.Trace.DatabaseMonitoring
             {
                 buffer.Append(unQuotedString);
             }
-
-            return buffer.ToString();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -50,6 +50,7 @@ public sealed class StringBuilderAspects
     [AspectCtorReplace("System.Text.StringBuilder::.ctor(System.String,System.Int32)", AspectFilter.StringLiteral_1)]
     public static StringBuilder Init(string? value, int capacity)
     {
+        // IAST aspects intentionally replace customer StringBuilder allocations — cannot use StringBuilderCache
 #pragma warning disable DDALLOC003
         var result = new StringBuilder(value, capacity);
 #pragma warning restore DDALLOC003
@@ -74,6 +75,7 @@ public sealed class StringBuilderAspects
     [AspectCtorReplace("System.Text.StringBuilder::.ctor(System.String,System.Int32,System.Int32,System.Int32)", AspectFilter.StringLiteral_1)]
     public static StringBuilder Init(string? value, int startIndex, int length, int capacity)
     {
+        // IAST aspects intentionally replace customer StringBuilder allocations — cannot use StringBuilderCache
 #pragma warning disable DDALLOC003
         var result = new StringBuilder(value, startIndex, length, capacity);
 #pragma warning restore DDALLOC003

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -27,7 +27,10 @@ public sealed class StringBuilderAspects
     [AspectCtorReplace("System.Text.StringBuilder::.ctor(System.String)", AspectFilter.StringLiteral_1)]
     public static StringBuilder Init(string? value)
     {
+        // IAST aspects intentionally replace customer StringBuilder allocations — cannot use StringBuilderCache
+#pragma warning disable DDALLOC003
         var result = new StringBuilder(value);
+#pragma warning restore DDALLOC003
         try
         {
             PropagationModuleImpl.PropagateTaint(value, result);
@@ -47,7 +50,9 @@ public sealed class StringBuilderAspects
     [AspectCtorReplace("System.Text.StringBuilder::.ctor(System.String,System.Int32)", AspectFilter.StringLiteral_1)]
     public static StringBuilder Init(string? value, int capacity)
     {
+#pragma warning disable DDALLOC003
         var result = new StringBuilder(value, capacity);
+#pragma warning restore DDALLOC003
         try
         {
             PropagationModuleImpl.PropagateTaint(value, result);
@@ -69,7 +74,9 @@ public sealed class StringBuilderAspects
     [AspectCtorReplace("System.Text.StringBuilder::.ctor(System.String,System.Int32,System.Int32,System.Int32)", AspectFilter.StringLiteral_1)]
     public static StringBuilder Init(string? value, int startIndex, int length, int capacity)
     {
+#pragma warning disable DDALLOC003
         var result = new StringBuilder(value, startIndex, length, capacity);
+#pragma warning restore DDALLOC003
         try
         {
             StringBuilderModuleImpl.OnStringBuilderSubSequence(value, startIndex, length, result);

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpMetricsSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpMetricsSerializer.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Util;
 
 #nullable enable
 
@@ -65,7 +66,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
             Array.Copy(tags, copy, tags.Length);
             Array.Sort(copy, (a, b) => string.CompareOrdinal(a.Key, b.Key));
 
-            var sb = new StringBuilder();
+            var sb = StringBuilderCache.Acquire();
             for (int i = 0; i < copy.Length; i++)
             {
                 if (i > 0)
@@ -80,7 +81,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
                 }
             }
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         private byte[] SerializeResourceMetrics(IReadOnlyList<MetricPoint> metrics)

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer;
 using Microsoft.CodeAnalysis.Testing;
@@ -28,16 +29,14 @@ public class StringBuilderCacheAnalyzerTests
         }
         """;
 
-    [Fact]
-    public async Task EmptySource_NoDiagnostic()
-    {
-        await Verifier.VerifyAnalyzerAsync(string.Empty);
-    }
+    // ── Constructor variants that should report a diagnostic ──────────────
 
-    [Fact]
-    public async Task NewStringBuilder_NoArgs_ReportsDiagnostic()
+    public static IEnumerable<object[]> ConstructorVariants_ReportDiagnostic => new[]
     {
-        var source = """
+        new object[]
+        {
+            "no args",
+            """
             using System.Text;
 
             class TestClass
@@ -49,16 +48,12 @@ public class StringBuilderCacheAnalyzerTests
                     var result = sb.ToString();
                 }
             }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_WithCapacity_ReportsDiagnostic()
-    {
-        var source = """
+            """,
+        },
+        new object[]
+        {
+            "capacity within MaxBuilderSize",
+            """
             using System.Text;
 
             class TestClass
@@ -70,37 +65,12 @@ public class StringBuilderCacheAnalyzerTests
                     var result = sb.ToString();
                 }
             }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_LargeCapacity_ReportsDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                void TestMethod()
-                {
-                    var sb = {|#0:new StringBuilder(500)|};
-                    sb.Append("hello");
-                    var result = sb.ToString();
-                }
-            }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_WithString_ReportsDiagnostic()
-    {
-        var source = """
+            """,
+        },
+        new object[]
+        {
+            "string arg",
+            """
             using System.Text;
 
             class TestClass
@@ -112,16 +82,12 @@ public class StringBuilderCacheAnalyzerTests
                     var result = sb.ToString();
                 }
             }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_WithStringAndCapacity_ReportsDiagnostic()
-    {
-        var source = """
+            """,
+        },
+        new object[]
+        {
+            "string and capacity args",
+            """
             using System.Text;
 
             class TestClass
@@ -133,11 +99,271 @@ public class StringBuilderCacheAnalyzerTests
                     var result = sb.ToString();
                 }
             }
+            """,
+        },
+        new object[]
+        {
+            "variable capacity (non-constant)",
+            """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod(int len)
+                {
+                    var sb = {|#0:new StringBuilder(len)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """,
+        },
+        new object[]
+        {
+            "implicit new() no args",
+            """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    StringBuilder sb = {|#0:new()|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """,
+        },
+        new object[]
+        {
+            "implicit new() with capacity",
+            """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    StringBuilder sb = {|#0:new(100)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """,
+        },
+    };
+
+    // ── Field/property assignment — suppressed ───────────────────────────
+
+    public static IEnumerable<object[]> FieldOrPropertyAssignment_NoDiagnostic => new[]
+    {
+        new object[]
+        {
+            "field initializer",
+            """
+            using System.Text;
+
+            class TestClass
+            {
+                private readonly StringBuilder _sb = new StringBuilder();
+
+                void TestMethod()
+                {
+                    _sb.Clear();
+                    _sb.Append("hello");
+                }
+            }
+            """,
+        },
+        new object[]
+        {
+            "field initializer with capacity",
+            """
+            using System.Text;
+
+            class TestClass
+            {
+                private readonly StringBuilder _sb = new StringBuilder(1024);
+
+                void TestMethod()
+                {
+                    _sb.Clear();
+                    _sb.Append("hello");
+                }
+            }
+            """,
+        },
+        new object[]
+        {
+            "constructor assignment to field",
+            """
+            using System.Text;
+
+            class TestClass
+            {
+                private readonly StringBuilder _sb;
+
+                TestClass()
+                {
+                    _sb = new StringBuilder(256);
+                }
+
+                void TestMethod()
+                {
+                    _sb.Clear();
+                    _sb.Append("hello");
+                }
+            }
+            """,
+        },
+        new object[]
+        {
+            "property initializer",
+            """
+            using System.Text;
+
+            class TestClass
+            {
+                private StringBuilder Sb { get; } = new StringBuilder();
+
+                void TestMethod()
+                {
+                    Sb.Clear();
+                    Sb.Append("hello");
+                }
+            }
+            """,
+        },
+    };
+
+    // ── Test methods ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EmptySource_NoDiagnostic()
+    {
+        await Verifier.VerifyAnalyzerAsync(string.Empty);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConstructorVariants_ReportDiagnostic))]
+    public async Task NewStringBuilder_VariousConstructors_ReportsDiagnostic(string description, string source)
+    {
+        _ = description; // used for test display only
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    // ── Capacity exceeds MaxBuilderSize — suppressed ─────────────────────
+
+    [Theory]
+    [InlineData(361)]
+    [InlineData(500)]
+    [InlineData(1024)]
+    public async Task NewStringBuilder_ConstantCapacityExceedsMaxBuilderSize_NoDiagnostic(int capacity)
+    {
+        var source = $$"""
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = new StringBuilder({{capacity}});
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_CapacityExactlyAtMaxBuilderSize_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder(360)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
             """;
 
         var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
         await Verifier.VerifyAnalyzerAsync(source, expected);
     }
+
+    [Fact]
+    public async Task NewStringBuilder_StringAndLargeCapacity_NoDiagnostic()
+    {
+        // StringBuilder(string, int capacity) where capacity > MaxBuilderSize
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = new StringBuilder("hello", 500);
+                    sb.Append(" world");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_FourArgConstructor_LargeCapacity_NoDiagnostic()
+    {
+        // StringBuilder(string, int startIndex, int length, int capacity) where capacity > MaxBuilderSize
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = new StringBuilder("hello world", 0, 5, 500);
+                    sb.Append(" more");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_CapacityAndMaxCapacity_LargeCapacity_NoDiagnostic()
+    {
+        // StringBuilder(int capacity, int maxCapacity) where capacity > MaxBuilderSize
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = new StringBuilder(500, 1000);
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    // ── StringBuilderCache already in use — suppressed ───────────────────
 
     [Fact]
     public async Task MethodAlreadyUsesStringBuilderCache_NoDiagnostic()
@@ -153,6 +379,31 @@ public class StringBuilderCacheAnalyzerTests
                     var sb = StringBuilderCache.Acquire();
                     sb.Append("hello");
                     var result = StringBuilderCache.GetStringAndRelease(sb);
+
+                    // This new StringBuilder should be suppressed because the method already uses StringBuilderCache
+                    var sb2 = new StringBuilder();
+                    sb2.Append("world");
+                    var result2 = sb2.ToString();
+                }
+            }
+            """ + StringBuilderCacheStub;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task MethodAlreadyUsesQualifiedStringBuilderCache_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = Datadog.Trace.Util.StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = Datadog.Trace.Util.StringBuilderCache.GetStringAndRelease(sb);
 
                     // This new StringBuilder should be suppressed because the method already uses StringBuilderCache
                     var sb2 = new StringBuilder();
@@ -182,6 +433,8 @@ public class StringBuilderCacheAnalyzerTests
 
         await Verifier.VerifyAnalyzerAsync(source);
     }
+
+    // ── Scope isolation (lambdas, local functions) ───────────────────────
 
     [Fact]
     public async Task NewStringBuilder_InLambda_WhenOuterMethodUsesCache_ReportsDiagnostic()
@@ -242,167 +495,6 @@ public class StringBuilderCacheAnalyzerTests
     }
 
     [Fact]
-    public async Task NewStringBuilder_FieldInitializer_NoDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                private readonly StringBuilder _sb = new StringBuilder();
-
-                void TestMethod()
-                {
-                    _sb.Clear();
-                    _sb.Append("hello");
-                }
-            }
-            """;
-
-        await Verifier.VerifyAnalyzerAsync(source);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_FieldInitializerWithCapacity_NoDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                private readonly StringBuilder _sb = new StringBuilder(1024);
-
-                void TestMethod()
-                {
-                    _sb.Clear();
-                    _sb.Append("hello");
-                }
-            }
-            """;
-
-        await Verifier.VerifyAnalyzerAsync(source);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_ConstructorAssignmentToField_NoDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                private readonly StringBuilder _sb;
-
-                TestClass()
-                {
-                    _sb = new StringBuilder(256);
-                }
-
-                void TestMethod()
-                {
-                    _sb.Clear();
-                    _sb.Append("hello");
-                }
-            }
-            """;
-
-        await Verifier.VerifyAnalyzerAsync(source);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_PropertyInitializer_NoDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                private StringBuilder Sb { get; } = new StringBuilder();
-
-                void TestMethod()
-                {
-                    Sb.Clear();
-                    Sb.Append("hello");
-                }
-            }
-            """;
-
-        await Verifier.VerifyAnalyzerAsync(source);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_VariableCapacity_ReportsDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                void TestMethod(int len)
-                {
-                    var sb = {|#0:new StringBuilder(len)|};
-                    sb.Append("hello");
-                    var result = sb.ToString();
-                }
-            }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_MultipleInSameMethod_NoDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                void TestMethod()
-                {
-                    var sb1 = new StringBuilder();
-                    var sb2 = new StringBuilder();
-                    sb1.Append("hello");
-                    sb2.Append("world");
-                }
-            }
-            """;
-
-        await Verifier.VerifyAnalyzerAsync(source);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_MultipleInDifferentMethods_ReportsDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                void Method1()
-                {
-                    var sb = {|#0:new StringBuilder()|};
-                    sb.Append("hello");
-                }
-
-                void Method2()
-                {
-                    var sb = {|#1:new StringBuilder()|};
-                    sb.Append("world");
-                }
-            }
-            """;
-
-        var expected = new[]
-        {
-            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0),
-            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(1),
-        };
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
     public async Task NewStringBuilder_MultipleButOneInLambda_ReportsDiagnostic()
     {
         // Each scope has only one StringBuilder, so both should be flagged
@@ -431,98 +523,6 @@ public class StringBuilderCacheAnalyzerTests
             Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0),
             Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(1),
         };
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_ImplicitNoArgs_ReportsDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                void TestMethod()
-                {
-                    StringBuilder sb = {|#0:new()|};
-                    sb.Append("hello");
-                    var result = sb.ToString();
-                }
-            }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_ImplicitWithCapacity_ReportsDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                void TestMethod()
-                {
-                    StringBuilder sb = {|#0:new(100)|};
-                    sb.Append("hello");
-                    var result = sb.ToString();
-                }
-            }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
-        await Verifier.VerifyAnalyzerAsync(source, expected);
-    }
-
-    [Fact]
-    public async Task MethodAlreadyUsesQualifiedStringBuilderCache_NoDiagnostic()
-    {
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                void TestMethod()
-                {
-                    var sb = Datadog.Trace.Util.StringBuilderCache.Acquire();
-                    sb.Append("hello");
-                    var result = Datadog.Trace.Util.StringBuilderCache.GetStringAndRelease(sb);
-
-                    // This new StringBuilder should be suppressed because the method already uses StringBuilderCache
-                    var sb2 = new StringBuilder();
-                    sb2.Append("world");
-                    var result2 = sb2.ToString();
-                }
-            }
-            """ + StringBuilderCacheStub;
-
-        await Verifier.VerifyAnalyzerAsync(source);
-    }
-
-    [Fact]
-    public async Task NewStringBuilder_MultipleInSameMethod_WithFieldAssignment_ReportsDiagnostic()
-    {
-        // Only one StringBuilder is method-scoped (the field assignment doesn't count),
-        // so the method-scoped one should be flagged
-        var source = """
-            using System.Text;
-
-            class TestClass
-            {
-                private StringBuilder _sb;
-
-                void TestMethod()
-                {
-                    _sb = new StringBuilder(256);
-                    var sb = {|#0:new StringBuilder()|};
-                    sb.Append("hello");
-                }
-            }
-            """;
-
-        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
         await Verifier.VerifyAnalyzerAsync(source, expected);
     }
 
@@ -609,5 +609,83 @@ public class StringBuilderCacheAnalyzerTests
             """ + StringBuilderCacheStub;
 
         await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    // ── Multiple allocations in same scope — suppressed ──────────────────
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleInSameMethod_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb1 = new StringBuilder();
+                    var sb2 = new StringBuilder();
+                    sb1.Append("hello");
+                    sb2.Append("world");
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleInDifferentMethods_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void Method1()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                }
+
+                void Method2()
+                {
+                    var sb = {|#1:new StringBuilder()|};
+                    sb.Append("world");
+                }
+            }
+            """;
+
+        var expected = new[]
+        {
+            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0),
+            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(1),
+        };
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleInSameMethod_WithFieldAssignment_ReportsDiagnostic()
+    {
+        // Only one StringBuilder is method-scoped (the field assignment doesn't count),
+        // so the method-scoped one should be flagged
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                private StringBuilder _sb;
+
+                void TestMethod()
+                {
+                    _sb = new StringBuilder(256);
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
@@ -555,4 +555,59 @@ public class StringBuilderCacheAnalyzerTests
         var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
         await Verifier.VerifyAnalyzerAsync(source, expected);
     }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleInLocalFunction_SuppressedCorrectly()
+    {
+        // Two StringBuilders in the same local function scope should suppress
+        // the diagnostic, just like they do in a regular method.
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    void LocalFunction()
+                    {
+                        var sb1 = new StringBuilder();
+                        var sb2 = new StringBuilder();
+                        sb1.Append("hello");
+                        sb2.Append("world");
+                    }
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_LocalFunctionWithCacheCall_SuppressedCorrectly()
+    {
+        // A local function that already calls StringBuilderCache.Acquire()
+        // should suppress the diagnostic for additional StringBuilder allocations in the same scope.
+        var source = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    void LocalFunction()
+                    {
+                        var sb = StringBuilderCache.Acquire();
+                        sb.Append("hello");
+                        var result = StringBuilderCache.GetStringAndRelease(sb);
+
+                        var sb2 = new StringBuilder();
+                        sb2.Append("world");
+                    }
+                }
+            }
+            """ + StringBuilderCacheStub;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
@@ -433,4 +433,126 @@ public class StringBuilderCacheAnalyzerTests
         };
         await Verifier.VerifyAnalyzerAsync(source, expected);
     }
+
+    [Fact]
+    public async Task NewStringBuilder_ImplicitNoArgs_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    StringBuilder sb = {|#0:new()|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_ImplicitWithCapacity_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    StringBuilder sb = {|#0:new(100)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task MethodAlreadyUsesQualifiedStringBuilderCache_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = Datadog.Trace.Util.StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = Datadog.Trace.Util.StringBuilderCache.GetStringAndRelease(sb);
+
+                    // This new StringBuilder should be suppressed because the method already uses StringBuilderCache
+                    var sb2 = new StringBuilder();
+                    sb2.Append("world");
+                    var result2 = sb2.ToString();
+                }
+            }
+            """ + StringBuilderCacheStub;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleInSameMethod_WithFieldAssignment_ReportsDiagnostic()
+    {
+        // Only one StringBuilder is method-scoped (the field assignment doesn't count),
+        // so the method-scoped one should be flagged
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                private StringBuilder _sb;
+
+                void TestMethod()
+                {
+                    _sb = new StringBuilder(256);
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_InNestedLambda_WhenOuterHasMultiple_ReportsDiagnostic()
+    {
+        // Outer method has 2 StringBuilders (suppressed), but nested lambda has just 1 (should be flagged)
+        var source = """
+            using System;
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb1 = new StringBuilder();
+                    var sb2 = new StringBuilder();
+                    sb1.Append("hello");
+                    sb2.Append("world");
+
+                    Action action = () =>
+                    {
+                        var sb3 = {|#0:new StringBuilder()|};
+                        sb3.Append("nested");
+                    };
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
@@ -242,6 +242,95 @@ public class StringBuilderCacheAnalyzerTests
     }
 
     [Fact]
+    public async Task NewStringBuilder_FieldInitializer_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                private readonly StringBuilder _sb = new StringBuilder();
+
+                void TestMethod()
+                {
+                    _sb.Clear();
+                    _sb.Append("hello");
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_FieldInitializerWithCapacity_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                private readonly StringBuilder _sb = new StringBuilder(1024);
+
+                void TestMethod()
+                {
+                    _sb.Clear();
+                    _sb.Append("hello");
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_ConstructorAssignmentToField_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                private readonly StringBuilder _sb;
+
+                TestClass()
+                {
+                    _sb = new StringBuilder(256);
+                }
+
+                void TestMethod()
+                {
+                    _sb.Clear();
+                    _sb.Append("hello");
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_PropertyInitializer_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                private StringBuilder Sb { get; } = new StringBuilder();
+
+                void TestMethod()
+                {
+                    Sb.Clear();
+                    Sb.Append("hello");
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
     public async Task NewStringBuilder_VariableCapacity_ReportsDiagnostic()
     {
         var source = """

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
@@ -1,0 +1,264 @@
+// <copyright file="StringBuilderCacheAnalyzerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+    Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer.StringBuilderCacheAnalyzer,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests.StringBuilderCacheAnalyzer;
+
+public class StringBuilderCacheAnalyzerTests
+{
+    private const string StringBuilderCacheStub = """
+        namespace Datadog.Trace.Util
+        {
+            internal static class StringBuilderCache
+            {
+                internal const int MaxBuilderSize = 360;
+                public static System.Text.StringBuilder Acquire(int capacity = 360) => new System.Text.StringBuilder(capacity);
+                public static string GetStringAndRelease(System.Text.StringBuilder sb) => sb.ToString();
+                public static void Release(System.Text.StringBuilder sb) { }
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task EmptySource_NoDiagnostic()
+    {
+        await Verifier.VerifyAnalyzerAsync(string.Empty);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_NoArgs_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_WithCapacity_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder(100)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_LargeCapacity_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder(500)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_WithString_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder("hello")|};
+                    sb.Append(" world");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_WithStringAndCapacity_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder("hello", 10)|};
+                    sb.Append(" world");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task MethodAlreadyUsesStringBuilderCache_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+
+                    // This new StringBuilder should be suppressed because the method already uses StringBuilderCache
+                    var sb2 = new StringBuilder();
+                    sb2.Append("world");
+                    var result2 = sb2.ToString();
+                }
+            }
+            """ + StringBuilderCacheStub;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task InsideStringBuilderCacheClass_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class StringBuilderCache
+            {
+                public static StringBuilder Acquire(int capacity = 360)
+                {
+                    return new StringBuilder(capacity);
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_InLambda_WhenOuterMethodUsesCache_ReportsDiagnostic()
+    {
+        // The lambda is a separate scope — the outer method's StringBuilderCache.Acquire() doesn't suppress it
+        var source = """
+            using System;
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+
+                    Action action = () =>
+                    {
+                        var sb2 = {|#0:new StringBuilder()|};
+                        sb2.Append("world");
+                    };
+                }
+            }
+            """ + StringBuilderCacheStub;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_InLocalFunction_WhenOuterMethodUsesCache_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+
+                    void LocalFunction()
+                    {
+                        var sb2 = {|#0:new StringBuilder()|};
+                        sb2.Append("world");
+                    }
+                }
+            }
+            """ + StringBuilderCacheStub;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_VariableCapacity_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod(int len)
+                {
+                    var sb = {|#0:new StringBuilder(len)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheAnalyzerTests.cs
@@ -350,4 +350,87 @@ public class StringBuilderCacheAnalyzerTests
         var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
         await Verifier.VerifyAnalyzerAsync(source, expected);
     }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleInSameMethod_NoDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb1 = new StringBuilder();
+                    var sb2 = new StringBuilder();
+                    sb1.Append("hello");
+                    sb2.Append("world");
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleInDifferentMethods_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void Method1()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                }
+
+                void Method2()
+                {
+                    var sb = {|#1:new StringBuilder()|};
+                    sb.Append("world");
+                }
+            }
+            """;
+
+        var expected = new[]
+        {
+            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0),
+            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(1),
+        };
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleButOneInLambda_ReportsDiagnostic()
+    {
+        // Each scope has only one StringBuilder, so both should be flagged
+        var source = """
+            using System;
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+
+                    Action action = () =>
+                    {
+                        var sb2 = {|#1:new StringBuilder()|};
+                        sb2.Append("world");
+                    };
+                }
+            }
+            """;
+
+        var expected = new[]
+        {
+            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0),
+            Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(1),
+        };
+        await Verifier.VerifyAnalyzerAsync(source, expected);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
@@ -103,8 +103,9 @@ public class StringBuilderCacheCodeFixTests
     }
 
     [Fact]
-    public async Task NewStringBuilder_MultipleToStringCalls_ReplacesAll()
+    public async Task NewStringBuilder_MultipleToStringCalls_WithMutations_OnlyReplacesLast()
     {
+        // Case B: mutations exist between .ToString() calls — only the last becomes GetStringAndRelease()
         var source = """
             using System.Text;
 
@@ -131,9 +132,49 @@ public class StringBuilderCacheCodeFixTests
                 {
                     var sb = StringBuilderCache.Acquire();
                     sb.Append("hello");
-                    var first = StringBuilderCache.GetStringAndRelease(sb);
+                    var first = sb.ToString();
                     sb.Append(" world");
                     var second = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleToStringCalls_NoMutations_UsesLocalVariable()
+    {
+        // Case A: no mutations between .ToString() calls — use single GetStringAndRelease() + local variable
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var first = sb.ToString();
+                    var second = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var sbResult = StringBuilderCache.GetStringAndRelease(sb);
+                    var first = sbResult;
+                    var second = sbResult;
                 }
             }
             """;
@@ -209,6 +250,40 @@ public class StringBuilderCacheCodeFixTests
                     sb = StringBuilderCache.Acquire();
                     sb.Append("hello");
                     var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_InlineUsage_ReplacesToStringWithGetStringAndRelease()
+    {
+        // Issue 3: When new StringBuilder() is used inline (not assigned to a variable),
+        // the code fix should still rewrite the full expression including .ToString().
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                string TestMethod()
+                {
+                    return {|#0:new StringBuilder()|}.Append("hello").ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                string TestMethod()
+                {
+                    return StringBuilderCache.GetStringAndRelease(StringBuilderCache.Acquire().Append("hello"));
                 }
             }
             """;

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
@@ -1,0 +1,219 @@
+// <copyright file="StringBuilderCacheCodeFixTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+extern alias AnalyzerCodeFixes;
+
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixVerifier<
+    Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer.StringBuilderCacheAnalyzer,
+    AnalyzerCodeFixes::Datadog.Trace.Tools.Analyzers.StringBuilderCacheAnalyzer.StringBuilderCacheCodeFixProvider,
+    Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests.StringBuilderCacheAnalyzer;
+
+public class StringBuilderCacheCodeFixTests
+{
+    private const string StringBuilderCacheStub = """
+        namespace Datadog.Trace.Util
+        {
+            internal static class StringBuilderCache
+            {
+                internal const int MaxBuilderSize = 360;
+                public static System.Text.StringBuilder Acquire(int capacity = 360) => new System.Text.StringBuilder(capacity);
+                public static string GetStringAndRelease(System.Text.StringBuilder sb) => sb.ToString();
+                public static void Release(System.Text.StringBuilder sb) { }
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task NewStringBuilder_NoArgs_ReplacesWithAcquireAndGetStringAndRelease()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_WithCapacity_ForwardsArgumentToAcquire()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder(100)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire(100);
+                    sb.Append("hello");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleToStringCalls_ReplacesAll()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var first = sb.ToString();
+                    sb.Append(" world");
+                    var second = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var first = StringBuilderCache.GetStringAndRelease(sb);
+                    sb.Append(" world");
+                    var second = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_ExistingUsingDirective_DoesNotDuplicate()
+    {
+        var source = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_AssignedViaAssignment_ReplacesToString()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    StringBuilder sb;
+                    sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    StringBuilder sb;
+                    sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
@@ -363,4 +363,188 @@ public class StringBuilderCacheCodeFixTests
         var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
         await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
     }
+
+    [Fact]
+    public async Task NewStringBuilder_WithNamedArgs_CorrectlyMapsCapacityAndValue()
+    {
+        // Named arguments in the same order as positional — should produce the same output
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder(value: "hello", capacity: 100)|};
+                    sb.Append(" world");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire(100).Append("hello");
+                    sb.Append(" world");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_WithSwappedNamedArgs_CorrectlyMapsCapacityAndValue()
+    {
+        // Named arguments in reversed order — capacity: first, value: second
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder(capacity: 100, value: "hello")|};
+                    sb.Append(" world");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire(100).Append("hello");
+                    sb.Append(" world");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_WithCapacityAndMaxCapacity_DiagnosticFiredButNoCodeFixApplied()
+    {
+        // StringBuilderCache.Acquire() has no maxCapacity parameter — code fix is not offered
+        // to avoid silently changing runtime semantics. Diagnostic still fires.
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|DDALLOC003:new StringBuilder(100, 500)|};
+                    sb.Append("hello");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleToStringCalls_PropertyAssignmentBetween_OnlyReplacesLast()
+    {
+        // sb.Length = 0 is a property assignment — treated as a mutation,
+        // so the code fix uses the "last only" path rather than collapsing to a single result.
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var first = sb.ToString();
+                    sb.Length = 0;
+                    sb.Append("world");
+                    var second = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var first = sb.ToString();
+                    sb.Length = 0;
+                    sb.Append("world");
+                    var second = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_MultipleToStringCalls_VariableReassignmentBetween_OnlyReplacesLast()
+    {
+        // sb = other is a variable reassignment — treated as a mutation,
+        // so the code fix uses the "last only" path rather than collapsing to a single result.
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod(StringBuilder other)
+                {
+                    var sb = {|#0:new StringBuilder()|};
+                    sb.Append("hello");
+                    var first = sb.ToString();
+                    sb = other;
+                    sb.Append("world");
+                    var second = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod(StringBuilder other)
+                {
+                    var sb = StringBuilderCache.Acquire();
+                    sb.Append("hello");
+                    var first = sb.ToString();
+                    sb = other;
+                    sb.Append("world");
+                    var second = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/StringBuilderCacheAnalyzer/StringBuilderCacheCodeFixTests.cs
@@ -291,4 +291,76 @@ public class StringBuilderCacheCodeFixTests
         var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
         await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
     }
+
+    [Fact]
+    public async Task NewStringBuilder_WithStringArg_ReplacesWithAcquireAndAppend()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder("hello")|};
+                    sb.Append(" world");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire().Append("hello");
+                    sb.Append(" world");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
+
+    [Fact]
+    public async Task NewStringBuilder_WithStringAndCapacityArgs_ReplacesWithAcquireCapacityAndAppend()
+    {
+        var source = """
+            using System.Text;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = {|#0:new StringBuilder("hello", 100)|};
+                    sb.Append(" world");
+                    var result = sb.ToString();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Text;
+            using Datadog.Trace.Util;
+
+            class TestClass
+            {
+                void TestMethod()
+                {
+                    var sb = StringBuilderCache.Acquire(100).Append("hello");
+                    sb.Append(" world");
+                    var result = StringBuilderCache.GetStringAndRelease(sb);
+                }
+            }
+            """;
+
+        var expected = Verifier.Diagnostic(Diagnostics.DiagnosticId).WithLocation(0);
+        await Verifier.VerifyCodeFixAsync(source + StringBuilderCacheStub, expected, fixedSource + StringBuilderCacheStub);
+    }
 }


### PR DESCRIPTION
## Summary of changes

Adds Roslyn analyzer `DDALLOC003` that flags `new StringBuilder()` allocations and suggests using `StringBuilderCache.Acquire()` / `GetStringAndRelease()`, with a code fix that rewrites them automatically. Includes fixes for reviewer-identified correctness issues in scope isolation, semantic type resolution, and qualified name handling.

## Reason for change

`StringBuilderCache` (thread-static cached instance) exists in the codebase but wasn't enforced. Developers using `new StringBuilder()` miss the opportunity to avoid heap allocations.

## Implementation details

- **Analyzer** (`StringBuilderCacheAnalyzer`): flags `new StringBuilder(...)` and implicit `new()` via semantic model for accurate type resolution. Suppresses:
  - Assignments to fields/properties (long-lived builders)
  - Methods that already call `StringBuilderCache.Acquire()` — including qualified forms like `Util.StringBuilderCache.Acquire()`
  - Methods with multiple `StringBuilder` allocations (cache holds one per thread); field assignments excluded from this count
  - The `StringBuilderCache` class itself
  - Lambdas/local functions analyzed as independent scopes

- **Code fix** (`StringBuilderCacheCodeFixProvider`): replaces `new StringBuilder()` → `StringBuilderCache.Acquire()` and `.ToString()` → `GetStringAndRelease()`. Handles:
  - Constructor arg mapping by parameter name (not position) — correctly handles named arguments like `new StringBuilder(capacity: 100, value: "x")`
  - Multiple `.ToString()` calls: detects mutations between them (method calls, property assignments like `sb.Length = 0`, element access, variable reassignment) to decide whether to collapse to a single `GetStringAndRelease()` or only replace the last call
  - Inline/chained usage (e.g., `new StringBuilder().Append("x").ToString()`)
  - Bail-out for `StringBuilder(capacity, maxCapacity)` — `StringBuilderCache.Acquire()` has no `maxCapacity` parameter, so rewriting would silently change runtime semantics
  - Capacity > `MaxBuilderSize` (360) suppressed — `StringBuilderCache` won't cache builders larger than this
  - Adds the required `using Datadog.Trace.Util` directive

- **Scope isolation correctness**: both `ContainsStringBuilderCacheAcquireCall` and `CountStringBuilderCreations` use `descendIntoChildren` to skip nested lambdas/local functions, which are analyzed independently. All type resolution uses the semantic model with `SymbolEqualityComparer` — no syntax-based name matching.

- **Scoped to `Datadog.Trace` only**: `isEnabledByDefault: false` in the analyzer, with `dotnet_diagnostic.DDALLOC003.severity = error` in `tracer/src/Datadog.Trace/.editorconfig`. Although `tracer/src/Directory.Build.props` registers the analyzer for all projects under `tracer/src/`, `StringBuilderCache` lives in `Datadog.Trace.Util` and is not accessible from other projects (e.g. `Datadog.FleetInstaller`, `Datadog.Trace.Tools.Shared`). Enabling the diagnostic globally would produce errors those projects cannot fix without copying or linking in `StringBuilderCache.cs`.

- Applied code fix to existing violations: `VendoredSqlHelpers`, `FileBitmap`, `MapEndpointsCollection`, `OtlpMetricsSerializer`. Added `#pragma` suppressions with explanatory comments for IAST `StringBuilderAspects` (intentionally replacing customer allocations) and MongoDB `BsonSerializationHelper` (StringBuilder passed to external BsonWriter).

- **`VendoredSqlHelpers` cleanup**: While applying the code fix, also made `ParseTypeName` private and removed the unused `isUdtTypeName` parameter, and changed `AppendQuotedString` to `private void` (return value was unused).

## Test coverage

**Analyzer tests:**
- All constructor overloads including implicit `new()` / `new(capacity)`
- Field/property initializers, constructor assignments to fields
- Capacity threshold: exact boundary at `MaxBuilderSize` (360), above 360, and non-constant capacity
- `StringBuilderCache` class exclusion
- Method-level suppression for both simple and fully qualified `StringBuilderCache.Acquire()` calls
- Multiple builders in same method; field assignments not counted toward suppression
- Lambda/local function scope isolation (outer cache call doesn't suppress inner scope; outer multiple-builder suppression doesn't suppress nested single-builder lambda)

**Code fix tests:**
- Basic rewrite (no args, with capacity, with string arg, with string + capacity)
- Named arguments in both ordinal and swapped order
- Multiple `.ToString()` with and without mutations (method calls, property assignments, variable reassignment)
- Inline/chained usage (`new StringBuilder().Append("x").ToString()`)
- `(capacity, maxCapacity)` constructor: diagnostic fires but code fix bails out
- Existing `using` directive not duplicated

## Other details

Stacked on #8421

`CountStringBuilderCreations` uses the semantic model (not syntax-based name matching) to correctly handle implicit `new()` and avoid false matches on non-`System.Text.StringBuilder` types named `StringBuilder`.

> *"I tried to use `new StringBuilder()` but the analyzer said 'cache me outside, how 'bout that?'"* — Claude 🤖

