### PR TITLE
Add a trace_stats_sampled scenario to macrobenchmarks

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -183,7 +183,7 @@ calltarget_ngen_sampled-x86:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
-    DD_TRACE_SAMPLE_RATE: "0.1"
+    DD_TRACE_SAMPLE_RATE: "0.001"
     ENDPOINT: "hello"
 
 single_span-x86:
@@ -220,7 +220,7 @@ trace_stats_sampled-x86:
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
     DD_TRACE_STATS_COMPUTATION_ENABLED: 1
-    DD_TRACE_SAMPLE_RATE: "0.1"
+    DD_TRACE_SAMPLE_RATE: "0.001"
     ENDPOINT: "hello"
 
 manual_only-x86:
@@ -407,7 +407,7 @@ calltarget_ngen_sampled-arm64:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
-    DD_TRACE_SAMPLE_RATE: "0.1"
+    DD_TRACE_SAMPLE_RATE: "0.001"
     ENDPOINT: "hello"
 
 single_span-arm64:
@@ -447,7 +447,7 @@ trace_stats_sampled-arm64:
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
     DD_TRACE_STATS_COMPUTATION_ENABLED: 1
-    DD_TRACE_SAMPLE_RATE: "0.1"
+    DD_TRACE_SAMPLE_RATE: "0.001"
     ENDPOINT: "hello"
 
 manual_only-arm64:
@@ -674,7 +674,7 @@ calltarget_ngen_sampled-win:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
-    DD_TRACE_SAMPLE_RATE: "0.1"
+    DD_TRACE_SAMPLE_RATE: "0.001"
     ENDPOINT: "hello"
 
 single_span-win:
@@ -705,7 +705,7 @@ trace_stats_sampled-win:
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
     DD_TRACE_STATS_COMPUTATION_ENABLED: 1
-    DD_TRACE_SAMPLE_RATE: "0.1"
+    DD_TRACE_SAMPLE_RATE: "0.001"
     ENDPOINT: "hello"
 
 manual_only-win:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -198,6 +198,19 @@ trace_stats-x86:
     DD_TRACE_STATS_COMPUTATION_ENABLED: 1
     ENDPOINT: "hello"
 
+trace_stats_sampled-x86:
+  extends: .benchmarks-x86
+  variables:
+    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_CLR_ENABLE_INLINING: 1
+    DD_CLR_ENABLE_NGEN: 1
+    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    DD_TRACE_SAMPLE_RATE: "0.1"
+    ENDPOINT: "hello"
+
 manual_only-x86:
   extends: .benchmarks-x86
   variables:
@@ -396,6 +409,20 @@ trace_stats-arm64:
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
     DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    ENDPOINT: "hello"
+
+trace_stats_sampled-arm64:
+  extends: .benchmarks-arm64
+  tags: ["runner:apm-k8s-arm-metal"]
+  variables:
+    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_CLR_ENABLE_INLINING: 1
+    DD_CLR_ENABLE_NGEN: 1
+    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    DD_TRACE_SAMPLE_RATE: "0.1"
     ENDPOINT: "hello"
 
 manual_only-arm64:
@@ -633,6 +660,17 @@ trace_stats-win:
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
     DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    ENDPOINT: "hello"
+
+trace_stats_sampled-win:
+  extends: .benchmarks-win
+  variables:
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_CLR_ENABLE_INLINING: 1
+    DD_CLR_ENABLE_NGEN: 1
+    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    DD_TRACE_SAMPLE_RATE: "0.1"
     ENDPOINT: "hello"
 
 manual_only-win:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -183,7 +183,7 @@ calltarget_ngen_sampled-x86:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
-    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    DD_TRACE_SAMPLE_RATE: "0.1"
     ENDPOINT: "hello"
 
 single_span-x86:
@@ -407,7 +407,7 @@ calltarget_ngen_sampled-arm64:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
-    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    DD_TRACE_SAMPLE_RATE: "0.1"
     ENDPOINT: "hello"
 
 single_span-arm64:
@@ -674,7 +674,7 @@ calltarget_ngen_sampled-win:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
-    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    DD_TRACE_SAMPLE_RATE: "0.1"
     ENDPOINT: "hello"
 
 single_span-win:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -174,6 +174,18 @@ calltarget_ngen-x86:
     DD_CLR_ENABLE_NGEN: 1
     ENDPOINT: "hello"
 
+calltarget_ngen_sampled-x86:
+  extends: .benchmarks-x86
+  variables:
+    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_CLR_ENABLE_INLINING: 1
+    DD_CLR_ENABLE_NGEN: 1
+    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+    ENDPOINT: "hello"
+
 single_span-x86:
   extends: .benchmarks-x86
   variables:
@@ -383,6 +395,19 @@ calltarget_ngen-arm64:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
+    ENDPOINT: "hello"
+
+calltarget_ngen_sampled-arm64:
+  extends: .benchmarks-arm64
+  tags: ["runner:apm-k8s-arm-metal"]
+  variables:
+    NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+    TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_CLR_ENABLE_INLINING: 1
+    DD_CLR_ENABLE_NGEN: 1
+    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
     ENDPOINT: "hello"
 
 single_span-arm64:
@@ -640,6 +665,16 @@ calltarget_ngen-win:
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
     DD_CLR_ENABLE_NGEN: 1
+    ENDPOINT: "hello"
+
+calltarget_ngen_sampled-win:
+  extends: .benchmarks-win
+  variables:
+    COR_ENABLE_PROFILING: 1
+    CORECLR_ENABLE_PROFILING: 1
+    DD_CLR_ENABLE_INLINING: 1
+    DD_CLR_ENABLE_NGEN: 1
+    DD_TRACE_STATS_COMPUTATION_ENABLED: 1
     ENDPOINT: "hello"
 
 single_span-win:


### PR DESCRIPTION
## Summary of changes

Adds 10% sampled scenarios to macrobenchmarks

## Reason for change

We'd like to understand the impact of sampling on throughput, particularly with regards to client-side-stats

## Implementation details

Added 2 new scenarios to each platform

## Test coverage

This is the test, hopefully it works 🤞 

## Other details

Related to this stack (but can and should be merged first and independently)

Part of a stack:
- https://github.com/DataDog/dd-trace-dotnet/pull/8417
- https://github.com/DataDog/dd-trace-dotnet/pull/8418
- https://github.com/DataDog/dd-trace-dotnet/pull/8420
- https://github.com/DataDog/dd-trace-dotnet/pull/8435
- https://github.com/DataDog/dd-trace-dotnet/pull/8436
- https://github.com/DataDog/dd-trace-dotnet/pull/8444