### PR TITLE
Fix excessive allocation in vendored `SharedArrayPool`

### DIFF
--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/Buffers/SharedArrayPool.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/Buffers/SharedArrayPool.cs
@@ -298,7 +298,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                 // Try to push on to the associated partition first.  If that fails,
                 // round-robin through the other partitions.
                 Partition[] partitions = _partitions;
-                int index = (int)((uint)Process.GetCurrentProcess().Id % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
+                int index = (int)((uint)Environment.CurrentManagedThreadId % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
                 // int index = (int)((uint)Thread.GetCurrentProcessorId() % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
                 for (int i = 0; i < partitions.Length; i++)
                 {
@@ -319,7 +319,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                 // Try to pop from the associated partition first.  If that fails, round-robin through the other partitions.
                 T[]? arr;
                 Partition[] partitions = _partitions;
-                int index = (int)((uint)Process.GetCurrentProcess().Id % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
+                int index = (int)((uint)Environment.CurrentManagedThreadId % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
                 // todo: fix int index = (int)((uint)Thread.GetCurrentProcessorId() % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
                 for (int i = 0; i < partitions.Length; i++)
                 {


### PR DESCRIPTION
## Summary of changes

Fixes a critical allocation regression in vendored `ArrayPool` implementation

## Reason for change

When vendored, the `SharedArrayPool` introduced a large allocation, by calling `Process.GetCurrentProcess()` every time an array is rented or returned. This causes significant allocation (potentially even more than _not_ using the pool would) on applicable TFMs (i.e. .NET Framework and <.NET Core 3.1).

This was obviously introduced during vendoring due to the lack of the `Thread.GetCurrentProcessorId()` method in .NET Framework, but unfortunately the chosen replacement is likely worse for performance than just using a constant 😢

```csharp
int index = (int)((uint)Process.GetCurrentProcess().Id % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
// todo: fix int index = (int)((uint)Thread.GetCurrentProcessorId() % (uint)SharedArrayPoolStatics.s_partitionCount); // mod by constant in tier 1
```

## Implementation details

The immediate fix is instead of calling `Process.GetCurrentProcess()`, use `Environment.CurrentManagedThreadId` to try to get _some_ kind of "round robin" behaviour. 

The longer-term fix is likely to update the vendor implementation to use the .NET Framework-appropriate versions instead of trying to backport .NET 7 to .NET Framework

## Test coverage

I discovered this when benchmarking something else, where it showed up as a stark difference in .NET Framework, which was the only TFM using the vendored array

| Method                          | Runtime            |        Mean | Allocated |
| ------------------------------- | ------------------ | ----------: | --------: |
| BuildKey_ClientSpanWithPeerTags | .NET 10.0          |   852.78 ns |     688 B |
| BuildKey_ClientSpanWithPeerTags | .NET 6.0           | 1,144.97 ns |     688 B |
| BuildKey_ClientSpanWithPeerTags | .NET Core 3.1      | 1,666.94 ns |     688 B |
| BuildKey_ClientSpanWithPeerTags | .NET Framework 4.8 | 4,002.83 ns |    2391 B |


## Other details

Should be fixed at source as part of https://datadoghq.atlassian.net/browse/APMLP-1207