### PR TITLE
[Dynamic Instrumentation] clarify unbound line probe diagnostics

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -48,14 +48,15 @@ namespace Datadog.Trace.Debugger
             return path.Split(DirectorySeparatorsCrossPlatform, StringSplitOptions.None).LastOrDefault() ?? string.Empty;
         }
 
-        private static string BuildLoadedAssemblySourceFileMismatchMessage()
+        private static string BuildAssemblyNotLoadedOrSymbolsUnavailableMessage(bool hasSameFileNameMatches)
         {
-            return "Source file location for probe did not match the PDB document path of a loaded, symbolicated assembly with the same file name.";
-        }
+            var message = "Source file location for probe could not be matched to any currently loaded assembly with available symbols. This can happen if the relevant assembly is not loaded yet or its symbols are unavailable.";
+            if (!hasSameFileNameMatches)
+            {
+                return message;
+            }
 
-        private static string BuildAssemblyNotLoadedOrSymbolsUnavailableMessage()
-        {
-            return "Source file location for probe could not be matched to any currently loaded assembly with available symbols. This can happen if the relevant assembly is not loaded yet or symbols are unavailable for the matching assembly.";
+            return message + " Loaded symbolicated assemblies with the same file name were found, so the configured source path may differ from the PDB document path.";
         }
 
         private IList<string>? GetDocumentsFromPDB(Assembly loadedAssembly)
@@ -184,17 +185,12 @@ namespace Datadog.Trace.Debugger
                 if (!TryFindAssemblyContainingFile(sourceFile, out var filePathFromPdb, out var assembly))
                 {
                     var searchDiagnostics = CollectAssemblySearchDiagnostics(sourceFile);
-                    var reason = searchDiagnostics.SameFileNameMatchCount > 0
-                                     ? LineProbeResolveReason.LoadedAssemblySourceFileMismatch
-                                     : LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable;
-                    var message = searchDiagnostics.SameFileNameMatchCount > 0
-                                      ? BuildLoadedAssemblySourceFileMismatchMessage()
-                                      : BuildAssemblyNotLoadedOrSymbolsUnavailableMessage();
+                    var hasSameFileNameMatches = searchDiagnostics.SameFileNameMatchCount > 0;
 
                     return new LineProbeResolveResult(
                         LiveProbeResolveStatus.Unbound,
-                        reason,
-                        message,
+                        LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable,
+                        BuildAssemblyNotLoadedOrSymbolsUnavailableMessage(hasSameFileNameMatches),
                         searchDiagnostics.ToDiagnostics(lineNum, probe.Id));
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/Models/LiveProbeResolveStatus.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Models/LiveProbeResolveStatus.cs
@@ -29,7 +29,6 @@ namespace Datadog.Trace.Debugger.Models
         None,
         MissingSourceFile,
         AssemblyNotLoadedOrSymbolsUnavailable,
-        LoadedAssemblySourceFileMismatch,
         MissingPdb,
         InvalidLineNumber,
         MissingSequencePoint,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
@@ -104,19 +104,21 @@ public class LineProbeResolverTest
     }
 
     [Fact]
-    public void MismatchedPathReturnsUnboundWithFileNameDiagnostics()
+    public void SameFileNameMatchAddsPathHintWithoutChangingUnboundReason()
     {
         _probeDefinition.Where.SourceFile = @"some\other\folder\LambdaSingleLine.cs";
 
         var result = _lineProbeResolver.TryResolveLineProbe(_probeDefinition, out var loc);
 
         result.Status.Should().Be(LiveProbeResolveStatus.Unbound);
-        result.Reason.Should().Be(LineProbeResolveReason.LoadedAssemblySourceFileMismatch);
+        result.Reason.Should().Be(LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable);
         result.Diagnostics.LoadedAssemblyCount.Should().BeGreaterThan(0);
         result.Diagnostics.SymbolicatedAssemblyCount.Should().BeGreaterThan(0);
         result.Diagnostics.SameFileNameMatchCount.Should().BeGreaterThan(0);
         result.Diagnostics.SameFileNameExamples.Should().NotBeNullOrEmpty();
-        result.Message.Should().Contain("did not match the PDB document path");
+        result.Message.Should().Contain("assembly is not loaded yet");
+        result.Message.Should().Contain("symbols are unavailable");
+        result.Message.Should().Contain("configured source path may differ from the PDB document path");
         loc.Should().BeNull();
     }
 
@@ -132,6 +134,7 @@ public class LineProbeResolverTest
         result.Diagnostics.SameFileNameMatchCount.Should().Be(0);
         result.Message.Should().Contain("assembly is not loaded yet");
         result.Message.Should().Contain("symbols are unavailable");
+        result.Message.Should().NotContain("configured source path may differ from the PDB document path");
         loc.Should().BeNull();
     }
 


### PR DESCRIPTION
## Summary of changes

- Clarify the unbound line probe fallback in `LineProbeResolver` so unresolved probes no longer imply the target assembly is simply unloaded when same-file-name diagnostics are available.
- Rename the ambiguous unbound resolver reason to `AssemblyNotLoadedOrSymbolsUnavailable`.
- Preserve `SameFileNameMatchCount` and `SameFileNameExamples` as supporting diagnostics, and add a conditional message hint when loaded symbolicated assemblies share the same file name.
- Extend `LineProbeResolverTest` to cover both the same-file-name hint path and the generic no-match fallback.

## Reason for change

- Filename-only matches are not strong enough evidence to prove a source-path mismatch.
- Returning a mismatch-specific reason in that case can misdirect support/debugging toward the wrong root cause when the real issue is that the assembly is not yet loaded or symbols are unavailable.

## Implementation details

- Keep `LiveProbeResolveStatus.Unbound` and return `LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable` for unresolved line probes.
- Append a source-path hint only when `AssemblySearchDiagnostics.SameFileNameMatchCount > 0`, so the additional context remains diagnostic rather than authoritative.
- Preserve the existing behavior for missing source files, missing PDBs, and missing sequence points.

## Test coverage

- Passed: `dotnet test "tracer/test/Datadog.Trace.Debugger.IntegrationTests/Datadog.Trace.Debugger.IntegrationTests.csproj" --filter "FullyQualifiedName~LineProbeResolverTest"`

## Other details
<!-- Fixes #{issue} -->