### PR TITLE
Docker run retry

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -61,6 +61,30 @@ steps:
 
     echo "Using SDK version $sdkVersion"
 
+    # Retry wrapper for transient Docker daemon errors (e.g., D-Bus/cgroup flakes).
+    # Exit code 125 = Docker daemon error (container creation failure, not a test/build failure).
+    docker_run_with_retry() {
+      local max_retries=3
+      local retry_delay=10
+      local attempt=1
+      while [ "$attempt" -le "$max_retries" ]; do
+        "$@"
+        local exit_code=$?
+        if [ "$exit_code" -eq 0 ]; then
+          return 0
+        fi
+        echo "##[warning][docker-retry] docker run failed with exit code ${exit_code} on attempt ${attempt}/${max_retries}."
+        if [ "$exit_code" -eq 125 ] && [ "$attempt" -lt "$max_retries" ]; then
+          echo "##[warning][docker-retry] Exit code 125 indicates a Docker daemon error. Retrying in ${retry_delay}s..."
+          sleep "$retry_delay"
+          attempt=$((attempt + 1))
+          continue
+        fi
+        return "$exit_code"
+      done
+    }
+
+    docker_run_with_retry \
     docker run --rm \
         --cap-add=SYS_PTRACE \
         --mount type=bind,source="$(System.DefaultWorkingDirectory)",target=/project \


### PR DESCRIPTION
## Summary of changes

Add a targeted retry wrapper around `docker run` in `run-in-docker.yml` to handle transient Docker daemon errors without blanket-retrying the entire CI step.

## Reason for change

After merging #8358 (Docker daemon readiness checks), we still observed transient failures where the daemon was confirmed ready but `docker run` failed with D-Bus/cgroup errors like:

> `unable to start unit "docker-....scope": Message recipient disconnected from message bus without replying`

The daemon is healthy (passes `docker info`), but systemd's D-Bus has a momentary hiccup during container cgroup creation. This is a transient infrastructure issue, not a test failure.

## Implementation details

- Adds a `docker_run_with_retry` shell function that wraps the `docker run` invocation
- **Only retries on exit code 125** (Docker daemon error — container creation failure), up to 3 attempts with 10s delay
- **Does not retry** on any other exit code (test/build failures inside the container pass through immediately)
- **Always logs the exit code** on failure (`##[warning]`), so we can observe actual exit codes for future Docker errors regardless of whether they trigger a retry

## Test coverage

CI pipeline change — no unit tests. Validated by reviewing Docker's exit code conventions (125 = daemon error).

## Other details

Follow-up to #8358.