### PR TITLE
[Coding Agents] Add HTTP REST API fallbacks for AzDO build analysis

### DIFF
--- a/.claude/skills/analyze-azdo-build/SKILL.md
+++ b/.claude/skills/analyze-azdo-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-azdo-build
-description: Analyze Azure DevOps CI build failures in dd-trace-dotnet pipeline. Use this skill whenever the user mentions a failing CI build, PR checks failing, Azure DevOps pipeline failures, test failures in CI, or when they share a build ID or PR number and want to understand what went wrong. Analyzes build failures, categorizes them (infrastructure/flaky/real), and provides actionable recommendations.
+description: Analyze Azure DevOps CI build failures in dd-trace-dotnet pipeline. This skill should be used when the user mentions a failing CI build, PR checks failing, Azure DevOps pipeline failures, test failures in CI, or when they share a build ID or PR number and want to understand what went wrong. Analyzes build failures, categorizes them (infrastructure/flaky/real), and provides actionable recommendations.
 argument-hint: <pr NUMBER | build BUILD_ID>
 user-invocable: true
 allowed-tools: WebFetch, Bash(pwsh -Version*), Bash(pwsh *Get-AzureDevOpsBuildAnalysis.ps1*), Bash(pwsh *Retry-AzureDevOpsFailedStages.ps1*), Bash(gh pr checks:*), Bash(az devops invoke:*), Bash(az pipelines build list:*), Bash(az pipelines build show:*), Bash(az pipelines runs artifact list:*), Bash(az pipelines runs list:*), Bash(az pipelines runs show:*)
@@ -12,40 +12,19 @@ Troubleshoot Azure DevOps pipeline failures with automated analysis.
 
 ## Prerequisites
 
-This skill requires the following tools. If any are missing, provide the relevant install instructions below.
+- **PowerShell 7+** (`pwsh`) — Required. PowerShell 5.1 minimum on Windows.
+- **Azure CLI** (`az`) — Optional for read-only analysis; required for stage retry.
+- **GitHub CLI** (`gh`) — Optional; HTTP fallback for public repos.
 
