### PR TITLE
Fix OTLP HTTP/protobuf export failures and improve OTLP integration test reliability

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -428,7 +428,6 @@
       <type fullname="System.Net.DnsEndPoint" />
       <type fullname="System.Net.EndPoint" />
       <type fullname="System.Net.HttpStatusCode" />
-      <type fullname="System.Net.HttpVersion" />
       <type fullname="System.Net.ICredentials" />
       <type fullname="System.Net.IPAddress" />
       <type fullname="System.Net.IPEndPoint" />

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Threading.Tasks;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
@@ -75,18 +74,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
         [DuckReverseMethod]
         public void Dispose()
         {
-            // Flush the shared log sink on a best-effort basis so pending batches drain when
-            // the ILoggerFactory is disposed deterministically (host shutdown, test teardown)
-            // rather than waiting for the process-exit hook. The sink is a global singleton
-            // owned by TracerManager, so this does not dispose it.
-            try
-            {
-                _sink.FlushAsync().Wait(TimeSpan.FromSeconds(10));
-            }
-            catch
-            {
-                // Never throw from Dispose. Final flush still runs via the process-exit hook.
-            }
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
@@ -74,6 +75,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
         [DuckReverseMethod]
         public void Dispose()
         {
+            // Flush the shared log sink on a best-effort basis so pending batches drain when
+            // the ILoggerFactory is disposed deterministically (host shutdown, test teardown)
+            // rather than waiting for the process-exit hook. The sink is a global singleton
+            // owned by TracerManager, so this does not dispose it.
+            try
+            {
+                _sink.FlushAsync().Wait(TimeSpan.FromSeconds(10));
+            }
+            catch
+            {
+                // Never throw from Dispose. Final flush still runs via the process-exit hook.
+            }
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -250,10 +250,17 @@ namespace Datadog.Trace.Configuration
                                     },
                                     validator: null);
 
