### PR TITLE
Fix benchmark reporting

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -34,41 +34,41 @@ echo *********************
 echo .NET Framework 4.8
 echo *********************
 dotnet timeit Samples.FakeDbCommand.windows.net48.json
-call :CopyLogs net48
 IF ERRORLEVEL 1 (
     echo ❌ .NET Framework 4.8 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs net48
 
 echo *********************
 echo .NET Core 3.1
 echo *********************
 dotnet timeit Samples.FakeDbCommand.windows.netcoreapp31.json
-call :CopyLogs netcoreapp3.1
 IF ERRORLEVEL 1 (
     echo ❌ .NET Core 3.1 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs netcoreapp3.1
 
 echo *********************
 echo .NET Core 6.0
 echo *********************
 dotnet timeit Samples.FakeDbCommand.windows.net60.json
-call :CopyLogs net6.0
 IF ERRORLEVEL 1 (
     echo ❌ .NET Core 6.0 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs net6.0
 
 echo *********************
 echo .NET Core 8.0
 echo *********************
 dotnet timeit Samples.FakeDbCommand.windows.net80.json
-call :CopyLogs net8.0
 IF ERRORLEVEL 1 (
     echo ❌ .NET Core 8.0 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs net8.0
 
 IF "!FAILED!"=="1" (
     echo =====================

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -64,5 +64,5 @@
     "benchmark.job.runtime.name": ".NET 6.0",
     "benchmark.job.runtime.moniker": "net6.0"
   },
-  "overheadThreshold": 2.87
+  "overheadThreshold": 3.80
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -64,5 +64,5 @@
     "benchmark.job.runtime.name": ".NET 8.0",
     "benchmark.job.runtime.moniker": "net8.0"
   },
-  "overheadThreshold": 2.54
+  "overheadThreshold": 3.80
 }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -34,41 +34,41 @@ echo *********************
 echo .NET Framework 4.8
 echo *********************
 dotnet timeit Samples.HttpMessageHandler.windows.net48.json
-call :CopyLogs net48
 IF ERRORLEVEL 1 (
     echo ❌ .NET Framework 4.8 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs net48
 
 echo *********************
 echo .NET Core 3.1
 echo *********************
 dotnet timeit Samples.HttpMessageHandler.windows.netcoreapp31.json
-call :CopyLogs netcoreapp3.1
 IF ERRORLEVEL 1 (
     echo ❌ .NET Core 3.1 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs netcoreapp3.1
 
 echo *********************
 echo .NET Core 6.0
 echo *********************
 dotnet timeit Samples.HttpMessageHandler.windows.net60.json
-call :CopyLogs net6.0
 IF ERRORLEVEL 1 (
     echo ❌ .NET Core 6.0 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs net6.0
 
 echo *********************
 echo .NET Core 8.0
 echo *********************
 dotnet timeit Samples.HttpMessageHandler.windows.net80.json
-call :CopyLogs net8.0
 IF ERRORLEVEL 1 (
     echo ❌ .NET Core 8.0 benchmark FAILED
     set FAILED=1
 )
+call :CopyLogs net8.0
 
 IF "!FAILED!"=="1" (
     echo =====================


### PR DESCRIPTION
## Summary of changes

Fix benchmark failures not being reported in CI

## Reason for change

The wrong ordering of commands meant we were ignoring benchmarking failures

## Implementation details

Make sure to check the `ERRORLOG` _before_ calling another command

## Test coverage

This is the test I guess, let's see what happens

## Other details

Spotted because @cbeauchesne noticed that #8367 regressed, but didn't fail the CI job