### PR TITLE
scrub process tags from debugger snapshots

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/Approver.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/Approver.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Debugger.IntegrationTests.Helpers
     {
         private static readonly string[] _typesToScrub = { nameof(IntPtr), nameof(Guid) };
         private static readonly string[] _knownPropertiesToReplace = { "duration", "timestamp", "dd.span_id", "dd.trace_id", "id", "lineNumber", "thread_name", "thread_id", "<>t__builder", "s_taskIdCounter", "<>u__1", "stack", "m_task" };
-        private static readonly string[] _knownPropertiesToRemove = { "CachedReusableFilters", "MaxStateDepth", "MaxValidationDepth" };
+        private static readonly string[] _knownPropertiesToRemove = { "CachedReusableFilters", "MaxStateDepth", "MaxValidationDepth", "process_tags" };
 
         internal static async Task ApproveSnapshots(string[] snapshots, string testName, ITestOutputHelper output, string[] knownPropertiesToReplace = null, string[] knownPropertiesToRemove = null, string[] typesToScrub = null, bool orderPostScrubbing = false)
         {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -690,6 +690,9 @@ public class ProbesTests : TestHelper
 
         foreach (var span in spans)
         {
+            // Remove process tags that can be injected on the first span in a payload
+            span.Tags.Remove(global::Datadog.Trace.Tags.ProcessTags);
+
             var toSanitize = span.Tags.Where(tag => tag.Key.StartsWith(errorTagStartWith) && tag.Key.EndsWith(errorTagEndWith)).ToList();
             foreach (var keyValuePair in toSanitize)
             {


### PR DESCRIPTION
## Summary of changes

follow up on https://github.com/DataDog/dd-trace-dotnet/pull/8296
debugger itests didn't run in the PR
so we missed the fact that we need to apply the same scrubbing we did on other tests for those too

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