+            var otlpGeneralProtocolName = OtlpGeneralProtocol switch
+            {
+                OtlpProtocol.Grpc => "grpc",
+                OtlpProtocol.HttpProtobuf => "http/protobuf",
+                _ => "grpc",
+            };
+
             OtlpMetricsProtocol = config
                                  .WithKeys(ConfigurationKeys.OpenTelemetry.ExporterOtlpMetricsProtocol)
                                  .GetAs(
-                                      defaultValue: new(OtlpProtocol.Grpc, "grpc"),
+                                      defaultValue: new(OtlpGeneralProtocol, otlpGeneralProtocolName),
                                       converter: x => x switch
                                       {
                                           not null when string.Equals(x, "grpc", StringComparison.OrdinalIgnoreCase) => OtlpProtocol.Grpc,
@@ -312,7 +319,7 @@ namespace Datadog.Trace.Configuration
             OtlpLogsProtocol = config
                              .WithKeys(ConfigurationKeys.OpenTelemetry.ExporterOtlpLogsProtocol)
                              .GetAs(
-                                  defaultValue: new(OtlpProtocol.Grpc, "grpc"),
+                                  defaultValue: new(OtlpGeneralProtocol, otlpGeneralProtocolName),
                                   converter: x => x switch
                                   {
                                       not null when string.Equals(x, "grpc", StringComparison.OrdinalIgnoreCase) => OtlpProtocol.Grpc,

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/OtlpSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/OtlpSubmissionLogSink.cs
@@ -76,7 +76,11 @@ internal sealed class OtlpSubmissionLogSink : BatchingSink<DirectSubmissionLogEv
 
     public override async Task DisposeAsync()
     {
-        await DisposeAsync(true).ConfigureAwait(false);
+        await base.DisposeAsync().ConfigureAwait(false);
+        if (!_otlpExporter.Shutdown(timeoutMilliseconds: 5000))
+        {
+            _logger.Warning("OTLP exporter shutdown did not complete successfully.");
+        }
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/OtlpSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/OtlpSubmissionLogSink.cs
@@ -76,8 +76,10 @@ internal sealed class OtlpSubmissionLogSink : BatchingSink<DirectSubmissionLogEv
 
     public override async Task DisposeAsync()
     {
+        // Final flush is awaited by base.DisposeAsync() and bounded by the HTTP
+        // client timeout; Shutdown() just releases the HTTP client resources.
         await base.DisposeAsync().ConfigureAwait(false);
-        if (!_otlpExporter.Shutdown(timeoutMilliseconds: 5000))
+        if (!_otlpExporter.Shutdown())
         {
             _logger.Warning("OTLP exporter shutdown did not complete successfully.");
         }

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/IOtlpExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/IOtlpExporter.cs
@@ -26,10 +26,11 @@ internal interface IOtlpExporter
     Task<ExportResult> ExportAsync(IReadOnlyList<LogPoint> logs);
 
     /// <summary>
-    /// Shuts down the exporter and ensures all pending exports complete.
+    /// Releases the exporter's HTTP resources. Does not wait on pending exports:
+    /// the final flush runs synchronously in the sink's DisposeAsync before this is
+    /// called, bounded by the HTTP client timeout (OTEL_EXPORTER_OTLP_TIMEOUT).
     /// </summary>
-    /// <param name="timeoutMilliseconds">Maximum time to wait for shutdown</param>
     /// <returns>True if shutdown completed successfully</returns>
-    bool Shutdown(int timeoutMilliseconds);
+    bool Shutdown();
 }
 #endif

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpExporter.cs
@@ -129,11 +129,12 @@ internal sealed class OtlpExporter : IOtlpExporter
     }
 
     /// <summary>
-    /// Shuts down the exporter and ensures all pending exports complete.
+    /// Releases the exporter's HTTP resources. The final flush already ran
+    /// synchronously in the sink's DisposeAsync (bounded by the HTTP client
+    /// timeout, OTEL_EXPORTER_OTLP_TIMEOUT), so there is nothing further to wait on.
     /// </summary>
-    /// <param name="timeoutMilliseconds">Maximum time to wait for shutdown</param>
     /// <returns>True if shutdown completed successfully</returns>
-    public bool Shutdown(int timeoutMilliseconds)
+    public bool Shutdown()
     {
         try
         {

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpExporter.cs
@@ -158,14 +158,11 @@ internal sealed class OtlpExporter : IOtlpExporter
         var httpClient = new HttpClient(tcpHandler)
         {
             Timeout = TimeSpan.FromMilliseconds(_timeoutMs),
-            DefaultRequestVersion = HttpVersion.Version20,
-            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
         };
 #else
         var httpClient = new HttpClient
         {
             Timeout = TimeSpan.FromMilliseconds(_timeoutMs),
-            DefaultRequestVersion = HttpVersion.Version20,
         };
 #endif
 

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/InMemoryExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/InMemoryExporter.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
             return Task.FromResult(result);
         }
 
-        public override bool Shutdown(int timeoutMilliseconds)
+        public override bool Shutdown()
         {
             return true;
         }

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricExporter.cs
@@ -23,9 +23,11 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
         public abstract Task<ExportResult> ExportAsync(IReadOnlyList<MetricPoint> metrics);
 
         /// <summary>
-        /// Shuts down the exporter.
+        /// Releases exporter resources. The final flush is driven by the caller
+        /// (MetricReader.StopAsync) and bounded by the export path's own timeout;
+        /// this method is not expected to block.
         /// </summary>
-        public abstract bool Shutdown(int timeoutMilliseconds);
+        public abstract bool Shutdown();
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricReader.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricReader.cs
@@ -24,7 +24,6 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(MetricReader));
         private readonly int _exportIntervalMs;
-        private readonly int _timeoutMs;
         private readonly MetricReaderHandler _handler;
         private readonly MetricExporter _exporter;
         private MeterListener? _listener;
@@ -33,7 +32,6 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
         public MetricReader(TracerSettings settings, MetricReaderHandler handler, MetricExporter exporter)
         {
             _exportIntervalMs = settings.OtelMetricExportIntervalMs;
-            _timeoutMs = settings.OtlpMetricsTimeoutMs;
             _handler = handler;
             _exporter = exporter;
         }
@@ -95,7 +93,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
             }
             finally
             {
-                _exporter.Shutdown(_timeoutMs);
+                _exporter.Shutdown();
                 _listener?.Dispose();
                 _listener = null;
                 Log.Debug("MetricReader stopped");

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpExporter.cs
@@ -146,7 +146,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
 
         /// <summary>
         /// Creates an HttpClient with Unix Domain Socket support if the endpoint uses unix:// scheme.
-        /// For TCP/IP endpoints (http:// or https://), creates a standard HttpClient with HTTP/2.
+        /// For TCP/IP endpoints (http:// or https://), creates a standard HttpClient.
         /// </summary>
         private static HttpClient CreateHttpClient(Uri endpoint)
         {
@@ -168,11 +168,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
                     }
                 };
 
-                return new HttpClient(handler)
-                {
-                    DefaultRequestVersion = HttpVersion.Version20,
-                    DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
-                };
+                return new HttpClient(handler);
             }
 
             // Standard TCP/IP endpoint
@@ -181,11 +177,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             };
 
-            return new HttpClient(tcpHandler)
-            {
-                DefaultRequestVersion = HttpVersion.Version20,
-                DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
-            };
+            return new HttpClient(tcpHandler);
         }
 
         private async Task<bool> SendOtlpRequest(IReadOnlyList<MetricPoint> metrics)

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpExporter.cs
@@ -126,11 +126,13 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
         }
 
         /// <summary>
