### PR TITLE
Implement Client-Side Stats (CSS) 1.2.0

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -43,7 +43,6 @@ src/Datadog.Trace/Agent/IStreamFactory.cs
 src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
 src/Datadog.Trace/Agent/NullStatsAggregator.cs
 src/Datadog.Trace/Agent/SpanBuffer.cs
-src/Datadog.Trace/Agent/StatsAggregationKey.cs
 src/Datadog.Trace/Agent/StatsAggregator.cs
 src/Datadog.Trace/Agent/StatsBucket.cs
 src/Datadog.Trace/Agent/StatsBuffer.cs

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Net.Sockets;
 using System.Threading;

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -220,7 +220,7 @@ namespace Datadog.Trace.Agent
 
             if (state.TracerObfuscationVersion > 0)
             {
-                request.AddHeader("Datadog-Obfuscation-Version", state.TracerObfuscationVersion.ToString());
+                request.AddHeader("Datadog-Obfuscation-Version", state.TracerObfuscationVersion.ToString(CultureInfo.InvariantCulture));
             }
 
             using var stream = new MemoryStream();

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -1,4 +1,4 @@
-// <copyright file="Api.cs" company="Datadog">
+﻿// <copyright file="Api.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -98,11 +98,11 @@ namespace Datadog.Trace.Agent
 
         public Task<bool> Ping() => SendTracesAsync(EmptyPayload, 0, false, 0, 0);
 
-        public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
+        public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
         {
             _log.Debug("Sending stats to the Datadog Agent.");
 
-            var state = new SendStatsState(stats, bucketDuration);
+            var state = new SendStatsState(stats, bucketDuration, tracerObfuscationVersion);
 
             return SendWithRetry(_statsEndpoint, _sendStats, state);
         }
@@ -217,6 +217,11 @@ namespace Datadog.Trace.Agent
             IApiResponse response = null;
 
             request.AddContainerMetadataHeaders(_containerMetadata);
+
+            if (state.TracerObfuscationVersion > 0)
+            {
+                request.AddHeader("Datadog-Obfuscation-Version", state.TracerObfuscationVersion.ToString());
+            }
 
             using var stream = new MemoryStream();
             state.Stats.Serialize(stream, state.BucketDuration);
@@ -441,11 +446,13 @@ namespace Datadog.Trace.Agent
         {
             public readonly StatsBuffer Stats;
             public readonly long BucketDuration;
+            public readonly int TracerObfuscationVersion;
 
-            public SendStatsState(StatsBuffer stats, long bucketDuration)
+            public SendStatsState(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
             {
                 Stats = stats;
                 BucketDuration = bucketDuration;
+                TracerObfuscationVersion = tracerObfuscationVersion;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -104,7 +104,8 @@ namespace Datadog.Trace.Agent
 
             var state = new SendStatsState(stats, bucketDuration, tracerObfuscationVersion);
 
-            return SendWithRetry(_statsEndpoint, _sendStats, state);
+            // We are supposed to be fire and forget for these stats, with no retries
+            return SendWithRetry(_statsEndpoint, _sendStats, state, retryLimit: 0);
         }
 
         public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans, bool apmTracingEnabled = true)
@@ -138,10 +139,9 @@ namespace Datadog.Trace.Agent
             return false;
         }
 
-        private async Task<bool> SendWithRetry<T>(Uri endpoint, SendCallback<T> callback, T state)
+        private async Task<bool> SendWithRetry<T>(Uri endpoint, SendCallback<T> callback, T state, int retryLimit = 5)
         {
             // retry up to 5 times with exponential back-off
-            var retryLimit = 5;
             var retryCount = 1;
             var sleepDuration = 100; // in milliseconds
 

--- a/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
+++ b/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
@@ -74,11 +74,11 @@ namespace Datadog.Trace.Agent
         // return true.
         public Task<bool> Ping() => Task.FromResult(true);
 
-        public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
+        public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
         {
             _log.Debug("Sending trace stats to the OTLP Metrics endpoint.");
 
-            var state = new SendStatsState(stats, bucketDuration);
+            var state = new SendStatsState(stats, bucketDuration, tracerObfuscationVersion);
 
             return SendWithRetry(_statsEndpoint, _sendStats, state);
         }
@@ -293,11 +293,13 @@ namespace Datadog.Trace.Agent
         {
             public readonly StatsBuffer Stats;
             public readonly long BucketDuration;
+            public readonly int TracerObfuscationVersion;
 
-            public SendStatsState(StatsBuffer stats, long bucketDuration)
+            public SendStatsState(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
             {
                 Stats = stats;
                 BucketDuration = bucketDuration;
+                TracerObfuscationVersion = tracerObfuscationVersion;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
+++ b/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
@@ -80,7 +80,8 @@ namespace Datadog.Trace.Agent
 
             var state = new SendStatsState(stats, bucketDuration, tracerObfuscationVersion);
 
-            return SendWithRetry(_statsEndpoint, _sendStats, state);
+            // We are supposed to be fire and forget for these stats, with no retries
+            return SendWithRetry(_statsEndpoint, _sendStats, state, retryLimit: 0);
         }
 
         public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans, bool apmTracingEnabled = true)
@@ -92,10 +93,9 @@ namespace Datadog.Trace.Agent
             return SendWithRetry(_tracesEndpoint, _sendTraces, state);
         }
 
-        private async Task<bool> SendWithRetry<T>(Uri endpoint, SendCallback<T> callback, T state)
+        private async Task<bool> SendWithRetry<T>(Uri endpoint, SendCallback<T> callback, T state, int retryLimit = 5)
         {
             // retry up to 5 times with exponential back-off
-            var retryLimit = 5;
             var retryCount = 1;
             var sleepDuration = 100; // in milliseconds
 

--- a/tracer/src/Datadog.Trace/Agent/ClientStatsPayload.cs
+++ b/tracer/src/Datadog.Trace/Agent/ClientStatsPayload.cs
@@ -24,8 +24,8 @@ namespace Datadog.Trace.Agent
             => Interlocked.Exchange(ref _settings, CreateSettings(settings));
 
         private static AppSettings CreateSettings(MutableSettings settings)
-            => new(settings.Environment, settings.ServiceVersion, settings.ProcessTags);
+            => new(settings.Environment, settings.ServiceVersion, settings.ProcessTags, settings.GitCommitSha);
 
-        internal sealed record AppSettings(string? Environment, string? Version, ProcessTags? ProcessTags);
+        internal sealed record AppSettings(string? Environment, string? Version, ProcessTags? ProcessTags, string? GitCommitSha);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/ClientStatsPayload.cs
+++ b/tracer/src/Datadog.Trace/Agent/ClientStatsPayload.cs
@@ -24,8 +24,8 @@ namespace Datadog.Trace.Agent
             => Interlocked.Exchange(ref _settings, CreateSettings(settings));
 
         private static AppSettings CreateSettings(MutableSettings settings)
-            => new(settings.Environment, settings.ServiceVersion, settings.ProcessTags, settings.GitCommitSha);
+            => new(settings.Environment, settings.ServiceVersion, settings.DefaultServiceName, settings.ProcessTags, settings.GitCommitSha);
 
-        internal sealed record AppSettings(string? Environment, string? Version, ProcessTags? ProcessTags, string? GitCommitSha);
+        internal sealed record AppSettings(string? Environment, string? Version, string DefaultServiceName, ProcessTags? ProcessTags, string? GitCommitSha);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -30,7 +30,7 @@ internal sealed record AgentConfiguration
         List<string>? peerTags = null,
         List<string>? spanKindsStatsComputed = null,
         int obfuscationVersion = 0,
-        List<string>? spanDerivedPrimaryTags = null)
+        AgentTraceFilterConfig? traceFilterConfig = null)
     {
         ConfigurationEndpoint = configurationEndpoint;
         DebuggerEndpoint = debuggerEndpoint;
@@ -50,7 +50,7 @@ internal sealed record AgentConfiguration
         PeerTags = peerTags;
         SpanKindsStatsComputed = spanKindsStatsComputed;
         ObfuscationVersion = obfuscationVersion;
-        SpanDerivedPrimaryTags = spanDerivedPrimaryTags;
+        TraceFilterConfig = traceFilterConfig ?? AgentTraceFilterConfig.Empty;
     }
 
     public string? ConfigurationEndpoint { get; }
@@ -101,5 +101,5 @@ internal sealed record AgentConfiguration
 
     public int ObfuscationVersion { get; }
 
-    public List<string>? SpanDerivedPrimaryTags { get; }
+    public AgentTraceFilterConfig TraceFilterConfig { get; }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -28,7 +28,8 @@ internal sealed record AgentConfiguration
         bool spanMetaStructs,
         bool? spanEvents,
         List<string>? peerTags = null,
-        List<string>? spanKindsStatsComputed = null)
+        List<string>? spanKindsStatsComputed = null,
+        int obfuscationVersion = 0)
     {
         ConfigurationEndpoint = configurationEndpoint;
         DebuggerEndpoint = debuggerEndpoint;
@@ -47,6 +48,7 @@ internal sealed record AgentConfiguration
         SpanEvents = spanEvents ?? false;
         PeerTags = peerTags;
         SpanKindsStatsComputed = spanKindsStatsComputed;
+        ObfuscationVersion = obfuscationVersion;
     }
 
     public string? ConfigurationEndpoint { get; }
@@ -94,4 +96,6 @@ internal sealed record AgentConfiguration
     public List<string>? PeerTags { get; }
 
     public List<string>? SpanKindsStatsComputed { get; }
+
+    public int ObfuscationVersion { get; }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -29,7 +29,8 @@ internal sealed record AgentConfiguration
         bool? spanEvents,
         List<string>? peerTags = null,
         List<string>? spanKindsStatsComputed = null,
-        int obfuscationVersion = 0)
+        int obfuscationVersion = 0,
+        List<string>? spanDerivedPrimaryTags = null)
     {
         ConfigurationEndpoint = configurationEndpoint;
         DebuggerEndpoint = debuggerEndpoint;
@@ -49,6 +50,7 @@ internal sealed record AgentConfiguration
         PeerTags = peerTags;
         SpanKindsStatsComputed = spanKindsStatsComputed;
         ObfuscationVersion = obfuscationVersion;
+        SpanDerivedPrimaryTags = spanDerivedPrimaryTags;
     }
 
     public string? ConfigurationEndpoint { get; }
@@ -98,4 +100,6 @@ internal sealed record AgentConfiguration
     public List<string>? SpanKindsStatsComputed { get; }
 
     public int ObfuscationVersion { get; }
+
+    public List<string>? SpanDerivedPrimaryTags { get; }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -5,6 +5,8 @@
 
 #nullable enable
 
+using System.Collections.Generic;
+
 namespace Datadog.Trace.Agent.DiscoveryService;
 
 internal sealed record AgentConfiguration
@@ -24,7 +26,9 @@ internal sealed record AgentConfiguration
         string? containerTagsHash,
         bool clientDropP0,
         bool spanMetaStructs,
-        bool? spanEvents)
+        bool? spanEvents,
+        List<string>? peerTags = null,
+        List<string>? spanKindsStatsComputed = null)
     {
         ConfigurationEndpoint = configurationEndpoint;
         DebuggerEndpoint = debuggerEndpoint;
@@ -41,6 +45,8 @@ internal sealed record AgentConfiguration
         ClientDropP0s = clientDropP0;
         SpanMetaStructs = spanMetaStructs;
         SpanEvents = spanEvents ?? false;
+        PeerTags = peerTags;
+        SpanKindsStatsComputed = spanKindsStatsComputed;
     }
 
     public string? ConfigurationEndpoint { get; }
@@ -84,4 +90,8 @@ internal sealed record AgentConfiguration
     public bool SpanMetaStructs { get; }
 
     public bool SpanEvents { get; }
+
+    public List<string>? PeerTags { get; }
+
+    public List<string>? SpanKindsStatsComputed { get; }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -28,7 +28,6 @@ internal sealed record AgentConfiguration
         bool spanMetaStructs,
         bool? spanEvents,
         List<string>? peerTags = null,
-        List<string>? spanKindsStatsComputed = null,
         int obfuscationVersion = 0,
         AgentTraceFilterConfig? traceFilterConfig = null)
     {
@@ -48,7 +47,6 @@ internal sealed record AgentConfiguration
         SpanMetaStructs = spanMetaStructs;
         SpanEvents = spanEvents ?? false;
         PeerTags = peerTags;
-        SpanKindsStatsComputed = spanKindsStatsComputed;
         ObfuscationVersion = obfuscationVersion;
         TraceFilterConfig = traceFilterConfig ?? AgentTraceFilterConfig.Empty;
     }
@@ -96,8 +94,6 @@ internal sealed record AgentConfiguration
     public bool SpanEvents { get; }
 
     public List<string>? PeerTags { get; }
-
-    public List<string>? SpanKindsStatsComputed { get; }
 
     public int ObfuscationVersion { get; }
 

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentTraceFilterConfig.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentTraceFilterConfig.cs
@@ -1,0 +1,31 @@
+// <copyright file="AgentTraceFilterConfig.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.Agent.DiscoveryService;
+
+/// <summary>
+/// Trace-level filtering configuration received from the agent's /info endpoint.
+/// Filters are applied to the root span before stats computation.
+/// </summary>
+internal sealed record AgentTraceFilterConfig(
+    List<string>? FilterTagsRequire,
+    List<string>? FilterTagsReject,
+    List<string>? FilterTagsRegexRequire,
+    List<string>? FilterTagsRegexReject,
+    List<string>? IgnoreResources)
+{
+    public static readonly AgentTraceFilterConfig Empty = new(null, null, null, null, null);
+
+    public bool HasFilters =>
+        FilterTagsRequire is { Count: > 0 } ||
+        FilterTagsReject is { Count: > 0 } ||
+        FilterTagsRegexRequire is { Count: > 0 } ||
+        FilterTagsRegexReject is { Count: > 0 } ||
+        IgnoreResources is { Count: > 0 };
+}

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -352,6 +352,21 @@ namespace Datadog.Trace.Agent.DiscoveryService
             var spanKindsStatsComputed = (jObject["span_kinds_stats_computed"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
             var obfuscationVersion = jObject["obfuscation_version"]?.Value<int>() ?? 0;
 
+            // Parse trace filter configuration
+            var filterTags = jObject["filter_tags"];
+            var filterTagsRegex = jObject["filter_tags_regex"];
+            var ignoreResources = (jObject["ignore_resources"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var filterTagsRequire = (filterTags?["require"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var filterTagsReject = (filterTags?["reject"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var filterTagsRegexRequire = (filterTagsRegex?["require"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var filterTagsRegexReject = (filterTagsRegex?["reject"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
+
+            AgentTraceFilterConfig? traceFilterConfig = null;
+            if (ignoreResources is not null || filterTagsRequire is not null || filterTagsReject is not null || filterTagsRegexRequire is not null || filterTagsRegexReject is not null)
+            {
+                traceFilterConfig = new AgentTraceFilterConfig(filterTagsRequire!, filterTagsReject!, filterTagsRegexRequire!, filterTagsRegexReject!, ignoreResources!);
+            }
+
             var discoveredEndpoints = (jObject["endpoints"] as JArray)?.Values<string>().ToArray();
             string? configurationEndpoint = null;
             string? debuggerEndpoint = null;
@@ -443,7 +458,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 peerTags: peerTags!,
                 spanKindsStatsComputed: spanKindsStatsComputed!,
                 obfuscationVersion: obfuscationVersion,
-                spanDerivedPrimaryTags: spanDerivedPrimaryTags!);
+                traceFilterConfig: traceFilterConfig);
 
             // Save the hash, whether the details we care about changed or not
             _configurationHash = HexString.ToHexString(sha256.Hash);

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -349,7 +349,6 @@ namespace Datadog.Trace.Agent.DiscoveryService
             var spanMetaStructs = jObject["span_meta_structs"]?.Value<bool>() ?? false;
             var spanEvents = jObject["span_events"]?.Value<bool>() ?? false;
             var peerTags = (jObject["peer_tags"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).Distinct().OrderBy(x => x).ToList();
-            var spanKindsStatsComputed = (jObject["span_kinds_stats_computed"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
             var obfuscationVersion = jObject["obfuscation_version"]?.Value<int>() ?? 0;
 
             // Parse trace filter configuration
@@ -456,7 +455,6 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 spanMetaStructs: spanMetaStructs,
                 spanEvents: spanEvents,
                 peerTags: peerTags!,
-                spanKindsStatsComputed: spanKindsStatsComputed!,
                 obfuscationVersion: obfuscationVersion,
                 traceFilterConfig: traceFilterConfig);
 

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -350,6 +350,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
             var spanEvents = jObject["span_events"]?.Value<bool>() ?? false;
             var peerTags = (jObject["peer_tags"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).Distinct().OrderBy(x => x).ToList();
             var spanKindsStatsComputed = (jObject["span_kinds_stats_computed"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var obfuscationVersion = jObject["obfuscation_version"]?.Value<int>() ?? 0;
 
             var discoveredEndpoints = (jObject["endpoints"] as JArray)?.Values<string>().ToArray();
             string? configurationEndpoint = null;
@@ -440,7 +441,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 spanMetaStructs: spanMetaStructs,
                 spanEvents: spanEvents,
                 peerTags: peerTags!,
-                spanKindsStatsComputed: spanKindsStatsComputed!);
+                spanKindsStatsComputed: spanKindsStatsComputed!,
+                obfuscationVersion: obfuscationVersion);
 
             // Save the hash, whether the details we care about changed or not
             _configurationHash = HexString.ToHexString(sha256.Hash);

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -348,6 +348,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
             var clientDropP0 = jObject["client_drop_p0s"]?.Value<bool>() ?? false;
             var spanMetaStructs = jObject["span_meta_structs"]?.Value<bool>() ?? false;
             var spanEvents = jObject["span_events"]?.Value<bool>() ?? false;
+            var peerTags = (jObject["peer_tags"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).Distinct().OrderBy(x => x).ToList();
+            var spanKindsStatsComputed = (jObject["span_kinds_stats_computed"] as JArray)?.Values<string>().Where(x => !string.IsNullOrEmpty(x)).ToList();
 
             var discoveredEndpoints = (jObject["endpoints"] as JArray)?.Values<string>().ToArray();
             string? configurationEndpoint = null;
@@ -436,7 +438,9 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 containerTagsHash: _serviceRemappingHash.ContainerTagsHash, // either the value just received, or the one we stored before (prevents overriding with null)
                 clientDropP0: clientDropP0,
                 spanMetaStructs: spanMetaStructs,
-                spanEvents: spanEvents);
+                spanEvents: spanEvents,
+                peerTags: peerTags!,
+                spanKindsStatsComputed: spanKindsStatsComputed!);
 
             // Save the hash, whether the details we care about changed or not
             _configurationHash = HexString.ToHexString(sha256.Hash);

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -442,7 +442,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 spanEvents: spanEvents,
                 peerTags: peerTags!,
                 spanKindsStatsComputed: spanKindsStatsComputed!,
-                obfuscationVersion: obfuscationVersion);
+                obfuscationVersion: obfuscationVersion,
+                spanDerivedPrimaryTags: spanDerivedPrimaryTags!);
 
             // Save the hash, whether the details we care about changed or not
             _configurationHash = HexString.ToHexString(sha256.Hash);

--- a/tracer/src/Datadog.Trace/Agent/IApi.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApi.cs
@@ -16,6 +16,6 @@ namespace Datadog.Trace.Agent
 
         Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans, bool apmTracingEnabled = true);
 
-        Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration);
+        Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.SourceGenerators;
 
@@ -50,5 +51,7 @@ namespace Datadog.Trace.Agent
         SpanCollection ProcessTrace(in SpanCollection trace);
 
         Task DisposeAsync();
+
+        StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/ManagedApi.cs
+++ b/tracer/src/Datadog.Trace/Agent/ManagedApi.cs
@@ -1,4 +1,4 @@
-// <copyright file="ManagedApi.cs" company="Datadog">
+﻿// <copyright file="ManagedApi.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -62,6 +62,6 @@ internal sealed class ManagedApi : IApi
     public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans, bool apmTracingEnabled = true)
         => Volatile.Read(ref _api).SendTracesAsync(traces, numberOfTraces, statsComputationEnabled, numberOfDroppedP0Traces, numberOfDroppedP0Spans, apmTracingEnabled);
 
-    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
-        => Volatile.Read(ref _api).SendStatsAsync(stats, bucketDuration);
+    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
+        => Volatile.Read(ref _api).SendStatsAsync(stats, bucketDuration, tracerObfuscationVersion);
 }

--- a/tracer/src/Datadog.Trace/Agent/ManagedApiOtlp.cs
+++ b/tracer/src/Datadog.Trace/Agent/ManagedApiOtlp.cs
@@ -47,8 +47,8 @@ internal sealed class ManagedApiOtlp : IApi
     public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans, bool apmTracingEnabled = true)
         => Volatile.Read(ref _api).SendTracesAsync(traces, numberOfTraces, statsComputationEnabled, numberOfDroppedP0Traces, numberOfDroppedP0Spans, apmTracingEnabled);
 
-    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
-        => Volatile.Read(ref _api).SendStatsAsync(stats, bucketDuration);
+    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
+        => Volatile.Read(ref _api).SendStatsAsync(stats, bucketDuration, tracerObfuscationVersion);
 }
 
 #endif

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -33,8 +33,29 @@ namespace Datadog.Trace.Agent
         public StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
         {
             utf8PeerTags = [];
-            utf8SpanDerivedPrimaryTags = [];
-            return new();
+
+            var rawHttpStatusCode = span.GetTag(Tags.HttpStatusCode);
+            if (rawHttpStatusCode is null || !int.TryParse(rawHttpStatusCode, out var httpStatusCode))
+            {
+                httpStatusCode = 0;
+            }
+
+            return new StatsAggregationKey(
+                span.ResourceName,
+                span.ServiceName,
+                span.OperationName,
+                span.Type,
+                httpStatusCode,
+                span.Context.Origin?.StartsWith("synthetics") == true,
+                string.Empty,
+                isError: false,
+                isTopLevel: false,
+                isTraceRoot: false,
+                string.Empty,
+                string.Empty,
+                grpcStatusCode: 0,
+                string.Empty,
+                peerTagsHash: 0);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.Agent
                 isTraceRoot: false,
                 string.Empty,
                 string.Empty,
-                grpcStatusCode: 0,
+                grpcStatusCode: string.Empty,
                 string.Empty,
                 peerTagsHash: 0);
         }

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
@@ -27,6 +28,12 @@ namespace Datadog.Trace.Agent
         public Task DisposeAsync()
         {
             return Task.CompletedTask;
+        }
+
+        public StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
+        {
+            utf8PeerTags = [];
+            return new();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -46,15 +46,15 @@ namespace Datadog.Trace.Agent
                 span.OperationName,
                 span.Type,
                 httpStatusCode,
-                span.Context.Origin?.StartsWith("synthetics") == true,
-                string.Empty,
+                isSyntheticsRequest: span.Context.Origin?.StartsWith("synthetics") == true,
+                spanKind: string.Empty,
                 isError: false,
                 isTopLevel: false,
                 isTraceRoot: false,
-                string.Empty,
-                string.Empty,
+                httpMethod: string.Empty,
+                httpEndpoint: string.Empty,
                 grpcStatusCode: string.Empty,
-                string.Empty,
+                serviceSource: string.Empty,
                 peerTagsHash: 0);
         }
     }

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -33,6 +33,7 @@ namespace Datadog.Trace.Agent
         public StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
         {
             utf8PeerTags = [];
+            utf8SpanDerivedPrimaryTags = [];
             return new();
         }
     }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Agent
         public readonly bool IsTraceRoot;
         public readonly string HttpMethod;
         public readonly string HttpEndpoint;
