### PR TITLE
Extract `ContainsSpanId` to `SpanCollection`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -148,7 +148,7 @@ internal readonly struct TraceChunkModel
 
             // the local root span is almost always at the end of the chunk, so start searching at the last index.
             // skip the HashSet to avoid initializing it yet, always iterate the array of spans.
-            ContainsLocalRootSpan = IndexOf(localRootSpanId, spans.Count - 1) >= 0;
+            ContainsLocalRootSpan = _spans.ContainsSpanId(localRootSpanId, spans.Count - 1);
 
             HasUpstreamService = localRootSpan.Context.ParentId is not (null or 0);
         }
@@ -239,55 +239,6 @@ internal readonly struct TraceChunkModel
             return hashSet.Contains(spanId);
         }
 
-        return IndexOf(spanId, startIndex) >= 0;
-    }
-
-    /// <summary>
-    /// Searches for the specified spanId by iterating the array of spans.
-    /// </summary>
-    private int IndexOf(ulong spanId, int startIndex)
-    {
-        // wrap around the end of the array
-        var count = _spans.Count;
-        if (count == 0)
-        {
-            return -1;
-        }
-
-        if (startIndex >= count)
-        {
-            startIndex = 0;
-        }
-
-        if (count == 1)
-        {
-            return _spans[0].SpanId == spanId ? 0 : -1;
-        }
-
-        if (_spans.TryGetArray() is not { } array)
-        {
-            // Shouldn't be possible, because we handle 0 and 1 spans above
-            return -1;
-        }
-
-        // iterate over the span array starting at the specified index + 1
-        for (var i = startIndex; i < count; i++)
-        {
-            if (spanId == array.Array![array.Offset + i].SpanId)
-            {
-                return i;
-            }
-        }
-
-        // if not found above, wrap around to the beginning to search the rest of the array
-        for (var i = 0; i < startIndex; i++)
-        {
-            if (spanId == array.Array![array.Offset + i].SpanId)
-            {
-                return i;
-            }
-        }
-
-        return -1;
+        return _spans.ContainsSpanId(spanId, startIndex);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/SpanCollection.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanCollection.cs
@@ -188,7 +188,7 @@ internal readonly struct SpanCollection : IEnumerable<Span>
         // Not Span, not null, can only be SpanArray
         var spans = Unsafe.As<Span[]>(value);
 
-        if (startIndex >= Count)
+        if (startIndex >= Count || startIndex < 0)
         {
             startIndex = 0;
         }

--- a/tracer/src/Datadog.Trace/Agent/SpanCollection.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanCollection.cs
@@ -167,6 +167,53 @@ internal readonly struct SpanCollection : IEnumerable<Span>
         return null;
     }
 