-        /// Shuts down the exporter and ensures all pending exports complete.
+        /// Releases the exporter's HTTP resources. The final export already ran
+        /// synchronously in MetricReader.StopAsync and is bounded by the HTTP
+        /// request timeout (OTEL_EXPORTER_OTLP_METRICS_TIMEOUT), so there is
+        /// nothing further to wait on here.
         /// </summary>
-        /// <param name="timeoutMilliseconds">Maximum time to wait for shutdown</param>
         /// <returns>True if shutdown completed successfully, false otherwise</returns>
-        public override bool Shutdown(int timeoutMilliseconds)
+        public override bool Shutdown()
         {
             try
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -716,9 +716,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         /// <summary>
         /// Polls the test-agent for data until non-empty results are returned or timeout is reached.
         /// The sample app exports data during shutdown, so there can be a brief delay
-        /// between process exit and data appearing in the test-agent.
+        /// between process exit and data appearing in the test-agent. The timeout is generous
+        /// because first-time gRPC connections (TCP+HTTP/2+TLS handshake) plus tracer shutdown
+        /// flushing can stack up on slower CI runners.
         /// </summary>
-        private static async Task<JToken> WaitForTestAgentData(string url, int timeoutSeconds = 30, int pollIntervalMs = 500)
+        private static async Task<JToken> WaitForTestAgentData(string url, int timeoutSeconds = 60, int pollIntervalMs = 500)
         {
             using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
             var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
@@ -254,10 +255,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var testAgentHost = Environment.GetEnvironmentVariable("TEST_AGENT_HOST") ?? "localhost";
             var otlpPort = protocol == "grpc" ? 4317 : 4318;
 
-            using (var httpClient = new System.Net.Http.HttpClient())
-            {
-                await httpClient.GetAsync($"http://{testAgentHost}:4318/test/session/clear");
-            }
+            await ClearTestAgentSession(testAgentHost);
 
             // This is the key configuration that is set differently from previous test cases:
             // OTEL_TRACES_EXPORTER=otlp enables the DD SDK to emit traces (and trace stats) via OTLP
@@ -497,8 +495,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
 #if NET6_0_OR_GREATER
         [SkippableTheory]
-        [Trait("SkipInCI", "True")]
-        [Flaky("New test agent seems to not always be ready", maxRetries: 3)]
         [Trait("Category", "EndToEnd")]
         [MemberData(nameof(GetOtlpTestData))]
         public async Task SubmitsOtlpMetrics(string packageVersion, string datadogMetricsEnabled, string otelMetricsEnabled, string protocol, bool useAgentHostBackup)
@@ -519,10 +515,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var testAgentHost = Environment.GetEnvironmentVariable("TEST_AGENT_HOST") ?? "localhost";
             var otlpPort = protocol == "grpc" ? 4317 : 4318;
 
-            using (var httpClient = new System.Net.Http.HttpClient())
-            {
-                await httpClient.GetAsync($"http://{testAgentHost}:4318/test/session/clear");
-            }
+            await ClearTestAgentSession(testAgentHost);
 
             SetEnvironmentVariable("DD_ENV", string.Empty);
             SetEnvironmentVariable("DD_SERVICE", string.Empty);
@@ -530,7 +523,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_METRICS_OTEL_ENABLED", datadogMetricsEnabled);
             SetEnvironmentVariable("OTEL_METRICS_EXPORTER_ENABLED", otelMetricsEnabled);
             SetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL", protocol);
-            SetEnvironmentVariable("OTEL_METRIC_EXPORT_INTERVAL", "1000");
+            // 60s so only the shutdown flush fires; periodic exports of observable instruments produce duplicate batches that break snapshot comparison
+            SetEnvironmentVariable("OTEL_METRIC_EXPORT_INTERVAL", "60000");
 
             if (useAgentHostBackup)
             {
@@ -547,13 +541,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = EnvironmentHelper.GetMockAgent();
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion ?? "1.13.1"))
             {
-                using var httpClient = new System.Net.Http.HttpClient();
-                var metricsResponse = await httpClient.GetAsync($"http://{testAgentHost}:4318/test/session/metrics");
-                metricsResponse.EnsureSuccessStatusCode();
-
-                var metricsJson = await metricsResponse.Content.ReadAsStringAsync();
-                var metricsData = JToken.Parse(metricsJson);
-
+                var metricsData = await WaitForTestAgentData($"http://{testAgentHost}:4318/test/session/metrics");
                 metricsData.Should().NotBeNullOrEmpty();
 
                 foreach (var attribute in metricsData.SelectTokens("$..resource.attributes[?(@.key == 'telemetry.sdk.version')]"))
@@ -595,8 +583,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
 #if NETCOREAPP3_1_OR_GREATER
         [SkippableTheory]
-        [Trait("SkipInCI", "True")]
-        [Flaky("New test agent seems to not always be ready", maxRetries: 3)]
         [Trait("Category", "EndToEnd")]
         [MemberData(nameof(GetOtlpTestData))]
         public async Task SubmitsOtlpLogs(string packageVersion, string datadogLogsEnabled, string otelLogsEnabled, string protocol, bool useAgentHostBackup)
@@ -615,10 +601,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var testAgentHost = Environment.GetEnvironmentVariable("TEST_AGENT_HOST") ?? "localhost";
             var otlpPort = protocol == "grpc" ? 4317 : 4318;
 
-            using (var httpClient = new System.Net.Http.HttpClient())
-            {
-                await httpClient.GetAsync($"http://{testAgentHost}:4318/test/session/clear");
-            }
+            await ClearTestAgentSession(testAgentHost);
 
             SetEnvironmentVariable("DD_ENV", "testing");
             SetEnvironmentVariable("DD_SERVICE", "OtlpLogsService");
@@ -626,7 +609,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_LOGS_OTEL_ENABLED", datadogLogsEnabled);
             SetEnvironmentVariable("OTEL_LOGS_EXPORTER_ENABLED", otelLogsEnabled);
             SetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL", protocol);
-            SetEnvironmentVariable("OTEL_LOG_EXPORT_INTERVAL", "1000");
+            // Short delay gives the OTel SDK multiple periodic exports before LoggerProviderSdk.Dispose() hits its 5s shutdown timeout.
+            // This is especially important for gRPC, where the first export warms the HTTP/2 connection.
+            SetEnvironmentVariable("OTEL_BLRP_SCHEDULE_DELAY", "500");
             SetEnvironmentVariable("DD_LOGS_DIRECT_SUBMISSION_MINIMUM_LEVEL", "Verbose");
 
             if (useAgentHostBackup)
@@ -645,13 +630,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var endTimeNanoseconds = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
 
-                using var httpClient = new System.Net.Http.HttpClient();
-                var logsResponse = await httpClient.GetAsync($"http://{testAgentHost}:4318/test/session/logs");
-                logsResponse.EnsureSuccessStatusCode();
-
-                var logsJson = await logsResponse.Content.ReadAsStringAsync();
-                var logsData = JToken.Parse(logsJson);
-
+                var logsData = await WaitForTestAgentData($"http://{testAgentHost}:4318/test/session/logs");
                 logsData.Should().NotBeNullOrEmpty();
                 logsData.SelectTokens("$..log_records[*]").Should().AllSatisfy(logRecord =>
                 {
@@ -705,6 +684,67 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 #endif
+
+        /// <summary>
+        /// Clears the test-agent session, retrying if the agent is not yet ready.
+        /// Ensures the OTLP HTTP endpoint is accepting connections before tests proceed.
+        /// </summary>
+        private static async Task ClearTestAgentSession(string testAgentHost, int maxRetries = 5, int delayMs = 1000)
+        {
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            var url = $"http://{testAgentHost}:4318/test/session/clear";
+
+            for (var attempt = 1; attempt <= maxRetries; attempt++)
+            {
+                try
+                {
+                    var response = await httpClient.GetAsync(url);
+                    response.EnsureSuccessStatusCode();
+                    return;
+                }
+                catch (Exception) when (attempt < maxRetries)
+                {
+                    await Task.Delay(delayMs);
+                }
+            }
+
+            // Final attempt -- let it throw if it fails
+            var finalResponse = await httpClient.GetAsync(url);
+            finalResponse.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Polls the test-agent for data until non-empty results are returned or timeout is reached.
+        /// The sample app exports data during shutdown, so there can be a brief delay
+        /// between process exit and data appearing in the test-agent.
+        /// </summary>
+        private static async Task<JToken> WaitForTestAgentData(string url, int timeoutSeconds = 30, int pollIntervalMs = 500)
+        {
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                var response = await httpClient.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                var data = JToken.Parse(json);
+
+                if (data.HasValues)
+                {
+                    return data;
+                }
+
+                await Task.Delay(pollIntervalMs);
+            }
+
+            // Final attempt -- return whatever we get so the caller's assertion shows the actual value
+            var finalResponse = await httpClient.GetAsync(url);
+            finalResponse.EnsureSuccessStatusCode();
+            var finalJson = await finalResponse.Content.ReadAsStringAsync();
+            return JToken.Parse(finalJson);
+        }
 
         private static string GetSuffix(string packageVersion)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -279,6 +279,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var applicationStartTimeUnixNano = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
             using var agent = EnvironmentHelper.GetMockAgent();
+            // When DD_AGENT_HOST=test-agent is set above, it also redirects the APM trace agent
+            // URL via the DD_TRACE_AGENT_HOSTNAME alias (the primary key wins). That points APM
+            // traces at test-agent:<mock-agent-port>, which does not exist, so AgentWriter
+            // retries fill the tracer's shutdown window and can starve the DirectLogSubmission
+            // final flush. Pin the APM URL back to the in-process MockAgent.
+            if (useAgentHostBackup && agent is MockTracerAgent.TcpUdpAgent tcpAgent)
+            {
+                SetEnvironmentVariable("DD_TRACE_AGENT_URL", $"http://127.0.0.1:{tcpAgent.Port}");
+            }
+
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion ?? "1.13.1"))
             {
                 using var httpClient = new System.Net.Http.HttpClient();
@@ -539,6 +549,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", runtimeMajor >= 9 ? "delta" : "cumulative");
 
             using var agent = EnvironmentHelper.GetMockAgent();
+            // See comment in SubmitsOtlpTraces. DD_AGENT_HOST=test-agent also redirects the APM
+            // trace agent URL; pin it back to the in-process MockAgent.
+            if (useAgentHostBackup && agent is MockTracerAgent.TcpUdpAgent tcpAgent)
+            {
+                SetEnvironmentVariable("DD_TRACE_AGENT_URL", $"http://127.0.0.1:{tcpAgent.Port}");
+            }
+
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion ?? "1.13.1"))
             {
                 var metricsData = await WaitForTestAgentData($"http://{testAgentHost}:4318/test/session/metrics");
@@ -626,6 +643,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var startTimeNanoseconds = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
 
             using var agent = EnvironmentHelper.GetMockAgent();
+            // See comment in SubmitsOtlpTraces. DD_AGENT_HOST=test-agent also redirects the APM
+            // trace agent URL; pin it back to the in-process MockAgent so AgentWriter retries
+            // don't starve the DirectLogSubmission final flush during shutdown.
+            if (useAgentHostBackup && agent is MockTracerAgent.TcpUdpAgent tcpAgent)
+            {
+                SetEnvironmentVariable("DD_TRACE_AGENT_URL", $"http://127.0.0.1:{tcpAgent.Port}");
+            }
+
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion ?? "1.13.1"))
             {
                 var endTimeNanoseconds = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -978,6 +978,8 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("invalid", null, OtlpProtocol.Grpc)]
         [InlineData("http/protobuf", null, OtlpProtocol.HttpProtobuf)]
         [InlineData("grpc", "http/protobuf", OtlpProtocol.Grpc)]
