### PR TITLE
Update base image used in download stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,7 @@ download-single-step-artifacts:
       allow_failure: false
     - when: on_success # Artifacts come from Azure pipeline, but as we already depend on build, we already have a delayed start
   script:
+    - apt-get install --yes --no-install-recommends jq
     - .gitlab/download-single-step-artifacts.sh
     - cp tracer/build/artifacts/requirements.json artifacts/requirements.json
     - cp -r artifacts-out artifacts/windows
@@ -170,6 +171,7 @@ download-serverless-artifacts:
     - when: delayed # Artifacts come from Azure pipeline, wait a reasonable time before polling
       start_in: 15 minutes
   script:
+    - apt-get install --yes --no-install-recommends jq
     - .gitlab/download-serverless-artifacts.sh
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,7 @@ publish:
 
 download-single-step-artifacts:
   stage: package
-  image: registry.ddbuild.io/docker:20.10.13-gbi-focal
+  image: registry.ddbuild.io/images/base/gbi-ubuntu_2404
   timeout: 45m
   tags: [ "arch:amd64" ]
   needs:
@@ -158,7 +158,7 @@ deploy_to_reliability_env:
 
 download-serverless-artifacts:
   stage: package
-  image: registry.ddbuild.io/docker:20.10.13-gbi-focal
+  image: registry.ddbuild.io/images/base/gbi-ubuntu_2404
   tags: [ "arch:amd64" ]
   needs: []
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,7 @@ publish:
 
 download-single-step-artifacts:
   stage: package
-  image: registry.ddbuild.io/images/base/gbi-ubuntu_2404
+  image: registry.ddbuild.io/images/ci/images:1.2.6
   timeout: 45m
   tags: [ "arch:amd64" ]
   needs:
@@ -126,7 +126,6 @@ download-single-step-artifacts:
       allow_failure: false
     - when: on_success # Artifacts come from Azure pipeline, but as we already depend on build, we already have a delayed start
   script:
-    - apt-get install --yes --no-install-recommends jq
     - .gitlab/download-single-step-artifacts.sh
     - cp tracer/build/artifacts/requirements.json artifacts/requirements.json
     - cp -r artifacts-out artifacts/windows
@@ -159,7 +158,7 @@ deploy_to_reliability_env:
 
 download-serverless-artifacts:
   stage: package
-  image: registry.ddbuild.io/images/base/gbi-ubuntu_2404
+  image: registry.ddbuild.io/images/ci/images:1.2.6
   tags: [ "arch:amd64" ]
   needs: []
   rules:
@@ -171,7 +170,6 @@ download-serverless-artifacts:
     - when: delayed # Artifacts come from Azure pipeline, wait a reasonable time before polling
       start_in: 15 minutes
   script:
-    - apt-get install --yes --no-install-recommends jq
     - .gitlab/download-serverless-artifacts.sh
   artifacts:
     expire_in: 2 weeks


### PR DESCRIPTION
## Summary of changes

Updates the base image used in download stages in GitLab

## Reason for change

It's old and needs updating

## Implementation details

Try just updating the image. I chose a somewhat arbitrary image from the registry - we couldn't use `[gbi-ubuntu_2404](https://github.com/DataDog/images/tree/master/base/gbi-ubuntu_2404)` directly, because it doesn't have `jq` installed, so this one seemed as good as any. _Really_ didn't seem worth building our own image just for that, but we could consider it if necessary.

## Test coverage

If the build works, we're fine

## Other details

https://datadoghq.atlassian.net/browse/CONTSEC-2034