-        public readonly int GrpcStatusCode;
+        public readonly string GrpcStatusCode;
         public readonly string ServiceSource;
         public readonly ulong PeerTagsHash;
 
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Agent
             bool isTraceRoot,
             string httpMethod,
             string httpEndpoint,
-            int grpcStatusCode,
+            string grpcStatusCode,
             string serviceSource,
             ulong peerTagsHash)
         {

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
@@ -74,7 +74,6 @@ namespace Datadog.Trace.Agent
                 && IsSyntheticsRequest == other.IsSyntheticsRequest
                 && IsError == other.IsError
                 && IsTopLevel == other.IsTopLevel
-                && IsSyntheticsRequest == other.IsSyntheticsRequest
                 && SpanKind == other.SpanKind
                 && IsTraceRoot == other.IsTraceRoot
                 && HttpMethod == other.HttpMethod

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace.Agent
@@ -13,11 +15,17 @@ namespace Datadog.Trace.Agent
         public readonly string Service;
         public readonly string OperationName;
         public readonly string Type;
-        public readonly string ServiceSource;
         public readonly int HttpStatusCode;
         public readonly bool IsSyntheticsRequest;
         public readonly bool IsError;
         public readonly bool IsTopLevel;
+        public readonly string SpanKind;
+        public readonly bool IsTraceRoot;
+        public readonly string HttpMethod;
+        public readonly string HttpEndpoint;
+        public readonly int GrpcStatusCode;
+        public readonly string ServiceSource;
+        public readonly ulong PeerTagsHash;
 
         // Constructs a StatsAgregationKey that represents the aggregation key used by Datadog,
         // which does not include IsError and IsTopLevel, since these should be part of the same timeseries
@@ -26,29 +34,42 @@ namespace Datadog.Trace.Agent
             string service,
             string operationName,
             string type,
-            string serviceSource,
             int httpStatusCode,
-            bool isSyntheticsRequest)
+            bool isSyntheticsRequest,
+            string spanKind,
+            bool isTraceRoot,
+            string httpMethod,
+            string httpEndpoint,
+            int grpcStatusCode,
+            string serviceSource,
+            ulong peerTagsHash)
         {
             Resource = resource;
             Service = service;
             OperationName = operationName;
             Type = type;
-            ServiceSource = serviceSource;
             HttpStatusCode = httpStatusCode;
             IsSyntheticsRequest = isSyntheticsRequest;
             IsError = false;
             IsTopLevel = false;
+            SpanKind = spanKind;
+            IsTraceRoot = isTraceRoot;
+            HttpMethod = httpMethod;
+            HttpEndpoint = httpEndpoint;
+            GrpcStatusCode = grpcStatusCode;
+            ServiceSource = serviceSource;
+            PeerTagsHash = peerTagsHash;
         }
 
         // Constructs a StatsAgregationKey that represents the aggregation key used by OpenTelemetry,
         // which considers IsError and IsTopLevel since these should be considered as unique timeseries
+        // but does not currently include the new additional fields
+        // TODO: Confirm whether the aggergations that we include _should_ be used by OTel too?
         public StatsAggregationKey(
             string resource,
             string service,
             string operationName,
             string type,
-            string serviceSource,
             int httpStatusCode,
             bool isSyntheticsRequest,
             bool isError,
@@ -58,11 +79,17 @@ namespace Datadog.Trace.Agent
             Service = service;
             OperationName = operationName;
             Type = type;
-            ServiceSource = serviceSource;
             HttpStatusCode = httpStatusCode;
             IsSyntheticsRequest = isSyntheticsRequest;
             IsError = isError;
             IsTopLevel = isTopLevel;
+            SpanKind = string.Empty;
+            IsTraceRoot = false;
+            HttpMethod = string.Empty;
+            HttpEndpoint = string.Empty;
+            GrpcStatusCode = 0;
+            ServiceSource = string.Empty;
+            PeerTagsHash = 0;
         }
 
         public bool Equals(StatsAggregationKey other)
@@ -72,33 +99,44 @@ namespace Datadog.Trace.Agent
                 && Service == other.Service
                 && OperationName == other.OperationName
                 && Type == other.Type
-                && ServiceSource == other.ServiceSource
                 && HttpStatusCode == other.HttpStatusCode
                 && IsSyntheticsRequest == other.IsSyntheticsRequest
                 && IsError == other.IsError
-                && IsTopLevel == other.IsTopLevel;
+                && IsTopLevel == other.IsTopLevel
+                && IsSyntheticsRequest == other.IsSyntheticsRequest
+                && SpanKind == other.SpanKind
+                && IsTraceRoot == other.IsTraceRoot
+                && HttpMethod == other.HttpMethod
+                && HttpEndpoint == other.HttpEndpoint
+                && GrpcStatusCode == other.GrpcStatusCode
+                && ServiceSource == other.ServiceSource
+                && PeerTagsHash == other.PeerTagsHash;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is StatsAggregationKey other && Equals(other);
         }
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                var hashCode = (Resource != null ? Resource.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Service != null ? Service.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (OperationName != null ? OperationName.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (Type != null ? Type.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (ServiceSource != null ? ServiceSource.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ HttpStatusCode;
-                hashCode = (hashCode * 397) ^ IsSyntheticsRequest.GetHashCode();
-                hashCode = (hashCode * 397) ^ IsError.GetHashCode();
-                hashCode = (hashCode * 397) ^ IsTopLevel.GetHashCode();
-                return hashCode;
-            }
+            var hashCode = new HashCode();
+            hashCode.Add(Resource);
+            hashCode.Add(Service);
+            hashCode.Add(OperationName);
+            hashCode.Add(Type);
+            hashCode.Add(HttpStatusCode);
+            hashCode.Add(IsSyntheticsRequest);
+            hashCode.Add(IsError);
+            hashCode.Add(IsTopLevel);
+            hashCode.Add(SpanKind);
+            hashCode.Add(IsTraceRoot);
+            hashCode.Add(HttpMethod);
+            hashCode.Add(HttpEndpoint);
+            hashCode.Add(GrpcStatusCode);
+            hashCode.Add(ServiceSource);
+            hashCode.Add(PeerTagsHash);
+            return hashCode.ToHashCode();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
@@ -59,6 +59,7 @@ namespace Datadog.Trace.Agent
             GrpcStatusCode = grpcStatusCode;
             ServiceSource = serviceSource;
             PeerTagsHash = peerTagsHash;
+            SpanDerivedPrimaryTagsHash = spanDerivedPrimaryTagsHash;
         }
 
         // Constructs a StatsAgregationKey that represents the aggregation key used by OpenTelemetry,

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
@@ -37,6 +37,8 @@ namespace Datadog.Trace.Agent
             int httpStatusCode,
             bool isSyntheticsRequest,
             string spanKind,
+            bool isError,
+            bool isTopLevel,
             bool isTraceRoot,
             string httpMethod,
             string httpEndpoint,
@@ -50,8 +52,8 @@ namespace Datadog.Trace.Agent
             Type = type;
             HttpStatusCode = httpStatusCode;
             IsSyntheticsRequest = isSyntheticsRequest;
-            IsError = false;
-            IsTopLevel = false;
+            IsError = isError;
+            IsTopLevel = isTopLevel;
             SpanKind = spanKind;
             IsTraceRoot = isTraceRoot;
             HttpMethod = httpMethod;
@@ -59,38 +61,6 @@ namespace Datadog.Trace.Agent
             GrpcStatusCode = grpcStatusCode;
             ServiceSource = serviceSource;
             PeerTagsHash = peerTagsHash;
-            SpanDerivedPrimaryTagsHash = spanDerivedPrimaryTagsHash;
-        }
-
-        // Constructs a StatsAgregationKey that represents the aggregation key used by OpenTelemetry,
-        // which considers IsError and IsTopLevel since these should be considered as unique timeseries
-        // but does not currently include the new additional fields
-        // TODO: Confirm whether the aggergations that we include _should_ be used by OTel too?
-        public StatsAggregationKey(
-            string resource,
-            string service,
-            string operationName,
-            string type,
-            int httpStatusCode,
-            bool isSyntheticsRequest,
-            bool isError,
-            bool isTopLevel)
-        {
-            Resource = resource;
-            Service = service;
-            OperationName = operationName;
-            Type = type;
-            HttpStatusCode = httpStatusCode;
-            IsSyntheticsRequest = isSyntheticsRequest;
-            IsError = isError;
-            IsTopLevel = isTopLevel;
-            SpanKind = string.Empty;
-            IsTraceRoot = false;
-            HttpMethod = string.Empty;
-            HttpEndpoint = string.Empty;
-            GrpcStatusCode = 0;
-            ServiceSource = string.Empty;
-            PeerTagsHash = 0;
         }
 
         public bool Equals(StatsAggregationKey other)

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -54,6 +54,7 @@ namespace Datadog.Trace.Agent
         private int _currentBuffer;
 
         private int _tracerObfuscationVersion;
+        private TraceFilter _traceFilter;
         private List<string> _peerTagKeys = [];
         // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L210-L213
         private List<string> _spanKindsStatsComputed =
@@ -149,6 +150,13 @@ namespace Datadog.Trace.Agent
 
         public void AddRange(in SpanCollection spans)
         {
+            // Trace-level filters from the agent must be applied before stats computation.
+            // Rejected traces should not contribute to stats.
+            if (IsTraceFiltered(in spans))
+            {
+                return;
+            }
+
             // Contention around this lock is expected to be very small:
             // AddRange is called from the serialization thread, and concurrent serialization
             // of traces is a rare corner-case (happening only during shutdown).
@@ -169,6 +177,12 @@ namespace Datadog.Trace.Agent
             if (_isOtlp)
             {
                 return _prioritySampler.Sample(in trace);
+            }
+
+            // Trace-level filters from the agent must reject traces before sampling.
+            if (IsTraceFiltered(in trace))
+            {
+                return false;
             }
 
             // Note: The RareSampler must be run before all other samplers so that
@@ -434,6 +448,26 @@ namespace Datadog.Trace.Agent
             }
         }
 
+        private bool IsTraceFiltered(in SpanCollection spans)
+        {
+            var filter = Volatile.Read(ref _traceFilter);
+            if (filter is null)
+            {
+                return false;
+            }
+
+            // Find the root span (ParentId == null or 0) and apply the filter
+            foreach (var span in spans)
+            {
+                if (span.Context.ParentId is null or 0)
+                {
+                    return !filter.ShouldKeepTrace(span);
+                }
+            }
+
+            return false;
+        }
+
         private void HandleConfigUpdate(AgentConfiguration config)
         {
             CanComputeStats = !string.IsNullOrWhiteSpace(config.StatsEndpoint) && config.ClientDropP0s == true;
@@ -448,9 +482,14 @@ namespace Datadog.Trace.Agent
                 Interlocked.Exchange(ref _peerTagKeys, config.PeerTags);
             }
 
-            if (config.SpanDerivedPrimaryTags is not null)
+            // Update trace filter from agent configuration
+            if (config.TraceFilterConfig.HasFilters)
             {
-                Interlocked.Exchange(ref _spanDerivedPrimaryTagKeys, config.SpanDerivedPrimaryTags);
+                Volatile.Write(ref _traceFilter, new TraceFilter(config.TraceFilterConfig));
+            }
+            else
+            {
+                Volatile.Write(ref _traceFilter, null);
             }
 
             // Tracer obfuscation version is 1. If the agent's version is > 0 and <= ours, the tracer obfuscates.

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -253,7 +253,6 @@ namespace Datadog.Trace.Agent
             var isTraceRoot = span.Context.ParentId is null or 0;
             var httpMethod = span.GetTag(Tags.HttpMethod) ?? string.Empty;
             var httpEndpoint = span.GetTag(Tags.HttpRoute) ?? string.Empty;
-            var serviceName = span.ServiceName;
 
             // Normalize service source to match trace serialization behavior:
             // clear the source when service name equals the default, unless it's
@@ -262,7 +261,7 @@ namespace Datadog.Trace.Agent
             var serviceNameEqualsDefault = string.Equals(span.ServiceName, span.Context.TraceContext?.Tracer?.DefaultServiceName, StringComparison.OrdinalIgnoreCase);
             if (serviceNameEqualsDefault && serviceSource?.StartsWith("opt.", StringComparison.Ordinal) != true)
             {
-                serviceSource = null;
+                serviceSource = string.Empty;
             }
 
             // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L53-L99

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -267,7 +267,7 @@ namespace Datadog.Trace.Agent
                         continue;
                     }
 
-                    // TODO: Quantize ip address
+                    tagValue = IpAddressObfuscationUtil.QuantizePeerIpAddresses(tagValue);
 
                     if (ReferenceEquals(utf8PeerTags, EmptyPeerTags))
                     {

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -243,15 +243,14 @@ namespace Datadog.Trace.Agent
                 httpStatusCode = 0;
             }
 
-            // Check gRPC status code tags in priority order per CSS v1.3.0 spec
-            var rawGrpcStatusCode = span.GetTag("rpc.grpc.status_code")
-                                 ?? span.GetTag("grpc.code")
-                                 ?? span.GetTag("rpc.grpc.status.code")
-                                 ?? span.GetTag(Tags.GrpcStatusCode);
-            if (rawGrpcStatusCode is null || !int.TryParse(rawGrpcStatusCode, out var grpcStatusCode))
-            {
-                grpcStatusCode = 0;
-            }
+            // Check gRPC status code tags in priority order per CSS v1.3.0 spec.
+            // Stored as string to match the Go agent's wire format (GRPCStatusCode is a string field).
+            // This preserves the distinction between "0" (gRPC OK) and "" (no gRPC status).
+            var grpcStatusCode = span.GetTag("rpc.grpc.status_code")
+                              ?? span.GetTag("grpc.code")
+                              ?? span.GetTag("rpc.grpc.status.code")
+                              ?? span.GetTag(Tags.GrpcStatusCode)
+                              ?? string.Empty;
 
             // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/aggregation.go
             var spanKind = (span.Tags is InstrumentationTags t ? t.SpanKind : span.GetTag(Tags.SpanKind)) ?? string.Empty;

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -239,7 +239,7 @@ namespace Datadog.Trace.Agent
                 httpStatusCode = 0;
             }
 
-            // Check gRPC status code tags in priority order per CSS v1.3.0 spec.
+            // Check gRPC status code tags in priority order per CSS v1.2.0 spec.
             // Stored as string to match the Go agent's wire format (GRPCStatusCode is a string field).
             // This preserves the distinction between "0" (gRPC OK) and "" (no gRPC status).
             var grpcStatusCode = span.GetTag("rpc.grpc.status_code")

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -449,7 +449,9 @@ namespace Datadog.Trace.Agent
 
             var duration = span.Duration.ToNanoseconds();
 
-            bucket.Duration += duration;
+            // Duration is weighted by sampling rate, matching the Go agent behavior:
+            // https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/statsraw.go
+            bucket.Duration += duration * weight;
 
             // If we are using OTLP, the errors are tracked as a separate aggregation entirely (different AggregationKey)
             // As a result, if using OTLP we always add to the OkSummary sketch.

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -212,8 +212,12 @@ namespace Datadog.Trace.Agent
                 httpStatusCode = 0;
             }
 
-            var rawGrpcStatusCode = span.GetTag(Tags.GrpcStatusCode);
-            if (rawGrpcStatusCode == null || !int.TryParse(rawGrpcStatusCode, out var grpcStatusCode))
+            // Check gRPC status code tags in priority order per CSS v1.3.0 spec
+            var rawGrpcStatusCode = span.GetTag("rpc.grpc.status_code")
+                                 ?? span.GetTag("grpc.code")
+                                 ?? span.GetTag("rpc.grpc.status.code")
+                                 ?? span.GetTag(Tags.GrpcStatusCode);
+            if (rawGrpcStatusCode is null || !int.TryParse(rawGrpcStatusCode, out var grpcStatusCode))
             {
                 grpcStatusCode = 0;
             }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -371,7 +371,7 @@ namespace Datadog.Trace.Agent
 
                 TelemetryFactory.Metrics.RecordGaugeStatsBuckets(buffer.Buckets.Count);
 
-                if (buffer.Buckets.Count > 0)
+                if (buffer.HasHits())
                 {
                     // Push the metrics
                     if (CanComputeStats == true)

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -53,6 +53,7 @@ namespace Datadog.Trace.Agent
 
         private int _currentBuffer;
 
+        private int _tracerObfuscationVersion;
         private List<string> _peerTagKeys = [];
         // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L210-L213
         private List<string> _spanKindsStatsComputed =
@@ -346,7 +347,7 @@ namespace Datadog.Trace.Agent
                     // Push the metrics
                     if (CanComputeStats == true)
                     {
-                        await _api.SendStatsAsync(buffer, _bucketDuration.ToNanoseconds()).ConfigureAwait(false);
+                        await _api.SendStatsAsync(buffer, _bucketDuration.ToNanoseconds(), Volatile.Read(ref _tracerObfuscationVersion)).ConfigureAwait(false);
                     }
 
                     buffer.Reset();
@@ -446,6 +447,11 @@ namespace Datadog.Trace.Agent
             {
                 Interlocked.Exchange(ref _peerTagKeys, config.PeerTags);
             }
+
+            // Tracer obfuscation version is 1. If the agent's version is > 0 and <= ours, the tracer obfuscates.
+            const int tracerObfuscationVersion = 1;
+            var agentVersion = config.ObfuscationVersion;
+            Volatile.Write(ref _tracerObfuscationVersion, agentVersion > 0 && agentVersion <= tracerObfuscationVersion ? tracerObfuscationVersion : 0);
 
             if (CanComputeStats.Value)
             {

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -66,8 +66,6 @@ namespace Datadog.Trace.Agent
             SpanKinds.Consumer,
         ];
 
-        private string _defaultServiceName;
-
         internal StatsAggregator(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
         {
             _api = api;
@@ -86,7 +84,6 @@ namespace Datadog.Trace.Agent
             _errorSampler = new ErrorSampler();
             _rareSampler = new RareSampler(settings, this);
             _analyticsEventSampler = new AnalyticsEventsSampler();
-            _defaultServiceName = settings.Manager.InitialMutableSettings.DefaultServiceName;
 
             // Create with the initial mutable settings, but be aware that this could change later
             var header = new ClientStatsPayload(settings.Manager.InitialMutableSettings)
@@ -99,7 +96,6 @@ namespace Datadog.Trace.Agent
                 if (changes.UpdatedMutable is { } mutable)
                 {
                     header.UpdateDetails(mutable);
-                    Interlocked.Exchange(ref _defaultServiceName, mutable.DefaultServiceName);
                 }
             });
 
@@ -262,14 +258,12 @@ namespace Datadog.Trace.Agent
             // Normalize service source to match trace serialization behavior:
             // clear the source when service name equals the default, unless it's
             // a configuration-driven override (opt.*).
-            var serviceNameSource = span.Context.ServiceNameSource;
+            var serviceSource = span.Context.ServiceNameSource;
             var serviceNameEqualsDefault = string.Equals(span.ServiceName, span.Context.TraceContext?.Tracer?.DefaultServiceName, StringComparison.OrdinalIgnoreCase);
-            if (serviceNameEqualsDefault && serviceNameSource?.StartsWith("opt.", StringComparison.Ordinal) != true)
+            if (serviceNameEqualsDefault && serviceSource?.StartsWith("opt.", StringComparison.Ordinal) != true)
             {
-                serviceNameSource = null;
+                serviceSource = null;
             }
-
-            var serviceNameIsDefault = span.ServiceName == Volatile.Read(ref _defaultServiceName);
 
             // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L53-L99
             // Peer tags are extracted for client/producer/consumer spans
@@ -280,9 +274,9 @@ namespace Datadog.Trace.Agent
             // chicken and egg - we need to convert everything to utf-8, so that we can get the hash, so that we
             // know whether we need the tags as byte[] or not..
             ulong peerTagsHash;
-            if (!serviceNameIsDefault && (string.IsNullOrEmpty(spanKind) || spanKind is SpanKinds.Internal))
+            if ((string.IsNullOrEmpty(spanKind) || spanKind is SpanKinds.Internal) && span.GetTag(Tags.BaseService) is { Length: >0 } baseService)
             {
-                utf8PeerTags = [EncodingHelpers.Utf8NoBom.GetBytes($"{Tags.BaseService}:{serviceName}")];
+                utf8PeerTags = [EncodingHelpers.Utf8NoBom.GetBytes($"{Tags.BaseService}:{baseService}")];
                 peerTagsHash = FnvHash64.GenerateHash(utf8PeerTags[0], FnvHash64.Version.V1A);
             }
             else if (spanKind is SpanKinds.Client or SpanKinds.Server or SpanKinds.Producer or SpanKinds.Consumer)

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -220,7 +220,7 @@ namespace Datadog.Trace.Agent
         }
 
         public StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