+        [InlineData(null, "http/protobuf", OtlpProtocol.HttpProtobuf)]
+        [InlineData(null, "grpc", OtlpProtocol.Grpc)]
         public void OtlpProtocolFallbacks(string metricsProtocol, string generalProtocol, object expected)
         {
             var source = CreateConfigurationSource(
@@ -1073,6 +1075,8 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("invalid", null, OtlpProtocol.Grpc)]
         [InlineData("http/protobuf", null, OtlpProtocol.HttpProtobuf)]
         [InlineData("grpc", "http/protobuf", OtlpProtocol.Grpc)]
+        [InlineData(null, "http/protobuf", OtlpProtocol.HttpProtobuf)]
+        [InlineData(null, "grpc", OtlpProtocol.Grpc)]
         public void OtlpLogsProtocolFallbacks(string logsProtocol, string generalProtocol, object expected)
         {
             var source = CreateConfigurationSource(

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/OtlpSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/OtlpSinkTests.cs
@@ -263,7 +263,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
                 return await _exportFunc(logs).ConfigureAwait(false);
             }
 
-            public bool Shutdown(int timeoutMilliseconds)
+            public bool Shutdown()
             {
                 return true;
             }

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/CustomTracerProviderBuilderExtensions.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/CustomTracerProviderBuilderExtensions.cs
@@ -5,6 +5,7 @@ using OpenTelemetry.Trace;
 using OpenTelemetry.Metrics;
 #endif
 #if OTEL_1_9
+using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Logs;
 #endif
 using Microsoft.Extensions.Logging;
@@ -61,33 +62,30 @@ public static class CustomMeterProviderBuilderExtensions
 #if OTEL_1_9
 public static class CustomLoggerFactoryBuilderExtensions
 {
-    public static ILoggerFactory AddOtlpExporterIfEnvironmentVariablePresent()
+    // Returns an IServiceProvider rather than an ILoggerFactory so callers can resolve
+    // the underlying OpenTelemetry.Logs.LoggerProvider and call ForceFlush before disposal.
+    // LoggerProviderSdk.Dispose() caps its shutdown flush at 5s; with gRPC, the first export
+    // can exceed that due to TCP/HTTP/2/TLS handshake, causing batched logs to be dropped.
+    public static ServiceProvider CreateLoggerServices()
     {
-        // Check if OpenTelemetry Logs Exporter is enabled (similar to metrics)
-        if (Environment.GetEnvironmentVariable("OTEL_LOGS_EXPORTER_ENABLED") is string value
-        && value == "true")
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
         {
-            return LoggerFactory.Create(builder =>
+            builder.SetMinimumLevel(LogLevel.Trace);
+
+            if (Environment.GetEnvironmentVariable("OTEL_LOGS_EXPORTER_ENABLED") is string value
+                && value == "true")
             {
-                builder.SetMinimumLevel(LogLevel.Trace);
 #if NET6_0_OR_GREATER
-                builder.AddOpenTelemetry(
-                    options =>
-                    {
-                        options.AddOtlpExporter();
-                    }
-                );
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddOtlpExporter();
+                });
 #endif
-            });
-        }
-        else
-        {
-            // Create logger factory without OTel - Datadog instrumentation will hook this
-            return LoggerFactory.Create(builder =>
-            {
-                builder.SetMinimumLevel(LogLevel.Trace);
-            });
-        }
+            }
+        });
+
+        return services.BuildServiceProvider();
     }
 }
 #endif

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/CustomTracerProviderBuilderExtensions.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/CustomTracerProviderBuilderExtensions.cs
@@ -63,7 +63,7 @@ public static class CustomMeterProviderBuilderExtensions
 public static class CustomLoggerFactoryBuilderExtensions
 {
     // Returns an IServiceProvider rather than an ILoggerFactory so callers can resolve
-    // the underlying OpenTelemetry.Logs.LoggerProvider and call ForceFlush before disposal.
+    // the underlying OpenTelemetry.Logs.LoggerProvider and call Shutdown before process exit.
     // LoggerProviderSdk.Dispose() caps its shutdown flush at 5s; with gRPC, the first export
     // can exceed that due to TCP/HTTP/2/TLS handshake, causing batched logs to be dropped.
     public static ServiceProvider CreateLoggerServices()

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -145,12 +145,13 @@ public static class Program
         }
 
 #if OTEL_1_2
