### PR TITLE
Set resource name after exception in OnEndRequest method

### DIFF
--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -263,6 +263,18 @@ namespace Datadog.Trace.AspNet
                 if (shouldDisposeScope)
                 {
                     // Dispose here, as the scope won't be in context items and won't get disposed on request end in that case...
+                    try
+                    {
+                        if (scope?.Span.ResourceName is null)
+                        {
+                            scope.Span.ResourceName = BuildResourceName(tracer, httpRequest);
+                        }
+                    }
+                    catch (Exception ex2)
+                    {
+                        Log.Debug(ex2, "Unable to set fallback resource name.");
+                    }
+
                     scope?.Dispose();
                     inferredProxyScope?.Dispose();
                 }

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -265,9 +265,9 @@ namespace Datadog.Trace.AspNet
                     // Dispose here, as the scope won't be in context items and won't get disposed on request end in that case...
                     try
                     {
-                        if (scope?.Span.ResourceName is null)
+                        if (scope?.Span is { ResourceName: null } span)
                         {
-                            scope.Span.ResourceName = BuildResourceName(tracer, httpRequest);
+                            span.ResourceName = BuildResourceName(tracer, httpRequest);
                         }
                     }
                     catch (Exception ex2)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -417,6 +417,20 @@ namespace Datadog.Trace.AspNet
                     }
                     finally
                     {
+                        // If an exception prevented the normal resource name logic from running,
+                        // set a fallback resource name before disposing to avoid defaulting to the operation name
+                        try
+                        {
+                            if (scope.Span.ResourceName is null)
+                            {
+                                scope.Span.ResourceName = BuildResourceName(tracer, app.Request);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Debug(ex, "Unable to set fallback resource name.");
+                        }
+
                         scope.Dispose();
                         proxyScope?.Dispose();
                         // Clear the context to make sure another TracingHttpModule doesn't try to close the same scope

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -130,10 +130,10 @@ namespace Datadog.Trace.AspNet
             Scope scope = null;
             Scope inferredProxyScope = null;
             bool shouldDisposeScope = true;
+            var tracer = Tracer.Instance;
 
             try
             {
-                var tracer = Tracer.Instance;
                 if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId))
                 {
                     // integration disabled
@@ -263,18 +263,17 @@ namespace Datadog.Trace.AspNet
                 if (shouldDisposeScope)
                 {
                     // Dispose here, as the scope won't be in context items and won't get disposed on request end in that case...
-                    // TEMPORARILY COMMENTED OUT for testing — remove to re-enable the fix
-                    // try
-                    // {
-                    //     if (scope?.Span is { ResourceName: null } span)
-                    //     {
-                    //         span.ResourceName = BuildResourceName(tracer, (sender as HttpApplication)?.Context?.Request);
-                    //     }
-                    // }
-                    // catch (Exception ex2)
-                    // {
-                    //     Log.Debug(ex2, "Unable to set fallback resource name.");
-                    // }
+                    try
+                    {
+                        if (scope?.Span is { ResourceName: null } span)
+                        {
+                            span.ResourceName = BuildResourceName(tracer, (sender as HttpApplication)?.Context?.Request);
+                        }
+                    }
+                    catch (Exception ex2)
+                    {
+                        Log.Debug(ex2, "Unable to set fallback resource name.");
+                    }
 
                     scope?.Dispose();
                     inferredProxyScope?.Dispose();
@@ -430,18 +429,17 @@ namespace Datadog.Trace.AspNet
                     }
                     finally
                     {
-                        // TEMPORARILY COMMENTED OUT for testing — remove to re-enable the fix
-                        // try
-                        // {
-                        //     if (scope.Span.ResourceName is null)
-                        //     {
-                        //         scope.Span.ResourceName = BuildResourceName(tracer, app.Request);
-                        //     }
-                        // }
-                        // catch (Exception ex)
-                        // {
-                        //     Log.Debug(ex, "Unable to set fallback resource name.");
-                        // }
+                        try
+                        {
+                            if (scope.Span.ResourceName is null)
+                            {
+                                scope.Span.ResourceName = BuildResourceName(tracer, app.Request);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Debug(ex, "Unable to set fallback resource name.");
+                        }
 
                         scope.Dispose();
                         proxyScope?.Dispose();

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracingHttpModule.cs" company="Datadog">
+// <copyright file="TracingHttpModule.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -130,13 +130,10 @@ namespace Datadog.Trace.AspNet
             Scope scope = null;
             Scope inferredProxyScope = null;
             bool shouldDisposeScope = true;
+            var tracer = Tracer.Instance;
+
             try
             {
-bool shouldDisposeScope = true;
-var tracer = Tracer.Instance;
-try
-{
-
                 if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId))
                 {
                     // integration disabled
@@ -270,7 +267,7 @@ try
                     {
                         if (scope?.Span is { ResourceName: null } span)
                         {
-                            span.ResourceName = BuildResourceName(tracer, httpRequest);
+                            span.ResourceName = BuildResourceName(tracer, (sender as HttpApplication)?.Context?.Request);
                         }
                     }
                     catch (Exception ex2)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -132,7 +132,10 @@ namespace Datadog.Trace.AspNet
             bool shouldDisposeScope = true;
             try
             {
-                var tracer = Tracer.Instance;
+bool shouldDisposeScope = true;
+var tracer = Tracer.Instance;
+try
+{
 
                 if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId))
                 {

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -130,10 +130,10 @@ namespace Datadog.Trace.AspNet
             Scope scope = null;
             Scope inferredProxyScope = null;
             bool shouldDisposeScope = true;
-            var tracer = Tracer.Instance;
 
             try
             {
+                var tracer = Tracer.Instance;
                 if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId))
                 {
                     // integration disabled
@@ -263,17 +263,18 @@ namespace Datadog.Trace.AspNet
                 if (shouldDisposeScope)
                 {
                     // Dispose here, as the scope won't be in context items and won't get disposed on request end in that case...
-                    try
-                    {
-                        if (scope?.Span is { ResourceName: null } span)
-                        {
-                            span.ResourceName = BuildResourceName(tracer, (sender as HttpApplication)?.Context?.Request);
-                        }
-                    }
-                    catch (Exception ex2)
-                    {
-                        Log.Debug(ex2, "Unable to set fallback resource name.");
-                    }
+                    // TEMPORARILY COMMENTED OUT for testing — remove to re-enable the fix
+                    // try
+                    // {
+                    //     if (scope?.Span is { ResourceName: null } span)
+                    //     {
+                    //         span.ResourceName = BuildResourceName(tracer, (sender as HttpApplication)?.Context?.Request);
+                    //     }
+                    // }
+                    // catch (Exception ex2)
+                    // {
+                    //     Log.Debug(ex2, "Unable to set fallback resource name.");
+                    // }
 
                     scope?.Dispose();
                     inferredProxyScope?.Dispose();
@@ -429,19 +430,18 @@ namespace Datadog.Trace.AspNet
                     }
                     finally
                     {
-                        // If an exception prevented the normal resource name logic from running,
-                        // set a fallback resource name before disposing to avoid defaulting to the operation name
-                        try
-                        {
-                            if (scope.Span.ResourceName is null)
-                            {
-                                scope.Span.ResourceName = BuildResourceName(tracer, app.Request);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Debug(ex, "Unable to set fallback resource name.");
-                        }
+                        // TEMPORARILY COMMENTED OUT for testing — remove to re-enable the fix
+                        // try
+                        // {
+                        //     if (scope.Span.ResourceName is null)
+                        //     {
+                        //         scope.Span.ResourceName = BuildResourceName(tracer, app.Request);
+                        //     }
+                        // }
+                        // catch (Exception ex)
+                        // {
+                        //     Log.Debug(ex, "Unable to set fallback resource name.");
+                        // }
 
                         scope.Dispose();
                         proxyScope?.Dispose();


### PR DESCRIPTION
When no resource-based sampling rules are configured, the resource name was only set in OnEndRequest. If OnEndRequest doesn't complete (e.g., client disconnect), the resource name remained null and defaulted to the operation name aspnet.request in Span.Finish(). This fix ensures the resource name is always set early in OnBeginRequest. Fixes APMS-19184

Made-with: Cursor

## Summary of changes

## Reason for change
https://datadoghq.atlassian.net/browse/APMS-19184

## Implementation details

## Test coverage

## Other details


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