-            => BuildKey(span, _peerTagKeys, out utf8PeerTags);
+            => BuildKey(span, Volatile.Read(ref _peerTagKeys), out utf8PeerTags);
 
         internal StatsAggregationKey BuildKey(Span span, List<string> peerTagKeys, out List<byte[]> utf8PeerTags)
         {

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -470,7 +470,16 @@ namespace Datadog.Trace.Agent
 
         private void HandleConfigUpdate(AgentConfiguration config)
         {
-            CanComputeStats = !string.IsNullOrWhiteSpace(config.StatsEndpoint) && config.ClientDropP0s == true;
+            // Client-side stats requires agent >= 7.65.0 which has full CSS v1.2.0 support.
+            // However, if the version is not parseable (e.g. test agents returning "test"), we don't
+            // block stats — the presence of the stats endpoint and client_drop_p0s is sufficient.
+
+            CanComputeStats = !string.IsNullOrWhiteSpace(config.StatsEndpoint)
+                           && config.ClientDropP0s
+                           && (config.AgentVersion is null
+                            || !Version.TryParse(config.AgentVersion, out var parsedVersion)
+                            || parsedVersion.Major >= 8
+                            || (parsedVersion.Major == 7 && parsedVersion.Minor >= 65));
 
             if (config.PeerTags is not null)
             {

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -399,7 +399,7 @@ namespace Datadog.Trace.Agent
                 return;
             }
 
-            var key = BuildKey(span, _peerTagKeys, out var peerTags);
+            var key = BuildKey(span, out var peerTags);
 
             var buffer = CurrentBuffer;
 
@@ -446,6 +446,11 @@ namespace Datadog.Trace.Agent
             if (config.PeerTags is not null)
             {
                 Interlocked.Exchange(ref _peerTagKeys, config.PeerTags);
+            }
+
+            if (config.SpanDerivedPrimaryTags is not null)
+            {
+                Interlocked.Exchange(ref _spanDerivedPrimaryTagKeys, config.SpanDerivedPrimaryTags);
             }
 
             // Tracer obfuscation version is 1. If the agent's version is > 0 and <= ours, the tracer obfuscates.

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -337,7 +337,7 @@ namespace Datadog.Trace.Agent
                 span.OperationName,
                 span.Type,
                 httpStatusCode,
-                span.Context.Origin.StartsWith("synthetics"),
+                span.Context.Origin?.StartsWith("synthetics") == true,
                 spanKind,
                 _isOtlp ? span.Error : false,
                 _isOtlp ? span.IsTopLevel : false,

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Agent
         private readonly IApi _api;
         private readonly bool _isOtlp;
         private readonly ITraceProcessor[] _traceProcessors;
-        private readonly ITraceProcessor _obfuscatorProcessor;
+        private readonly ObfuscatorTraceProcessor _obfuscatorProcessor;
 
         private readonly TaskCompletionSource<bool> _processExit;
 
@@ -338,9 +338,9 @@ namespace Datadog.Trace.Agent
                 span.Type,
                 httpStatusCode,
                 span.Context.Origin == "synthetics",
+                spanKind,
                 _isOtlp ? span.Error : false,
                 _isOtlp ? span.IsTopLevel : false,
-                spanKind,
                 isTraceRoot,
                 httpMethod,
                 httpEndpoint,

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -364,16 +364,14 @@ namespace Datadog.Trace.Agent
 
                 TelemetryFactory.Metrics.RecordGaugeStatsBuckets(buffer.Buckets.Count);
 
-                if (buffer.HasHits())
+                if (buffer.HasHits() && CanComputeStats == true)
                 {
-                    // Push the metrics
-                    if (CanComputeStats == true)
-                    {
-                        await _api.SendStatsAsync(buffer, _bucketDuration.ToNanoseconds(), Volatile.Read(ref _tracerObfuscationVersion)).ConfigureAwait(false);
-                    }
-
-                    buffer.Reset();
+                    await _api.SendStatsAsync(buffer, _bucketDuration.ToNanoseconds(), Volatile.Read(ref _tracerObfuscationVersion)).ConfigureAwait(false);
                 }
+
+                // Always reset the buffer so Start is re-aligned and stale keys are pruned,
+                // even when no hits were recorded this interval.
+                buffer.Reset();
             }
             while (!_processExit.Task.IsCompleted);
         }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Agent.TraceSamplers;
@@ -15,6 +16,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Processors;
 using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Tagging;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
@@ -26,6 +28,8 @@ namespace Datadog.Trace.Agent
         private const int BufferCount = 2;
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
+        private static readonly List<byte[]> EmptyPeerTags = [];
+        private static readonly byte[] PeerTagSeparator = [0];
 
         private readonly StatsBuffer[] _buffers;
 
@@ -49,6 +53,18 @@ namespace Datadog.Trace.Agent
 
         private int _currentBuffer;
 
+        private List<string> _peerTagKeys = [];
+        // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L210-L213
+        private List<string> _spanKindsStatsComputed =
+        [
+            SpanKinds.Client,
+            SpanKinds.Server,
+            SpanKinds.Producer,
+            SpanKinds.Consumer,
+        ];
+
+        private string _defaultServiceName;
+
         internal StatsAggregator(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
         {
             _api = api;
@@ -64,8 +80,9 @@ namespace Datadog.Trace.Agent
 
             _prioritySampler = new PrioritySampler();
             _errorSampler = new ErrorSampler();
-            _rareSampler = new RareSampler(settings, isOtlp);
+            _rareSampler = new RareSampler(settings, this);
             _analyticsEventSampler = new AnalyticsEventsSampler();
+            _defaultServiceName = settings.Manager.InitialMutableSettings.DefaultServiceName;
 
             // Create with the initial mutable settings, but be aware that this could change later
             var header = new ClientStatsPayload(settings.Manager.InitialMutableSettings)
@@ -78,6 +95,7 @@ namespace Datadog.Trace.Agent
                 if (changes.UpdatedMutable is { } mutable)
                 {
                     header.UpdateDetails(mutable);
+                    Interlocked.Exchange(ref _defaultServiceName, mutable.DefaultServiceName);
                 }
             });
 
@@ -182,7 +200,10 @@ namespace Datadog.Trace.Agent
             return spans;
         }
 
-        internal static StatsAggregationKey BuildKey(Span span, bool isOtlp = false)
+        internal StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
+            => BuildKey(span, _peerTagKeys, out utf8PeerTags);
+
+        internal StatsAggregationKey BuildKey(Span span, List<string> peerTagKeys, out List<byte[]> utf8PeerTags)
         {
             var rawHttpStatusCode = span.GetTag(Tags.HttpStatusCode);
 
@@ -190,6 +211,19 @@ namespace Datadog.Trace.Agent
             {
                 httpStatusCode = 0;
             }
+
+            var rawGrpcStatusCode = span.GetTag(Tags.GrpcStatusCode);
+            if (rawGrpcStatusCode == null || !int.TryParse(rawGrpcStatusCode, out var grpcStatusCode))
+            {
+                grpcStatusCode = 0;
+            }
+
+            // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/aggregation.go
+            var spanKind = (span.Tags is InstrumentationTags t ? t.SpanKind : span.GetTag(Tags.SpanKind)) ?? string.Empty;
+            var isTraceRoot = span.Context.ParentId is null or 0;
+            var httpMethod = span.GetTag(Tags.HttpMethod) ?? string.Empty;
+            var httpEndpoint = span.GetTag(Tags.HttpRoute) ?? string.Empty;
+            var serviceName = span.ServiceName;
 
             // Normalize service source to match trace serialization behavior:
             // clear the source when service name equals the default, unless it's
@@ -201,6 +235,63 @@ namespace Datadog.Trace.Agent
                 serviceNameSource = null;
             }
 
+            var serviceNameIsDefault = span.ServiceName == Volatile.Read(ref _defaultServiceName);
+
+            // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L53-L99
+            // Peer tags are extracted for client/producer/consumer spans
+            // If the span kind is missing or internal, and we have a "base service" tag `_dd.base_service`
+            // then we only aggregate based on the `_dd.base_service`
+            // TODO: work out how to optimize the peer tags allocations, to avoid all the extra utf8 allocations
+            // - on .NET Core these are only necessary for the first instance of the key, but this makes for a tricky
+            // chicken and egg - we need to convert everything to utf-8, so that we can get the hash, so that we
+            // know whether we need the tags as byte[] or not..
+            ulong peerTagsHash;
+            if (!serviceNameIsDefault && (string.IsNullOrEmpty(spanKind) || spanKind is SpanKinds.Internal))
+            {
+                utf8PeerTags = [EncodingHelpers.Utf8NoBom.GetBytes($"{Tags.BaseService}:{serviceName}")];
+                peerTagsHash = FnvHash64.GenerateHash(utf8PeerTags[0], FnvHash64.Version.V1A);
+            }
+            else if (spanKind is SpanKinds.Client or SpanKinds.Server or SpanKinds.Producer or SpanKinds.Consumer)
+            {
+                // Hash should be generated as TAGNAME:TAGVALUE, and should be in sorted order (we sort ahead of time)
+                // peerTagKeys should already be in sorted order
+                // We serialize to the utf-8 bytes because we need to serialize them during sending anyway
+                // TODO: Verify we get the same results as the go code
+                utf8PeerTags = EmptyPeerTags;
+                peerTagsHash = 0;
+                foreach (var tagKey in peerTagKeys)
+                {
+                    var tagValue = span.GetTag(tagKey);
+                    if (string.IsNullOrEmpty(tagValue))
+                    {
+                        continue;
+                    }
+
+                    // TODO: Quantize ip address
+
+                    if (ReferenceEquals(utf8PeerTags, EmptyPeerTags))
+                    {
+                        // We're not setting the capacity here, because there's
+                        // a _lot_ of potential peer tags, and _most_ of them won't apply
+                        utf8PeerTags = new();
+                    }
+                    else
+                    {
+                        // add the separator
+                        peerTagsHash = FnvHash64.GenerateHash(PeerTagSeparator, FnvHash64.Version.V1A, peerTagsHash);
+                    }
+
+                    var bytes = EncodingHelpers.Utf8NoBom.GetBytes($"{tagKey}:{tagValue}");
+                    peerTagsHash = FnvHash64.GenerateHash(bytes, FnvHash64.Version.V1A, peerTagsHash);
+                    utf8PeerTags.Add(bytes);
+                }
+            }
+            else
+            {
+                peerTagsHash = 0;
+                utf8PeerTags = EmptyPeerTags;
+            }
+
             // When submitting trace metrics over OTLP, we must create inidividual timeseries
             // timeseries for each unique set of attributes, including the Error and IsTopLevel attributes.
             // As a result, we must create distinct Aggregation keys (and consequently, unique stats) by these attributes.
@@ -210,11 +301,17 @@ namespace Datadog.Trace.Agent
                 span.ServiceName,
                 span.OperationName,
                 span.Type,
-                serviceNameSource,
                 httpStatusCode,
                 span.Context.Origin == "synthetics",
-                isOtlp ? span.Error : false,
-                isOtlp ? span.IsTopLevel : false);
+                _isOtlp ? span.Error : false,
+                _isOtlp ? span.IsTopLevel : false,
+                spanKind,
+                isTraceRoot,
+                httpMethod,
+                httpEndpoint,
+                grpcStatusCode,
+                serviceSource,
+                peerTagsHash);
         }
 
         internal async Task Flush()
@@ -277,29 +374,42 @@ namespace Datadog.Trace.Agent
             return ns << shift;
         }
 
+        // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/weight.go
+        private static double GetWeight(Span span)
+        {
+            var rate = span.Context.TraceContext.AppliedSamplingRate;
+            return (rate is > 0) ? 1.0 / rate.Value : 1.0;
+        }
+
         private void AddToBuffer(Span span)
         {
+            // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L210-L217
+            var spanKind = (span.Tags is InstrumentationTags t ? t.SpanKind : span.GetTag(Tags.SpanKind));
+            var isSpanKindEligible = !string.IsNullOrEmpty(spanKind) && _spanKindsStatsComputed.Contains(spanKind);
+
             if (!_isOtlp // If we are using OTLP, we include both top-level and non-top-level spans
-                && ((!span.IsTopLevel && span.GetMetric(Tags.Measured) != 1.0) || span.GetMetric(Tags.PartialSnapshot) > 0))
+                && (!(span.IsTopLevel || isSpanKindEligible || span.GetMetric(Tags.Measured) == 1.0)
+                 || span.GetMetric(Tags.PartialSnapshot) > 0))
             {
                 return;
             }
 
-            var key = BuildKey(span, _isOtlp);
+            var key = BuildKey(span, _peerTagKeys, out var peerTags);
 
             var buffer = CurrentBuffer;
 
             if (!buffer.Buckets.TryGetValue(key, out var bucket))
             {
-                bucket = new StatsBucket(key);
+                bucket = new StatsBucket(key, peerTags);
                 buffer.Buckets.Add(key, bucket);
             }
 
-            bucket.Hits++;
+            var weight = GetWeight(span);
+            bucket.Hits += weight;
 
             if (span.IsTopLevel)
             {
-                bucket.TopLevelHits++;
+                bucket.TopLevelHits += weight;
             }
 
             var duration = span.Duration.ToNanoseconds();
@@ -310,7 +420,7 @@ namespace Datadog.Trace.Agent
             // As a result, if using OTLP we always add to the OkSummary sketch.
             if (span.Error && !_isOtlp)
             {
-                bucket.Errors++;
+                bucket.Errors += weight;
                 bucket.ErrorSummary.Add(ConvertTimestamp(duration));
             }
             else