-        // Flush OTLP metric batches before Dispose. MeterProviderSdk.Dispose caps its shutdown
-        // call at 5s, but the first gRPC export (TCP+HTTP/2+TLS handshake) can exceed that and
-        // the OTel SDK's metric export timeout default is 30s. Force a flush on the critical
-        // path with the full export timeout instead of racing the 5s shutdown cap.
-        meterProvider?.ForceFlush(timeoutMilliseconds: 30_000);
-        meterProvider?.Dispose();
+        // Shutdown with a generous timeout so the single final Collect+Export can complete even
+        // when the first gRPC export has to negotiate TCP+HTTP/2+TLS. We avoid ForceFlush-then-
+        // Dispose because two Collects on cumulative-temporality observable instruments re-emit
+        // the same cumulative values and produce duplicate resource_metrics batches. Shutdown
+        // performs exactly one Collect; the `using var` Dispose at end-of-scope no-ops via the
+        // SDK's internal shutdown-count guard.
+        meterProvider?.Shutdown(timeoutMilliseconds: 30_000);
 #endif
 #if OTEL_1_9
         // Flush OTLP log batches before the ServiceProvider's `using` disposes them.

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -7,6 +7,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Metrics;
 #endif
 #if OTEL_1_9
+using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Logs;
 #endif
 using System.Collections.Generic;
