### PR TITLE
[CI Tools] Add prerequisite validation to AzureDevOps helper scripts

### DIFF
--- a/tracer/tools/AzureDevOpsHelpers.psm1
+++ b/tracer/tools/AzureDevOpsHelpers.psm1
@@ -250,11 +250,11 @@ GitHub CLI (gh) not found.
 
         # 6. GitHub CLI authenticated
         if ($hasGh) {
-            $null = & gh auth status 2>$null
+            $null = & gh auth status --hostname github.com 2>$null
             if ($LASTEXITCODE -ne 0) {
                 $errors += @"
-GitHub CLI is not authenticated.
-  Run: gh auth login
+GitHub CLI is not authenticated for github.com.
+  Run: gh auth login --hostname github.com
 "@
             }
         }


### PR DESCRIPTION
## Summary of changes

Add a `Test-Prerequisites` function to `AzureDevOpsHelpers.psm1` that validates all required CLI tools are installed, authenticated, and properly configured before running Azure DevOps build analysis or retry scripts.

## Reason for change

When users run `Get-AzureDevOpsBuildAnalysis.ps1` or `Retry-AzureDevOpsFailedStages.ps1` directly (not via the Claude skill), missing or misconfigured prerequisites produce unhelpful error messages. The Claude skill had guidance for these scenarios, but the scripts themselves only checked if `az` and `gh` were installed.

## Implementation details

New `Test-Prerequisites` function checks (in order):
1. **`az` CLI installed** — with install links for Windows/macOS
2. **`azure-devops` extension** — with `az extension add` command
3. **`az` authenticated** — with `az login` guidance (including MFA hint)
4. **Subscription logging** — logs current subscription at `Verbose` level for troubleshooting
5. **`gh` CLI installed** — only when needed for PR-based resolution
6. **`gh` authenticated** — scoped to `github.com` only, so GHES auth issues don't block

`Resolve-BuildId` (the shared entry point for both scripts) now delegates to `Test-Prerequisites` instead of inline `Get-Command` checks.

Additionally, `Invoke-AzDevOpsApi` now includes a troubleshooting tip in its error message suggesting the user check and switch Azure subscriptions if needed.

## Test coverage

Tested manually:
- [x] `az` not installed
- [x] `az` installed without `azure-devops` extension
- [x] `az` installed but not authenticated
- [x] `gh` not installed
- [x] `gh` installed but not authenticated

## Other details

The subscription is not validated upfront because `az devops invoke --org <url> --detect false` targets the org URL directly, so the subscription doesn't strictly control API routing. However, the wrong subscription can affect token permissions, so `Invoke-AzDevOpsApi` now suggests checking subscriptions in its error message.

> *"I validate your prerequisites so you don't have to validate your life choices."* — Claude 🤖