@@ -322,6 +432,16 @@ namespace Datadog.Trace.Agent
         private void HandleConfigUpdate(AgentConfiguration config)
         {
             CanComputeStats = !string.IsNullOrWhiteSpace(config.StatsEndpoint) && config.ClientDropP0s == true;
+
+            if (config.SpanKindsStatsComputed is not null)
+            {
+                Interlocked.Exchange(ref _spanKindsStatsComputed, config.SpanKindsStatsComputed);
+            }
+
+            if (config.PeerTags is not null)
+            {
+                Interlocked.Exchange(ref _peerTagKeys, config.PeerTags);
+            }
 
             if (CanComputeStats.Value)
             {

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -337,7 +337,7 @@ namespace Datadog.Trace.Agent
                 span.OperationName,
                 span.Type,
                 httpStatusCode,
-                span.Context.Origin == "synthetics",
+                span.Context.Origin.StartsWith("synthetics"),
                 spanKind,
                 _isOtlp ? span.Error : false,
                 _isOtlp ? span.IsTopLevel : false,

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -36,6 +36,7 @@ namespace Datadog.Trace.Agent
         private readonly IApi _api;
         private readonly bool _isOtlp;
         private readonly ITraceProcessor[] _traceProcessors;
+        private readonly ITraceProcessor _obfuscatorProcessor;
 
         private readonly TaskCompletionSource<bool> _processExit;
 
@@ -77,8 +78,9 @@ namespace Datadog.Trace.Agent
             _traceProcessors = new ITraceProcessor[]
             {
                 new Processors.NormalizerTraceProcessor(),
-                new Processors.ObfuscatorTraceProcessor(),
             };
+
+            _obfuscatorProcessor = new Processors.ObfuscatorTraceProcessor();
 
             _prioritySampler = new PrioritySampler();
             _errorSampler = new ErrorSampler();
@@ -209,6 +211,20 @@ namespace Datadog.Trace.Agent
                 catch (Exception e)
                 {
                     Log.Error(e, "Error executing trace processor {TraceProcessorType}", processor?.GetType());
+                }
+            }
+
+            // Only obfuscate resources when the tracer has negotiated obfuscation responsibility.
+            // The tracer currently only supports obfuscation version 1 (SQL, Cassandra, Redis).
+            if (Volatile.Read(ref _tracerObfuscationVersion) == 1)
+            {
+                try
+                {
+                    spans = _obfuscatorProcessor.Process(in spans);
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e, "Error executing obfuscator trace processor");
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -200,7 +200,7 @@ namespace Datadog.Trace.Agent
             return spans;
         }
 
-        internal StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
+        public StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
             => BuildKey(span, _peerTagKeys, out utf8PeerTags);
 
         internal StatsAggregationKey BuildKey(Span span, List<string> peerTagKeys, out List<byte[]> utf8PeerTags)

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -57,14 +57,6 @@ namespace Datadog.Trace.Agent
         private int _tracerObfuscationVersion;
         private TraceFilter _traceFilter;
         private List<string> _peerTagKeys = [];
-        // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L210-L213
-        private List<string> _spanKindsStatsComputed =
-        [
-            SpanKinds.Client,
-            SpanKinds.Server,
-            SpanKinds.Producer,
-            SpanKinds.Consumer,
-        ];
 
         internal StatsAggregator(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
         {
@@ -410,7 +402,7 @@ namespace Datadog.Trace.Agent
         {
             // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L210-L217
             var spanKind = (span.Tags is InstrumentationTags t ? t.SpanKind : span.GetTag(Tags.SpanKind));
-            var isSpanKindEligible = !string.IsNullOrEmpty(spanKind) && _spanKindsStatsComputed.Contains(spanKind);
+            var isSpanKindEligible = spanKind is SpanKinds.Client or SpanKinds.Server or SpanKinds.Consumer or SpanKinds.Producer;
 
             if (!_isOtlp // If we are using OTLP, we include both top-level and non-top-level spans
                 && (!(span.IsTopLevel || isSpanKindEligible || span.GetMetric(Tags.Measured) == 1.0)
@@ -479,11 +471,6 @@ namespace Datadog.Trace.Agent
         private void HandleConfigUpdate(AgentConfiguration config)
         {
             CanComputeStats = !string.IsNullOrWhiteSpace(config.StatsEndpoint) && config.ClientDropP0s == true;
-
-            if (config.SpanKindsStatsComputed is not null)
-            {
-                Interlocked.Exchange(ref _spanKindsStatsComputed, config.SpanKindsStatsComputed);
-            }
 
             if (config.PeerTags is not null)
             {

--- a/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using Datadog.Trace.Vendors.Datadog.Sketches;
 using Datadog.Trace.Vendors.Datadog.Sketches.Mappings;
 using Datadog.Trace.Vendors.Datadog.Sketches.Stores;
@@ -11,18 +12,21 @@ namespace Datadog.Trace.Agent
 {
     internal sealed class StatsBucket
     {
-        public StatsBucket(StatsAggregationKey key)
+        public StatsBucket(StatsAggregationKey key, List<byte[]> peerTags)
         {
             Key = key;
             OkSummary = CreateSketch();
             ErrorSummary = CreateSketch();
+            PeerTags = peerTags;
         }
 
         public StatsAggregationKey Key { get; }
 
-        public long Hits { get; set; }
+        // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/weight.go
+        // Hits, Errors, and TopLevelHits are doubles to accumulate fractional sampling weights (1/rate)
+        public double Hits { get; set; }
 
-        public long Errors { get; set; }
+        public double Errors { get; set; }
 
         public long Duration { get; set; }
 
@@ -30,7 +34,9 @@ namespace Datadog.Trace.Agent
 
         public DDSketch ErrorSummary { get; }
 
-        public long TopLevelHits { get; set; }
+        public double TopLevelHits { get; set; }
+
+        public List<byte[]> PeerTags { get; }
 
         public void Clear()
         {

--- a/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
@@ -28,7 +28,9 @@ namespace Datadog.Trace.Agent
 
         public double Errors { get; set; }
 
-        public long Duration { get; set; }
+        // Duration is a double to accumulate fractional sampling weights (1/rate), like Hits/Errors/TopLevelHits.
+        // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/statsraw.go
+        public double Duration { get; set; }
 
         public DDSketch OkSummary { get; }
 

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -30,6 +30,23 @@ namespace Datadog.Trace.Agent
 
         public long Start { get; private set; }
 
+        /// <summary>
+        /// Returns true if any bucket has received hits in the current interval.
+        /// Buckets with zero hits are retained for sketch reuse but should not trigger a flush.
+        /// </summary>
+        public bool HasHits()
+        {
+            foreach (var bucket in Buckets.Values)
+            {
+                if (bucket.Hits != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public void Reset()
         {
             // We need to do some cleanup because the application could have an unlimited number of endpoints,

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -28,8 +28,6 @@ namespace Datadog.Trace.Agent
 
         public Dictionary<StatsAggregationKey, StatsBucket> Buckets { get; }
 
-        public DateTimeOffset StartTime { get; private set; }
-
         public long Start { get; private set; }
 
         public void Reset()
@@ -56,8 +54,9 @@ namespace Datadog.Trace.Agent
 
             _keysToRemove.Clear();
 
-            StartTime = DateTimeOffset.UtcNow;
-            Start = StartTime.ToUnixTimeNanoseconds();
+            // Align to 10-second boundary to match the Go tracer's alignTs: ts - ts % bucketSize
+            var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+            Start = nowNs - (nowNs % 10_000_000_000);
         }
 
         public void Serialize(Stream stream, long bucketDuration)

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -72,6 +72,12 @@ namespace Datadog.Trace.Agent
                 count++;
             }
 
+            var writeGitCommitSha = !StringUtil.IsNullOrEmpty(details.GitCommitSha);
+            if (writeGitCommitSha)
+            {
+                count++;
+            }
+
             MessagePackBinary.WriteMapHeader(stream, count);
 
             MessagePackBinary.WriteString(stream, "Hostname");
@@ -104,6 +110,12 @@ namespace Datadog.Trace.Agent
 
             MessagePackBinary.WriteString(stream, "Sequence");
             MessagePackBinary.WriteInt64(stream, _header.GetSequenceNumber());
+
+            if (writeGitCommitSha)
+            {
+                MessagePackBinary.WriteString(stream, "GitCommitSha");
+                MessagePackBinary.WriteString(stream, details.GitCommitSha);
+            }
         }
 
         private static void SerializeBucket(Stream stream, StatsBucket bucket)

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -166,7 +166,7 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.Errors));
 
             MessagePackBinary.WriteString(stream, "Duration");
-            MessagePackBinary.WriteInt64(stream, bucket.Duration);
+            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.Duration));
 
             MessagePackBinary.WriteString(stream, "OkSummary");
             SerializeSketch(stream, bucket.OkSummary);

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -108,17 +108,20 @@ namespace Datadog.Trace.Agent
         private static void SerializeBucket(Stream stream, StatsBucket bucket)
         {
             var hasServiceSource = !string.IsNullOrEmpty(bucket.Key.ServiceSource);
-            var mapSize = hasServiceSource ? 13 : 12;
-            MessagePackBinary.WriteMapHeader(stream, mapSize);
+            var fieldCount = bucket.PeerTags.Count == 0
+                                 ? (hasServiceSource ? 19 : 18)
+                                 : (hasServiceSource ? 20 : 19);
+            MessagePackBinary.WriteMapHeader(stream, fieldCount);
 
+            // TODO: precompute the string constants in this file
             MessagePackBinary.WriteString(stream, "Service");
-            MessagePackBinary.WriteString(stream, bucket.Key.Service ?? string.Empty);
+            MessagePackBinary.WriteString(stream, bucket.Key.Service);
 
             MessagePackBinary.WriteString(stream, "Name");
-            MessagePackBinary.WriteString(stream, bucket.Key.OperationName ?? string.Empty);
+            MessagePackBinary.WriteString(stream, bucket.Key.OperationName);
 
             MessagePackBinary.WriteString(stream, "Resource");
-            MessagePackBinary.WriteString(stream, bucket.Key.Resource ?? string.Empty);
+            MessagePackBinary.WriteString(stream, bucket.Key.Resource);
 
             MessagePackBinary.WriteString(stream, "Synthetics");
             MessagePackBinary.WriteBoolean(stream, bucket.Key.IsSyntheticsRequest);
@@ -127,19 +130,15 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteInt32(stream, bucket.Key.HttpStatusCode);
 
             MessagePackBinary.WriteString(stream, "Type");
-            MessagePackBinary.WriteString(stream, bucket.Key.Type ?? string.Empty);
+            MessagePackBinary.WriteString(stream, bucket.Key.Type);
 
-            if (hasServiceSource)
-            {
-                MessagePackBinary.WriteString(stream, "srv_src");
-                MessagePackBinary.WriteString(stream, bucket.Key.ServiceSource);
-            }
-
+            // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/weight.go
+            // Hits, Errors, TopLevelHits are weighted by 1/sampling_rate; cast to long for wire format
             MessagePackBinary.WriteString(stream, "Hits");
-            MessagePackBinary.WriteInt64(stream, bucket.Hits);
+            MessagePackBinary.WriteInt64(stream, (long)bucket.Hits);
 
             MessagePackBinary.WriteString(stream, "Errors");
-            MessagePackBinary.WriteInt64(stream, bucket.Errors);
+            MessagePackBinary.WriteInt64(stream, (long)bucket.Errors);
 
             MessagePackBinary.WriteString(stream, "Duration");
             MessagePackBinary.WriteInt64(stream, bucket.Duration);
@@ -151,7 +150,40 @@ namespace Datadog.Trace.Agent
             SerializeSketch(stream, bucket.ErrorSummary);
 
             MessagePackBinary.WriteString(stream, "TopLevelHits");
-            MessagePackBinary.WriteInt64(stream, bucket.TopLevelHits);
+            MessagePackBinary.WriteInt64(stream, (long)bucket.TopLevelHits);
+
+            // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/aggregation.go
+            MessagePackBinary.WriteString(stream, "SpanKind");
+            MessagePackBinary.WriteString(stream, bucket.Key.SpanKind);
+
+            MessagePackBinary.WriteString(stream, "IsTraceRoot");
+            MessagePackBinary.WriteBoolean(stream, bucket.Key.IsTraceRoot);
+
+            MessagePackBinary.WriteString(stream, "HTTPMethod");
+            MessagePackBinary.WriteString(stream, bucket.Key.HttpMethod);
+
+            MessagePackBinary.WriteString(stream, "HTTPEndpoint");
+            MessagePackBinary.WriteString(stream, bucket.Key.HttpEndpoint);
+
+            MessagePackBinary.WriteString(stream, "GRPCStatusCode");
+            MessagePackBinary.WriteInt32(stream, bucket.Key.GrpcStatusCode);
+
+            if (hasServiceSource)
+            {
+                MessagePackBinary.WriteString(stream, "srv_src");
+                MessagePackBinary.WriteString(stream, bucket.Key.ServiceSource);
+            }
+
+            // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/span_concentrator.go#L53-L99
+            if (bucket.PeerTags.Count != 0)
+            {
+                MessagePackBinary.WriteString(stream, "PeerTags");
+                MessagePackBinary.WriteArrayHeader(stream, bucket.PeerTags.Count);
+                foreach (var tag in bucket.PeerTags)
+                {
+                    MessagePackBinary.WriteStringBytes(stream, tag);
+                }
+            }
         }
 
         private static void SerializeSketch(Stream stream, DDSketch sketch)

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -139,7 +139,7 @@ namespace Datadog.Trace.Agent
 
         private static void SerializeBucket(Stream stream, StatsBucket bucket)
         {
-            var fieldCount = 17;
+            var fieldCount = 18;
             if (bucket.PeerTags.Count != 0)
             {
                 fieldCount++;

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Agent
 
         public void Serialize(Stream stream, long bucketDuration)
         {
-            var count = 8;
+            var count = 9; // Base: Hostname, Env, Version, Stats, Lang, TracerVersion, RuntimeID, Sequence, Service
             var details = _header.Details;
 
             var serializedTags = details.ProcessTags?.SerializedTags;
@@ -110,6 +110,9 @@ namespace Datadog.Trace.Agent
 
             MessagePackBinary.WriteString(stream, "Sequence");
             MessagePackBinary.WriteInt64(stream, _header.GetSequenceNumber());
+
+            MessagePackBinary.WriteString(stream, "Service");
+            MessagePackBinary.WriteString(stream, details.DefaultServiceName ?? string.Empty);
 
             if (writeGitCommitSha)
             {
@@ -193,6 +196,7 @@ namespace Datadog.Trace.Agent
 
             if (hasServiceSource)
             {
+                // Wire name is "srv_src" per the Go agent's generated msgpack code
                 MessagePackBinary.WriteString(stream, "srv_src");
                 MessagePackBinary.WriteString(stream, bucket.Key.ServiceSource);
             }

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteString(stream, _header.HostName ?? string.Empty);
 
             MessagePackBinary.WriteString(stream, "Env");
-            MessagePackBinary.WriteString(stream, details.Environment ?? string.Empty);
+            MessagePackBinary.WriteString(stream, StringUtil.IsNullOrEmpty(details.Environment) ? "unknown-env" : details.Environment);
 
             MessagePackBinary.WriteString(stream, "Version");
             MessagePackBinary.WriteString(stream, details.Version ?? string.Empty);

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -139,14 +139,8 @@ namespace Datadog.Trace.Agent
 
         private static void SerializeBucket(Stream stream, StatsBucket bucket)
         {
-            var fieldCount = 18;
+            var fieldCount = 17;
             if (bucket.PeerTags.Count != 0)
-            {
-                fieldCount++;
-            }
-
-            var hasServiceSource = !string.IsNullOrEmpty(bucket.Key.ServiceSource);
-            if (hasServiceSource)
             {
                 fieldCount++;
             }
@@ -210,12 +204,9 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteString(stream, "GRPCStatusCode");
             MessagePackBinary.WriteString(stream, bucket.Key.GrpcStatusCode);
 
-            if (hasServiceSource)
-            {
-                // Wire name is "srv_src" per the Go agent's generated msgpack code
-                MessagePackBinary.WriteString(stream, "srv_src");
-                MessagePackBinary.WriteString(stream, bucket.Key.ServiceSource);
-            }
+            // Wire name is "srv_src" per the Go agent's generated msgpack code
+            MessagePackBinary.WriteString(stream, "srv_src");
+            MessagePackBinary.WriteString(stream, bucket.Key.ServiceSource);
 
             // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/span_concentrator.go#L53-L99
             if (bucket.PeerTags.Count != 0)

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -156,8 +156,9 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteString(stream, "SpanKind");
             MessagePackBinary.WriteString(stream, bucket.Key.SpanKind);
 
+            // Spec defines Trilean: NOT_SET=0, TRUE=1, FALSE=2
             MessagePackBinary.WriteString(stream, "IsTraceRoot");
-            MessagePackBinary.WriteBoolean(stream, bucket.Key.IsTraceRoot);
+            MessagePackBinary.WriteInt32(stream, bucket.Key.IsTraceRoot ? 1 : 2);
 
             MessagePackBinary.WriteString(stream, "HTTPMethod");
             MessagePackBinary.WriteString(stream, bucket.Key.HttpMethod);

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteString(stream, bucket.Key.HttpEndpoint);
 
             MessagePackBinary.WriteString(stream, "GRPCStatusCode");
-            MessagePackBinary.WriteString(stream, bucket.Key.GrpcStatusCode == 0 ? string.Empty : bucket.Key.GrpcStatusCode.ToString());
+            MessagePackBinary.WriteString(stream, bucket.Key.GrpcStatusCode);
 
             if (hasServiceSource)
             {

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteString(stream, bucket.Key.HttpEndpoint);
 
             MessagePackBinary.WriteString(stream, "GRPCStatusCode");
-            MessagePackBinary.WriteInt32(stream, bucket.Key.GrpcStatusCode);
+            MessagePackBinary.WriteString(stream, bucket.Key.GrpcStatusCode == 0 ? string.Empty : bucket.Key.GrpcStatusCode.ToString());
 
             if (hasServiceSource)
             {

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Datadog.Sketches;
 using Datadog.Trace.Vendors.MessagePack;
 
@@ -133,12 +134,13 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteString(stream, bucket.Key.Type);
 
             // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/weight.go
-            // Hits, Errors, TopLevelHits are weighted by 1/sampling_rate; cast to long for wire format
+            // Hits, Errors, TopLevelHits are weighted by 1/sampling_rate.
+            // Use stochastic rounding to convert to int64 to prevent systematic bias.
             MessagePackBinary.WriteString(stream, "Hits");
-            MessagePackBinary.WriteInt64(stream, (long)bucket.Hits);
+            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.Hits));
 
             MessagePackBinary.WriteString(stream, "Errors");
-            MessagePackBinary.WriteInt64(stream, (long)bucket.Errors);
+            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.Errors));
 
             MessagePackBinary.WriteString(stream, "Duration");
             MessagePackBinary.WriteInt64(stream, bucket.Duration);
@@ -150,7 +152,7 @@ namespace Datadog.Trace.Agent
             SerializeSketch(stream, bucket.ErrorSummary);
 
             MessagePackBinary.WriteString(stream, "TopLevelHits");
-            MessagePackBinary.WriteInt64(stream, (long)bucket.TopLevelHits);
+            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.TopLevelHits));
 
             // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/aggregation.go
             MessagePackBinary.WriteString(stream, "SpanKind");
@@ -198,6 +200,22 @@ namespace Datadog.Trace.Agent
             stream.WriteByte((byte)size);
 
             sketch.Serialize(stream);
+        }
+
+        /// <summary>
+        /// Converts a floating-point value to long using stochastic rounding.
+        /// The fractional part is used as a probability of rounding up, preventing
+        /// systematic bias that occurs with simple truncation.
+        /// </summary>
+        private static long StochasticRound(double value)
+        {
+            var truncated = (long)value;
+            if (ThreadSafeRandom.Shared.NextDouble() < value - truncated)
+            {
+                return truncated + 1;
+            }
+
+            return truncated;
         }
 
         private void SerializeBuckets(Stream stream, long bucketDuration)

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -120,10 +120,18 @@ namespace Datadog.Trace.Agent
 
         private static void SerializeBucket(Stream stream, StatsBucket bucket)
         {
+            var fieldCount = 18;
+            if (bucket.PeerTags.Count != 0)
+            {
+                fieldCount++;
+            }
+
             var hasServiceSource = !string.IsNullOrEmpty(bucket.Key.ServiceSource);
-            var fieldCount = bucket.PeerTags.Count == 0
-                                 ? (hasServiceSource ? 19 : 18)
-                                 : (hasServiceSource ? 20 : 19);
+            if (hasServiceSource)
+            {
+                fieldCount++;
+            }
+
             MessagePackBinary.WriteMapHeader(stream, fieldCount);
 
             // TODO: precompute the string constants in this file

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
@@ -17,9 +17,9 @@ namespace Datadog.Trace.Agent.TraceSamplers
 
         private readonly HashSet<StatsAggregationKey> _keys = new();
         private readonly Queue<StatsAggregationKey> _cache = new();
-        private readonly StatsAggregator _aggregator;
+        private readonly IStatsAggregator _aggregator;
 
-        public RareSampler(TracerSettings settings, StatsAggregator aggregator)
+        public RareSampler(TracerSettings settings, IStatsAggregator aggregator)
         {
             IsEnabled = settings.IsRareSamplerEnabled;
             _aggregator = aggregator;

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
@@ -17,16 +17,15 @@ namespace Datadog.Trace.Agent.TraceSamplers
 
         private readonly HashSet<StatsAggregationKey> _keys = new();
         private readonly Queue<StatsAggregationKey> _cache = new();
+        private readonly StatsAggregator _aggregator;
 
-        public RareSampler(TracerSettings settings, bool isOtlp)
+        public RareSampler(TracerSettings settings, StatsAggregator aggregator)
         {
             IsEnabled = settings.IsRareSamplerEnabled;
-            IsOtlp = isOtlp;
+            _aggregator = aggregator;
         }
 
         public bool IsEnabled { get; }
-
-        public bool IsOtlp { get; }
 
         /// <summary>
         /// Samples the trace chunk with the following rules:
@@ -92,7 +91,7 @@ namespace Datadog.Trace.Agent.TraceSamplers
 
         private bool SampleSpan(Span span)
         {
-            var key = StatsAggregator.BuildKey(span, IsOtlp);
+            var key = _aggregator.BuildKey(span, out _);
             var isNewKey = _keys.Add(key);
 
             if (isNewKey)
@@ -106,7 +105,7 @@ namespace Datadog.Trace.Agent.TraceSamplers
 
         private void UpdateSpan(Span span)
         {
-            var key = StatsAggregator.BuildKey(span, IsOtlp);
+            var key = _aggregator.BuildKey(span, out _);
             var isNewKey = _keys.Add(key);
 
             if (isNewKey)

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/TraceFilter.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/TraceFilter.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Tagging;
@@ -21,16 +22,16 @@ internal sealed class TraceFilter
 {
     private readonly List<string> _filterTagsRequire;
     private readonly List<string> _filterTagsReject;
-    private readonly List<Regex> _filterTagsRegexRequire;
-    private readonly List<Regex> _filterTagsRegexReject;
+    private readonly List<RegexTagFilter> _filterTagsRegexRequire;
+    private readonly List<RegexTagFilter> _filterTagsRegexReject;
     private readonly List<Regex> _ignoreResources;
 
     public TraceFilter(AgentTraceFilterConfig config)
     {
         _filterTagsRequire = config.FilterTagsRequire ?? [];
         _filterTagsReject = config.FilterTagsReject ?? [];
-        _filterTagsRegexRequire = CompilePatterns(config.FilterTagsRegexRequire);
-        _filterTagsRegexReject = CompilePatterns(config.FilterTagsRegexReject);
+        _filterTagsRegexRequire = CompileTagFilters(config.FilterTagsRegexRequire);
+        _filterTagsRegexReject = CompileTagFilters(config.FilterTagsRegexReject);
         _ignoreResources = CompilePatterns(config.IgnoreResources);
     }
 
@@ -61,9 +62,9 @@ internal sealed class TraceFilter
             }
         }
 
-        foreach (var pattern in _filterTagsRegexReject)
+        foreach (var filter in _filterTagsRegexReject)
         {
-            if (MatchesRegexFilter(rootSpan, pattern))
+            if (MatchesRegexTagFilter(rootSpan, filter))
             {
                 return false;
             }
@@ -78,9 +79,9 @@ internal sealed class TraceFilter
             }
         }
 
-        foreach (var pattern in _filterTagsRegexRequire)
+        foreach (var filter in _filterTagsRegexRequire)
         {
-            if (!MatchesRegexFilter(rootSpan, pattern))
+            if (!MatchesRegexTagFilter(rootSpan, filter))
             {
                 return false;
             }
@@ -108,12 +109,13 @@ internal sealed class TraceFilter
     }
 
     /// <summary>
-    /// Matches a regex filter against span tags.
-    /// The regex is matched against the "key:value" string of each tag.
+    /// Matches a regex tag filter against span tags.
+    /// Per the spec, patterns are either "key_pattern" (matches any tag whose key matches)
+    /// or "key_pattern:value_pattern" (both key and value must match their respective patterns).
     /// </summary>
-    private static bool MatchesRegexFilter(Span span, Regex pattern)
+    private static bool MatchesRegexTagFilter(Span span, RegexTagFilter filter)
     {
-        var processor = new RegexTagMatchProcessor(pattern);
+        var processor = new RegexTagFilterProcessor(filter);
         span.Tags.EnumerateTags(ref processor);
         return processor.Matched;
     }
@@ -137,22 +139,84 @@ internal sealed class TraceFilter
         return compiled;
     }
 
-    private struct RegexTagMatchProcessor : IItemProcessor<string>
+    /// <summary>
+    /// Parses regex filter patterns into structured filters that match key and value separately.
+    /// Format: "key_pattern" (key-only) or "key_pattern:value_pattern" (key and value).
+    /// </summary>
+    private static List<RegexTagFilter> CompileTagFilters(List<string>? patterns)
     {
-        private readonly Regex _pattern;
+        if (patterns is null or { Count: 0 })
+        {
+            return [];
+        }
+
+        var filters = new List<RegexTagFilter>(patterns.Count);
+        foreach (var pattern in patterns)
+        {
+            if (string.IsNullOrEmpty(pattern))
+            {
+                continue;
+            }
+
+            var colonIndex = pattern.IndexOf(':');
+            if (colonIndex < 0)
+            {
+                // Key-only pattern: matches any tag whose key matches
+                filters.Add(new RegexTagFilter(
+                    new Regex(pattern, RegexOptions.Compiled, matchTimeout: TimeSpan.FromSeconds(1)),
+                    valuePattern: null));
+            }
+            else
+            {
+                // key_pattern:value_pattern — both must match
+                var keyPart = pattern.Substring(0, colonIndex);
+                var valuePart = pattern.Substring(colonIndex + 1);
+                filters.Add(new RegexTagFilter(
+                    new Regex(keyPart, RegexOptions.Compiled, matchTimeout: TimeSpan.FromSeconds(1)),
+                    new Regex(valuePart, RegexOptions.Compiled, matchTimeout: TimeSpan.FromSeconds(1))));
+            }
+        }
+
+        return filters;
+    }
+
+    /// <summary>
+    /// A parsed regex tag filter with separate key and optional value patterns.
+    /// </summary>
+    private readonly struct RegexTagFilter
+    {
+        public readonly Regex KeyPattern;
+        public readonly Regex? ValuePattern;
+
+        public RegexTagFilter(Regex keyPattern, Regex? valuePattern)
+        {
+            KeyPattern = keyPattern;
+            ValuePattern = valuePattern;
+        }
+    }
+
+    private struct RegexTagFilterProcessor : IItemProcessor<string>
+    {
+        private readonly RegexTagFilter _filter;
         public bool Matched;
 
-        public RegexTagMatchProcessor(Regex pattern)
+        public RegexTagFilterProcessor(RegexTagFilter filter)
         {
-            _pattern = pattern;
+            _filter = filter;
             Matched = false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Process(TagItem<string> item)
         {
             if (!Matched && item.Value is not null)
             {
-                Matched = _pattern.IsMatch($"{item.Key}:{item.Value}");
+                if (_filter.KeyPattern.IsMatch(item.Key))
+                {
+                    // Key-only filter: any matching key is sufficient
+                    // Key:Value filter: value must also match
+                    Matched = _filter.ValuePattern is null || _filter.ValuePattern.IsMatch(item.Value);
+                }
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/TraceFilter.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/TraceFilter.cs
@@ -20,19 +20,54 @@ namespace Datadog.Trace.Agent.TraceSamplers;
 /// </summary>
 internal sealed class TraceFilter
 {
-    private readonly List<string> _filterTagsRequire;
-    private readonly List<string> _filterTagsReject;
+    private readonly List<string> _filterTagKeysRequire;
+    private readonly List<KeyValuePair<string, string>> _filterTagKeyValuesRequire;
+    private readonly List<string> _filterTagKeysReject;
+    private readonly List<KeyValuePair<string, string>> _filterTagKeyValuesReject;
     private readonly List<RegexTagFilter> _filterTagsRegexRequire;
     private readonly List<RegexTagFilter> _filterTagsRegexReject;
     private readonly List<Regex> _ignoreResources;
+    private readonly bool _hasFilters;
 
     public TraceFilter(AgentTraceFilterConfig config)
     {
-        _filterTagsRequire = config.FilterTagsRequire ?? [];
-        _filterTagsReject = config.FilterTagsReject ?? [];
+        BuildFilterTags(config.FilterTagsRequire, out _filterTagKeysRequire, out _filterTagKeyValuesRequire);
+        BuildFilterTags(config.FilterTagsReject, out _filterTagKeysReject, out _filterTagKeyValuesReject);
         _filterTagsRegexRequire = CompileTagFilters(config.FilterTagsRegexRequire);
         _filterTagsRegexReject = CompileTagFilters(config.FilterTagsRegexReject);
         _ignoreResources = CompilePatterns(config.IgnoreResources);
+
+        // Short circuit because these are _relatively_ rare, so we can avoid all the work if needs be
+        _hasFilters = _filterTagKeysRequire.Count > 0
+                   || _filterTagKeyValuesRequire.Count > 0
+                   || _filterTagKeysReject.Count > 0
+                   || _filterTagKeyValuesReject.Count > 0
+                   || _filterTagsRegexRequire.Count > 0
+                   || _filterTagsRegexReject.Count > 0
+                   || _ignoreResources.Count > 0;
+
+        static void BuildFilterTags(List<string>? filters, out List<string> keyFilters, out List<KeyValuePair<string, string>> keyValueFilters)
+        {
+            keyFilters = [];
+            keyValueFilters = [];
+            if (filters is not null)
+            {
+                foreach (var filter in filters)
+                {
+                    var colonIndex = filter.IndexOf(':');
+                    if (colonIndex < 0)
+                    {
+                        keyFilters.Add(filter);
+                    }
+                    else
+                    {
+                        var key = filter.Substring(0, colonIndex);
+                        var value = filter.Substring(colonIndex + 1);
+                        keyValueFilters.Add(new(key, value));
+                    }
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -41,6 +76,11 @@ internal sealed class TraceFilter
     /// </summary>
     public bool ShouldKeepTrace(Span rootSpan)
     {
+        if (!_hasFilters)
+        {
+            return true;
+        }
+
         // 1. Resource filtering: reject if resource matches any ignore_resources pattern
         if (_ignoreResources.Count > 0 && !string.IsNullOrEmpty(rootSpan.ResourceName))
         {
@@ -53,10 +93,20 @@ internal sealed class TraceFilter
             }
         }
 
-        // 2. Reject filtering: reject if any tag matches reject filters
-        foreach (var filter in _filterTagsReject)
+        // 2a. Reject filtering: reject if any tag matches reject filters
+        foreach (var filter in _filterTagKeysReject)
         {
-            if (MatchesExactFilter(rootSpan, filter))
+            // Key-only filter: matches if tag key exists with any value
+            if (rootSpan.GetTag(filter) is not null)
+            {
+                return false;
+            }
+        }
+
+        foreach (var filter in _filterTagKeyValuesReject)
+        {
+            // Key-Value filter: matches if tag key exists with specific value
+            if (rootSpan.GetTag(filter.Key) == filter.Value)
             {
                 return false;
             }
@@ -71,9 +121,19 @@ internal sealed class TraceFilter
         }
 
         // 3. Require filtering: ALL require filters must match
-        foreach (var filter in _filterTagsRequire)
+        foreach (var filter in _filterTagKeysRequire)
         {
-            if (!MatchesExactFilter(rootSpan, filter))
+            // Key-only filter: matches if tag key exists with any value
+            if (rootSpan.GetTag(filter) is null)
+            {
+                return false;
+            }
+        }
+
+        foreach (var filter in _filterTagKeyValuesRequire)
+        {
+            // Key-Value filter: matches if tag key exists with specific value
+            if (rootSpan.GetTag(filter.Key) != filter.Value)
             {
                 return false;
             }
@@ -88,24 +148,6 @@ internal sealed class TraceFilter
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Matches an exact filter against span tags.
-    /// Filter format: "key" (matches any tag with this key) or "key:value" (matches specific key-value).
-    /// </summary>
-    private static bool MatchesExactFilter(Span span, string filter)
-    {
-        var colonIndex = filter.IndexOf(':');
-        if (colonIndex < 0)
-        {
-            // Key-only filter: matches if tag key exists with any value
-            return span.GetTag(filter) is not null;
-        }
-
-        var key = filter.Substring(0, colonIndex);
-        var value = filter.Substring(colonIndex + 1);
-        return span.GetTag(key) == value;
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/TraceFilter.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/TraceFilter.cs
@@ -1,0 +1,159 @@
+// <copyright file="TraceFilter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.Agent.TraceSamplers;
+
+/// <summary>
+/// Evaluates trace-level filtering rules received from the agent's /info endpoint.
+/// Filters are applied to the root span only, before stats computation.
+/// </summary>
+internal sealed class TraceFilter
+{
+    private readonly List<string> _filterTagsRequire;
+    private readonly List<string> _filterTagsReject;
+    private readonly List<Regex> _filterTagsRegexRequire;
+    private readonly List<Regex> _filterTagsRegexReject;
+    private readonly List<Regex> _ignoreResources;
+
+    public TraceFilter(AgentTraceFilterConfig config)
+    {
+        _filterTagsRequire = config.FilterTagsRequire ?? [];
+        _filterTagsReject = config.FilterTagsReject ?? [];
+        _filterTagsRegexRequire = CompilePatterns(config.FilterTagsRegexRequire);
+        _filterTagsRegexReject = CompilePatterns(config.FilterTagsRegexReject);
+        _ignoreResources = CompilePatterns(config.IgnoreResources);
+    }
+
+    /// <summary>
+    /// Returns true if the trace should be kept, false if it should be rejected.
+    /// Evaluation is based on the root span only.
+    /// </summary>
+    public bool ShouldKeepTrace(Span rootSpan)
+    {
+        // 1. Resource filtering: reject if resource matches any ignore_resources pattern
+        if (_ignoreResources.Count > 0 && !string.IsNullOrEmpty(rootSpan.ResourceName))
+        {
+            foreach (var pattern in _ignoreResources)
+            {
+                if (pattern.IsMatch(rootSpan.ResourceName))
+                {
+                    return false;
+                }
+            }
+        }
+
+        // 2. Reject filtering: reject if any tag matches reject filters
+        foreach (var filter in _filterTagsReject)
+        {
+            if (MatchesExactFilter(rootSpan, filter))
+            {
+                return false;
+            }
+        }
+
+        foreach (var pattern in _filterTagsRegexReject)
+        {
+            if (MatchesRegexFilter(rootSpan, pattern))
+            {
+                return false;
+            }
+        }
+
+        // 3. Require filtering: ALL require filters must match
+        foreach (var filter in _filterTagsRequire)
+        {
+            if (!MatchesExactFilter(rootSpan, filter))
+            {
+                return false;
+            }
+        }
+
+        foreach (var pattern in _filterTagsRegexRequire)
+        {
+            if (!MatchesRegexFilter(rootSpan, pattern))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Matches an exact filter against span tags.
+    /// Filter format: "key" (matches any tag with this key) or "key:value" (matches specific key-value).
+    /// </summary>
+    private static bool MatchesExactFilter(Span span, string filter)
+    {
+        var colonIndex = filter.IndexOf(':');
+        if (colonIndex < 0)
+        {
+            // Key-only filter: matches if tag key exists with any value
+            return span.GetTag(filter) is not null;
+        }
+
+        var key = filter.Substring(0, colonIndex);
+        var value = filter.Substring(colonIndex + 1);
+        return span.GetTag(key) == value;
+    }
+
+    /// <summary>
+    /// Matches a regex filter against span tags.
+    /// The regex is matched against the "key:value" string of each tag.
+    /// </summary>
+    private static bool MatchesRegexFilter(Span span, Regex pattern)
+    {
+        var processor = new RegexTagMatchProcessor(pattern);
+        span.Tags.EnumerateTags(ref processor);
+        return processor.Matched;
+    }
+
+    private static List<Regex> CompilePatterns(List<string>? patterns)
+    {
+        if (patterns is null or { Count: 0 })
+        {
+            return [];
+        }
+
+        var compiled = new List<Regex>(patterns.Count);
+        foreach (var pattern in patterns)
+        {
+            if (!string.IsNullOrEmpty(pattern))
+            {
+                compiled.Add(new Regex(pattern, RegexOptions.Compiled, matchTimeout: TimeSpan.FromSeconds(1)));
+            }
+        }
+
+        return compiled;
+    }
+
+    private struct RegexTagMatchProcessor : IItemProcessor<string>
+    {
+        private readonly Regex _pattern;
+        public bool Matched;
+
+        public RegexTagMatchProcessor(Regex pattern)
+        {
+            _pattern = pattern;
+            Matched = false;
+        }
+
+        public void Process(TagItem<string> item)
+        {
+            if (!Matched && item.Value is not null)
+            {
+                Matched = _pattern.IsMatch($"{item.Key}:{item.Value}");
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/ManagedTraceExporter.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/ManagedTraceExporter.cs
@@ -83,10 +83,10 @@ internal sealed class ManagedTraceExporter : IApi, IDisposable
             ?? Task.FromResult(false);
     }
 
-    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
+    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion = 0)
     {
         // Handle shutdown scenario where api is null
-        return Volatile.Read(ref _current)?.SendStatsAsync(stats, bucketDuration) ?? Task.FromResult(false);
+        return Volatile.Read(ref _current)?.SendStatsAsync(stats, bucketDuration, tracerObfuscationVersion) ?? Task.FromResult(false);
     }
 
     // Internal for testing

--- a/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/TraceExporter.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/TraceExporter.cs
@@ -1,4 +1,4 @@
-// <copyright file="TraceExporter.cs" company="Datadog">
+﻿// <copyright file="TraceExporter.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -91,7 +91,7 @@ internal sealed class TraceExporter : SafeHandle, IApi
         }
     }
 
-    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
+    public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
     {
         _log.Debug("No-op: stats computation happens in the data pipeline.");
         return Task.FromResult(true);

--- a/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
@@ -23,7 +23,14 @@ namespace Datadog.Trace.Processors
         static ObfuscatorTraceProcessor()
         {
             var numericLiterals = new[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '+', '.' };
-            var splitterChars = new[] { ',', '(', ')', '|' };
+            // Operator characters must act as token splitters to match the Go agent's SQL obfuscation
+            // behavior (DataDog/go-sqllexer isOperator function). Without these, queries like
+            // WHERE id='1' (no spaces around =) won't have their literals replaced with ?.
+            // See: https://github.com/DataDog/go-sqllexer/blob/main/sqllexer_utils.go
+            // Note: '+' and '-' are excluded because they are already in numericLiteralPrefix
+            // and adding them as splitters would break negative number obfuscation (e.g., col > -123).
+            // The Go lexer handles this with look-ahead logic that our simpler approach can't replicate.
+            var splitterChars = new[] { ',', '(', ')', '|', '*', '/', '=', '<', '>', '!', '&', '^', '%', '~', '?', '@', ':', '#' };
 
             foreach (var c in numericLiterals)
             {

--- a/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
@@ -7,8 +7,10 @@
 
 using System;
 using System.Collections;
+using System.Text;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Processors
 {
@@ -129,7 +131,10 @@ namespace Datadog.Trace.Processors
 
                 if (modified)
                 {
-                    return new string(sqlChars, 0, outputLength);
+                    // The Go agent normalizes SQL by adding spaces between tokens (via go-sqllexer's
+                    // Normalizer). After replacing literals with ?, ensure spaces exist around operator
+                    // characters adjacent to ? so that e.g. "id='1'" becomes "id = ?" not "id=?".
+                    return NormalizeAroundPlaceholders(sqlChars, outputLength);
                 }
             }
             catch (Exception ex)
@@ -188,6 +193,62 @@ namespace Datadog.Trace.Processors
         {
             return NumericLiteralPrefix.Get(Convert.ToByte(c));
         }
+
+        /// <summary>
+        /// Scans forward through the obfuscated SQL, and when it encounters a run of comparison
+        /// operators (=, &lt;, &gt;, !) immediately followed by ?, it ensures spaces exist
+        /// around the operator run. For example, "id=?" becomes "id = ?" and "col&lt;>?" becomes "col &lt;> ?".
+        /// This matches the Go agent's go-sqllexer Normalizer, which adds spaces between all tokens.
+        /// Limited to comparison operators to avoid disrupting concatenation (||?||) and arithmetic patterns.
+        /// </summary>
+        private static string NormalizeAroundPlaceholders(char[] sqlChars, int length)
+        {
+            StringBuilder? sb = null;
+
+            for (var i = 0; i < length; i++)
+            {
+                if (IsComparisonOperator(sqlChars[i]))
+                {
+                    var opStart = i;
+                    var opEnd = i + 1;
+                    while (opEnd < length && IsComparisonOperator(sqlChars[opEnd]))
+                    {
+                        opEnd++;
+                    }
+
+                    if (opEnd < length && sqlChars[opEnd] == '?')
+                    {
+                        // Lazily allocate StringBuilder on first normalization needed,
+                        // copying everything we've already scanned past.
+                        if (sb is null)
+                        {
+                            sb = StringBuilderCache.Acquire();
+                            sb.Append(sqlChars, 0, i);
+                        }
+
+                        // Add space before operator if needed
+                        if (sb.Length > 0 && sb[sb.Length - 1] != ' ')
+                        {
+                            sb.Append(' ');
+                        }
+
+                        // Append the operator chars and a trailing space before ?
+                        sb.Append(sqlChars, opStart, opEnd - opStart);
+                        sb.Append(' ');
+
+                        i = opEnd - 1; // loop will increment to opEnd (the '?')
+                        continue;
+                    }
+                }
+
+                sb?.Append(sqlChars[i]);
+            }
+
+            return sb is null ? new string(sqlChars, 0, length) : StringBuilderCache.GetStringAndRelease(sb);
+        }
+
+        private static bool IsComparisonOperator(char c)
+            => c is '=' or '<' or '>' or '!';
 
         private static bool IsQuoted(char[] sqlChars, int start, int end)
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/MockApi.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockApi.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.TestHelpers
             return Task.FromResult(true);
         }
 
-        public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
+        public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
         {
             throw new NotImplementedException();
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1082,7 +1082,7 @@ namespace Datadog.Trace.TestHelpers
             public bool ClientDropP0s { get; set; } = true;
 
             [JsonProperty("version")]
-            public string AgentVersion { get; set; }
+            public string AgentVersion { get; set; } = "7.65.0";
 
             [JsonProperty("span_meta_structs")]
             public bool SpanMetaStructs { get; set; } = true;

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1089,6 +1089,9 @@ namespace Datadog.Trace.TestHelpers
 
             [JsonProperty("span_events")]
             public bool SpanEvents { get; set; } = false;
+
+            [JsonProperty("obfuscation_version")]
+            public int ObfuscationVersion { get; set; } = 1;
         }
 
         public class TcpUdpAgent : MockTracerAgent

--- a/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
@@ -53,7 +53,7 @@ public class MockClientGroupedStats
     public string SpanKind { get; set; }
 
     [Key("IsTraceRoot")]
-    public bool IsTraceRoot { get; set; }
+    public int IsTraceRoot { get; set; }
 
     [Key("HTTPMethod")]
     public string HttpMethod { get; set; }

--- a/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
@@ -49,6 +49,24 @@ public class MockClientGroupedStats
     [Key("TopLevelHits")]
     public long TopLevelHits { get; set; }
 
+    [Key("SpanKind")]
+    public string SpanKind { get; set; }
+
+    [Key("IsTraceRoot")]
+    public bool IsTraceRoot { get; set; }
+
+    [Key("HTTPMethod")]
+    public string HttpMethod { get; set; }
+
+    [Key("HTTPEndpoint")]
+    public string HttpEndpoint { get; set; }
+
+    [Key("GRPCStatusCode")]
+    public int GrpcStatusCode { get; set; }
+
     [Key("srv_src")]
     public string ServiceSource { get; set; }
+
+    [Key("PeerTags")]
+    public string[] PeerTags { get; set; }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
@@ -62,7 +62,7 @@ public class MockClientGroupedStats
     public string HttpEndpoint { get; set; }
 
     [Key("GRPCStatusCode")]
-    public int GrpcStatusCode { get; set; }
+    public string GrpcStatusCode { get; set; }
 
     [Key("srv_src")]
     public string ServiceSource { get; set; }

--- a/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientStatsPayload.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientStatsPayload.cs
@@ -41,6 +41,9 @@ namespace Datadog.Trace.TestHelpers.Stats
         [Key("Service")]
         public string Service { get; set; }
 
+        [Key("GitCommitSha")]
+        public string GitCommitSha { get; set; }
+
         [Key("Stats")]
         public List<MockClientStatsBucket> Stats { get; set; }
     }

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -606,6 +606,12 @@ namespace Datadog.Trace.Tests.Agent
             public SpanCollection ProcessTrace(in SpanCollection trace) => processTrace(trace);
 
             public Task DisposeAsync() => Task.CompletedTask;
+
+            public StatsAggregationKey BuildKey(Span span, out List<byte[]> utf8PeerTags)
+            {
+                utf8PeerTags = [];
+                return new();
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
@@ -246,7 +246,8 @@ namespace Datadog.Trace.Tests.Agent
 
             await api.SendStatsAsync(statsBuffer, 1, 0);
 
-            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Exactly(5));
+            // Stats are fire-and-forget (no retries per CSS v1.3.0 spec), so only 1 attempt
+            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Once());
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
@@ -221,7 +221,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var statsBuffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
 
-            await api.SendStatsAsync(statsBuffer, 1);
+            await api.SendStatsAsync(statsBuffer, 1, 0);
 
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Once());
         }
@@ -244,7 +244,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var statsBuffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
 
-            await api.SendStatsAsync(statsBuffer, 1);
+            await api.SendStatsAsync(statsBuffer, 1, 0);
 
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Exactly(5));
         }

--- a/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
@@ -246,7 +246,7 @@ namespace Datadog.Trace.Tests.Agent
 
             await api.SendStatsAsync(statsBuffer, 1, 0);
 
-            // Stats are fire-and-forget (no retries per CSS v1.3.0 spec), so only 1 attempt
+            // Stats are fire-and-forget (no retries per CSS v1.2.0 spec), so only 1 attempt
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Once());
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
@@ -58,7 +59,7 @@ namespace Datadog.Trace.Tests.Agent
                 while (stopwatch.Elapsed.Minutes < 1)
                 {
                     // Flush is not called if no spans are processed
-                    aggregator.Add(new Span(new SpanContext(1, 1), DateTime.UtcNow));
+                    aggregator.Add(CreateTopLevelSpan(DateTime.UtcNow));
 
                     if (mutex.Wait(TimeSpan.FromMilliseconds(100)))
                     {
@@ -87,7 +88,7 @@ namespace Datadog.Trace.Tests.Agent
             // Dispose immediately to make Flush complete without delay
             await aggregator.DisposeAsync();
 
-            aggregator.Add(new Span(new SpanContext(1, 2), DateTimeOffset.UtcNow));
+            aggregator.Add(CreateTopLevelSpan(DateTimeOffset.UtcNow));
 
             await aggregator.Flush();
 
@@ -112,7 +113,6 @@ namespace Datadog.Trace.Tests.Agent
             const long durationMs = 100;
             const long duration = durationMs * millisecondsToNanoseconds;
 
-            ulong id = 0;
             var start = DateTimeOffset.UtcNow;
 
             var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
@@ -120,25 +120,25 @@ namespace Datadog.Trace.Tests.Agent
             try
             {
                 // Baseline
-                var baselineSpan = CreateSpan(id++, start, durationMs);
+                var baselineSpan = CreateSpan(start, durationMs);
 
                 // Unique Name (Operation)
-                var operationSpan = CreateSpan(id++, start, durationMs, operationName: "unique-name");
+                var operationSpan = CreateSpan(start, durationMs, operationName: "unique-name");
 
                 // Unique Resource
-                var resourceSpan = CreateSpan(id++, start, durationMs, resourceName: "unique-resource");
+                var resourceSpan = CreateSpan(start, durationMs, resourceName: "unique-resource");
 
                 // Unique Service
-                var serviceSpan = CreateSpan(id++, start, durationMs, serviceName: "unique-service");
+                var serviceSpan = CreateSpan(start, durationMs, serviceName: "unique-service");
 
                 // Unique Type
-                var typeSpan = CreateSpan(id++, start, durationMs, type: "unique-type");
+                var typeSpan = CreateSpan(start, durationMs, type: "unique-type");
 
                 // Unique Synthetics
-                var syntheticsSpan = CreateSpan(id++, start, durationMs, origin: "synthetics");
+                var syntheticsSpan = CreateSpan(start, durationMs, origin: "synthetics");
 
                 // Unique HTTP Status Code
-                var httpSpan = CreateSpan(id++, start, durationMs, httpStatusCode: "400");
+                var httpSpan = CreateSpan(start, durationMs, httpStatusCode: "400");
 
                 var spans = new Span[] { baselineSpan, operationSpan, resourceSpan, serviceSpan, typeSpan, syntheticsSpan, httpSpan };
                 aggregator.Add(spans);
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Tests.Agent
 
                 foreach (var span in spans)
                 {
-                    var key = StatsAggregator.BuildKey(span);
+                    var key = aggregator.BuildKey(span, out _);
                     buffer.Buckets.Should().ContainKey(key);
 
                     var bucket = buffer.Buckets[key];
@@ -168,13 +168,12 @@ namespace Datadog.Trace.Tests.Agent
                 await aggregator.DisposeAsync();
             }
 
-            Span CreateSpan(ulong id, DateTimeOffset start, long durationMs, string operationName = "name", string resourceName = "resource", string serviceName = "service", string type = "http", string httpStatusCode = "200", string origin = "rum")
+            Span CreateSpan(DateTimeOffset start, long durationMs, string operationName = "name", string resourceName = "resource", string serviceName = "service", string type = "http", string httpStatusCode = "200", string origin = "rum")
             {
-                var span = new Span(new SpanContext(id, id), start);
+                var span = CreateTopLevelSpan(start, serviceName);
                 span.SetDuration(TimeSpan.FromMilliseconds(durationMs));
 
                 span.ResourceName = resourceName;
-                span.SetService(serviceName, null);
                 span.OperationName = operationName;
                 span.Type = type;
                 span.SetTag(Tags.HttpStatusCode, httpStatusCode);
@@ -199,7 +198,7 @@ namespace Datadog.Trace.Tests.Agent
 
             try
             {
-                var parentSpan = new Span(new SpanContext(1, 1, serviceName: "service"), start);
+                var parentSpan = CreateTopLevelSpan(start, "service");
                 parentSpan.OperationName = "web.request";
                 parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
 
@@ -262,14 +261,14 @@ namespace Datadog.Trace.Tests.Agent
 
             try
             {
-                var simpleSpan = new Span(new SpanContext(1, 1, serviceName: "service"), start);
+                var simpleSpan = CreateTopLevelSpan(start, "service");
                 simpleSpan.SetDuration(TimeSpan.FromMilliseconds(100));
 
-                var parentSpan = new Span(new SpanContext(2, 2, serviceName: "service"), start);
+                var parentSpan = CreateTopLevelSpan(start, "service");
                 parentSpan.SetDuration(TimeSpan.FromMilliseconds(200));
 
                 // snapshotSpan shouldn't be recorded, because it has the PartialSnapshot metric (even though it is top-level)
-                var snapshotSpan = new Span(new SpanContext(5, 5, serviceName: "service"), start);
+                var snapshotSpan = CreateTopLevelSpan(start, "service");
                 snapshotSpan.SetMetric(Tags.PartialSnapshot, 1.0);
                 snapshotSpan.SetDuration(TimeSpan.FromMilliseconds(300));
 
@@ -283,7 +282,7 @@ namespace Datadog.Trace.Tests.Agent
 
                 buffer.Buckets.Should().HaveCount(2);
 
-                var serviceKey = StatsAggregator.BuildKey(simpleSpan);
+                var serviceKey = aggregator.BuildKey(simpleSpan, out _);
                 buffer.Buckets.Should().ContainKey(serviceKey);
                 var serviceBucket = buffer.Buckets[serviceKey];
 
@@ -297,7 +296,7 @@ namespace Datadog.Trace.Tests.Agent
                 serviceBucket.OkSummary.GetSum().Should().BeApproximately(
                     expectedOkDuration, expectedOkDuration * serviceBucket.OkSummary.IndexMapping.RelativeAccuracy);
 
-                var httpClientServiceKey = StatsAggregator.BuildKey(httpClientServiceSpan);
+                var httpClientServiceKey = aggregator.BuildKey(httpClientServiceSpan, out _);
                 buffer.Buckets.Should().ContainKey(httpClientServiceKey);
                 var httpClientServiceBucket = buffer.Buckets[httpClientServiceKey];
 
@@ -332,13 +331,13 @@ namespace Datadog.Trace.Tests.Agent
 
             try
             {
-                var success1Span = new Span(new SpanContext(1, 1, serviceName: "service"), start);
+                var success1Span = CreateTopLevelSpan(start, "service");
                 success1Span.SetDuration(TimeSpan.FromMilliseconds(100));
 
-                var success2Span = new Span(new SpanContext(2, 2, serviceName: "service"), start);
+                var success2Span = CreateTopLevelSpan(start, "service");
                 success2Span.SetDuration(TimeSpan.FromMilliseconds(200));
 
-                var errorSpan = new Span(new SpanContext(3, 3, serviceName: "service"), start);
+                var errorSpan = CreateTopLevelSpan(start, "service");
                 errorSpan.Error = true;
                 errorSpan.SetDuration(TimeSpan.FromMilliseconds(400));
 
@@ -379,7 +378,7 @@ namespace Datadog.Trace.Tests.Agent
                 var durations = new double[sampleCount];
                 for (int i = 0; i < sampleCount; i++)
                 {
-                    var span = new Span(new SpanContext((ulong)i, (ulong)i, serviceName: "service"), start);
+                    var span = CreateTopLevelSpan(start, "service");
                     var duration = TimeSpan.FromMilliseconds(i * 100);
 
                     span.SetDuration(duration);
@@ -456,6 +455,321 @@ namespace Datadog.Trace.Tests.Agent
             aggregator.ShouldKeepTrace(traceChunk).Should().BeFalse();
         }
 
+        [Fact]
+        public async Task SpanKindEligibility_ServerAndClientSpansAreIncluded()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                var parentSpan = CreateTopLevelSpan(start, "service");
+                parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // Child span with span.kind = "server" — should be included even though not top-level
+                var serverChildSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(new StubDatadogTracer()), "service"), start);
+                serverChildSpan.SetTag(Tags.SpanKind, SpanKinds.Server);
+                serverChildSpan.OperationName = "server.child";
+                serverChildSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // Child span with span.kind = "client" — should be included
+                var clientChildSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(new StubDatadogTracer()), "service"), start);
+                clientChildSpan.SetTag(Tags.SpanKind, SpanKinds.Client);
+                clientChildSpan.OperationName = "client.child";
+                clientChildSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // Child span with span.kind = "internal" — should NOT be included
+                var internalChildSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(new StubDatadogTracer()), "service"), start);
+                internalChildSpan.SetTag(Tags.SpanKind, SpanKinds.Internal);
+                internalChildSpan.OperationName = "internal.child";
+                internalChildSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // Child span with no span.kind — should NOT be included
+                var noKindChildSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(new StubDatadogTracer()), "service"), start);
+                noKindChildSpan.OperationName = "nokind.child";
+                noKindChildSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(parentSpan, serverChildSpan, clientChildSpan, internalChildSpan, noKindChildSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+
+                // parent, server child, client child are included; internal and no-kind are not
+                buffer.Buckets.Should().HaveCount(3);
+                buffer.Buckets.Should().ContainKey(aggregator.BuildKey(parentSpan, out _));
+                buffer.Buckets.Should().ContainKey(aggregator.BuildKey(serverChildSpan, out _));
+                buffer.Buckets.Should().ContainKey(aggregator.BuildKey(clientChildSpan, out _));
+                buffer.Buckets.Should().NotContainKey(aggregator.BuildKey(internalChildSpan, out _));
+                buffer.Buckets.Should().NotContainKey(aggregator.BuildKey(noKindChildSpan, out _));
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task SpanKindCreatesDistinctBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                // Two top-level spans identical except span.kind
+                var clientSpan = CreateTopLevelSpan(start, "service");
+                clientSpan.OperationName = "op";
+                clientSpan.SetTag(Tags.SpanKind, SpanKinds.Client);
+                clientSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var serverSpan = CreateTopLevelSpan(start, "service");
+                serverSpan.OperationName = "op";
+                serverSpan.SetTag(Tags.SpanKind, SpanKinds.Server);
+                serverSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(clientSpan, serverSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(2);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task IsTraceRootCreatesDistinctBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                // Span A: no parent (IsTraceRoot = true)
+                var rootSpan = CreateTopLevelSpan(start, "svc");
+                rootSpan.OperationName = "op";
+                rootSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // Span B: has a parent from a different trace (IsTraceRoot = false, but IsTopLevel = true via service boundary)
+                var upstreamContext = new SpanContext(traceId: 2, spanId: 999, serviceName: "upstream-svc");
+                var entrySpan = new Span(new SpanContext(upstreamContext, new TraceContext(new StubDatadogTracer()), "svc"), start);
+                entrySpan.OperationName = "op";
+                entrySpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(rootSpan, entrySpan);
+
+                var buffer = aggregator.CurrentBuffer;
+                // They have the same resource/operation/type but different IsTraceRoot → 2 buckets
+                buffer.Buckets.Should().HaveCount(2);
+
+                var rootKey = aggregator.BuildKey(rootSpan, out _);
+                var entryKey = aggregator.BuildKey(entrySpan, out _);
+                rootKey.IsTraceRoot.Should().BeTrue();
+                entryKey.IsTraceRoot.Should().BeFalse();
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task HttpMethodCreatesDistinctBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                var getSpan = CreateTopLevelSpan(start, "svc");
+                getSpan.OperationName = "http.request";
+                getSpan.SetTag(Tags.HttpMethod, "GET");
+                getSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var postSpan = CreateTopLevelSpan(start, "svc");
+                postSpan.OperationName = "http.request";
+                postSpan.SetTag(Tags.HttpMethod, "POST");
+                postSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(getSpan, postSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(2);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task HttpEndpointCreatesDistinctBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                var usersSpan = CreateTopLevelSpan(start, "svc");
+                usersSpan.OperationName = "http.request";
+                usersSpan.SetTag(Tags.HttpRoute, "/users/{id}");
+                usersSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var ordersSpan = CreateTopLevelSpan(start, "svc");
+                ordersSpan.OperationName = "http.request";
+                ordersSpan.SetTag(Tags.HttpRoute, "/orders/{id}");
+                ordersSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(usersSpan, ordersSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(2);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task GrpcStatusCodeCreatesDistinctBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                var okSpan = CreateTopLevelSpan(start, "svc");
+                okSpan.OperationName = "grpc.call";
+                okSpan.SetTag(Tags.GrpcStatusCode, "0");
+                okSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var errorSpan = CreateTopLevelSpan(start, "svc");
+                errorSpan.OperationName = "grpc.call";
+                errorSpan.SetTag(Tags.GrpcStatusCode, "2");
+                errorSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(okSpan, errorSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(2);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task ServiceSourceCreatesDistinctBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                var span1 = CreateTopLevelSpan(start, "svc");
+                span1.OperationName = "op";
+                span1.SetTag(Tags.ServiceNameSource, "integration");
+                span1.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var span2 = CreateTopLevelSpan(start, "svc");
+                span2.OperationName = "op";
+                span2.SetTag(Tags.ServiceNameSource, "user");
+                span2.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(span1, span2);
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(2);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task SamplingWeightIsApplied()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                // Span with sampling rate 0.1 → weight = 1/0.1 = 10
+                // GetWeight uses TraceContext.AppliedSamplingRate
+                var sampledTraceContext = new TraceContext(new StubDatadogTracer());
+                sampledTraceContext.AppliedSamplingRate = 0.1f;
+                var sampledSpan = new Span(new SpanContext(null, sampledTraceContext, "svc"), start);
+                sampledSpan.OperationName = "op";
+                sampledSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // Span with no sampling rate → weight = 1.0
+                var unweightedSpan = CreateTopLevelSpan(start, "svc2");
+                unweightedSpan.OperationName = "op";
+                unweightedSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(sampledSpan, unweightedSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+                var sampledKey = aggregator.BuildKey(sampledSpan, out _);
+                var unweightedKey = aggregator.BuildKey(unweightedSpan, out _);
+
+                buffer.Buckets[sampledKey].Hits.Should().BeApproximately(10.0, 0.001);
+                buffer.Buckets[unweightedKey].Hits.Should().BeApproximately(1.0, 0.001);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task PeerTagsCreateDistinctBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), new StubDiscoveryService(), isOtlp: false);
+
+            try
+            {
+                // Two client spans with same resource but different peer.service values
+                // Use Tags.SetTag directly to avoid PeerService special handling in Span.SetTag that requires TraceContext
+                var span1 = CreateTopLevelSpan(start, "svc");
+                span1.OperationName = "http.client";
+                span1.SetTag(Tags.SpanKind, SpanKinds.Client);
+                span1.Tags.SetTag(Tags.PeerService, "service-a");
+                span1.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var span2 = CreateTopLevelSpan(start, "svc");
+                span2.OperationName = "http.client";
+                span2.SetTag(Tags.SpanKind, SpanKinds.Client);
+                span2.Tags.SetTag(Tags.PeerService, "service-b");
+                span2.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(span1, span2);
+
+                var buffer = aggregator.CurrentBuffer;
+                // Different peer.service → 2 distinct buckets
+                buffer.Buckets.Should().HaveCount(2);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        /// Creates a top-level span with a TraceContext (required by GetWeight).
+        /// </summary>
+        private static Span CreateTopLevelSpan(DateTimeOffset start, string serviceName = null)
+        {
+            var tracer = new StubDatadogTracer();
+            var traceContext = new TraceContext(tracer);
+            var context = new SpanContext(null, traceContext, serviceName);
+            return new Span(context, start);
+        }
+
         private static TracerSettings GetSettings(int? statsComputationIntervalSeconds = null)
         {
             var settings = statsComputationIntervalSeconds.HasValue
@@ -501,7 +815,9 @@ namespace Datadog.Trace.Tests.Agent
                              containerTagsHash: "containerTagsHash",
                              clientDropP0: true,
                              spanMetaStructs: true,
-                             spanEvents: true));
+                             spanEvents: true,
+                             peerTags: [Tags.PeerService],
+                             spanKindsStatsComputed: [SpanKinds.Client, SpanKinds.Server, SpanKinds.Producer, SpanKinds.Consumer]));
             }
 
             public void RemoveSubscription(Action<AgentConfiguration> callback)

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -127,6 +127,36 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public async Task IdleFlush_StillResetsStartTimestamp()
+        {
+            var api = new Mock<IApi>();
+            var aggregator = new StatsAggregator(api.Object, GetSettings(), new StubDiscoveryService(), isOtlp: false);
+            await aggregator.DisposeAsync();
+
+            // Add a span and flush to populate the buffer
+            aggregator.Add(CreateTopLevelSpan(DateTimeOffset.UtcNow));
+            await aggregator.Flush();
+            api.Reset();
+
+            // Record the Start timestamp after the first flush (buffer was swapped, so
+            // the "current" buffer is the one that will receive new spans next).
+            var buffer = aggregator.CurrentBuffer;
+            var startAfterFirstFlush = buffer.Start;
+
+            // Flush with no new spans — no API call, but Reset must still run to
+            // re-align Start and prune stale keys.
+            await aggregator.Flush();
+
+            // The buffer has been swapped again; grab the one that was just flushed.
+            // After the second flush, the buffer that was "current" has been reset.
+            // Its Start should have been updated (re-aligned to the current 10s boundary).
+            // Because at least a few nanoseconds have elapsed, or at the very least the
+            // stale keys from the first flush should have been pruned.
+            buffer.Start.Should().BeGreaterOrEqualTo(startAfterFirstFlush);
+            buffer.Buckets.Should().BeEmpty("stale keys with zero hits should be pruned by Reset");
+        }
+
+        [Fact]
         public async Task CreatesDistinctBuckets_TS003()
         {
             const int millisecondsToNanoseconds = 1_000_000;

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -748,12 +748,12 @@ namespace Datadog.Trace.Tests.Agent
             {
                 var span1 = CreateTopLevelSpan(start, "svc");
                 span1.OperationName = "op";
-                span1.SetTag(Tags.ServiceNameSource, "integration");
+                span1.Context.ServiceNameSource = "integration";
                 span1.SetDuration(TimeSpan.FromMilliseconds(100));
 
                 var span2 = CreateTopLevelSpan(start, "svc");
                 span2.OperationName = "op";
-                span2.SetTag(Tags.ServiceNameSource, "user");
+                span2.Context.ServiceNameSource = "user";
                 span2.SetDuration(TimeSpan.FromMilliseconds(100));
 
                 aggregator.Add(span1, span2);

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -924,8 +924,7 @@ namespace Datadog.Trace.Tests.Agent
                              clientDropP0: true,
                              spanMetaStructs: true,
                              spanEvents: true,
-                             peerTags: [Tags.PeerService],
-                             spanKindsStatsComputed: [SpanKinds.Client, SpanKinds.Server, SpanKinds.Producer, SpanKinds.Consumer]));
+                             peerTags: [Tags.PeerService]));
             }
 
             public void RemoveSubscription(Action<AgentConfiguration> callback)

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -660,6 +660,64 @@ namespace Datadog.Trace.Tests.Agent
             }
         }
 
+        [Theory]
+        [InlineData("rpc.grpc.status_code", "5")]
+        [InlineData("grpc.code", "5")]
+        [InlineData("rpc.grpc.status.code", "5")]
+        [InlineData("grpc.status.code", "5")]
+        public async Task GrpcStatusCodeFallbackTags(string tagName, string tagValue)
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                var span = CreateTopLevelSpan(start, "svc");
+                span.OperationName = "grpc.call";
+                span.SetTag(tagName, tagValue);
+                span.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(span);
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(1);
+                var key = buffer.Buckets.Keys.First();
+                key.GrpcStatusCode.Should().Be(5);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task GrpcStatusCodePriorityOrder()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                // When multiple gRPC tags are present, the highest priority one wins
+                var span = CreateTopLevelSpan(start, "svc");
+                span.OperationName = "grpc.call";
+                span.SetTag("rpc.grpc.status_code", "1");
+                span.SetTag("grpc.status.code", "2");
+                span.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(span);
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(1);
+                var key = buffer.Buckets.Keys.First();
+                key.GrpcStatusCode.Should().Be(1);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
         [Fact]
         public async Task ServiceSourceCreatesDistinctBuckets()
         {

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -107,6 +107,26 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public async Task StaleBuckets_DoNotTriggerFlush()
+        {
+            var api = new Mock<IApi>();
+            var aggregator = new StatsAggregator(api.Object, GetSettings(), new StubDiscoveryService(), isOtlp: false);
+            await aggregator.DisposeAsync();
+
+            // Add a span and flush — this should send stats
+            aggregator.Add(CreateTopLevelSpan(DateTimeOffset.UtcNow));
+            await aggregator.Flush();
+            api.Verify(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), It.IsAny<long>(), It.IsAny<int>()), Times.Once);
+            api.Reset();
+
+            // Flush again with no new spans. The buffer still has stale keys (retained
+            // for DDSketch reuse) but with Hits == 0. This should NOT trigger a send,
+            // otherwise the agent receives an empty stats array.
+            await aggregator.Flush();
+            api.Verify(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), It.IsAny<long>(), It.IsAny<int>()), Times.Never);
+        }
+
+        [Fact]
         public async Task CreatesDistinctBuckets_TS003()
         {
             const int millisecondsToNanoseconds = 1_000_000;

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -682,7 +682,7 @@ namespace Datadog.Trace.Tests.Agent
                 var buffer = aggregator.CurrentBuffer;
                 buffer.Buckets.Should().HaveCount(1);
                 var key = buffer.Buckets.Keys.First();
-                key.GrpcStatusCode.Should().Be(5);
+                key.GrpcStatusCode.Should().Be("5");
             }
             finally
             {
@@ -710,7 +710,7 @@ namespace Datadog.Trace.Tests.Agent
                 var buffer = aggregator.CurrentBuffer;
                 buffer.Buckets.Should().HaveCount(1);
                 var key = buffer.Buckets.Keys.First();
-                key.GrpcStatusCode.Should().Be(1);
+                key.GrpcStatusCode.Should().Be("1");
             }
             finally
             {

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Tests.Agent
             int invocationCount = 0;
 
             var api = new Mock<IApi>();
-            api.Setup(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), bucketDuration.ToNanoseconds()))
+            api.Setup(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), bucketDuration.ToNanoseconds(), It.IsAny<int>()))
                 .Callback(
                     () =>
                     {
@@ -93,7 +93,7 @@ namespace Datadog.Trace.Tests.Agent
             await aggregator.Flush();
 
             // Make sure that SendStatsAsync was called
-            api.Verify(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), It.IsAny<long>()), Times.Once);
+            api.Verify(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), It.IsAny<long>(), It.IsAny<int>()), Times.Once);
             api.Reset();
 
             // Now the actual test
@@ -103,7 +103,7 @@ namespace Datadog.Trace.Tests.Agent
             await aggregator.Flush();
 
             // No span is pushed so SendStatsAsync shouldn't be called
-            api.Verify(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), It.IsAny<long>()), Times.Never);
+            api.Verify(a => a.SendStatsAsync(It.IsAny<StatsBuffer>(), It.IsAny<long>(), It.IsAny<int>()), Times.Never);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -76,6 +76,31 @@ namespace Datadog.Trace.Tests.Agent
             }
         }
 
