### PR TITLE
[DSM] Test: verify DSM produce checkpoints with ASB 7.18.0

### DIFF
--- a/docker/servicebus-emulator-config.json
+++ b/docker/servicebus-emulator-config.json
@@ -15,6 +15,94 @@
               "RequiresDuplicateDetection": false,
               "RequiresSession": false
             }
+          },
+          {
+            "Name": "dsm-direct-queue",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 10,
+              "EnablePartitioning": false,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          }
+        ],
+        "Topics": [
+          {
+            "Name": "dsm-topic-subscription-filters",
+            "Properties": {
+              "DefaultMessageTimeToLive": "PT1H"
+            },
+            "Subscriptions": [
+              {
+                "Name": "subscription1",
+                "Properties": {
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10
+                },
+                "Rules": [
+                  {
+                    "Name": "typeFilter",
+                    "Properties": {
+                      "FilterType": "Correlation",
+                      "CorrelationFilter": {
+                        "Label": "order"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "subscription2",
+                "Properties": {
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10
+                },
+                "Rules": [
+                  {
+                    "Name": "typeFilter",
+                    "Properties": {
+                      "FilterType": "Correlation",
+                      "CorrelationFilter": {
+                        "Label": "order"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Name": "dsm-topic2",
+            "Properties": {
+              "DefaultMessageTimeToLive": "PT1H"
+            },
+            "Subscriptions": [
+              {
+                "Name": "subscription",
+                "Properties": {
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10
+                }
+              }
+            ]
+          },
+          {
+            "Name": "dsm-topic3",
+            "Properties": {
+              "DefaultMessageTimeToLive": "PT1H"
+            },
+            "Subscriptions": [
+              {
+                "Name": "subscription",
+                "Properties": {
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10
+                }
+              }
+            ]
           }
         ]
       }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
@@ -34,7 +34,8 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
     [SkippableTheory]
     [MemberData(nameof(GetPackageVersions))]
     [Trait("Category", "EndToEnd")]
-    [Trait("SkipInCI", "True")] // "This has only been tested on a live Azure Service Bus namespace using a connection string. Unskip this if you'd like to run locally or if you've correctly configured piotr-rojek/devopsifyme-sbemulator in CI"
+    [Trait("RequiresDockerDependency", "true")]
+    [Trait("DockerGroup", "2")]
     public async Task HandleProduceAndConsume(string packageVersion)
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
@@ -62,7 +63,8 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
     [SkippableTheory]
     [MemberData(nameof(GetPackageVersions))]
     [Trait("Category", "EndToEnd")]
-    [Trait("SkipInCI", "True")] // This has only been tested on a live Azure Service Bus namespace using a connection string. Unskip this if you'd like to run locally or if you've correctly configured piotr-rojek/devopsifyme-sbemulator in CI
+    [Trait("RequiresDockerDependency", "true")]
+    [Trait("DockerGroup", "2")]
     public async Task ValidateSpanTags(string packageVersion)
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.AzureServiceBus/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.AzureServiceBus/Program.cs
@@ -15,6 +15,7 @@ namespace Samples.DataStreams.AzureServiceBus
     public static class Program
     {
         private static readonly string ConnectionString = Environment.GetEnvironmentVariable("ASB_CONNECTION_STRING");
+        private static readonly bool UseEmulator = ConnectionString?.Contains("UseDevelopmentEmulator=true") == true;
         private static readonly ServiceBusClient Client = new(ConnectionString);
         private static readonly ServiceBusAdministrationClient AdminClient = new(ConnectionString);
 
@@ -99,6 +100,13 @@ namespace Samples.DataStreams.AzureServiceBus
 
         private static async Task InitializeServiceBusAsync()
         {
+            if (UseEmulator)
+            {
+                // Entities are pre-created via the emulator config (servicebus-emulator-config.json)
+                Console.WriteLine("Using emulator — skipping admin API entity creation");
+                return;
+            }
+
             // Create queue
             await AdminClient.CreateQueueAsync(QueueName);
 
@@ -189,10 +197,13 @@ namespace Samples.DataStreams.AzureServiceBus
 
         private static async Task DisposeServiceBusAsync()
         {
-            await AdminClient.DeleteQueueAsync(QueueName); // Delete so each test is self-contained
-            await AdminClient.DeleteTopicAsync(TopicWithFiltersName); // Delete so each test is self-contained
-            await AdminClient.DeleteTopicAsync(Topic2Name); // Delete so each test is self-contained
-            await AdminClient.DeleteTopicAsync(Topic3Name); // Delete so each test is self-contained
+            if (!UseEmulator)
+            {
+                await AdminClient.DeleteQueueAsync(QueueName); // Delete so each test is self-contained
+                await AdminClient.DeleteTopicAsync(TopicWithFiltersName); // Delete so each test is self-contained
+                await AdminClient.DeleteTopicAsync(Topic2Name); // Delete so each test is self-contained
+                await AdminClient.DeleteTopicAsync(Topic3Name); // Delete so each test is self-contained
+            }
 
             await Client.DisposeAsync();
         }

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.AzureServiceBus/Samples.DataStreams.AzureServiceBus.csproj
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.AzureServiceBus/Samples.DataStreams.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.14.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.0" />
     <PackageReference Include="OpenTelemetry" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />


### PR DESCRIPTION
## Summary
- Bump the DSM Azure Service Bus test sample from 7.14.0 to 7.18.0
- Enable the DSM integration test in CI (was previously `SkipInCI`)
- Pre-create DSM entities in the emulator config since the admin API is unavailable
- **No tracer code changes** — this PR only tests whether DSM produce checkpoints work with ASB 7.18.0

## Motivation
We suspect DSM produce checkpoints may be broken for Azure Service Bus SDK 7.18.x+. The DSM test was previously hardcoded to 7.14.0 and skipped in CI, so there was no coverage.

If the `ValidateSpanTags` test fails (fewer than 9 spans with `pathway.hash`), it confirms the produce-side DSM checkpoint is broken and we need a fix.

## Test plan
- [ ] Watch CI — expect `DataStreamsMonitoringAzureServiceBusTests` to either pass (DSM works) or fail (confirms the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)