@@ -50,8 +51,8 @@ public static class Program
 #endif
 
 #if OTEL_1_9
-        using var loggerFactory = CustomLoggerFactoryBuilderExtensions
-            .AddOtlpExporterIfEnvironmentVariablePresent();
+        using var loggerServices = CustomLoggerFactoryBuilderExtensions.CreateLoggerServices();
+        var loggerFactory = loggerServices.GetRequiredService<ILoggerFactory>();
 #endif
 
         _tracer = tracerProvider.GetTracer(serviceName); // The version is omitted so the ActivitySource.Version / otel.library.version is not set
@@ -147,8 +148,11 @@ public static class Program
         meterProvider?.Dispose();
 #endif
 #if OTEL_1_9
-
-        loggerFactory?.Dispose();
+        // Flush OTLP log batches before the ServiceProvider's `using` disposes them.
+        // LoggerProviderSdk.Dispose caps shutdown flush at 5s, which is often insufficient
+        // for the first gRPC export (TCP+HTTP/2+TLS handshake). A generous ForceFlush here
+        // drains pending batches on the critical path instead of racing a hard-coded timeout.
+        loggerServices.GetService<LoggerProvider>()?.ForceFlush(timeoutMilliseconds: 10_000);
 #endif
     }
 

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -54,7 +54,11 @@ public static class Program
 #endif
 
 #if OTEL_1_9