+        [Theory]
+        [InlineData("7.65.0", true)]
+        [InlineData("7.66.0", true)]
+        [InlineData("8.0.0", true)]
+        [InlineData("7.64.0", false)]
+        [InlineData("7.64.99", false)]
+        [InlineData("7.0.0", false)]
+        [InlineData("not-a-version", true)]  // Unparseable versions don't block (e.g. test agents)
+        [InlineData(null, true)]              // Null version doesn't block
+        public async Task StatsComputation_RequiresMinimumAgentVersion(string agentVersion, bool expectedEnabled)
+        {
+            var api = new Mock<IApi>();
+            var discovery = new StubDiscoveryService(agentVersion);
+            var aggregator = new StatsAggregator(api.Object, GetSettings(), discovery, isOtlp: false);
+
+            try
+            {
+                aggregator.CanComputeStats.Should().Be(expectedEnabled);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
         [Fact]
         public async Task EmptyBuckets()
         {
@@ -904,7 +929,7 @@ namespace Datadog.Trace.Tests.Agent
             return ns << shift;
         }
 
-        private class StubDiscoveryService : IDiscoveryService
+        private class StubDiscoveryService(string agentVersion = "7.65.0") : IDiscoveryService
         {
             public void SubscribeToChanges(Action<AgentConfiguration> callback)
             {
@@ -914,7 +939,7 @@ namespace Datadog.Trace.Tests.Agent
                              debuggerV2Endpoint: "debuggerV2Endpoint",
                              diagnosticsEndpoint: "diagnosticsEndpoint",
                              symbolDbEndpoint: "symbolDbEndpoint",
-                             agentVersion: "agentVersion",
+                             agentVersion: agentVersion,
                              statsEndpoint: "traceStatsEndpoint",
                              dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
                              eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
@@ -17,24 +18,15 @@ namespace Datadog.Trace.Tests.Agent
 {
     public class StatsBufferTests
     {
+        private static readonly List<byte[]> EmptyPeerTags = [];
+
         [Fact]
         public void KeyEquality()
         {
-            var key1 = new StatsAggregationKey("resource1", "service1", "operation1", "type1", null, 1, false);
-            var key2 = new StatsAggregationKey("resource1", "service1", "operation1", "type1", null, 1, false);
+            var key1 = CreateKey("resource1", "service1", "operation1", "type1", 1, false);
+            var key2 = CreateKey("resource1", "service1", "operation1", "type1", 1, false);
 
             key1.Should().Be(key2);
-        }
-
-        [Fact]
-        public void KeyEquality_WithServiceSource()
-        {
-            var key1 = new StatsAggregationKey("resource1", "service1", "operation1", "type1", "m", 1, false);
-            var key2 = new StatsAggregationKey("resource1", "service1", "operation1", "type1", "m", 1, false);
-            var key3 = new StatsAggregationKey("resource1", "service1", "operation1", "type1", null, 1, false);
-
-            key1.Should().Be(key2);
-            key1.Should().NotBe(key3);
         }
 
         [Theory]
@@ -66,13 +58,13 @@ namespace Datadog.Trace.Tests.Agent
 
             var buffer = new StatsBuffer(payload);
 
-            var key1 = new StatsAggregationKey("resource1", "service1", "operation1", "type1", null, 1, true);
-            var key2 = new StatsAggregationKey("resource2", "service2", "operation2", "type2", null, 2, false);
-            var key3 = new StatsAggregationKey("resource3", "service3", "operation3", "type3", null, 2, true);
+            var key1 = CreateKey("resource1", "service1", "operation1", "type1", 1, true);
+            var key2 = CreateKey("resource2", "service2", "operation2", "type2", 2, false);
+            var key3 = CreateKey("resource3", "service3", "operation3", "type3", 2, true);
 
-            var statsBucket1 = new StatsBucket(key1) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
-            var statsBucket2 = new StatsBucket(key2) { Duration = 2, Errors = 22, Hits = 222, TopLevelHits = 20 };
-            var statsBucket3 = new StatsBucket(key3) { Duration = 3, Errors = 0, Hits = 0, TopLevelHits = 0 };
+            var statsBucket1 = new StatsBucket(key1, EmptyPeerTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
+            var statsBucket2 = new StatsBucket(key2, EmptyPeerTags) { Duration = 2, Errors = 22, Hits = 222, TopLevelHits = 20 };
+            var statsBucket3 = new StatsBucket(key3, EmptyPeerTags) { Duration = 3, Errors = 0, Hits = 0, TopLevelHits = 0 };
 
             buffer.Buckets.Add(key1, statsBucket1);
             buffer.Buckets.Add(key2, statsBucket2);
@@ -115,43 +107,15 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public void Serialization_WithServiceSource()
-        {
-            var buffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])) { HostName = "host" });
-
-            var keyWithSource = new StatsAggregationKey("resource1", "service1", "operation1", "type1", "m", 1, false);
-            var keyWithoutSource = new StatsAggregationKey("resource2", "service2", "operation2", "type2", null, 2, false);
-
-            var bucket1 = new StatsBucket(keyWithSource) { Duration = 1, Errors = 0, Hits = 1, TopLevelHits = 1 };
-            var bucket2 = new StatsBucket(keyWithoutSource) { Duration = 2, Errors = 0, Hits = 1, TopLevelHits = 1 };
-
-            buffer.Buckets.Add(keyWithSource, bucket1);
-            buffer.Buckets.Add(keyWithoutSource, bucket2);
-
-            var stream = new MemoryStream();
-            buffer.Serialize(stream, 10);
-            var result = MessagePackSerializer.Deserialize<MockClientStatsPayload>(stream.ToArray());
-
-            var stats = result.Stats[0].Stats;
-            stats.Should().HaveCount(2);
-
-            var groupWithSource = stats.Single(g => g.Name == keyWithSource.OperationName);
-            groupWithSource.ServiceSource.Should().Be("m");
-
-            var groupWithoutSource = stats.Single(g => g.Name == keyWithoutSource.OperationName);
-            groupWithoutSource.ServiceSource.Should().BeNull();
-        }
-
-        [Fact]
         public void Reset()
         {
             var buffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
 
-            var key1 = new StatsAggregationKey("resource1", "service1", "operation1", "type1", null, 1, false);
-            var key2 = new StatsAggregationKey("resource2", "service2", "operation2", "type2", null, 2, false);
+            var key1 = CreateKey("resource1", "service1", "operation1", "type1", 1, false);
+            var key2 = CreateKey("resource2", "service2", "operation2", "type2", 2, false);
 
-            var statsBucket1 = new StatsBucket(key1) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
-            var statsBucket2 = new StatsBucket(key2) { Duration = 2, Errors = 0, Hits = 0, TopLevelHits = 0 };
+            var statsBucket1 = new StatsBucket(key1, EmptyPeerTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
+            var statsBucket2 = new StatsBucket(key2, EmptyPeerTags) { Duration = 2, Errors = 0, Hits = 0, TopLevelHits = 0 };
 
             buffer.Buckets.Add(key1, statsBucket1);
             buffer.Buckets.Add(key2, statsBucket2);
@@ -183,8 +147,8 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
 
-            var key = new StatsAggregationKey("resource1", "service1", "operation1", "type1", null, 1, false);
-            var statsBucket = new StatsBucket(key) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
+            var key = CreateKey("resource1", "service1", "operation1", "type1", 1, false);
+            var statsBucket = new StatsBucket(key, EmptyPeerTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
 
             buffer.Buckets.Add(key, statsBucket);
 
@@ -201,6 +165,76 @@ namespace Datadog.Trace.Tests.Agent
             result.Sequence.Should().Be(2);
         }
 
+        [Fact]
+        public void KeyEquality_NewDimensions()
+        {
+            // Different SpanKind
+            var key1 = CreateKey("r", "s", "o", "t", 0, false, spanKind: "client");
+            var key2 = CreateKey("r", "s", "o", "t", 0, false, spanKind: "server");
+            key1.Should().NotBe(key2);
+
+            // Different IsTraceRoot
+            var key3 = CreateKey("r", "s", "o", "t", 0, false, isTraceRoot: true);
+            var key4 = CreateKey("r", "s", "o", "t", 0, false, isTraceRoot: false);
+            key3.Should().NotBe(key4);
+
+            // Different HttpMethod
+            var key5 = CreateKey("r", "s", "o", "t", 0, false, httpMethod: "GET");
+            var key6 = CreateKey("r", "s", "o", "t", 0, false, httpMethod: "POST");
+            key5.Should().NotBe(key6);
+
+            // Different HttpEndpoint
+            var key7 = CreateKey("r", "s", "o", "t", 0, false, httpEndpoint: "/users/{id}");
+            var key8 = CreateKey("r", "s", "o", "t", 0, false, httpEndpoint: "/orders/{id}");
+            key7.Should().NotBe(key8);
+
+            // Different GrpcStatusCode
+            var key9 = CreateKey("r", "s", "o", "t", 0, false, grpcStatusCode: 0);
+            var key10 = CreateKey("r", "s", "o", "t", 0, false, grpcStatusCode: 2);
+            key9.Should().NotBe(key10);
+
+            // Different ServiceSource
+            var key11 = CreateKey("r", "s", "o", "t", 0, false, serviceSource: "integration");
+            var key12 = CreateKey("r", "s", "o", "t", 0, false, serviceSource: "user");
+            key11.Should().NotBe(key12);
+
+            // Different PeerTagsHash
+            var key13 = CreateKey("r", "s", "o", "t", 0, false, peerTagsHash: 1);
+            var key14 = CreateKey("r", "s", "o", "t", 0, false, peerTagsHash: 2);
+            key13.Should().NotBe(key14);
+        }
+
+        private static StatsAggregationKey CreateKey(
+            string resource,
+            string service,
+            string operationName,
+            string type,
+            int httpStatusCode,
+            bool isSyntheticsRequest,
+            string spanKind = null,
+            bool isTraceRoot = false,
+            string httpMethod = null,
+            string httpEndpoint = null,
+            int grpcStatusCode = 0,
+            string serviceSource = null,
+            ulong peerTagsHash = 0)
+        {
+            return new StatsAggregationKey(
+                resource,
+                service,
+                operationName,
+                type,
+                httpStatusCode,
+                isSyntheticsRequest,
+                spanKind ?? string.Empty,
+                isTraceRoot,
+                httpMethod ?? string.Empty,
+                httpEndpoint ?? string.Empty,
+                grpcStatusCode,
+                serviceSource ?? string.Empty,
+                peerTagsHash);
+        }
+
         private static void AssertStatsGroup(MockClientGroupedStats group, StatsAggregationKey expectedKey, StatsBucket expectedBucket)
         {
             group.Service.Should().Be(expectedKey.Service);
@@ -209,11 +243,17 @@ namespace Datadog.Trace.Tests.Agent
             group.HttpStatusCode.Should().Be(expectedKey.HttpStatusCode);
             group.Type.Should().Be(expectedKey.Type);
             group.DbType.Should().BeNull();
-            group.Hits.Should().Be(expectedBucket.Hits);
-            group.Errors.Should().Be(expectedBucket.Errors);
+            // Hits/Errors/TopLevelHits are doubles in StatsBucket but longs on the wire
+            group.Hits.Should().Be((long)expectedBucket.Hits);
+            group.Errors.Should().Be((long)expectedBucket.Errors);
             group.Duration.Should().Be(expectedBucket.Duration);
             group.Synthetics.Should().Be(expectedKey.IsSyntheticsRequest);
-            group.TopLevelHits.Should().Be(expectedBucket.TopLevelHits);
+            group.TopLevelHits.Should().Be((long)expectedBucket.TopLevelHits);
+            group.SpanKind.Should().Be(expectedKey.SpanKind);
+            group.IsTraceRoot.Should().Be(expectedKey.IsTraceRoot);
+            group.HttpMethod.Should().Be(expectedKey.HttpMethod);
+            group.HttpEndpoint.Should().Be(expectedKey.HttpEndpoint);
+            group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode);
             group.ServiceSource.Should().Be(expectedKey.ServiceSource);
 
             var stream = new MemoryStream();

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -257,7 +257,7 @@ namespace Datadog.Trace.Tests.Agent
             group.IsTraceRoot.Should().Be(expectedKey.IsTraceRoot ? 1 : 2);
             group.HttpMethod.Should().Be(expectedKey.HttpMethod);
             group.HttpEndpoint.Should().Be(expectedKey.HttpEndpoint);
-            group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode);
+            group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode == 0 ? string.Empty : expectedKey.GrpcStatusCode.ToString());
             group.ServiceSource.Should().Be(expectedKey.ServiceSource);
 
             var stream = new MemoryStream();

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -227,6 +227,8 @@ namespace Datadog.Trace.Tests.Agent
                 httpStatusCode,
                 isSyntheticsRequest,
                 spanKind ?? string.Empty,
+                isError: false,
+                isTopLevel: false,
                 isTraceRoot,
                 httpMethod ?? string.Empty,
                 httpEndpoint ?? string.Empty,

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -243,7 +243,8 @@ namespace Datadog.Trace.Tests.Agent
             group.HttpStatusCode.Should().Be(expectedKey.HttpStatusCode);
             group.Type.Should().Be(expectedKey.Type);
             group.DbType.Should().BeNull();
-            // Hits/Errors/TopLevelHits are doubles in StatsBucket but longs on the wire
+            // Hits/Errors/TopLevelHits use stochastic rounding from double to long.
+            // Test values are whole numbers, so stochastic rounding == truncation.
             group.Hits.Should().Be((long)expectedBucket.Hits);
             group.Errors.Should().Be((long)expectedBucket.Errors);
             group.Duration.Should().Be(expectedBucket.Duration);

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -249,7 +249,7 @@ namespace Datadog.Trace.Tests.Agent
             // Test values are whole numbers, so stochastic rounding == truncation.
             group.Hits.Should().Be((long)expectedBucket.Hits);
             group.Errors.Should().Be((long)expectedBucket.Errors);
-            group.Duration.Should().Be(expectedBucket.Duration);
+            group.Duration.Should().Be((long)expectedBucket.Duration);
             group.Synthetics.Should().Be(expectedKey.IsSyntheticsRequest);
             group.TopLevelHits.Should().Be((long)expectedBucket.TopLevelHits);
             group.SpanKind.Should().Be(expectedKey.SpanKind);

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -258,8 +258,7 @@ namespace Datadog.Trace.Tests.Agent
             group.HttpMethod.Should().Be(expectedKey.HttpMethod);
             group.HttpEndpoint.Should().Be(expectedKey.HttpEndpoint);
             group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode);
-            // srv_src is only serialized when non-empty, so null on the wire maps to empty
-            group.ServiceSource.Should().Be(string.IsNullOrEmpty(expectedKey.ServiceSource) ? null : expectedKey.ServiceSource);
+            group.ServiceSource.Should().Be(expectedKey.ServiceSource);
 
             var stream = new MemoryStream();
             expectedBucket.ErrorSummary.Serialize(stream);

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tests.Agent
             result.RuntimeId.Should().Be(Tracer.RuntimeId);
             result.Sequence.Should().Be(1);
             result.AgentAggregation.Should().BeNull();
-            result.Service.Should().BeNull();
+            result.Service.Should().Be(payload.Details.DefaultServiceName);
             result.Stats.Should().HaveCount(1);
 
             if (propagateProcessTags)

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -189,8 +189,8 @@ namespace Datadog.Trace.Tests.Agent
             key7.Should().NotBe(key8);
 
             // Different GrpcStatusCode
-            var key9 = CreateKey("r", "s", "o", "t", 0, false, grpcStatusCode: 0);
-            var key10 = CreateKey("r", "s", "o", "t", 0, false, grpcStatusCode: 2);
+            var key9 = CreateKey("r", "s", "o", "t", 0, false, grpcStatusCode: "0");
+            var key10 = CreateKey("r", "s", "o", "t", 0, false, grpcStatusCode: "2");
             key9.Should().NotBe(key10);
 
             // Different ServiceSource
@@ -215,7 +215,7 @@ namespace Datadog.Trace.Tests.Agent
             bool isTraceRoot = false,
             string httpMethod = null,
             string httpEndpoint = null,
-            int grpcStatusCode = 0,
+            string grpcStatusCode = "",
             string serviceSource = null,
             ulong peerTagsHash = 0)
         {
@@ -257,7 +257,7 @@ namespace Datadog.Trace.Tests.Agent
             group.IsTraceRoot.Should().Be(expectedKey.IsTraceRoot ? 1 : 2);
             group.HttpMethod.Should().Be(expectedKey.HttpMethod);
             group.HttpEndpoint.Should().Be(expectedKey.HttpEndpoint);
-            group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode == 0 ? string.Empty : expectedKey.GrpcStatusCode.ToString());
+            group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode);
             group.ServiceSource.Should().Be(expectedKey.ServiceSource);
 
             var stream = new MemoryStream();

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -250,7 +250,8 @@ namespace Datadog.Trace.Tests.Agent
             group.Synthetics.Should().Be(expectedKey.IsSyntheticsRequest);
             group.TopLevelHits.Should().Be((long)expectedBucket.TopLevelHits);
             group.SpanKind.Should().Be(expectedKey.SpanKind);
