### PR TITLE
Add integration test for case apms19196

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         public async Task SubmitTraces()
         {
-            const int expectedSpanCount = 51;
+            const int expectedSpanCount = 52;
             var ddTraceMethodsString = string.Empty;
 
             foreach (var type in TestTypes)
@@ -87,6 +87,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             ddTraceMethodsString += ";Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]";
+
+            // Add method with extreme exception handling nesting (APMS-19196 regression test)
+            // Must target the sync method which has the EH directly in its body (not in an async state machine)
+            ddTraceMethodsString += ";Samples.TraceAnnotations.ExtremeExceptionHandling[DeepNestedExceptionHandlingSync]";
 
             SetEnvironmentVariable("DD_TRACE_METHODS", ddTraceMethodsString);
             // Don't bother with telemetry in version mismatch scenarios because older versions may only support V1 telemetry

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.Core.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.Core.verified.txt
@@ -844,5 +844,19 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.DotNet.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.DotNet.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -836,6 +836,20 @@
     SpanId: Id_61,
     Name: trace.annotation,
     Resource: ProgramHelpers.NewRelicTraceMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.Net.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.Net.verified.txt
@@ -844,5 +844,19 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.Core.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.Core.verified.txt
@@ -844,5 +844,19 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.DotNet.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.DotNet.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -836,6 +836,20 @@
     SpanId: Id_61,
     Name: trace.annotation,
     Resource: ProgramHelpers.NewRelicTraceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.Net.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.Net.verified.txt
@@ -844,5 +844,19 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.Core.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.Core.verified.txt
@@ -844,5 +844,19 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.DotNet.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.DotNet.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -836,6 +836,20 @@
     SpanId: Id_61,
     Name: trace.annotation,
     Resource: ProgramHelpers.NewRelicTraceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.Net.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.Net.verified.txt
@@ -844,5 +844,19 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: trace.annotation,
+    Resource: ExtremeExceptionHandling.DeepNestedExceptionHandlingSync,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Samples.TraceAnnotations.VersionMismatch.AfterFeature.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Samples.TraceAnnotations.VersionMismatch.AfterFeature.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
@@ -21,5 +21,6 @@
     <Compile Include="..\Samples.TraceAnnotations\ProgramHelpers.cs" />
     <Compile Include="..\Samples.TraceAnnotations\TestType.cs" />
     <Compile Include="..\Samples.TraceAnnotations\TraceAttribute.cs" />
+    <Compile Include="..\Samples.TraceAnnotations\ExtremeExceptionHandling.cs" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Samples.TraceAnnotations.VersionMismatch.BeforeFeature.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Samples.TraceAnnotations.VersionMismatch.BeforeFeature.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
@@ -21,5 +21,6 @@
     <Compile Include="..\Samples.TraceAnnotations\ProgramHelpers.cs" />
     <Compile Include="..\Samples.TraceAnnotations\TestType.cs" />
     <Compile Include="..\Samples.TraceAnnotations\TraceAttribute.cs" />
+    <Compile Include="..\Samples.TraceAnnotations\ExtremeExceptionHandling.cs" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ExtremeExceptionHandling.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ExtremeExceptionHandling.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Samples.TraceAnnotations
+{
+    /// <summary>
+    /// Test class with deeply nested try/catch/finally patterns that triggered
+    /// a bug in the IL rewriter's exception handler sorting logic (APMS-19196).
+    /// The bug causes InvalidProgramException on Linux x86/x64 due to stricter EH clause
+    /// validation by the Linux CLR; Windows does not exhibit the crash.
+    /// </summary>
+    public static class ExtremeExceptionHandling
+    {
+        private static int _counter = 0;
+
+        /// <summary>
+        /// Async wrapper that calls the sync method with deep EH nesting.
+        /// </summary>
+        public static async Task<string> DeepNestedExceptionHandlingAsync()
+        {
+            await Task.Yield();
+            return DeepNestedExceptionHandlingSync();
+        }
+
+        /// <summary>
+        /// Synchronous method with 9 levels of nested try/catch/finally.
+        /// This pattern triggers the EH clause sorting bug when instrumented.
+        /// The EH is directly in this method (not in a state machine).
+        /// </summary>
+        public static string DeepNestedExceptionHandlingSync()
+        {
+            var requestId = System.Threading.Interlocked.Increment(ref _counter);
+
+            try
+            {
+                // Level 1
+                try
+                {
+                    Console.WriteLine($"[L1] {requestId}");
+
+                    // Level 5 (skipping L2,L3,L4 - the crashing pattern!)
+                    try
+                    {
+                        Console.WriteLine($"[L5] {requestId}");
+
+                        // Level 6
+                        try
+                        {
+                            Console.WriteLine($"[L6] {requestId}");
+
+                            // Level 7
+                            try
+                            {
+                                Console.WriteLine($"[L7] {requestId}");
+
+                                // Level 8
+                                try
+                                {
+                                    Console.WriteLine($"[L8] {requestId}");
+
+                                    // Level 9 - THE CRASH TRIGGER
+                                    try
+                                    {
+                                        Console.WriteLine($"[L9] {requestId}");
+                                        System.Threading.Thread.Sleep(1);
+                                        Console.WriteLine($"[L9] Success {requestId}");
+                                    }
+                                    catch (Exception l9Ex)
+                                    {
+                                        Console.WriteLine($"[L9] Exception: {l9Ex.GetType().Name}");
+                                    }
+                                    finally
+                                    {
+                                        Console.WriteLine($"[L9] Finally {requestId}");
+                                    }
+                                }
+                                catch (Exception l8Ex)
+                                {
+                                    Console.WriteLine($"[L8] Exception: {l8Ex.GetType().Name}");
+                                }
+                                finally
+                                {
+                                    Console.WriteLine($"[L8] Finally {requestId}");
+                                }
+                            }
+                            catch (Exception l7Ex)
+                            {
+                                Console.WriteLine($"[L7] Exception: {l7Ex.GetType().Name}");
+                            }
+                            finally
+                            {
+                                Console.WriteLine($"[L7] Finally {requestId}");
+                            }
+                        }
+                        catch (Exception l6Ex)
+                        {
+                            Console.WriteLine($"[L6] Exception: {l6Ex.GetType().Name}");
+                        }
+                        finally
+                        {
+                            Console.WriteLine($"[L6] Finally {requestId}");
+                        }
+                    }
+                    catch (Exception l5Ex)
+                    {
+                        Console.WriteLine($"[L5] Exception: {l5Ex.GetType().Name}");
+                    }
+                    finally
+                    {
+                        Console.WriteLine($"[L5] Finally {requestId}");
+                    }
+                }
+                finally
+                {
+                    Console.WriteLine($"[L1] Finally {requestId}");
+                }
+            }
+            catch (Exception rootEx)
+            {
+                Console.WriteLine($"[ROOT] Exception: {rootEx.GetType().Name}");
+            }
+            finally
+            {
+                Console.WriteLine($"[ROOT] Finally {requestId}");
+            }
+
+            return $"Success {requestId}";
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
@@ -133,6 +133,10 @@ namespace Samples.TraceAnnotations
             await WaitUsingOfficialAttribute();
             await NewRelicTransactionMethodAsync("Hello World");
             NewRelicTraceMethod(42);
+
+            // Test extreme exception handling patterns (APMS-19196 regression test)
+            // This exercises the IL rewriter with complex try/catch/finally nesting
+            await ExtremeExceptionHandling.DeepNestedExceptionHandlingAsync();
         }
 
         [OfficialTrace(OperationName = "overridden.attribute", ResourceName = "Program_WaitUsingOfficialAttribute")]


### PR DESCRIPTION
## Summary of changes

This reproduces the crash [described in this README](https://github.com/DataDog/dd-trace-dotnet/blob/82cc4cf0e29478fd2fdc41afdf764a2abf662199/repro/APMS-19196/README.md) on linux x64 arch.

Aim is to merge to https://github.com/DataDog/dd-trace-dotnet/pull/8428
First tested it's crashing on master 
<img width="2830" height="851" alt="image" src="https://github.com/user-attachments/assets/96e882fa-308e-44b6-8116-c93c7d5b7bb2" />


## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