-        using var loggerServices = CustomLoggerFactoryBuilderExtensions.CreateLoggerServices();
+        // Not `using var`: we call Shutdown on the LoggerProvider below with a generous
+        // timeout. Letting the ServiceProvider dispose here would trigger a second shutdown
+        // via LoggerProviderSdk.Dispose, which caps at 5s and can guillotine in-flight OTLP
+        // exports. Process exit handles cleanup, matching the meterProvider pattern above.
+        var loggerServices = CustomLoggerFactoryBuilderExtensions.CreateLoggerServices();
         var loggerFactory = loggerServices.GetRequiredService<ILoggerFactory>();
 #endif
 
@@ -158,11 +162,12 @@ public static class Program
         meterProvider?.Shutdown(timeoutMilliseconds: 30_000);
 #endif
 #if OTEL_1_9
-        // Flush OTLP log batches before the ServiceProvider's `using` disposes them.
-        // LoggerProviderSdk.Dispose caps shutdown flush at 5s, which is often insufficient
-        // for the first gRPC export (TCP+HTTP/2+TLS handshake). A generous ForceFlush here
-        // drains pending batches on the critical path instead of racing a hard-coded timeout.
-        loggerServices.GetService<LoggerProvider>()?.ForceFlush(timeoutMilliseconds: 10_000);
+        // Shutdown rather than ForceFlush: ForceFlush drains the processor queue but does not
+        // tear down the exporter's HttpClient, so a subsequent ServiceProvider dispose would
+        // still run LoggerProviderSdk.Dispose with its hard 5s shutdown cap and could guillotine
+        // in-flight exports. Shutdown drains and stops the processor with our timeout; we then
+        // let process exit clean up the ServiceProvider rather than risking the 5s Dispose race.
+        loggerServices.GetService<LoggerProvider>()?.Shutdown(timeoutMilliseconds: 30_000);
 #endif
     }
 

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -145,6 +145,11 @@ public static class Program
         }
 
 #if OTEL_1_2
+        // Flush OTLP metric batches before Dispose. MeterProviderSdk.Dispose caps its shutdown
+        // call at 5s, but the first gRPC export (TCP+HTTP/2+TLS handshake) can exceed that and
+        // the OTel SDK's metric export timeout default is 30s. Force a flush on the critical
+        // path with the full export timeout instead of racing the 5s shutdown cap.
+        meterProvider?.ForceFlush(timeoutMilliseconds: 30_000);
         meterProvider?.Dispose();
 #endif
 #if OTEL_1_9

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -45,7 +45,10 @@ public static class Program
             .Build();
 
 #if OTEL_1_2
-        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+        // Not `using var`: we call Shutdown explicitly below, and OTel SDK <= 1.3.2 re-collects
+        // on a second Shutdown/Dispose which produces a duplicate cumulative batch the test
+        // snapshot doesn't expect. Process exit handles cleanup.
+        var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddOtlpExporterIfEnvironmentVariablePresent()
             .Build();
 #endif
@@ -149,8 +152,9 @@ public static class Program
         // when the first gRPC export has to negotiate TCP+HTTP/2+TLS. We avoid ForceFlush-then-
         // Dispose because two Collects on cumulative-temporality observable instruments re-emit
         // the same cumulative values and produce duplicate resource_metrics batches. Shutdown
-        // performs exactly one Collect; the `using var` Dispose at end-of-scope no-ops via the
-        // SDK's internal shutdown-count guard.
+        // performs exactly one Collect; `meterProvider` is deliberately not `using var` so the
+        // runtime doesn't re-invoke Dispose->Shutdown after this (older OTel SDKs like 1.3.2
+        // re-collect in that second call).
         meterProvider?.Shutdown(timeoutMilliseconds: 30_000);
 #endif
 #if OTEL_1_9


### PR DESCRIPTION
## Summary of changes

This fixes some export failures occurring in OTLP Logs/Metrics exports that were caused by both bugs within the exporter code (forced HTTP/2 and a unclosed `_otlpExporter`) and also with some test changes.