-            group.IsTraceRoot.Should().Be(expectedKey.IsTraceRoot);
+            // Trilean: NOT_SET=0, TRUE=1, FALSE=2
+            group.IsTraceRoot.Should().Be(expectedKey.IsTraceRoot ? 1 : 2);
             group.HttpMethod.Should().Be(expectedKey.HttpMethod);
             group.HttpEndpoint.Should().Be(expectedKey.HttpEndpoint);
             group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode);

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -258,7 +258,8 @@ namespace Datadog.Trace.Tests.Agent
             group.HttpMethod.Should().Be(expectedKey.HttpMethod);
             group.HttpEndpoint.Should().Be(expectedKey.HttpEndpoint);
             group.GrpcStatusCode.Should().Be(expectedKey.GrpcStatusCode);
-            group.ServiceSource.Should().Be(expectedKey.ServiceSource);
+            // srv_src is only serialized when non-empty, so null on the wire maps to empty
+            group.ServiceSource.Should().Be(string.IsNullOrEmpty(expectedKey.ServiceSource) ? null : expectedKey.ServiceSource);
 
             var stream = new MemoryStream();
             expectedBucket.ErrorSummary.Serialize(stream);

--- a/tracer/test/Datadog.Trace.Tests/Agent/TraceFilterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/TraceFilterTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="TraceFilterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Agent.TraceSamplers;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Tests.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Agent;
+
+public class TraceFilterTests
+{
+    [Fact]
+    public void EmptyFilter_KeepsAllTraces()
+    {
+        var filter = new TraceFilter(AgentTraceFilterConfig.Empty);
+        var span = CreateRootSpan();
+        span.ResourceName = "GET /users";
+
+        filter.ShouldKeepTrace(span).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IgnoreResources_RejectsMatchingResource()
+    {
+        var config = new AgentTraceFilterConfig(null, null, null, null, ["(GET|POST) /healthcheck", "GET /ping"]);
+        var filter = new TraceFilter(config);
+
+        var healthcheck = CreateRootSpan();
+        healthcheck.ResourceName = "GET /healthcheck";
+        filter.ShouldKeepTrace(healthcheck).Should().BeFalse();
+
+        var ping = CreateRootSpan();
+        ping.ResourceName = "GET /ping";
+        filter.ShouldKeepTrace(ping).Should().BeFalse();
+
+        var users = CreateRootSpan();
+        users.ResourceName = "GET /users";
+        filter.ShouldKeepTrace(users).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FilterTagsReject_RejectsMatchingTag()
+    {
+        var config = new AgentTraceFilterConfig(null, ["debug", "env:test"], null, null, null);
+        var filter = new TraceFilter(config);
+
+        // Key-only reject: any span with "debug" tag
+        var debugSpan = CreateRootSpan();
+        debugSpan.SetTag("debug", "true");
+        filter.ShouldKeepTrace(debugSpan).Should().BeFalse();
+
+        // Key:value reject
+        var testSpan = CreateRootSpan();
+        testSpan.SetTag("env", "test");
+        filter.ShouldKeepTrace(testSpan).Should().BeFalse();
+
+        // Different value: not rejected
+        var prodSpan = CreateRootSpan();
+        prodSpan.SetTag("env", "prod");
+        filter.ShouldKeepTrace(prodSpan).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FilterTagsRequire_RejectsWhenMissing()
+    {
+        var config = new AgentTraceFilterConfig(["env:prod"], null, null, null, null);
+        var filter = new TraceFilter(config);
+
+        // Missing required tag: rejected
+        var noEnvSpan = CreateRootSpan();
+        filter.ShouldKeepTrace(noEnvSpan).Should().BeFalse();
+
+        // Wrong value: rejected
+        var testSpan = CreateRootSpan();
+        testSpan.SetTag("env", "test");
+        filter.ShouldKeepTrace(testSpan).Should().BeFalse();
+
+        // Correct value: kept
+        var prodSpan = CreateRootSpan();
+        prodSpan.SetTag("env", "prod");
+        filter.ShouldKeepTrace(prodSpan).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FilterTagsRegexReject_RejectsMatchingPattern()
+    {
+        var config = new AgentTraceFilterConfig(null, null, null, ["version:.*-beta"], null);
+        var filter = new TraceFilter(config);
+
+        // Tags set via Tags.SetTag go into the additional tags list
+        // which is enumerated by EnumerateTags
+        var betaSpan = CreateRootSpan();
+        betaSpan.Tags.SetTag("version", "1.0.0-beta");
+        filter.ShouldKeepTrace(betaSpan).Should().BeFalse();
+
+        var stableSpan = CreateRootSpan();
+        stableSpan.Tags.SetTag("version", "1.0.0");
+        filter.ShouldKeepTrace(stableSpan).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FilterOrder_ResourceThenRejectThenRequire()
+    {
+        // Resource reject takes priority over require
+        var config = new AgentTraceFilterConfig(
+            FilterTagsRequire: ["env:prod"],
+            FilterTagsReject: null,
+            FilterTagsRegexRequire: null,
+            FilterTagsRegexReject: null,
+            IgnoreResources: ["GET /healthcheck"]);
+        var filter = new TraceFilter(config);
+
+        // Even with correct required tag, resource reject wins
+        var span = CreateRootSpan();
+        span.ResourceName = "GET /healthcheck";
+        span.SetTag("env", "prod");
+        filter.ShouldKeepTrace(span).Should().BeFalse();
+    }
+
+    private static Span CreateRootSpan()
+    {
+        var tracer = new StubDatadogTracer();
+        var traceContext = new TraceContext(tracer);
+        var context = new SpanContext(null, traceContext, "test-service");
+        return new Span(context, DateTimeOffset.UtcNow);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.TraceSamplers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -21,7 +22,7 @@ namespace Datadog.Trace.Tests.Sampling
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
-            var sampler = new RareSampler(settings, isOtlp: false);
+            var sampler = new RareSampler(settings, new NullStatsAggregator());
 
             var trace1 = new[] { tracer.StartSpan("1"), tracer.StartSpan("1") };
             trace1[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
@@ -50,7 +51,7 @@ namespace Datadog.Trace.Tests.Sampling
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
-            var sampler = new RareSampler(settings, isOtlp: false);
+            var sampler = new RareSampler(settings, new NullStatsAggregator());
 
             var trace = new[] { tracer.StartSpan("1") };
             trace[0].Context.TraceContext.SetSamplingPriority(priority);
@@ -70,7 +71,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void DisabledByDefault()
         {
-            var sampler = new RareSampler(new TracerSettings(), isOtlp: false);
+            var sampler = new RareSampler(new TracerSettings(), new NullStatsAggregator());
 
             sampler.IsEnabled.Should().BeFalse();
         }
@@ -81,7 +82,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Configuration(bool enabled)
         {
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, enabled } });
-            var sampler = new RareSampler(settings, isOtlp: false);
+            var sampler = new RareSampler(settings, new NullStatsAggregator());
 
             sampler.IsEnabled.Should().Be(enabled);
         }
@@ -90,7 +91,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void DoNotSampleIfDisabled()
         {
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, false } });
-            var sampler = new RareSampler(settings, isOtlp: false);
+            var sampler = new RareSampler(settings, new NullStatsAggregator());
 
             var trace = new[] { Tracer.Instance.StartSpan("1") };
             trace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
@@ -104,7 +105,7 @@ namespace Datadog.Trace.Tests.Sampling
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
-            var sampler = new RareSampler(settings, isOtlp: false);
+            var sampler = new RareSampler(settings, new NullStatsAggregator());
 
             var knownTrace = new[] { tracer.StartSpan("1") };
             knownTrace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
@@ -130,7 +131,7 @@ namespace Datadog.Trace.Tests.Sampling
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
-            var sampler = new RareSampler(settings, isOtlp: false);
+            var sampler = new RareSampler(settings, new NullStatsAggregator());
 
             var knownTrace = new[] { tracer.StartSpan("1") };
             knownTrace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
@@ -45,6 +45,17 @@ namespace Datadog.Trace.Tests.TraceProcessors
             yield return new object[] { "SELECT * FROM TABLE WHERE col!='excluded'", "SELECT * FROM TABLE WHERE col != ?" };
             yield return new object[] { "SELECT * FROM TABLE WHERE col<>'other'", "SELECT * FROM TABLE WHERE col <> ?" };
 
+            // Multi-character comparison operators: <=, >=
+            // Based on Go agent test cases from pkg/obfuscate/sql_test.go
+            yield return new object[] { "SELECT * FROM users WHERE age>=18", "SELECT * FROM users WHERE age >= ?" };
+            yield return new object[] { "SELECT * FROM users WHERE age<=100", "SELECT * FROM users WHERE age <= ?" };
+            yield return new object[] { "SELECT id FROM jq_jobs WHERE schedulable_at<=1555367948 AND queue_name='order_jobs'", "SELECT id FROM jq_jobs WHERE schedulable_at <= ? AND queue_name = ?" };
+            yield return new object[] { "SELECT * FROM t WHERE a>=1 AND b<=2 AND c!='x' AND d<>'y'", "SELECT * FROM t WHERE a >= ? AND b <= ? AND c != ? AND d <> ?" };
+
+            // Multi-character operators with spaces already present (should be preserved as-is)
+            yield return new object[] { "SELECT * FROM users WHERE age >= 18", "SELECT * FROM users WHERE age >= ?" };
+            yield return new object[] { "SELECT * FROM users WHERE age <= 100", "SELECT * FROM users WHERE age <= ?" };
+
             // Arithmetic and other operators as splitters (no space normalization for non-comparison operators)
             yield return new object[] { "SELECT col*2 FROM TABLE", "SELECT col*? FROM TABLE" };
             yield return new object[] { "SELECT col/2 FROM TABLE", "SELECT col/? FROM TABLE" };

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
@@ -34,6 +34,27 @@ namespace Datadog.Trace.Tests.TraceProcessors
             yield return new object[] { "SELECT * FROM TABLE WHERE userId = 'abc1287681964' ORDER BY FOO DESC", "SELECT * FROM TABLE WHERE userId = ? ORDER BY FOO DESC" };
             yield return new object[] { "SELECT * FROM TABLE WHERE userId = 'abc\\'1287\\'681\\'\\'\\'\\'964' ORDER BY FOO DESC", "SELECT * FROM TABLE WHERE userId = ? ORDER BY FOO DESC" };
             yield return new object[] { "SELECT * FROM TABLE JOIN SOMETHING ON TABLE.foo = SOMETHING.bar", "SELECT * FROM TABLE JOIN SOMETHING ON TABLE.foo = SOMETHING.bar" };
+
+            // No spaces around comparison operators (must match Go agent's go-sqllexer behavior)
+            yield return new object[] { "SELECT * FROM users WHERE id='1'", "SELECT * FROM users WHERE id=?" };
+            yield return new object[] { "SELECT * FROM users WHERE id='test'", "SELECT * FROM users WHERE id=?" };
+            yield return new object[] { "SELECT * FROM users WHERE age>30", "SELECT * FROM users WHERE age>?" };
+            yield return new object[] { "SELECT * FROM users WHERE age<100", "SELECT * FROM users WHERE age<?" };
+            yield return new object[] { "SELECT * FROM TABLE WHERE col='val' AND col2=123", "SELECT * FROM TABLE WHERE col=? AND col2=?" };
+            yield return new object[] { "SELECT * FROM TABLE WHERE col!='excluded'", "SELECT * FROM TABLE WHERE col!=?" };
+            yield return new object[] { "SELECT * FROM TABLE WHERE col<>'other'", "SELECT * FROM TABLE WHERE col<>?" };
+
+            // Arithmetic and other operators as splitters
+            yield return new object[] { "SELECT col*2 FROM TABLE", "SELECT col*? FROM TABLE" };
+            yield return new object[] { "SELECT col/2 FROM TABLE", "SELECT col/? FROM TABLE" };
+            yield return new object[] { "SELECT col%2 FROM TABLE", "SELECT col%? FROM TABLE" };
+            yield return new object[] { "SELECT col&0xFF FROM TABLE", "SELECT col&? FROM TABLE" };
+            yield return new object[] { "SELECT col^0xFF FROM TABLE", "SELECT col^? FROM TABLE" };
+            yield return new object[] { "SELECT ~1 FROM TABLE", "SELECT ~? FROM TABLE" };
+
+            // Operators should not interfere with non-literal identifiers
+            yield return new object[] { "SELECT a*b FROM TABLE", "SELECT a*b FROM TABLE" };
+            yield return new object[] { "SELECT * FROM TABLE", "SELECT * FROM TABLE" };
             yield return new object[] { "CREATE TABLE \"VALUE\"", "CREATE TABLE \"VALUE\"" };
             yield return new object[] { "INSERT INTO \"VALUE\" (\"column\") VALUES (\'ljahklshdlKASH\')", "INSERT INTO \"VALUE\" (\"column\") VALUES (?)" };
             yield return new object[] { "INSERT INTO \"VALUE\" (\"col1\",\"col2\",\"col3\") VALUES (\'blah\',12983,X'ff')", "INSERT INTO \"VALUE\" (\"col1\",\"col2\",\"col3\") VALUES (?,?,?)" };

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
@@ -35,16 +35,17 @@ namespace Datadog.Trace.Tests.TraceProcessors
             yield return new object[] { "SELECT * FROM TABLE WHERE userId = 'abc\\'1287\\'681\\'\\'\\'\\'964' ORDER BY FOO DESC", "SELECT * FROM TABLE WHERE userId = ? ORDER BY FOO DESC" };
             yield return new object[] { "SELECT * FROM TABLE JOIN SOMETHING ON TABLE.foo = SOMETHING.bar", "SELECT * FROM TABLE JOIN SOMETHING ON TABLE.foo = SOMETHING.bar" };
 
-            // No spaces around comparison operators (must match Go agent's go-sqllexer behavior)
-            yield return new object[] { "SELECT * FROM users WHERE id='1'", "SELECT * FROM users WHERE id=?" };
-            yield return new object[] { "SELECT * FROM users WHERE id='test'", "SELECT * FROM users WHERE id=?" };
-            yield return new object[] { "SELECT * FROM users WHERE age>30", "SELECT * FROM users WHERE age>?" };
-            yield return new object[] { "SELECT * FROM users WHERE age<100", "SELECT * FROM users WHERE age<?" };
-            yield return new object[] { "SELECT * FROM TABLE WHERE col='val' AND col2=123", "SELECT * FROM TABLE WHERE col=? AND col2=?" };
-            yield return new object[] { "SELECT * FROM TABLE WHERE col!='excluded'", "SELECT * FROM TABLE WHERE col!=?" };
-            yield return new object[] { "SELECT * FROM TABLE WHERE col<>'other'", "SELECT * FROM TABLE WHERE col<>?" };
+            // No spaces around comparison operators: spaces are inserted around operators adjacent to ?
+            // to match Go agent's go-sqllexer Normalizer output
+            yield return new object[] { "SELECT * FROM users WHERE id='1'", "SELECT * FROM users WHERE id = ?" };
+            yield return new object[] { "SELECT * FROM users WHERE id='test'", "SELECT * FROM users WHERE id = ?" };
+            yield return new object[] { "SELECT * FROM users WHERE age>30", "SELECT * FROM users WHERE age > ?" };
+            yield return new object[] { "SELECT * FROM users WHERE age<100", "SELECT * FROM users WHERE age < ?" };
+            yield return new object[] { "SELECT * FROM TABLE WHERE col='val' AND col2=123", "SELECT * FROM TABLE WHERE col = ? AND col2 = ?" };
+            yield return new object[] { "SELECT * FROM TABLE WHERE col!='excluded'", "SELECT * FROM TABLE WHERE col != ?" };
+            yield return new object[] { "SELECT * FROM TABLE WHERE col<>'other'", "SELECT * FROM TABLE WHERE col <> ?" };
 
-            // Arithmetic and other operators as splitters
+            // Arithmetic and other operators as splitters (no space normalization for non-comparison operators)
             yield return new object[] { "SELECT col*2 FROM TABLE", "SELECT col*? FROM TABLE" };
             yield return new object[] { "SELECT col/2 FROM TABLE", "SELECT col/? FROM TABLE" };
             yield return new object[] { "SELECT col%2 FROM TABLE", "SELECT col%? FROM TABLE" };

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -231,7 +231,7 @@ namespace Benchmarks.Trace
                     return Task.FromResult(true);
                 }
 
-                public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration)
+                public Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration, int tracerObfuscationVersion)
                 {
                     return Task.FromResult(true);
                 }


