### PR TITLE
Allow passing an offset and count to `FnvHash64.GenerateHash()`

### DIFF
--- a/tracer/src/Datadog.Trace/Util/FnvHash64.cs
+++ b/tracer/src/Datadog.Trace/Util/FnvHash64.cs
@@ -90,7 +90,7 @@ internal static class FnvHash64
     /// </summary>
     /// <returns>The 64-bit FNV hash of the data, as a <c>ulong</c></returns>
     public static ulong GenerateHash(byte[] data, Version version)
-        => GenerateHash(data, version, OffsetBasis);
+        => GenerateHash(data, 0, data.Length, version, OffsetBasis);
 
     /// <summary>
     /// Generates the 64-bit FNV hash of <paramref name="data"/> using hash version <paramref name="version"/>.
@@ -99,16 +99,32 @@ internal static class FnvHash64
     /// </summary>
     /// <returns>The 64-bit FNV hash of the data, as a <c>ulong</c></returns>
     public static ulong GenerateHash(byte[] data, Version version, ulong initialHash)
+        => GenerateHash(data, 0, data.Length, version, initialHash);
+
+    /// <summary>
+    /// Generates the 64-bit FNV hash of a region of <paramref name="data"/> using hash version <paramref name="version"/>.
+    /// </summary>
+    /// <returns>The 64-bit FNV hash of the data, as a <c>ulong</c></returns>
+    public static ulong GenerateHash(byte[] data, int offset, int count, Version version)
+        => GenerateHash(data, offset, count, version, OffsetBasis);
+
+    /// <summary>
+    /// Generates the 64-bit FNV hash of a region of <paramref name="data"/> using hash version <paramref name="version"/>.
+    /// Appends the hash to the existing value <paramref name="initialHash"/>. Equivalent to concatenating
+    /// the two data values and subsequently calling GenerateHash.
+    /// </summary>
+    /// <returns>The 64-bit FNV hash of the data, as a <c>ulong</c></returns>
+    public static ulong GenerateHash(byte[] data, int offset, int count, Version version, ulong initialHash)
         => version == Version.V1
-               ? GenerateV1Hash(data, initialHash)
-               : GenerateV1AHash(data, initialHash);
+               ? GenerateV1Hash(data, offset, count, initialHash)
+               : GenerateV1AHash(data, offset, count, initialHash);
 
 #if NETCOREAPP
     /// <summary>
     /// Generates the 64-bit FNV hash of <paramref name="data"/> using hash version <paramref name="version"/>.
     /// </summary>
     /// <returns>The 64-bit FNV hash of the data, as a <c>ulong</c></returns>
-    public static ulong GenerateHash(Span<byte> data, Version version)
+    public static ulong GenerateHash(ReadOnlySpan<byte> data, Version version)
         => GenerateHash(data, version, OffsetBasis);
 
     /// <summary>
@@ -117,38 +133,40 @@ internal static class FnvHash64
     /// the two data values and subsequently calling GenerateHash.
     /// </summary>
     /// <returns>The 64-bit FNV hash of the data, as a <c>ulong</c></returns>
-    public static ulong GenerateHash(Span<byte> data, Version version, ulong initialHash)
+    public static ulong GenerateHash(ReadOnlySpan<byte> data, Version version, ulong initialHash)
         => version == Version.V1
                ? GenerateV1Hash(data, initialHash)
                : GenerateV1AHash(data, initialHash);
 #endif
 
-    private static ulong GenerateV1Hash(byte[] bytes, ulong hash)
+    private static ulong GenerateV1Hash(byte[] bytes, int offset, int count, ulong hash)
     {
         // for each octet_of_data to be hashed
-        foreach (var b in bytes)
+        var max = offset + count;
+        for (var i = offset; i < max; i++)
         {
             unchecked
             {
                 // hash = hash * FNV_prime
                 hash *= FnvPrime;
                 // hash = hash xor octet_of_data
-                hash ^= b;
+                hash ^= bytes[i];
             }
         }
 
         return hash;
     }
 
-    private static ulong GenerateV1AHash(byte[] bytes, ulong hash)
+    private static ulong GenerateV1AHash(byte[] bytes, int offset, int count, ulong hash)
     {
         // for each octet_of_data to be hashed
-        foreach (var b in bytes)
+        var max = offset + count;
+        for (var i = offset; i < max; i++)
         {
             unchecked
             {
                 // hash = hash xor octet_of_data
-                hash ^= b;
+                hash ^= bytes[i];
                 // hash = hash * FNV_prime
                 hash *= FnvPrime;
             }

--- a/tracer/test/Datadog.Trace.Tests/Util/FnvHash64Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/FnvHash64Tests.cs
@@ -246,6 +246,36 @@ public class FnvHash64Tests
         v1A.ToString("x16").Should().Be("0803564445050395");
     }
 
+    [Theory]
+    [MemberData(nameof(BinaryData))]
+    public void CalculatesOffsetCountHashCorrectly(byte[] data, string v1HashAsHex, string v1AHashAsHex)
+    {
+        var v1 = FnvHash64.GenerateHash(data, 0, data.Length, FnvHash64.Version.V1);
+        var v1A = FnvHash64.GenerateHash(data, 0, data.Length, FnvHash64.Version.V1A);
+
+        using var a = new AssertionScope();
+        v1.ToString("x16").Should().Be(v1HashAsHex);
+        v1A.ToString("x16").Should().Be(v1AHashAsHex);
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryData))]
+    public void CalculatesOffsetCountHashCorrectlyWithOffset(byte[] data, string v1HashAsHex, string v1AHashAsHex)
+    {
+        // Embed the data in the middle of a larger array to test that offset is handled correctly
+        const int padding = 5;
+        var padded = new byte[data.Length + (padding * 2)];
+        new Random().NextBytes(padded);
+        Array.Copy(data, 0, padded, padding, data.Length);
+
+        var v1 = FnvHash64.GenerateHash(padded, padding, data.Length, FnvHash64.Version.V1);
+        var v1A = FnvHash64.GenerateHash(padded, padding, data.Length, FnvHash64.Version.V1A);
+
+        using var a = new AssertionScope();
+        v1.ToString("x16").Should().Be(v1HashAsHex);
+        v1A.ToString("x16").Should().Be(v1AHashAsHex);
+    }
+
 #if NETCOREAPP3_1_OR_GREATER
     [Theory]
     [MemberData(nameof(StringData))]


### PR DESCRIPTION
## Summary of changes

Allow passing an offset and count to `FnvHash64.GenerateHash()`

## Reason for change

Let's us hash values stored in a `byte[]` that comes from an array pool, instead of requiring hashing the _whole_ `byte[]`. Allows for various optimizations in places.

## Implementation details

- Add a new overload that takes `int offset, int count` values
- Update existing `byte[]` to use the overload
- Add unit tests for checking the new behaviour. Existing is already covered

## Test coverage

Added unit tests to cover the new behaviour

## Other details

Part of a stack:
- https://github.com/DataDog/dd-trace-dotnet/pull/8417
- https://github.com/DataDog/dd-trace-dotnet/pull/8418
- https://github.com/DataDog/dd-trace-dotnet/pull/8420
- https://github.com/DataDog/dd-trace-dotnet/pull/8435
- https://github.com/DataDog/dd-trace-dotnet/pull/8436