## Reason for change

I've been noticing on many of my CI runs that I kept running into the following error that requires a retry:
```
[Error] Exception when sending logs OTLP HTTP request. System.Threading.Tasks.TaskCanceledException: The request was canceled due to the configured HttpClient.Timeout of 10 seconds elapsing.
```

On looking further I found a few issues of note:

- The `HttpClient`s for Logs/Metrics for our OTLP implementation forced HTTP/2. However, the test agent that we us only supports an HTTP/1.1 aiohttp server. **Note: this is technically a production change for a test issue I'm fine reverting this and just leaving these tests as `[Flaky]`**
  - I had Claude look into https://github.com/DataDog/dd-apm-test-agent for verification on this. (will put that findings in the Other details)
- `OtlpSubmissionLogSink.DisposeAsync()` never called `_otlpExporter.Shutdown()` which appears to have left the `HttpClient` open.
- Tests used `OTEL_LOG_EXPORT_INTERVAL` instead of `OTEL_BLRP_SCHEDULE_DELAY` (former doesn't seem to exist ever or anymore)
- We did not honor the base protocol `OTEL_EXPORTER_OTLP_PROTOCOL` applying to metrics/logs protocol(s) when they are not set -> https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options

## Implementation details

It does seem that the test agent is a bit finicky to work with and since we don't use it very much anywhere else I opted to go for some polling strategies instead of single shots for getting request data.


- Fix `OTEL_LOG_EXPORT_INTERVAL` to `OTEL_BLRP_SCHEDULE_DELAY`
- Replace fire-and-forget `/test/session/clear` with `ClearTestAgentSession` retry helper
- Replace single-GET data fetch with `WaitForTestAgentData` polling helper (30s timeout, 500ms interval)
-  Set `OTEL_METRIC_EXPORT_INTERVAL=60000` so only the shutdown flush fires (one clean batch)
- Set` OTEL_BLRP_SCHEDULE_DELAY=500`; The OpenTelemetry SDK has a hard 5s shutdown timeout that we hit so this should be good enough to get our data out and flush it before it is timed out. I'll add this to the Other Details as well. This seems to be the flakiest bit left
-  Remove `[Flaky]` from `SubmitsOtlpMetrics` and `SubmitsOtlpLogs`
  - Remove the newly added Skip as well
- Force the `OTEL_EXPORTER_OTLP_PROTOCOL` value to set the metric/log protocol when not set
- Removed the paramter from `Shutdown` as it wasn't used (and I attempted to use it)

## Test coverage

I'm going to run the CI a few times against this to see if this helps get the tests running quicker and pass

## Other details
<!-- Fixes #{issue} -->

> Claude response on test agent HTTP/2 support

``` txt
The test-agent's HTTP server on port 4318 is created in agent.py:

  otlp_http_app = make_otlp_http_app(agent)       # line 2436
  otlp_http_runner = web.AppRunner(otlp_http_app)  # line 2470
  otlp_http_site = web.TCPSite(otlp_http_runner, port=parsed_args.otlp_http_port)  # line 2490

  This is aiohttp.web -- its TCPSite serves HTTP/1.1 only. aiohttp does not support HTTP/2. You can see it declared as a dependency in
   setup.py:

  install_requires=[
      "aiohttp",
      ...
  ]

  There's no h2, hyper, hypercorn, or any other HTTP/2 library in the dependencies.

  For contrast, port 4317 (gRPC) uses grpc_aio.server() (line 2481), which speaks HTTP/2 natively -- that's why gRPC tests were never
  affected.

  Source: https://github.com/DataDog/dd-apm-test-agent -- setup.py for dependencies, ddapm_test_agent/agent.py lines 2436-2490 for
  server setup.
```

> Claude response on OpenTelemetry SDK Log Shutdown Chain

```txt
 LoggerProviderSdk.Dispose() calls Processor.Shutdown(5000) -- hardcoded, not
  configurable. BatchExportProcessor.OnShutdown(5000) calls worker.Shutdown(5000)
  which does Thread.Join(5000). The worker thread runs PerformExport() which calls
  Exporter.Export() with no timeout parameter and no cancellation token. The OTLP
  exporter then calls HttpClient.SendAsync() with HttpClient.Timeout set from
  OTEL_EXPORTER_OTLP_TIMEOUT (default 10s). When the 5s Thread.Join expires before the
   10s HTTP timeout, the dispose path proceeds to cancel the in-flight request and
  dispose the worker. The export silently fails, data is lost, and the process exits
  with code 0.

  OTEL_BLRP_EXPORT_TIMEOUT (default 30s) is parsed and stored but never read during
  export or shutdown -- it's a dead field.
```

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->