### PR DESCRIPTION
## Summary of changes

Updates the existing client-side-stats implementation to match version 1.2.0 [as defined in the RFC](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/6378947571/Client-Side+Stats+v1.2.0) and as [implemented in the agent](https://github.com/DataDog/datadog-agent/blob/c1d67a906f4c594654600760da1eea4c8037471a/pkg/proto/datadog/trace/stats.proto#L83).

## Reason for change

Our implementation is severely lagging the latest implementation in the agent. This hasn't been a big deal, as it's not documented and not enabled by default, but we'd like to fix the implementation to make it usable.  

## Implementation details

This was driven almost entirely by 🤖, by comparing our existing implementation to the RFC, and also taking the agent/go implementation as the canonical implementation.

> Implementing this in .NET highlighted a number of missing aspects in the RFC, which I've raised elsewhere, and aim to get incorporated into the RFC.

At a high level, the PR contains the following changes:

- Stats Wire Format & Serialization
  - **Added new aggregation dimensions**: `SpanKind`, `IsTraceRoot` (as Trilean), `HTTPMethod`, `HTTPEndpoint`, `GRPCStatusCode`, `ServiceSource`, `PeerTags` to both the aggregation key and the msgpack wire format
  - **Fixed `GRPCStatusCode` type**: Changed from `int` to `string` to match Go agent's wire format (agent was returning 400 Bad Request in system tests)
  - **gRPC status code extraction**: Checks 4 tag names in priority order (`rpc.grpc.status_code`, `grpc.code`, `rpc.grpc.status.code`, `grpc.status.code`)
  - **Stochastic rounding**: `Hits`, `Errors`, `Duration`, `TopLevelHits` accumulated as `double` (weighted by sampling rate) then rounded probabilistically to `int64` for serialization
  - **Duration weighting**: Durations are now multiplied by sampling weight (`1/rate`), matching Go agent behavior
  - **Default env**: Serializes `"unknown-env"` when environment is not configured
  - **`git_commit_sha`**: Added as optional field in stats payload
  - **`Service`**: Added as top-level field in stats payload
  - **Empty bucket suppression**: `HasHits()` check prevents sending payloads with zero-hit buckets (stale keys retained for sketch reuse)
- Bucket Timing
  - **10-second alignment**: Bucket `Start` timestamps aligned to 10-second boundaries (`ts - ts % 10_000_000_000`) matching Go tracer's `alignTs`
  - **Removed unused `StartTime`** property (only `Start` as aligned nanoseconds)
- Agent Discovery (`/info` Endpoint)
  - **`peer_tags`**: Parsed, sorted, deduplicated; used for peer tag extraction on client/producer/consumer spans
  - **`span_kinds_stats_computed`**: Parsed to override eligible span kinds
  - **`obfuscation_version`**: Parsed for obfuscation negotiation
  - **Trace filters**: Parsed `filter_tags`, `filter_tags_regex`, `ignore_resources` from `/info`
- Trace Filtering
  - **`TraceFilter` implementation**: Evaluates agent-configured filters (exact tags, regex tags, resource patterns) against root spans before stats computation
  - **Tag-only filters**: Handles filter entries that match on tag key presence without a specific value
- SQL Obfuscation
  - **Operator splitters**: Added `* / = < > ! & ^ % ~ ? @ : #` as token splitters (matching Go agent's `go-sqllexer` `isOperator()`) so queries like `WHERE id='1'` are properly obfuscated
  - **Whitespace normalization**: Post-processing pass adds spaces around comparison operators (`=`, `<`, `>`, `!`) adjacent to `?` placeholders, matching Go agent's normalizer output (e.g., `id='1'` → `id = ?`)
  - **Obfuscation gating**: Only runs when `obfuscation_version` is negotiated with agent; sends `Datadog-Obfuscation-Version` header
- Peer Tags
  - **IP quantization**: Peer tag values run through `IpAddressObfuscationUtil.QuantizePeerIpAddresses()` replacing non-allowed IPs with `"blocked-ip-address"`
  - **Base service handling**: Internal/missing-kind spans with non-default service name use `_dd.base_service:{serviceName}` as sole peer tag
  - **FNV-1a hashing**: Peer tags hashed with null-byte separators for aggregation key
- Other
  - **No retries for stats**: Stats sends are fire-and-forget (retry limit = 0)
  - **Synthetics detection**: Uses `StartsWith("synthetics")` prefix matching (not exact match)
  - **Mock agent updates**: Test mock agent returns `obfuscation_version` in `/info` response

## Test coverage

There's a _lot_ going on in this PR, because we were so far behind. I _could_ split this into implementing individual features, but there would be a lot of duplication between PRs, and it didn't seem like it would be that easy to track. At least with this big bang we can compare directly against the system tests etc.

The existing system tests for stats computation were checked, and made to pass (which identified a number of hidden expectations which will be added to the RFC). I'll create a PR to enable these in the system-tests repo

## Other details

Part of a stack

- https://github.com/DataDog/dd-trace-dotnet/pull/8417
- https://github.com/DataDog/dd-trace-dotnet/pull/8418

There are still some _theoretical_ gaps between the go implementation and the .NET implementation, but I _think_ these are non-issues in _most_ cases:


  | Area | Gap | Impact |
  |------|-----|--------|
  | gRPC status code normalization | Go agent normalizes string statuses (e.g., `"CANCELLED"` → `"1"`); .NET passes raw tag value | Stats mismatch if gRPC library uses string-form status codes |
  | HTTP status code tags | Go agent checks both `http.status_code` and `http.response.status_code` (OTel convention); .NET only checks `http.status_code` | OTel spans using newer convention would get `0` in .NET |
  | Duration precision truncation | Go agent uses float bit masking; .NET uses integer shifting — both target ~10 bits but may produce slightly different values | Minor histogram differences |
  | SQL obfuscation | Go agent uses full tokenizer + normalizer; .NET uses character-level splitter with targeted normalization around comparison operators only | Complex SQL with unusual formatting may produce different resource strings |
  | `HTTP_method` / `HTTP_endpoint` | .NET always populates from span tags; Go agent only populates from newer OTel pipeline paths | Creates different aggregation keys — Go groups all methods/routes together in default path |
  | `_top_level` metric | Go checks both `_top_level` and `_dd.top_level`; .NET only checks `_dd.top_level` | Spans using older metric name would be missed by .NET |
  | `span_derived_primary_tags` | Still in Go agent code but implemented in v1.3.0 RFC, which was reverted; removed from .NET | No current impact; may need to re-add if spec reverts back |

There is another big elephant in the room, which is perf. The peer tags, in particular, currently requires a _bunch_ of allocation. I'd rather defer trying to fight against that to another PR if possible, unless anyone has some clear ideas 😄 

Another aspect I'm not sure about is how this interacts with @zacharycmontoya's recent work to publish OTLP stats. I took a random guess and fought the refactoring, but need to verify it.