### PR TITLE
Make microbenchmark post-processing steps non-fatal

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
@@ -79,7 +79,7 @@ convert_results() {
     done
 
     if [ "$files_found" = false ]; then
-        echo "  Warning: No $BASELINE_OR_CANDIDATE results found"
+        echo "  WARNING: No $BASELINE_OR_CANDIDATE results found"
     fi
 }
 
@@ -97,7 +97,7 @@ if [ -n "$BASELINE_CI_COMMIT_SHORT_SHA" ]; then
         "$BASELINE_CI_COMMIT_SHORT_SHA" "$BASELINE_COMMIT_DATE" "$BASELINE_CI_JOB_ID" "$BASELINE_CI_PIPELINE_ID" "$BASELINE_JOB_DATE"
 else
     echo ""
-    echo "Warning: No baseline metadata found (BASELINE_CI_COMMIT_SHORT_SHA not set)."
+    echo "WARNING: No baseline metadata found (BASELINE_CI_COMMIT_SHORT_SHA not set)."
     echo "This is expected on the first run or when no master baseline exists yet."
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
@@ -79,7 +79,7 @@ convert_results() {
     done
 
     if [ "$files_found" = false ]; then
-        echo "  WARNING: No $BASELINE_OR_CANDIDATE results found"
+        echo "  Warning: No $BASELINE_OR_CANDIDATE results found"
     fi
 }
 
@@ -97,7 +97,7 @@ if [ -n "$BASELINE_CI_COMMIT_SHORT_SHA" ]; then
         "$BASELINE_CI_COMMIT_SHORT_SHA" "$BASELINE_COMMIT_DATE" "$BASELINE_CI_JOB_ID" "$BASELINE_CI_PIPELINE_ID" "$BASELINE_JOB_DATE"
 else
     echo ""
-    echo "WARNING: No baseline metadata found (BASELINE_CI_COMMIT_SHORT_SHA not set)."
+    echo "Warning: No baseline metadata found (BASELINE_CI_COMMIT_SHORT_SHA not set)."
     echo "This is expected on the first run or when no master baseline exists yet."
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
@@ -83,7 +83,7 @@ convert_results() {
             echo "  ERROR: No candidate results found in $ARTIFACTS_DIR"
             exit 1
         else
-            echo "  Warning: No $BASELINE_OR_CANDIDATE results found"
+            echo "  WARNING: No $BASELINE_OR_CANDIDATE results found"
         fi
     fi
 }
@@ -102,7 +102,7 @@ if [ -n "$BASELINE_CI_COMMIT_SHORT_SHA" ]; then
         "$BASELINE_CI_COMMIT_SHORT_SHA" "$BASELINE_COMMIT_DATE" "$BASELINE_CI_JOB_ID" "$BASELINE_CI_PIPELINE_ID" "$BASELINE_JOB_DATE"
 else
     echo ""