+    /// <summary>
+    /// Returns true if the <see cref="SpanCollection"/> contains a span with the provided <paramref name="spanId"/>.
+    /// Starts searching from startIndex, and then loops around back to the start
+    /// </summary>
+    public bool ContainsSpanId(ulong spanId, int startIndex)
+    {
+        // Take local copy of _values so type checks remain valid even if the SpanCollection is overwritten in memory
+        var value = _values;
+        if (value is Span span)
+        {
+            return span.SpanId == spanId;
+        }
+
+        if (value is null)
+        {
+            return false;
+        }
+
+        // Not Span, not null, can only be SpanArray
+        var spans = Unsafe.As<Span[]>(value);
+
+        if (startIndex >= Count)
+        {
+            startIndex = 0;
+        }
+
+        // iterate over the span array starting at the specified index
+        for (var i = startIndex; i < Count; i++)
+        {
+            if (spans[i].SpanId == spanId)
+            {
+                return true;
+            }
+        }
+
+        // if not found above, wrap around to the beginning to search the rest of the array
+        for (var i = 0; i < startIndex; i++)
+        {
+            if (spans[i].SpanId == spanId)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static Span[] GrowIfNeeded(Span[] array, int currentCount)
     {
         if (currentCount < array.Length)

--- a/tracer/test/Datadog.Trace.Tests/Agent/SpanCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/SpanCollectionTests.cs
@@ -146,7 +146,41 @@ public class SpanCollectionTests
     }
 
     [Fact]
-    public void Append_ToArrayWithCapacityCollection()
+    public void Append_ToArrayWithCapacityCollection0()
+    {
+        var collection = new SpanCollection(arrayBuilderCapacity: 4);
+        var array = collection.TryGetArray();
+        array.HasValue.Should().BeTrue();
+        array!.Value.Count.Should().Be(0);
+
+        foreach (var span in collection)
+        {
+            Assert.Fail("We shouldn't have a span to enumerate: " + span);
+        }
+    }
+
+    [Fact]
+    public void Append_ToArrayWithCapacityCollection1()
+    {
+        var spans = new[] { CreateSpan("span1"), null, null, null };
+        var collection = new SpanCollection(spans, 1);
+        var array = collection.TryGetArray();
+        array.HasValue.Should().BeTrue();
+        array!.Value.Count.Should().Be(1);
+        array.Value.Array.Should().BeSameAs(spans);
+
+        var enumerated = new List<Span>();
+        foreach (var span in collection)
+        {
+            enumerated.Add(span);
+        }
+
+        enumerated.Should().HaveCount(1);
+        enumerated[0].Should().BeSameAs(spans[0]);
+    }
+
+    [Fact]
+    public void Append_ToArrayWithCapacityCollection2()
     {
         var spans = new[] { CreateSpan("span1"), CreateSpan("span2"), null, null };
         var collection = new SpanCollection(spans, 2);
@@ -154,6 +188,16 @@ public class SpanCollectionTests
         array.HasValue.Should().BeTrue();
         array!.Value.Count.Should().Be(2);
         array.Value.Array.Should().BeSameAs(spans);
+
+        var enumerated = new List<Span>();
+        foreach (var span in collection)
+        {
+            enumerated.Add(span);
+        }
+
+        enumerated.Should().HaveCount(2);
+        enumerated[0].Should().BeSameAs(spans[0]);
+        enumerated[1].Should().BeSameAs(spans[1]);
 
         var span3 = CreateSpan("span3");
         var result = SpanCollection.Append(in collection, span3);
@@ -163,7 +207,18 @@ public class SpanCollectionTests
         result[1].Should().BeSameAs(spans[1]);
         result[2].Should().BeSameAs(span3);
 
-        collection.TryGetArray()!.Value.Array.Should().BeSameAs(spans);
+        enumerated = new List<Span>();
+        foreach (var span in result)
+        {
+            enumerated.Add(span);
+        }
+
+        enumerated.Should().HaveCount(3);
+        enumerated[0].Should().BeSameAs(spans[0]);
+        enumerated[1].Should().BeSameAs(spans[1]);
+        enumerated[2].Should().BeSameAs(span3);
+
+        result.TryGetArray()!.Value.Array.Should().BeSameAs(spans);
     }
 
     [Fact]
@@ -240,14 +295,27 @@ public class SpanCollectionTests
         collection.ContainsSpanId(99, 0).Should().BeFalse();
     }
 
-    [Fact]
-    public void ContainsSpanId_SingleSpan_IgnoresStartIndex()
+    [Theory]
+    [InlineData(5)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ContainsSpanId_SingleSpan_IgnoresStartIndex(int startIndex)
     {
         var span = CreateSpan(spanId: 42);
         var collection = new SpanCollection(span);
 
         // startIndex is irrelevant for single-span collections
-        collection.ContainsSpanId(42, 5).Should().BeTrue();
+        collection.ContainsSpanId(42, startIndex).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    public void ContainsSpanId_EmptyArrayBackedCollection_ReturnsFalse(int startIndex)
+    {
+        var collection = new SpanCollection(arrayBuilderCapacity: 4);
+        collection.ContainsSpanId(spanId: 10, startIndex).Should().BeFalse();
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Agent/SpanCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/SpanCollectionTests.cs
@@ -214,9 +214,80 @@ public class SpanCollectionTests
         array!.Value.Array!.Length.Should().Be(16);
     }
 
-    private static Span CreateSpan(string operationName = "test-span")
+    [Fact]
+    public void ContainsSpanId_DefaultCollection_ReturnsFalse()
     {
-        var spanContext = new SpanContext(traceId: 1UL, spanId: 2, samplingPriority: SamplingPriority.AutoKeep);
+        SpanCollection collection = default;
+
+        collection.ContainsSpanId(1, 0).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsSpanId_SingleSpan_FindsMatch()
+    {
+        var span = CreateSpan(spanId: 42);
+        var collection = new SpanCollection(span);
+
+        collection.ContainsSpanId(42, 0).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsSpanId_SingleSpan_NoMatch()
+    {
+        var span = CreateSpan(spanId: 42);
+        var collection = new SpanCollection(span);
+
+        collection.ContainsSpanId(99, 0).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsSpanId_SingleSpan_IgnoresStartIndex()
+    {
+        var span = CreateSpan(spanId: 42);
+        var collection = new SpanCollection(span);
+
+        // startIndex is irrelevant for single-span collections
+        collection.ContainsSpanId(42, 5).Should().BeTrue();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void ContainsSpanId_Array_FindsMatch(
+        [CombinatorialValues(10, 20, 30)]ulong spanToFind,
+        [CombinatorialValues(0, 1, 2, 3, 4)]int spanIndex)
+    {
+        var collection = new SpanCollection(
+            [CreateSpan(spanId: 10), CreateSpan(spanId: 20), CreateSpan(spanId: 30)]);
+
+        collection.ContainsSpanId(spanToFind, spanIndex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsSpanId_Array_NoMatch()
+    {
+        var collection = new SpanCollection(
+            [CreateSpan(spanId: 10), CreateSpan(spanId: 20), CreateSpan(spanId: 30)]);
+
+        collection.ContainsSpanId(99, 0).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsSpanId_ArrayWithCount_OnlySearchesWithinCount()
+    {
+        // Array has 4 slots but only 2 are logically populated.
+        // ContainsSpanId should only search within Count, not the entire backing array.
+        var collection = new SpanCollection(
+            [CreateSpan(spanId: 10), CreateSpan(spanId: 20), CreateSpan(spanId: 30), CreateSpan(spanId: 40)], count: 2);
+
+        collection.ContainsSpanId(10, 0).Should().BeTrue();
+        collection.ContainsSpanId(20, 0).Should().BeTrue();
+        collection.ContainsSpanId(30, 0).Should().BeFalse();
+        collection.ContainsSpanId(40, 0).Should().BeFalse();
+    }
+
+    private static Span CreateSpan(string operationName = "test-span", ulong spanId = 2)
+    {
+        var spanContext = new SpanContext(traceId: 1UL, spanId: spanId, samplingPriority: SamplingPriority.AutoKeep);
         return new Span(spanContext, DateTimeOffset.UtcNow)
         {
             OperationName = operationName


### PR DESCRIPTION
## Summary of changes

Extracts `ContainsSpanId` from `TraceChunkModel` to `SpanCollection`

## Reason for change

I need to find a given span in a `SpanCollection` for client-side-stats. The algorithm used by `TraceChunkModel` does it "properly" (by stating from the last span when looking for a root span), so it seems to make sense to move this method to `SpanCollection`. Additionally, this essentially hides some of the internals about the `SpanCollection` type, so seems like a better place for it anyway.

## Implementation details

- Move the `IndexOf()` method from `TraceChunkModel` to `SpanCollection`
- Switch it to `Contains()` instead, seeing as the index is never actually used AFAICT. It's easy to switch it back later if we _do_ need it.

## Test coverage

Added some unit tests for the method

## Other details


Part of a stack

- https://github.com/DataDog/dd-trace-dotnet/pull/8417
- https://github.com/DataDog/dd-trace-dotnet/pull/8418
- https://github.com/DataDog/dd-trace-dotnet/pull/8420