-### PowerShell 7+ (`pwsh`) — Required
-
-The build analysis script requires PowerShell. PowerShell 7+ (`pwsh`) is recommended; PowerShell 5.1 (`powershell.exe`, Windows only) is the minimum.
-
-- **Verify**: `pwsh -Version`
-- **Install**: `winget install Microsoft.PowerShell` (Windows) · `brew install powershell/tap/powershell` (macOS)
-- **Docs**: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell
+See [scripts-reference.md](scripts-reference.md#prerequisites) for install instructions, verification commands, and HTTP fallback details.
 
 **If the user does not have PowerShell installed**:
 1. Check for `pwsh` first: `pwsh -Version`
 2. If not found and on Windows, check for PowerShell 5.1: `powershell -NoProfile -Command '$PSVersionTable.PSVersion'`
-3. If neither found or version is too old, provide installation instructions above
+3. If neither found or version is too old, provide installation instructions from [scripts-reference.md](scripts-reference.md#prerequisites)
 4. Do NOT attempt to replicate the script functionality using bash/jq - the logic is too complex
 
 **Always prefer `pwsh` over `powershell.exe`** when both are available.
-
-### GitHub CLI (`gh`) — Required for PR analysis
-
-Used to resolve PR numbers to Azure DevOps build IDs. Must be authenticated.
-
-- **Verify**: `gh auth status`
-- **Install**: `winget install GitHub.cli` (Windows) · `brew install gh` (macOS)
-- **Docs**: https://cli.github.com/
-
-### Azure CLI (`az`) with `azure-devops` extension — Required
-
-Used by the PowerShell script to query Azure DevOps build and timeline APIs.
-
-- **Verify**: `az version` (check that `azure-devops` appears under "extensions")
-- **Install CLI**: `winget install Microsoft.AzureCLI` (Windows) · `brew install azure-cli` (macOS)
-- **Install extension**: `az extension add --name azure-devops`
-- **Docs**: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli
 
 ## Additional Resources
 
@@ -55,7 +34,7 @@ Used by the PowerShell script to query Azure DevOps build and timeline APIs.
 
 ## Task
 
-You are analyzing CI failures for the dd-trace-dotnet repository.
+Analyze CI failures for the dd-trace-dotnet repository.
 
 **Phase 1 - Quick Initial Analysis (DO THIS FIRST)**:
 1. **Fetch build details** - Get build status, branch, commit
@@ -320,8 +299,8 @@ The Azure DevOps timeline contains a hierarchy:
 
 ## Notes
 
-- Requires `gh` CLI authenticated for PR analysis (see Prerequisites)
-- Requires `az` CLI with `azure-devops` extension (see Prerequisites)
+- `gh` and `az` CLIs are optional for read-only analysis (HTTP fallback for public repos/projects)
+- `az` CLI with `azure-devops` extension is required for stage retry (PATCH operations)
 - Large builds may take 30-60 seconds to analyze
 - Log downloads are best-effort; may fail due to Azure DevOps API issues
 - Always use scratchpad directory from system prompt, never hardcode /tmp paths

--- a/.claude/skills/analyze-azdo-build/SKILL.md
+++ b/.claude/skills/analyze-azdo-build/SKILL.md
@@ -12,7 +12,7 @@ Troubleshoot Azure DevOps pipeline failures with automated analysis.
 
 ## Prerequisites
 
-- **PowerShell 7+** (`pwsh`) — Required. PowerShell 5.1 minimum on Windows.
+- **PowerShell 5.1+** — Minimum required. PowerShell 7+ (`pwsh`) preferred; PowerShell 5.1 (`powershell.exe`, Windows only) is supported.
 - **Azure CLI** (`az`) — Optional for read-only analysis; required for stage retry.
 - **GitHub CLI** (`gh`) — Optional; HTTP fallback for public repos.
 

--- a/.claude/skills/analyze-azdo-build/scripts-reference.md
+++ b/.claude/skills/analyze-azdo-build/scripts-reference.md
@@ -60,7 +60,7 @@ $buildId = Resolve-BuildId -ParameterSetName 'ByPullRequest' -PullRequest 8172
 
 ### Prerequisites
 
-- **PowerShell 7+** (`pwsh`) — **required**; minimum PowerShell 5.1 (`powershell.exe`, Windows only)
+- **PowerShell 5.1+** — Minimum required. PowerShell 7+ (`pwsh`) preferred; PowerShell 5.1 (`powershell.exe`, Windows only) is supported.
   - Verify: `pwsh -Version`
   - Install: `winget install Microsoft.PowerShell` (Windows) · `brew install powershell/tap/powershell` (macOS)
   - Docs: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell
@@ -73,7 +73,7 @@ $buildId = Resolve-BuildId -ParameterSetName 'ByPullRequest' -PullRequest 8172
   - Install: `winget install GitHub.cli` (Windows) · `brew install gh` (macOS)
   - Docs: https://cli.github.com/
 
-**Note**: This script uses PowerShell-specific features (e.g., `-notin` operator, `HashSet<T>`, `Invoke-RestMethod`) that cannot be easily replicated in bash. Always prefer `pwsh` over `powershell.exe` when both are available.
+**Note**: This script uses PowerShell-specific features (e.g., `HashSet<T>`, `Invoke-RestMethod`) that cannot be easily replicated in bash. Always prefer `pwsh` over `powershell.exe` when both are available.
 
 **HTTP Fallback**: When `az` or `gh` are not available (or fail), the module falls back to direct HTTP requests via `Invoke-RestMethod`. No authentication is needed for GET requests against the public `dd-trace-dotnet` project and repo. The fallback emits warnings indicating degraded mode. Stage retry (PATCH) has no HTTP fallback and requires a working `az` CLI.
 
@@ -283,7 +283,7 @@ Use `-Verbose` to see:
 
 ### Prerequisites
 
-Same as `Get-AzureDevOpsBuildAnalysis.ps1` (PowerShell 7+ required, Azure CLI and GitHub CLI optional for read-only operations). **Note**: Stage retry requires a working Azure CLI with authentication — there is no HTTP fallback for PATCH operations.
+Same as `Get-AzureDevOpsBuildAnalysis.ps1` (PowerShell 5.1+, Azure CLI and GitHub CLI optional for read-only operations). **Note**: Stage retry requires a working Azure CLI with authentication — there is no HTTP fallback for PATCH operations.
 
 ### Parameters
 

--- a/.claude/skills/analyze-azdo-build/scripts-reference.md
+++ b/.claude/skills/analyze-azdo-build/scripts-reference.md
@@ -10,15 +10,15 @@ Both scripts share common functions via the `AzureDevOpsHelpers.psm1` module (au
 
 **Location:** `tracer/tools/AzureDevOpsHelpers.psm1`
 
-**Purpose:** Shared module providing common Azure DevOps API functions used by both analysis and retry scripts.
+**Purpose:** Shared module providing common Azure DevOps API functions used by both analysis and retry scripts. Uses CLI tools (`az`, `gh`) when available, with automatic HTTP fallback for read-only operations against public projects/repos.
 
 ### Exported Functions
 
 | Function | Description |
 |----------|-------------|
-| `Invoke-AzDevOpsApi` | Calls Azure DevOps REST API via `az devops invoke`. Supports GET/PATCH/POST/PUT, JSON request bodies, and configurable API versions. |
-| `Get-BuildIdFromPR` | Resolves an Azure DevOps build ID from a GitHub PR number using `gh pr checks`. |
-| `Resolve-BuildId` | Unified build ID resolution: accepts `ByBuildId` (passthrough), `ByPullRequest`, or `ByCurrentBranch` (auto-detect via `gh pr view`). Checks CLI prerequisites. |
+| `Invoke-AzDevOpsApi` | Calls Azure DevOps REST API. Tries `az devops invoke` first; falls back to direct HTTP (`Invoke-RestMethod`) for GET requests. PATCH/POST/PUT require `az`. |
+| `Get-BuildIdFromPR` | Resolves an Azure DevOps build ID from a GitHub PR number. Tries `gh pr checks` first; falls back to GitHub REST API (PR → commit statuses). |
+| `Resolve-BuildId` | Unified build ID resolution: accepts `ByBuildId` (passthrough), `ByPullRequest`, or `ByCurrentBranch`. Uses `gh` or GitHub REST API for PR/branch resolution. |
 
 ### `Invoke-AzDevOpsApi` Parameters
 
@@ -60,20 +60,22 @@ $buildId = Resolve-BuildId -ParameterSetName 'ByPullRequest' -PullRequest 8172
 
 ### Prerequisites
 
-- **PowerShell 7+** (`pwsh`) — recommended; minimum PowerShell 5.1 (`powershell.exe`, Windows only)
+- **PowerShell 7+** (`pwsh`) — **required**; minimum PowerShell 5.1 (`powershell.exe`, Windows only)
   - Verify: `pwsh -Version`
   - Install: `winget install Microsoft.PowerShell` (Windows) · `brew install powershell/tap/powershell` (macOS)
   - Docs: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell
-- **Azure CLI** (`az`) with `azure-devops` extension — used for build/timeline API queries
+- **Azure CLI** (`az`) with `azure-devops` extension — **optional** for read-only analysis (HTTP fallback for public projects); **required** for stage retry
   - Verify: `az version` (check that `azure-devops` appears under "extensions")
   - Install: `winget install Microsoft.AzureCLI` (Windows) · `brew install azure-cli` (macOS), then `az extension add --name azure-devops`
   - Docs: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli
-- **GitHub CLI** (`gh`) — authenticated; only needed for `-PullRequest` parameter or auto-detect mode
+- **GitHub CLI** (`gh`) — **optional** for PR/branch resolution (HTTP fallback for public repos, rate-limited to 60 req/hour)
   - Verify: `gh auth status`
   - Install: `winget install GitHub.cli` (Windows) · `brew install gh` (macOS)
   - Docs: https://cli.github.com/
 
 **Note**: This script uses PowerShell-specific features (e.g., `-notin` operator, `HashSet<T>`, `Invoke-RestMethod`) that cannot be easily replicated in bash. Always prefer `pwsh` over `powershell.exe` when both are available.
+
+**HTTP Fallback**: When `az` or `gh` are not available (or fail), the module falls back to direct HTTP requests via `Invoke-RestMethod`. No authentication is needed for GET requests against the public `dd-trace-dotnet` project and repo. The fallback emits warnings indicating degraded mode. Stage retry (PATCH) has no HTTP fallback and requires a working `az` CLI.
 
 ### Parameters
 
@@ -281,7 +283,7 @@ Use `-Verbose` to see:
 
 ### Prerequisites
 
-Same as `Get-AzureDevOpsBuildAnalysis.ps1` (PowerShell 7+, Azure CLI, GitHub CLI for PR modes).
+Same as `Get-AzureDevOpsBuildAnalysis.ps1` (PowerShell 7+ required, Azure CLI and GitHub CLI optional for read-only operations). **Note**: Stage retry requires a working Azure CLI with authentication — there is no HTTP fallback for PATCH operations.
 
 ### Parameters
 

--- a/tracer/tools/AzureDevOpsHelpers.psm1
+++ b/tracer/tools/AzureDevOpsHelpers.psm1
@@ -571,7 +571,7 @@ function Get-PRNumberForCurrentBranch {
     $repo = 'DataDog/dd-trace-dotnet'
     $owner = 'DataDog'
     $encodedHead = [Uri]::EscapeDataString("${owner}:${branch}")
-    $url = "https://api.github.com/repos/$repo/pulls?head=$encodedHead&state=all&per_page=1"
+    $url = "https://api.github.com/repos/$repo/pulls?head=$encodedHead&state=open&per_page=1"
 
     Write-Verbose "Searching for open PRs with head=$encodedHead..."
     try {

--- a/tracer/tools/AzureDevOpsHelpers.psm1
+++ b/tracer/tools/AzureDevOpsHelpers.psm1
@@ -5,15 +5,26 @@
     Shared helper functions for Azure DevOps CI scripts.
 
 .DESCRIPTION
-    Provides common functions for interacting with the Azure DevOps REST API
-    via the Azure CLI. Used by Get-AzureDevOpsBuildAnalysis.ps1 and
+    Provides common functions for interacting with the Azure DevOps REST API.
+    Uses the Azure CLI when available, with direct HTTP fallback for GET requests
+    (the dd-trace-dotnet project is public). Mutating operations (PATCH/POST/PUT)
+    require the Azure CLI. Used by Get-AzureDevOpsBuildAnalysis.ps1 and
     Retry-AzureDevOpsFailedStages.ps1.
 #>
+
+# Organization and project constants
+$script:AzDevOpsOrg = 'https://dev.azure.com/datadoghq'
+$script:AzDevOpsProject = 'dd-trace-dotnet'
 
 function Invoke-AzDevOpsApi {
     <#
     .SYNOPSIS
-        Invokes an Azure DevOps REST API endpoint via 'az devops invoke'.
+        Invokes an Azure DevOps REST API endpoint.
+
+    .DESCRIPTION
+        Uses 'az devops invoke' when the Azure CLI is available. For GET requests,
+        falls back to direct HTTP via Invoke-RestMethod (no auth required for public
+        projects). Mutating requests (PATCH/POST/PUT) require the Azure CLI.
 
     .PARAMETER Area
         The API area (e.g., 'build').
@@ -50,12 +61,73 @@ function Invoke-AzDevOpsApi {
         [string]$SaveToFile = ''
     )
 
-    # Build argument array to avoid command injection via Invoke-Expression
+    $hasAz = [bool](Get-Command az -ErrorAction SilentlyContinue)
+    $isGet = $HttpMethod -eq 'GET'
+
+    # Mutating requests require the az CLI (authentication needed)
+    if (-not $isGet -and -not $hasAz) {
+        throw "Azure CLI (az) is required for $HttpMethod requests. Install: https://aka.ms/azure-cli"
+    }
+
+    $json = $null
+    $useHttp = $false
+
+    # Try az CLI first if available
+    if ($hasAz) {
+        try {
+            $json = Invoke-AzDevOpsApiViaCli -Area $Area -Resource $Resource `
+                -RouteParameters $RouteParameters -QueryParameters $QueryParameters `
+                -HttpMethod $HttpMethod -Body $Body -ApiVersion $ApiVersion
+        }
+        catch {
+            if (-not $isGet) {
+                # Mutating requests have no fallback — rethrow
+                throw
+            }
+            Write-Warning "Azure CLI call failed, falling back to direct HTTP: $($_.Exception.Message)"
+            $useHttp = $true
+        }
+    }
+    else {
+        $useHttp = $true
+    }
+
+    # Fall back to direct HTTP for GET requests when CLI is missing or failed
+    if ($useHttp) {
+        Write-Verbose "Using direct HTTP for Azure DevOps API GET request"
+        $json = Invoke-AzDevOpsApiViaHttp -Area $Area -Resource $Resource `
+            -RouteParameters $RouteParameters -QueryParameters $QueryParameters `
+            -ApiVersion $ApiVersion
+    }
+
+    if ($SaveToFile -and $null -ne $json) {
+        $json | ConvertTo-Json -Depth 100 | Set-Content -Path $SaveToFile -Encoding UTF8
+        Write-Verbose "Saved to: $SaveToFile"
+    }
+
+    return $json
+}
+
+function Invoke-AzDevOpsApiViaCli {
+    <#
+    .SYNOPSIS
+        Invokes an Azure DevOps REST API endpoint via 'az devops invoke'.
+    #>
+    param(
+        [string]$Area,
+        [string]$Resource,
+        [string]$RouteParameters = '',
+        [hashtable]$QueryParameters = @{},
+        [string]$HttpMethod = 'GET',
+        [hashtable]$Body = $null,
+        [string]$ApiVersion = '6.0'
+    )
+
     $azArgs = @(
         'devops', 'invoke',
         '--area', $Area,
         '--resource', $Resource,
-        '--org', 'https://dev.azure.com/datadoghq',
+        '--org', $script:AzDevOpsOrg,
         '--api-version', $ApiVersion,
         '--detect', 'false'
     )
@@ -120,14 +192,99 @@ Azure DevOps API call failed
         return $null
     }
 
-    $json = $output | ConvertFrom-Json
+    return $output | ConvertFrom-Json
+}
 
-    if ($SaveToFile) {
-        $json | ConvertTo-Json -Depth 100 | Set-Content -Path $SaveToFile -Encoding UTF8
-        Write-Verbose "Saved to: $SaveToFile"
+function Invoke-AzDevOpsApiViaHttp {
+    <#
+    .SYNOPSIS
+        Invokes an Azure DevOps REST API GET endpoint via direct HTTP.
+
+    .DESCRIPTION
+        Builds the REST URL from area/resource/route parameters and calls
+        Invoke-RestMethod. No authentication is needed for GET requests
+        against public Azure DevOps projects.
+    #>
+    param(
+        [string]$Area,
+        [string]$Resource,
+        [string]$RouteParameters = '',
+        [hashtable]$QueryParameters = @{},
+        [string]$ApiVersion = '6.0'
+    )
+
+    # Parse route parameters into a hashtable
+    $routeParams = @{}
+    if ($RouteParameters) {
+        foreach ($pair in ($RouteParameters -split '\s+')) {
+            $parts = $pair -split '=', 2
+            if ($parts.Count -eq 2) {
+                $routeParams[$parts[0]] = $parts[1]
+            }
+        }
     }
 
-    return $json
+    $project = if ($routeParams.ContainsKey('project')) { $routeParams['project'] } else { $script:AzDevOpsProject }
+
+    # Build URL path based on area/resource/route parameters
+    # Pattern: {org}/{project}/_apis/{area}/{resource}/{resourceId}[/{subResource}/{subResourceId}]
+    $url = "$script:AzDevOpsOrg/$project/_apis/$Area"
+
+    # Map well-known route parameter patterns to URL segments
+    switch ($Area) {
+        'build' {
+            switch ($Resource) {
+                'builds' {
+                    if ($routeParams.ContainsKey('buildId')) {
+                        $url += "/builds/$($routeParams['buildId'])"
+                    } else {
+                        $url += '/builds'
+                    }
+                }
+                'timeline' {
+                    $url += "/builds/$($routeParams['buildId'])/timeline"
+                }
+                'stages' {
+                    $url += "/builds/$($routeParams['buildId'])/stages"
+                    if ($routeParams.ContainsKey('stageRefName')) {
+                        $url += "/$($routeParams['stageRefName'])"
+                    }
+                }
+                default {
+                    $url += "/$Resource"
+                }
+            }
+        }
+        default {
+            $url += "/$Resource"
+        }
+    }
+
+    # Add query parameters
+    $queryParts = @("api-version=$([Uri]::EscapeDataString($ApiVersion))")
+    foreach ($kvp in $QueryParameters.GetEnumerator()) {
+        $queryParts += "$([Uri]::EscapeDataString($kvp.Key))=$([Uri]::EscapeDataString($kvp.Value))"
+    }
+    $url += "?$($queryParts -join '&')"
+
+    Write-Verbose "HTTP GET: $url"
+
+    try {
+        return Invoke-RestMethod -Uri $url -Method Get -ContentType 'application/json'
+    }
+    catch {
+        $statusCode = $null
+        if ($_.Exception.Response) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        throw @"
+Azure DevOps HTTP request failed
+  URL: $url
+  Status: $statusCode
+  Error: $($_.Exception.Message)
+  Tip: If this is a 401/403 error, the project may require authentication. Install the Azure CLI: https://aka.ms/azure-cli
+"@
+    }
 }
 
 function Get-BuildIdFromPR {
@@ -135,12 +292,41 @@ function Get-BuildIdFromPR {
     .SYNOPSIS
         Resolves an Azure DevOps build ID from a GitHub PR number.
 
+    .DESCRIPTION
+        Uses 'gh pr checks' when the GitHub CLI is available. Falls back to the
+        GitHub REST API (get PR head SHA, then commit statuses) when gh is not
+        installed. No authentication is needed for public repositories.
+
     .PARAMETER PRNumber
         The GitHub pull request number.
     #>
     param([int]$PRNumber)
 
     Write-Verbose "Resolving build ID from PR #$PRNumber..."
+
+    $hasGh = [bool](Get-Command gh -ErrorAction SilentlyContinue)
+
+    if ($hasGh) {
+        try {
+            return Get-BuildIdFromPRViaGh -PRNumber $PRNumber
+        }
+        catch {
+            Write-Warning "GitHub CLI call failed, falling back to direct HTTP: $($_.Exception.Message)"
+        }
+    }
+    else {
+        Write-Verbose "GitHub CLI not found, using direct HTTP fallback"
+    }
+
+    return Get-BuildIdFromPRViaHttp -PRNumber $PRNumber
+}
+
+function Get-BuildIdFromPRViaGh {
+    <#
+    .SYNOPSIS
+        Resolves build ID from PR checks using the GitHub CLI.
+    #>
+    param([int]$PRNumber)
 
     $stderrFile = [System.IO.Path]::GetTempFileName()
     try {
@@ -171,98 +357,134 @@ function Get-BuildIdFromPR {
     throw "Could not extract build ID from URL: $($azureCheck.link)"
 }
 
+function Get-BuildIdFromPRViaHttp {
+    <#
+    .SYNOPSIS
+        Resolves build ID from PR commit statuses using the GitHub REST API.
+
+    .DESCRIPTION
+        Azure DevOps builds appear as commit statuses (not check runs) on GitHub.
+        This function gets the PR's head SHA, then queries commit statuses to find
+        the Azure DevOps build URL. No authentication required for public repos
+        (rate-limited to 60 requests/hour).
+    #>
+    param([int]$PRNumber)
+
+    $repo = 'DataDog/dd-trace-dotnet'
+    $baseUrl = "https://api.github.com/repos/$repo"
+
+    # Step 1: Get PR head SHA
+    Write-Verbose "Fetching PR #$PRNumber details from GitHub API..."
+    try {
+        $pr = Invoke-RestMethod -Uri "$baseUrl/pulls/$PRNumber" -ContentType 'application/json'
+    }
+    catch {
+        throw "Failed to get PR #$PRNumber from GitHub API: $($_.Exception.Message)"
+    }
+
+    $headSha = $pr.head.sha
+    if (-not $headSha) {
+        throw "Could not get head SHA for PR #$PRNumber"
+    }
+    Write-Verbose "PR #$PRNumber head SHA: $headSha"
+
+    # Step 2: Get commit statuses (where Azure DevOps checks appear)
+    Write-Verbose "Fetching commit statuses for $headSha..."
+    try {
+        $statuses = Invoke-RestMethod -Uri "$baseUrl/commits/$headSha/statuses?per_page=100" -ContentType 'application/json'
+    }
+    catch {
+        throw "Failed to get commit statuses from GitHub API: $($_.Exception.Message)"
+    }
+
+    # Find status with Azure DevOps URL
+    $azureStatus = $statuses | Where-Object { $_.target_url -like '*dev.azure.com*' } | Select-Object -First 1
+
+    if (-not $azureStatus) {
+        throw "No Azure DevOps status found for PR #$PRNumber (SHA: $headSha)"
+    }
+
+    if ($azureStatus.target_url -match 'buildId=(\d+)') {
+        $buildId = [int]$matches[1]
+        Write-Verbose "Resolved build ID: $buildId from status: $($azureStatus.context)"
+        return $buildId
+    }
+
+    throw "Could not extract build ID from URL: $($azureStatus.target_url)"
+}
+
 function Test-Prerequisites {
     <#
     .SYNOPSIS
-        Validates that required CLI tools are installed, authenticated, and properly configured.
+        Validates that required CLI tools are available or that HTTP fallback can be used.
 
     .DESCRIPTION
-        Collects all prerequisite issues and reports them together so the user can fix
-        everything in one pass rather than discovering problems one at a time.
+        For read-only operations (GET), the Azure CLI and GitHub CLI are optional —
+        direct HTTP requests work against public projects/repos. Mutating operations
+        (stage retry) require the Azure CLI with authentication.
 
-    .PARAMETER NeedsGh
-        When set, also validates that the GitHub CLI (gh) is installed and authenticated.
-        Required for PR-based build resolution.
+        When a CLI is missing or misconfigured, a warning is emitted and the script
+        continues (the CLI call will fail at runtime and fall back to HTTP).
+
+    .PARAMETER ParameterSetName
+        The parameter set being used: 'ByBuildId', 'ByPullRequest', or 'ByCurrentBranch'.
+        Determines which tools are needed.
     #>
     param(
-        [switch]$NeedsGh
+        [string]$ParameterSetName = 'ByBuildId'
     )
 
-    $errors = @()
-
-    # 1. Azure CLI installed
+    # Azure CLI: optional for read-only analysis (HTTP fallback exists for GET requests).
+    # When present but misconfigured, warn — the CLI call will fail and fall back to HTTP.
+    # Stage retry (PATCH) requires a working az CLI, but that's enforced at call time.
     $hasAz = [bool](Get-Command az -ErrorAction SilentlyContinue)
     if (-not $hasAz) {
-        $errors += @"
-Azure CLI (az) not found.
-  Install: https://aka.ms/azure-cli
-  Windows: winget install Microsoft.AzureCLI
-  macOS:   brew install azure-cli
-"@
+        Write-Warning "Azure CLI (az) not found. Using direct HTTP for Azure DevOps API (read-only). Stage retry will not be available."
+        Write-Warning "  Install: https://aka.ms/azure-cli"
     }
-
-    if ($hasAz) {
-        # 2. azure-devops extension installed
+    else {
+        # Warn about misconfiguration — the CLI functions will fall back to HTTP on failure
         $null = & az extension show --name azure-devops 2>$null
         if ($LASTEXITCODE -ne 0) {
-            $errors += @"
-Azure CLI 'azure-devops' extension not found.
-  Install with: az extension add --name azure-devops
-"@
+            Write-Warning "Azure CLI 'azure-devops' extension not found. CLI calls will fall back to direct HTTP."
+            Write-Warning "  Install with: az extension add --name azure-devops"
         }
 
-        # 3. Azure CLI authenticated
         $accountOutput = $null
         $accountOutput = & az account show --output json 2>$null
         if ($LASTEXITCODE -ne 0) {
-            $errors += @"
-Azure CLI is not logged in.
-  Run: az login
-  For MFA-enabled tenants: az login --tenant <TENANT_ID> --use-device-code
-"@
+            Write-Warning "Azure CLI is not logged in. CLI calls will fall back to direct HTTP."
+            Write-Warning "  Run: az login"
         }
 
-        # 4. Log current subscription for troubleshooting (warn only — the --org flag
-        #    targets the org directly, but the wrong subscription can affect token permissions)
+        # Log current subscription for troubleshooting
         if ($accountOutput) {
             try {
                 $account = $accountOutput | ConvertFrom-Json
                 Write-Verbose "Current Azure subscription: '$($account.name)'"
             }
             catch {
-                # Non-fatal: if we can't parse the account info, just continue
                 Write-Verbose "Could not parse Azure account info for subscription check: $_"
             }
         }
     }
 
-    if ($NeedsGh) {
-        # 5. GitHub CLI installed
+    # GitHub CLI: optional for PR/branch resolution (HTTP fallback exists).
+    # When present but not authenticated, warn — the functions will fall back to HTTP.
+    $needsGh = $ParameterSetName -ne 'ByBuildId'
+    if ($needsGh) {
         $hasGh = [bool](Get-Command gh -ErrorAction SilentlyContinue)
         if (-not $hasGh) {
-            $errors += @"
-GitHub CLI (gh) not found.
-  Install: https://cli.github.com
-  Windows: winget install GitHub.cli
-  macOS:   brew install gh
-"@
+            Write-Warning "GitHub CLI (gh) not found. Using GitHub REST API for PR resolution (rate-limited to 60 requests/hour)."
+            Write-Warning "  Install: https://cli.github.com"
         }
-
-        # 6. GitHub CLI authenticated
-        if ($hasGh) {
+        else {
             $null = & gh auth status --hostname github.com 2>$null
             if ($LASTEXITCODE -ne 0) {
-                $errors += @"
-GitHub CLI is not authenticated for github.com.
-  Run: gh auth login --hostname github.com
-"@
+                Write-Warning "GitHub CLI is not authenticated. CLI calls will fall back to GitHub REST API."
+                Write-Warning "  Run: gh auth login --hostname github.com"
             }
         }
-    }
-
-    if ($errors.Count -gt 0) {
-        $separator = "`n`n"
-        throw "Prerequisite check failed:`n`n$($errors -join $separator)"
     }
 }
 
@@ -289,30 +511,81 @@ function Resolve-BuildId {
         [int]$PullRequest = 0
     )
 
-    $needsGh = $ParameterSetName -ne 'ByBuildId'
-    Test-Prerequisites -NeedsGh:$needsGh
+    Test-Prerequisites -ParameterSetName $ParameterSetName
 
     if ($ParameterSetName -eq 'ByBuildId') {
         return $BuildId
     }
 
     if ($ParameterSetName -eq 'ByCurrentBranch') {
-        Write-Verbose "No arguments provided. Detecting PR for current branch..."
-        $stderrFile = [System.IO.Path]::GetTempFileName()
-        try {
-            $prOutput = & gh pr view --json number -q .number 2>$stderrFile
-            if ($LASTEXITCODE -ne 0) {
-                throw "No PR found for current branch. Specify -PullRequest or -BuildId."
-            }
-        }
-        finally {
-            Remove-Item -Path $stderrFile -Force -ErrorAction SilentlyContinue
-        }
-        $PullRequest = [int]$prOutput
+        $PullRequest = Get-PRNumberForCurrentBranch
         Write-Verbose "Detected PR #$PullRequest for current branch."
     }
 
     return Get-BuildIdFromPR -PRNumber $PullRequest
+}
+
+function Get-PRNumberForCurrentBranch {
+    <#
+    .SYNOPSIS
+        Gets the PR number for the current git branch.
+
+    .DESCRIPTION
+        Uses 'gh pr view' when the GitHub CLI is available. Falls back to the
+        GitHub REST API (search open PRs by head branch) when gh is not installed.
+    #>
+
+    Write-Verbose "No arguments provided. Detecting PR for current branch..."
+
+    $hasGh = [bool](Get-Command gh -ErrorAction SilentlyContinue)
+
+    if ($hasGh) {
+        Write-Verbose "Using gh CLI..."
+        $stderrFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $prOutput = & gh pr view --json number -q .number 2>$stderrFile
+            if ($LASTEXITCODE -ne 0) {
+                $stderr = Get-Content -Path $stderrFile -Raw -ErrorAction SilentlyContinue
+                throw "gh pr view failed: $stderr"
+            }
+            return [int]$prOutput
+        }
+        catch {
+            Write-Warning "GitHub CLI call failed, falling back to direct HTTP: $($_.Exception.Message)"
+        }
+        finally {
+            Remove-Item -Path $stderrFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+    else {
+        Write-Verbose "GitHub CLI not found, using direct HTTP fallback"
+    }
+
+    # HTTP fallback: search GitHub API for open PRs matching current branch
+    $branch = & git rev-parse --abbrev-ref HEAD 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $branch) {
+        throw "Could not determine current git branch. Specify -PullRequest or -BuildId."
+    }
+    Write-Verbose "Current branch: $branch"
+
+    $repo = 'DataDog/dd-trace-dotnet'
+    $owner = 'DataDog'
+    $encodedHead = [Uri]::EscapeDataString("${owner}:${branch}")
+    $url = "https://api.github.com/repos/$repo/pulls?head=$encodedHead&state=all&per_page=1"
+
+    Write-Verbose "Searching for open PRs with head=$encodedHead..."
+    try {
+        $prs = Invoke-RestMethod -Uri $url -ContentType 'application/json'
+    }
+    catch {
+        throw "Failed to search PRs from GitHub API: $($_.Exception.Message)"
+    }
+
+    if (-not $prs -or $prs.Count -eq 0) {
+        throw "No open PR found for branch '$branch'. Specify -PullRequest or -BuildId."
+    }
+
+    return [int]$prs[0].number
 }
 
 Export-ModuleMember -Function Invoke-AzDevOpsApi, Get-BuildIdFromPR, Resolve-BuildId, Test-Prerequisites

--- a/tracer/tools/AzureDevOpsHelpers.psm1
+++ b/tracer/tools/AzureDevOpsHelpers.psm1
@@ -366,7 +366,7 @@ function Get-BuildIdFromPRViaHttp {
         Azure DevOps builds appear as commit statuses (not check runs) on GitHub.
         This function gets the PR's head SHA, then queries commit statuses to find
         the Azure DevOps build URL. No authentication required for public repos
-        (rate-limited to 60 requests/hour).
+        (rate-limited).
     #>
     param([int]$PRNumber)
 
@@ -475,7 +475,7 @@ function Test-Prerequisites {
     if ($needsGh) {
         $hasGh = [bool](Get-Command gh -ErrorAction SilentlyContinue)
         if (-not $hasGh) {
-            Write-Warning "GitHub CLI (gh) not found. Using GitHub REST API for PR resolution (rate-limited to 60 requests/hour)."
+            Write-Warning "GitHub CLI (gh) not found. Using GitHub REST API for PR resolution (rate-limited)."
             Write-Warning "  Install: https://cli.github.com"
         }
         else {


### PR DESCRIPTION
## Summary of changes

Add HTTP fallback to `AzureDevOpsHelpers.psm1` so the CI build analysis skill works without `az` or `gh` CLIs installed.

## Reason for change

The `az` and `gh` CLI tools are not always available (e.g., fresh machines, CI environments, or teammates without them installed). Since `dd-trace-dotnet` is a public project on both Azure DevOps and GitHub, read-only API requests work without authentication.

## Implementation details

- `Invoke-AzDevOpsApi`: tries `az devops invoke` first; on failure or missing CLI, falls back to `Invoke-RestMethod` with direct REST URLs for `GET` requests. `PATCH`/`POST`/`PUT` still require `az`.
- `Get-BuildIdFromPR`: tries `gh pr checks` first; falls back to GitHub REST API (get PR → get commit statuses → extract AzDO build URL).
- `Get-PRNumberForCurrentBranch` (new): tries `gh pr view`; falls back to GitHub pulls API with `?head=DataDog:{branch}` filter.
- `Test-Prerequisites`: now warns instead of erroring when CLIs are missing/misconfigured, since HTTP fallback covers read-only operations.
- Skill docs (`SKILL.md`, `scripts-reference.md`) updated to reflect optional CLI requirements.

New internal helper functions: `Invoke-AzDevOpsApiViaCli`, `Invoke-AzDevOpsApiViaHttp`, `Get-BuildIdFromPRViaGh`, `Get-BuildIdFromPRViaHttp`.

## Test coverage

Manually tested all three invocation paths with HTTP fallback forced:
- `-BuildId <ID>` — direct AzDO HTTP GET
- `-PullRequest <NUMBER>` — GitHub REST API → AzDO HTTP GET
- Auto-detect (no args) — GitHub REST API PR search → AzDO HTTP GET

## Other details

Stage retry (`Retry-AzureDevOpsFailedStages.ps1`) intentionally has no HTTP fallback because it requires authenticated `az` CLI for `PATCH` operations.

🤖 Generated with Claude Code