-    echo "Warning: No baseline metadata found (BASELINE_CI_COMMIT_SHORT_SHA not set)."
+    echo "WARNING: No baseline metadata found (BASELINE_CI_COMMIT_SHORT_SHA not set)."
     echo "This is expected on the first run or when no master baseline exists yet."
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/analyze-results.sh
@@ -79,7 +79,12 @@ convert_results() {
     done
 
     if [ "$files_found" = false ]; then
-        echo "  Warning: No $BASELINE_OR_CANDIDATE results found"
+        if [ "$BASELINE_OR_CANDIDATE" = "candidate" ]; then
+            echo "  ERROR: No candidate results found in $ARTIFACTS_DIR"
+            exit 1
+        else
+            echo "  Warning: No $BASELINE_OR_CANDIDATE results found"
+        fi
     fi
 }
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/fetch-results.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/fetch-results.sh
@@ -39,7 +39,7 @@ prepare_baseline_results() {
     local BASELINE_DIR=$1
 
     if [ ! -d "$BASELINE_DIR" ]; then
-        echo "WARNING: Baseline directory $BASELINE_DIR not found"
+        echo "Warning: Baseline directory $BASELINE_DIR not found"
         return
     fi
 
@@ -98,7 +98,7 @@ echo "Source: s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$S3_PREFIX"
 aws s3 cp "s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$S3_PREFIX" "$ARTIFACTS_DIR/" \
     --region "$AWS_REGION" \
     --profile "$AWS_PROFILE" \
-    --recursive || echo "WARNING: No candidate results found in S3"
+    --recursive || echo "Warning: No candidate results found in S3"
 
 # Handle legacy format for candidate files (BP_INFRA_TEST mode)
 prepare_candidate_results
@@ -114,7 +114,7 @@ echo "Source: s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$BASELINE_PREFIX"
 aws s3 cp "s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$BASELINE_PREFIX" "$BASELINE_DIR/" \
     --region "$AWS_REGION" \
     --profile "$AWS_PROFILE" \
-    --recursive || echo "WARNING: No baseline results found in S3 (first run?)"
+    --recursive || echo "Warning: No baseline results found in S3 (first run?)"
 
 # Rename baseline files
 echo ""

--- a/.gitlab/benchmarks/microbenchmarks/scripts/fetch-results.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/fetch-results.sh
@@ -39,7 +39,7 @@ prepare_baseline_results() {
     local BASELINE_DIR=$1
 
     if [ ! -d "$BASELINE_DIR" ]; then
-        echo "Warning: Baseline directory $BASELINE_DIR not found"
+        echo "WARNING: Baseline directory $BASELINE_DIR not found"
         return
     fi
 
@@ -98,7 +98,7 @@ echo "Source: s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$S3_PREFIX"
 aws s3 cp "s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$S3_PREFIX" "$ARTIFACTS_DIR/" \
     --region "$AWS_REGION" \
     --profile "$AWS_PROFILE" \
-    --recursive || echo "Warning: No candidate results found in S3"
+    --recursive || echo "WARNING: No candidate results found in S3"
 
 # Handle legacy format for candidate files (BP_INFRA_TEST mode)
 prepare_candidate_results
@@ -114,7 +114,7 @@ echo "Source: s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$BASELINE_PREFIX"
 aws s3 cp "s3://$BP_INFRA_ARTIFACTS_BUCKET_NAME/$BASELINE_PREFIX" "$BASELINE_DIR/" \
     --region "$AWS_REGION" \
     --profile "$AWS_PROFILE" \
-    --recursive || echo "Warning: No baseline results found in S3 (first run?)"
+    --recursive || echo "WARNING: No baseline results found in S3 (first run?)"
 
 # Rename baseline files
 echo ""

--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -99,6 +99,7 @@ set -e
 
 if [ $pr_commenter_exit -ne 0 ]; then
     echo "WARNING: pr-commenter failed (exit $pr_commenter_exit), PR comment was not posted."
+    echo "This does not affect benchmark correctness. The CI job will continue."
     exit 0
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -98,7 +98,7 @@ pr_commenter_exit=$?
 set -e
 
 if [ $pr_commenter_exit -ne 0 ]; then
-    echo "Warning: pr-commenter failed (exit $pr_commenter_exit), PR comment was not posted."
+    echo "WARNING: pr-commenter failed (exit $pr_commenter_exit), PR comment was not posted."
     exit 0
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -32,8 +32,8 @@ candidate_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#candidate_files[@]} -eq 0 ]; then
-    echo "WARNING: No candidate results found in $ARTIFACTS_DIR, skipping PR comment."
-    exit 0
+    echo "ERROR: No candidate results found in $ARTIFACTS_DIR"
+    exit 1
 fi
 
 if [ ${#baseline_files[@]} -eq 0 ]; then
@@ -80,20 +80,12 @@ fi
 export UNCONFIDENCE_THRESHOLD
 
 echo "Comparing benchmark results..."
-set +e
 benchmark_analyzer compare pairwise \
     --baseline='{"baseline_or_candidate":"baseline"}' \
     --candidate='{"baseline_or_candidate":"candidate"}' \
     --format='md-nodejs' \
     --outpath="$ARTIFACTS_DIR/comparison.md" \
     "$ARTIFACTS_DIR"/baseline*.converted.json "$ARTIFACTS_DIR"/candidate*.converted.json
-compare_exit=$?
-set -e
-
-if [ $compare_exit -ne 0 ]; then
-    echo "WARNING: benchmark_analyzer compare failed (exit $compare_exit), skipping PR comment."
-    exit 0
-fi
 
 echo "Posting PR comment..."
 set +e

--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -98,7 +98,7 @@ pr_commenter_exit=$?
 set -e
 
 if [ $pr_commenter_exit -ne 0 ]; then
-    echo "WARNING: pr-commenter failed (exit $pr_commenter_exit), PR comment was not posted."
+    echo "Warning: pr-commenter failed (exit $pr_commenter_exit), PR comment was not posted."
     exit 0
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -32,8 +32,8 @@ candidate_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#candidate_files[@]} -eq 0 ]; then
-    echo "ERROR: No candidate results found in $ARTIFACTS_DIR"
-    exit 1
+    echo "Warning: No candidate results found in $ARTIFACTS_DIR — skipping PR comment."
+    exit 0
 fi
 
 if [ ${#baseline_files[@]} -eq 0 ]; then
@@ -80,18 +80,34 @@ fi
 export UNCONFIDENCE_THRESHOLD
 
 echo "Comparing benchmark results..."
+set +e
 benchmark_analyzer compare pairwise \
     --baseline='{"baseline_or_candidate":"baseline"}' \
     --candidate='{"baseline_or_candidate":"candidate"}' \
     --format='md-nodejs' \
     --outpath="$ARTIFACTS_DIR/comparison.md" \
     "$ARTIFACTS_DIR"/baseline*.converted.json "$ARTIFACTS_DIR"/candidate*.converted.json
+compare_exit=$?
+set -e
+
+if [ $compare_exit -ne 0 ]; then
+    echo "Warning: benchmark_analyzer compare failed (exit $compare_exit) — skipping PR comment."
+    exit 0
+fi
 
 echo "Posting PR comment..."
+set +e
 cat "$ARTIFACTS_DIR/comparison.md" | pr-commenter \
     --for-repo="$CI_PROJECT_NAME" \
     --for-pr="$CI_COMMIT_REF_NAME" \
     --header='Benchmarks' \
     --on-duplicate=replace
+pr_commenter_exit=$?
+set -e
+
+if [ $pr_commenter_exit -ne 0 ]; then
+    echo "Warning: pr-commenter failed (exit $pr_commenter_exit) — PR comment was not posted."
+    exit 0
+fi
 
 echo "PR comment posted successfully!"

--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -32,7 +32,7 @@ candidate_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#candidate_files[@]} -eq 0 ]; then
-    echo "WARNING: No candidate results found in $ARTIFACTS_DIR — skipping PR comment."
+    echo "WARNING: No candidate results found in $ARTIFACTS_DIR, skipping PR comment."
     exit 0
 fi
 
@@ -91,7 +91,7 @@ compare_exit=$?
 set -e
 
 if [ $compare_exit -ne 0 ]; then
-    echo "WARNING: benchmark_analyzer compare failed (exit $compare_exit) — skipping PR comment."
+    echo "WARNING: benchmark_analyzer compare failed (exit $compare_exit), skipping PR comment."
     exit 0
 fi
 
@@ -106,7 +106,7 @@ pr_commenter_exit=$?
 set -e
 
 if [ $pr_commenter_exit -ne 0 ]; then
-    echo "WARNING: pr-commenter failed (exit $pr_commenter_exit) — PR comment was not posted."
+    echo "WARNING: pr-commenter failed (exit $pr_commenter_exit), PR comment was not posted."
     exit 0
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -32,7 +32,7 @@ candidate_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#candidate_files[@]} -eq 0 ]; then
-    echo "Warning: No candidate results found in $ARTIFACTS_DIR — skipping PR comment."
+    echo "WARNING: No candidate results found in $ARTIFACTS_DIR — skipping PR comment."
     exit 0
 fi
 
@@ -91,7 +91,7 @@ compare_exit=$?
 set -e
 
 if [ $compare_exit -ne 0 ]; then
-    echo "Warning: benchmark_analyzer compare failed (exit $compare_exit) — skipping PR comment."
+    echo "WARNING: benchmark_analyzer compare failed (exit $compare_exit) — skipping PR comment."
     exit 0
 fi
 
@@ -106,7 +106,7 @@ pr_commenter_exit=$?
 set -e
 
 if [ $pr_commenter_exit -ne 0 ]; then
-    echo "Warning: pr-commenter failed (exit $pr_commenter_exit) — PR comment was not posted."
+    echo "WARNING: pr-commenter failed (exit $pr_commenter_exit) — PR comment was not posted."
     exit 0
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/read-baseline-env.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/read-baseline-env.sh
@@ -8,7 +8,7 @@ ARTIFACTS_DIR="${ARTIFACTS_DIR:-./artifacts}"
 env_file="$ARTIFACTS_DIR/baseline_env_vars.txt"
 
 if [ ! -f "$env_file" ]; then
-    echo "Warning: Baseline env vars file not found at $env_file"
+    echo "WARNING: Baseline env vars file not found at $env_file"
     return 0 2>/dev/null || exit 0
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/read-baseline-env.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/read-baseline-env.sh
@@ -8,7 +8,7 @@ ARTIFACTS_DIR="${ARTIFACTS_DIR:-./artifacts}"
 env_file="$ARTIFACTS_DIR/baseline_env_vars.txt"
 
 if [ ! -f "$env_file" ]; then
-    echo "WARNING: Baseline env vars file not found at $env_file"
+    echo "Warning: Baseline env vars file not found at $env_file"
     return 0 2>/dev/null || exit 0
 fi
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
@@ -6,6 +6,9 @@
 #
 # Optional:
 #   ARTIFACTS_DIR - Directory containing converted results (default: ./artifacts)
+#
+# This script always exits 0. Upload failures are logged as warnings so that a
+# transient network or service error does not fail the benchmark CI job.
 
 set -e
 
@@ -20,25 +23,51 @@ converted_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#converted_files[@]} -eq 0 ]; then
-    echo "ERROR: No converted results found in $ARTIFACTS_DIR"
+    echo "Warning: No converted results found in $ARTIFACTS_DIR"
     echo "Make sure to run analyze-results.sh first."
-    exit 1
+    exit 0
 fi
+
+upload_failed=false
 
 for CONVERTED_JSON in "${converted_files[@]}"; do
     echo "Uploading $(basename "$CONVERTED_JSON") to Benchmarking Platform..."
 
-    STATUS_CODE=$(curl --retry 3 --retry-max-time 300 \
-        -s -o /dev/null -w "%{http_code}" \
+    set +e
+    response=$(curl --retry 3 --retry-max-time 300 \
+        -s -w "\n%{http_code}" \
         --form file=@"$CONVERTED_JSON" \
         "https://benchmarking-service.us1.prod.dog/benchmarks/upload/$CI_PROJECT_NAME?baseline_commit_sha=${BASELINE_CI_COMMIT_SHORT_SHA:-}&baseline_ci_pipeline_id=${BASELINE_CI_PIPELINE_ID:-}")
+    curl_exit=$?
+    set -e
 
-    if [ "$STATUS_CODE" -ne 200 ]; then
-        echo "ERROR: Upload failed with status code $STATUS_CODE"
-        exit 1
+    STATUS_CODE=$(echo "$response" | tail -n1)
+    RESPONSE_BODY=$(echo "$response" | head -n-1)
+
+    if [ $curl_exit -ne 0 ]; then
+        echo "Warning: curl failed (exit $curl_exit) while uploading $(basename "$CONVERTED_JSON")"
+        upload_failed=true
+        continue
     fi
 
-    echo "  Uploaded successfully!"
+    if [ "$STATUS_CODE" -ne 200 ]; then
+        echo "Warning: Upload of $(basename "$CONVERTED_JSON") failed with status $STATUS_CODE"
+        if [ -n "$RESPONSE_BODY" ]; then
+            echo "  Response: $RESPONSE_BODY"
+        fi
+        upload_failed=true
+        continue
+    fi
+
+    echo "  Uploaded successfully."
 done
 
-echo "All uploads complete!"
+if [ "$upload_failed" = true ]; then
+    echo ""
+    echo "Warning: One or more uploads failed. Benchmark results were not fully recorded in the Benchmarking Platform UI."
+    echo "This does not affect benchmark correctness. The CI job will continue."
+else
+    echo "All uploads complete."
+fi
+
+exit 0

--- a/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
@@ -7,8 +7,8 @@
 # Optional:
 #   ARTIFACTS_DIR - Directory containing converted results (default: ./artifacts)
 #
-# This script always exits 0. Upload failures are logged as warnings so that a
-# transient network or service error does not fail the benchmark CI job.
+# Upload failures are logged as warnings and do not fail the CI job. Missing
+# converted files are treated as an error since that indicates a pipeline failure.
 
 set -e
 
@@ -23,9 +23,9 @@ converted_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#converted_files[@]} -eq 0 ]; then
-    echo "Warning: No converted results found in $ARTIFACTS_DIR"
+    echo "ERROR: No converted results found in $ARTIFACTS_DIR"
     echo "Make sure to run analyze-results.sh first."
-    exit 0
+    exit 1
 fi
 
 upload_failed=false

--- a/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
@@ -1,14 +1,4 @@
 #!/usr/bin/env bash
-# Uploads converted benchmark results to the Benchmarking Platform UI service.
-#
-# Required environment variables:
-#   CI_PROJECT_NAME - GitLab/GitHub project name
-#
-# Optional:
-#   ARTIFACTS_DIR - Directory containing converted results (default: ./artifacts)
-#
-# Upload failures are logged as warnings and do not fail the CI job. Missing
-# converted files are treated as an error since that indicates a pipeline failure.
 
 set -e
 

--- a/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
@@ -23,7 +23,7 @@ converted_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#converted_files[@]} -eq 0 ]; then
-    echo "Warning: No converted results found in $ARTIFACTS_DIR"
+    echo "WARNING: No converted results found in $ARTIFACTS_DIR"
     echo "Make sure to run analyze-results.sh first."
     exit 0
 fi
@@ -45,13 +45,13 @@ for CONVERTED_JSON in "${converted_files[@]}"; do
     RESPONSE_BODY=$(echo "$response" | head -n-1)
 
     if [ $curl_exit -ne 0 ]; then
-        echo "Warning: curl failed (exit $curl_exit) while uploading $(basename "$CONVERTED_JSON")"
+        echo "WARNING: curl failed (exit $curl_exit) while uploading $(basename "$CONVERTED_JSON")"
         upload_failed=true
         continue
     fi
 
     if [ "$STATUS_CODE" -ne 200 ]; then
-        echo "Warning: Upload of $(basename "$CONVERTED_JSON") failed with status $STATUS_CODE"
+        echo "WARNING: Upload of $(basename "$CONVERTED_JSON") failed with status $STATUS_CODE"
         if [ -n "$RESPONSE_BODY" ]; then
             echo "  Response: $RESPONSE_BODY"
         fi
@@ -64,7 +64,7 @@ done
 
 if [ "$upload_failed" = true ]; then
     echo ""
-    echo "Warning: One or more uploads failed. Benchmark results were not fully recorded in the Benchmarking Platform UI."
+    echo "WARNING: One or more uploads failed. Benchmark results were not fully recorded in the Benchmarking Platform UI."
     echo "This does not affect benchmark correctness. The CI job will continue."
 else
     echo "All uploads complete."

--- a/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
@@ -23,7 +23,7 @@ converted_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
 shopt -u nullglob
 
 if [ ${#converted_files[@]} -eq 0 ]; then
-    echo "WARNING: No converted results found in $ARTIFACTS_DIR"
+    echo "Warning: No converted results found in $ARTIFACTS_DIR"
     echo "Make sure to run analyze-results.sh first."
     exit 0
 fi
@@ -45,13 +45,13 @@ for CONVERTED_JSON in "${converted_files[@]}"; do
     RESPONSE_BODY=$(echo "$response" | head -n-1)
 
     if [ $curl_exit -ne 0 ]; then
-        echo "WARNING: curl failed (exit $curl_exit) while uploading $(basename "$CONVERTED_JSON")"
+        echo "Warning: curl failed (exit $curl_exit) while uploading $(basename "$CONVERTED_JSON")"
         upload_failed=true
         continue
     fi
 
     if [ "$STATUS_CODE" -ne 200 ]; then
-        echo "WARNING: Upload of $(basename "$CONVERTED_JSON") failed with status $STATUS_CODE"
+        echo "Warning: Upload of $(basename "$CONVERTED_JSON") failed with status $STATUS_CODE"
         if [ -n "$RESPONSE_BODY" ]; then
             echo "  Response: $RESPONSE_BODY"
         fi
@@ -64,7 +64,7 @@ done
 
 if [ "$upload_failed" = true ]; then
     echo ""
-    echo "WARNING: One or more uploads failed. Benchmark results were not fully recorded in the Benchmarking Platform UI."
+    echo "Warning: One or more uploads failed. Benchmark results were not fully recorded in the Benchmarking Platform UI."
     echo "This does not affect benchmark correctness. The CI job will continue."
 else
     echo "All uploads complete."

--- a/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/upload-to-bp-ui.sh
@@ -45,13 +45,13 @@ for CONVERTED_JSON in "${converted_files[@]}"; do
     RESPONSE_BODY=$(echo "$response" | head -n-1)
 
     if [ $curl_exit -ne 0 ]; then
-        echo "Warning: curl failed (exit $curl_exit) while uploading $(basename "$CONVERTED_JSON")"
+        echo "WARNING: curl failed (exit $curl_exit) while uploading $(basename "$CONVERTED_JSON")"
         upload_failed=true
         continue
     fi
 
     if [ "$STATUS_CODE" -ne 200 ]; then
-        echo "Warning: Upload of $(basename "$CONVERTED_JSON") failed with status $STATUS_CODE"
+        echo "WARNING: Upload of $(basename "$CONVERTED_JSON") failed with status $STATUS_CODE"
         if [ -n "$RESPONSE_BODY" ]; then
             echo "  Response: $RESPONSE_BODY"
         fi
@@ -64,7 +64,7 @@ done
 
 if [ "$upload_failed" = true ]; then
     echo ""
-    echo "Warning: One or more uploads failed. Benchmark results were not fully recorded in the Benchmarking Platform UI."
+    echo "WARNING: One or more uploads failed. Benchmark results were not fully recorded in the Benchmarking Platform UI."
     echo "This does not affect benchmark correctness. The CI job will continue."
 else
     echo "All uploads complete."


### PR DESCRIPTION
## Summary of changes
- `upload-to-bp-ui.sh`: curl and HTTP failures are non-fatal, logged as warnings, script always exits 0
- `post-pr-comment.sh`: `pr-commenter` failure is non-fatal, logged as a warning
- `analyze-results.sh`: fails fast if no candidate results are found
- `WARNING:` casing normalized consistently across all scripts

## Reason for change
Transient upload or PR comment failures were marking `run-benchmarks` as failed even when benchmarks succeeded, causing unnecessary reruns.

## Test coverage
Verified curl failure, HTTP 503, and HTTP 200 paths via shell tests.
