### PR TITLE
Use the built-in System.Reflection.Metadata types for .NET Core

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -184,7 +184,6 @@
       <type fullname="System.Collections.Immutable.ImmutableHashSet`1" />
       <type fullname="System.Collections.Immutable.ImmutableHashSet`1/Builder" />
       <type fullname="System.Collections.Immutable.ImmutableHashSet`1/Enumerator" />
-      <type fullname="System.Linq.ImmutableArrayExtensions" />
    </assembly>
    <assembly fullname="System.Collections.NonGeneric">
       <type fullname="System.Collections.Queue" />
@@ -320,7 +319,6 @@
       <type fullname="System.IO.IsolatedStorage.IsolatedStorageScope" />
    </assembly>
    <assembly fullname="System.IO.MemoryMappedFiles">
-      <type fullname="Microsoft.Win32.SafeHandles.SafeMemoryMappedViewHandle" />
       <type fullname="System.IO.MemoryMappedFiles.MemoryMappedFile" />
       <type fullname="System.IO.MemoryMappedFiles.MemoryMappedFileAccess" />
       <type fullname="System.IO.MemoryMappedFiles.MemoryMappedViewAccessor" />
@@ -500,12 +498,104 @@
    <assembly fullname="System.Reflection.Emit.Lightweight">
       <type fullname="System.Reflection.Emit.DynamicMethod" />
    </assembly>
+   <assembly fullname="System.Reflection.Metadata">
+      <type fullname="System.Reflection.Metadata.ArrayShape" />
+      <type fullname="System.Reflection.Metadata.AssemblyDefinition" />
+      <type fullname="System.Reflection.Metadata.AssemblyReference" />
+      <type fullname="System.Reflection.Metadata.AssemblyReferenceHandle" />
+      <type fullname="System.Reflection.Metadata.BlobHandle" />
+      <type fullname="System.Reflection.Metadata.BlobReader" />
+      <type fullname="System.Reflection.Metadata.CustomAttribute" />
+      <type fullname="System.Reflection.Metadata.CustomAttributeHandle" />
+      <type fullname="System.Reflection.Metadata.CustomAttributeHandleCollection" />
+      <type fullname="System.Reflection.Metadata.CustomAttributeHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.CustomAttributeTypedArgument`1" />
+      <type fullname="System.Reflection.Metadata.CustomAttributeValue`1" />
+      <type fullname="System.Reflection.Metadata.CustomDebugInformation" />
+      <type fullname="System.Reflection.Metadata.CustomDebugInformationHandle" />
+      <type fullname="System.Reflection.Metadata.CustomDebugInformationHandleCollection" />
+      <type fullname="System.Reflection.Metadata.CustomDebugInformationHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.Document" />
+      <type fullname="System.Reflection.Metadata.DocumentHandle" />
+      <type fullname="System.Reflection.Metadata.DocumentHandleCollection" />
+      <type fullname="System.Reflection.Metadata.DocumentHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.DocumentNameBlobHandle" />
+      <type fullname="System.Reflection.Metadata.Ecma335.MetadataTokens" />
+      <type fullname="System.Reflection.Metadata.Ecma335.SignatureDecoder`2" />
+      <type fullname="System.Reflection.Metadata.EntityHandle" />
+      <type fullname="System.Reflection.Metadata.FieldDefinition" />
+      <type fullname="System.Reflection.Metadata.FieldDefinitionHandle" />
+      <type fullname="System.Reflection.Metadata.FieldDefinitionHandleCollection" />
+      <type fullname="System.Reflection.Metadata.FieldDefinitionHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.GuidHandle" />
+      <type fullname="System.Reflection.Metadata.Handle" />
+      <type fullname="System.Reflection.Metadata.HandleKind" />
+      <type fullname="System.Reflection.Metadata.IConstructedTypeProvider`1" />
+      <type fullname="System.Reflection.Metadata.ICustomAttributeTypeProvider`1" />
+      <type fullname="System.Reflection.Metadata.InterfaceImplementation" />
+      <type fullname="System.Reflection.Metadata.InterfaceImplementationHandle" />
+      <type fullname="System.Reflection.Metadata.InterfaceImplementationHandleCollection" />
+      <type fullname="System.Reflection.Metadata.InterfaceImplementationHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.ISignatureTypeProvider`2" />
+      <type fullname="System.Reflection.Metadata.ISimpleTypeProvider`1" />
+      <type fullname="System.Reflection.Metadata.ISZArrayTypeProvider`1" />
+      <type fullname="System.Reflection.Metadata.LocalConstant" />
+      <type fullname="System.Reflection.Metadata.LocalConstantHandle" />
+      <type fullname="System.Reflection.Metadata.LocalConstantHandleCollection" />
+      <type fullname="System.Reflection.Metadata.LocalConstantHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.LocalScope" />
+      <type fullname="System.Reflection.Metadata.LocalScopeHandle" />
+      <type fullname="System.Reflection.Metadata.LocalScopeHandleCollection" />
+      <type fullname="System.Reflection.Metadata.LocalScopeHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.LocalVariable" />
+      <type fullname="System.Reflection.Metadata.LocalVariableAttributes" />
+      <type fullname="System.Reflection.Metadata.LocalVariableHandle" />
+      <type fullname="System.Reflection.Metadata.LocalVariableHandleCollection" />
+      <type fullname="System.Reflection.Metadata.LocalVariableHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.MemberReference" />
+      <type fullname="System.Reflection.Metadata.MemberReferenceHandle" />
+      <type fullname="System.Reflection.Metadata.MetadataReader" />
+      <type fullname="System.Reflection.Metadata.MetadataReaderOptions" />
+      <type fullname="System.Reflection.Metadata.MetadataReaderProvider" />
+      <type fullname="System.Reflection.Metadata.MetadataStringDecoder" />
+      <type fullname="System.Reflection.Metadata.MethodBodyBlock" />
+      <type fullname="System.Reflection.Metadata.MethodDebugInformation" />
+      <type fullname="System.Reflection.Metadata.MethodDebugInformationHandle" />
+      <type fullname="System.Reflection.Metadata.MethodDefinition" />
+      <type fullname="System.Reflection.Metadata.MethodDefinitionHandle" />
+      <type fullname="System.Reflection.Metadata.MethodDefinitionHandleCollection" />
+      <type fullname="System.Reflection.Metadata.MethodDefinitionHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.MethodSignature`1" />
+      <type fullname="System.Reflection.Metadata.ModuleReference" />
+      <type fullname="System.Reflection.Metadata.ModuleReferenceHandle" />
+      <type fullname="System.Reflection.Metadata.Parameter" />
+      <type fullname="System.Reflection.Metadata.ParameterHandle" />
+      <type fullname="System.Reflection.Metadata.ParameterHandleCollection" />
+      <type fullname="System.Reflection.Metadata.ParameterHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.PEReaderExtensions" />
+      <type fullname="System.Reflection.Metadata.PrimitiveTypeCode" />
+      <type fullname="System.Reflection.Metadata.SequencePoint" />
+      <type fullname="System.Reflection.Metadata.SequencePointCollection" />
+      <type fullname="System.Reflection.Metadata.SequencePointCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.StandaloneSignature" />
+      <type fullname="System.Reflection.Metadata.StandaloneSignatureHandle" />
+      <type fullname="System.Reflection.Metadata.StringHandle" />
+      <type fullname="System.Reflection.Metadata.TypeDefinition" />
+      <type fullname="System.Reflection.Metadata.TypeDefinitionHandle" />
+      <type fullname="System.Reflection.Metadata.TypeDefinitionHandleCollection" />
+      <type fullname="System.Reflection.Metadata.TypeDefinitionHandleCollection/Enumerator" />
+      <type fullname="System.Reflection.Metadata.TypeReference" />
+      <type fullname="System.Reflection.Metadata.TypeReferenceHandle" />
+      <type fullname="System.Reflection.Metadata.TypeSpecification" />
+      <type fullname="System.Reflection.Metadata.TypeSpecificationHandle" />
+      <type fullname="System.Reflection.PortableExecutable.PEReader" />
+      <type fullname="System.Reflection.PortableExecutable.PEStreamOptions" />
+   </assembly>
    <assembly fullname="System.Reflection.Primitives">
       <type fullname="System.Reflection.Emit.OpCode" />
       <type fullname="System.Reflection.Emit.OpCodes" />
    </assembly>
    <assembly fullname="System.Resources.ResourceManager">
-      <type fullname="System.Resources.MissingManifestResourceException" />
       <type fullname="System.Resources.NeutralResourcesLanguageAttribute" />
       <type fullname="System.Resources.ResourceManager" />
    </assembly>
@@ -690,7 +780,6 @@
       <type fullname="System.IO.StringWriter" />
       <type fullname="System.IO.TextReader" />
       <type fullname="System.IO.TextWriter" />
-      <type fullname="System.IO.UnmanagedMemoryStream" />
       <type fullname="System.IObservable`1" />
       <type fullname="System.IObserver`1" />
       <type fullname="System.ISpanFormattable" />
@@ -715,7 +804,6 @@
       <type fullname="System.OperatingSystem" />
       <type fullname="System.OperationCanceledException" />
       <type fullname="System.OutOfMemoryException" />
-      <type fullname="System.OverflowException" />
       <type fullname="System.ParamArrayAttribute" />
       <type fullname="System.PlatformID" />
       <type fullname="System.PlatformNotSupportedException" />
@@ -728,7 +816,6 @@
       <type fullname="System.Reflection.Assembly" />
       <type fullname="System.Reflection.AssemblyCompanyAttribute" />
       <type fullname="System.Reflection.AssemblyConfigurationAttribute" />
-      <type fullname="System.Reflection.AssemblyContentType" />
       <type fullname="System.Reflection.AssemblyCopyrightAttribute" />
       <type fullname="System.Reflection.AssemblyDescriptionAttribute" />
       <type fullname="System.Reflection.AssemblyFileVersionAttribute" />
@@ -747,11 +834,9 @@
       <type fullname="System.Reflection.CustomAttributeNamedArgument" />
       <type fullname="System.Reflection.CustomAttributeTypedArgument" />
       <type fullname="System.Reflection.DefaultMemberAttribute" />
-      <type fullname="System.Reflection.EventAttributes" />
       <type fullname="System.Reflection.EventInfo" />
       <type fullname="System.Reflection.FieldAttributes" />
       <type fullname="System.Reflection.FieldInfo" />
-      <type fullname="System.Reflection.GenericParameterAttributes" />
       <type fullname="System.Reflection.ICustomAttributeProvider" />
       <type fullname="System.Reflection.IntrospectionExtensions" />
       <type fullname="System.Reflection.LocalVariableInfo" />
@@ -774,7 +859,6 @@
       <type fullname="System.Reflection.TypeAttributes" />
       <type fullname="System.Reflection.TypeInfo" />
       <type fullname="System.ResolveEventArgs" />
-      <type fullname="System.Resources.MissingManifestResourceException" />
       <type fullname="System.Resources.NeutralResourcesLanguageAttribute" />
       <type fullname="System.Resources.ResourceManager" />
       <type fullname="System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute" />
@@ -826,7 +910,6 @@
       <type fullname="System.Runtime.CompilerServices.UnsafeValueTypeAttribute" />
       <type fullname="System.Runtime.CompilerServices.YieldAwaitable" />
       <type fullname="System.Runtime.CompilerServices.YieldAwaitable/YieldAwaiter" />
-      <type fullname="System.Runtime.ConstrainedExecution.CriticalFinalizerObject" />
       <type fullname="System.Runtime.ExceptionServices.ExceptionDispatchInfo" />
       <type fullname="System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs" />
       <type fullname="System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute" />
@@ -834,7 +917,6 @@
       <type fullname="System.Runtime.InteropServices.GCHandle" />
       <type fullname="System.Runtime.InteropServices.GCHandleType" />
       <type fullname="System.Runtime.InteropServices.InAttribute" />
-      <type fullname="System.Runtime.InteropServices.SafeBuffer" />
       <type fullname="System.Runtime.InteropServices.SafeHandle" />
       <type fullname="System.Runtime.Serialization.IFormatterConverter" />
       <type fullname="System.Runtime.Serialization.ISerializable" />
@@ -972,7 +1054,6 @@
    <assembly fullname="System.Runtime.InteropServices">
       <type fullname="System.DllNotFoundException" />
       <type fullname="System.IO.UnmanagedMemoryAccessor" />
-      <type fullname="System.IO.UnmanagedMemoryStream" />
       <type fullname="System.Runtime.InteropServices.CallingConvention" />
       <type fullname="System.Runtime.InteropServices.CollectionsMarshal" />
       <type fullname="System.Runtime.InteropServices.COMException" />
@@ -987,7 +1068,6 @@
       <type fullname="System.Runtime.InteropServices.PosixSignal" />
       <type fullname="System.Runtime.InteropServices.PosixSignalContext" />
       <type fullname="System.Runtime.InteropServices.PosixSignalRegistration" />
-      <type fullname="System.Runtime.InteropServices.SafeBuffer" />
       <type fullname="System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute" />
       <type fullname="System.Security.SecureString" />
    </assembly>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -101,7 +101,7 @@
 
   <!-- we don't need the vendored .NET runtime code when targetting .NET Core 3.1+ -->
   <PropertyGroup>
-    <DotNetRuntimeFiles>Vendors/System.Collections.Immutable/**;Vendors/System.Memory/**;Vendors/System.Reflection.Metadata/**;Vendors/System.Runtime.CompilerServices.Unsafe/**</DotNetRuntimeFiles>
+    <DotNetRuntimeFiles>Vendors/System.Collections.Immutable/**;Vendors/System.Memory/**;Vendors/System.Private.CoreLib/**;Vendors/System.Reflection.Metadata/**;Vendors/System.Runtime.CompilerServices.Unsafe/**</DotNetRuntimeFiles>
   </PropertyGroup>
 
     <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))">

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -100,9 +100,8 @@
   </ItemGroup>
 
   <!-- we don't need the vendored .NET runtime code when targetting .NET Core 3.1+ -->
-  <!-- but keep Vendors/System.Reflection.Metadata/** for now because we use it to access internal members -->
   <PropertyGroup>
-    <DotNetRuntimeFiles>Vendors/System.Collections.Immutable/**;Vendors/System.Memory/**;Vendors/System.Runtime.CompilerServices.Unsafe/**</DotNetRuntimeFiles>
+    <DotNetRuntimeFiles>Vendors/System.Collections.Immutable/**;Vendors/System.Memory/**;Vendors/System.Reflection.Metadata/**;Vendors/System.Runtime.CompilerServices.Unsafe/**</DotNetRuntimeFiles>
   </PropertyGroup>
 
     <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))">

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/CachedItems.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/CachedItems.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Vendors.MessagePack;
-using Fnv1aHash = Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Internal.Hash;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionNormalizer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionNormalizer.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Fnv1aHash = Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Internal.Hash;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
@@ -33,7 +32,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 throw new ArgumentException(@"Exception string cannot be null or empty", nameof(exceptionString));
             }
 
-            var fnvHashCode = HashLine(outerExceptionType.AsSpan(), Fnv1aHash.FnvOffsetBias);
+            var fnvHashCode = HashLine(outerExceptionType.AsSpan(), SimpleHash.FnvOffsetBias);
 
             if (innerExceptionType != null)
             {
@@ -93,7 +92,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         {
             for (var i = 0; i < line.Length; i++)
             {
-                fnvHashCode = Fnv1aHash.Combine((uint)line[i], fnvHashCode);
+                fnvHashCode = SimpleHash.Combine((uint)line[i], fnvHashCode);
             }
 
             return fnvHashCode;

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionProbeProcessor.cs
@@ -16,7 +16,6 @@ using Datadog.Trace.Debugger.PInvoke;
 using Datadog.Trace.Debugger.Sink.Models;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Logging;
-using Fnv1aHash = Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Internal.Hash;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
@@ -115,17 +114,17 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 Array.Reverse(installedProbes);
             }
 
-            var hash = Fnv1aHash.FnvOffsetBias;
+            var hash = SimpleHash.FnvOffsetBias;
 
             if (installedProbes.Length != 0)
             {
                 foreach (var probe in installedProbes)
                 {
-                    hash = Fnv1aHash.Combine(probe.Method.Method.MetadataToken, hash);
+                    hash = SimpleHash.Combine(probe.Method.Method.MetadataToken, hash);
                 }
             }
 
-            return Fnv1aHash.Combine(ExceptionReplayProcessor.Method.Method.MetadataToken, hash);
+            return SimpleHash.Combine(ExceptionReplayProcessor.Method.Method.MetadataToken, hash);
         }
 
         internal void InvalidateEnterLeave()

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProcessor.cs
@@ -9,7 +9,6 @@ using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Logging;
-using Fnv1aHash = Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Internal.Hash;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
@@ -71,7 +70,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                     case MethodState.EntryAsync:
                         shadowStack = ShadowStackHolder.EnsureShadowStackEnabled();
                         var currentFrame = shadowStack.CurrentStackFrameNode;
-                        snapshotCreator.EnterHash = Fnv1aHash.Combine(info.Method.MetadataToken, shadowStack.CurrentStackFrameNode?.EnterSequenceHash ?? Fnv1aHash.FnvOffsetBias);
+                        snapshotCreator.EnterHash = SimpleHash.Combine(info.Method.MetadataToken, shadowStack.CurrentStackFrameNode?.EnterSequenceHash ?? SimpleHash.FnvOffsetBias);
 
                         if (currentFrame?.Method == info.Method && _isMisleadingMethod)
                         {

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/FakeTrackedStackFrameNode.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/FakeTrackedStackFrameNode.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
 using Datadog.Trace.Debugger.Snapshots;
-using Fnv1aHash = Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Internal.Hash;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
@@ -35,7 +34,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                     return firstChild.LeaveSequenceHash;
                 }
 
-                return Fnv1aHash.Combine(Method.MetadataToken, Fnv1aHash.FnvOffsetBias);
+                return SimpleHash.Combine(Method.MetadataToken, SimpleHash.FnvOffsetBias);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedStackFrameNode.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedStackFrameNode.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
 using Datadog.Trace.Debugger.Snapshots;
-using Fnv1aHash = Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Internal.Hash;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
@@ -54,7 +53,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         {
             get
             {
-                return Fnv1aHash.Combine(EnterSequenceHash, LeaveSequenceHash);
+                return SimpleHash.Combine(EnterSequenceHash, LeaveSequenceHash);
             }
         }
 
@@ -222,7 +221,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
         protected virtual int ComputeEnterSequenceHash()
         {
-            return Fnv1aHash.Combine(Method.MetadataToken, _parent?.EnterSequenceHash ?? Fnv1aHash.FnvOffsetBias);
+            return SimpleHash.Combine(Method.MetadataToken, _parent?.EnterSequenceHash ?? SimpleHash.FnvOffsetBias);
         }
 
         /// <summary>
@@ -237,10 +236,10 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 if (ActiveChildNodes?.Count > 0)
                 {
                     var firstChild = ActiveChildNodes.First();
-                    return Fnv1aHash.Combine(Method.MetadataToken, firstChild.LeaveSequenceHash);
+                    return SimpleHash.Combine(Method.MetadataToken, firstChild.LeaveSequenceHash);
                 }
 
-                return Fnv1aHash.Combine(Method.MetadataToken, Fnv1aHash.FnvOffsetBias);
+                return SimpleHash.Combine(Method.MetadataToken, SimpleHash.FnvOffsetBias);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/SimpleHash.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SimpleHash.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="SimpleHash.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+// A vendored version of System.Reflection.Internal.Hash
+
+namespace Datadog.Trace.Debugger;
+
+internal static class SimpleHash
+{
+    /// <summary>
+    /// The offset bias value used in the FNV-1a algorithm
+    /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    /// Note however, that the <c>Combine</c> methods in this class
+    /// do _not_ implement the FNV-1a algorithm.
+    /// </summary>
+    internal const int FnvOffsetBias = unchecked((int)2166136261);
+
+    internal static int Combine(int data, int initialHash)
+    {
+        return unchecked((initialHash * (int)0xA5555529) + data);
+    }
+
+    internal static int Combine(uint data, int initialHash)
+    {
+        return unchecked((initialHash * (int)0xA5555529) + (int)data);
+    }
+
+    internal static int Combine(bool data, int initialHash)
+    {
+        return Combine(initialHash, data ? 1 : 0);
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -11,8 +11,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Pdb;
+
+#if NETCOREAPP
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata.Ecma335;
+#endif
 
 namespace Datadog.Trace.Debugger.SpanCodeOrigin;
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/AsyncStateMachineAttributeTypeProvider.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/AsyncStateMachineAttributeTypeProvider.cs
@@ -6,7 +6,12 @@
 #nullable enable
 
 using System.Runtime.CompilerServices;
+
+#if NETCOREAPP
+using System.Reflection.Metadata;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols;
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -10,8 +10,14 @@ using System.Reflection;
 using Datadog.Trace.Debugger.Symbols.Model;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
-using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata; // keep vendored versions for now because we access internal members
+
+#if NETCOREAPP
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata.Ecma335;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols
 {

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -476,7 +476,7 @@ namespace Datadog.Trace.Debugger.Symbols
                     }
 
                     var methodDef = MetadataReader.GetMethodDefinition(methodDefHandle);
-                    if (!TryCreateMethodScope(type, methodDef, out methodScope))
+                    if (!TryCreateMethodScope(type, methodDefHandle, methodDef, out methodScope))
                     {
                         continue;
                     }
@@ -580,7 +580,7 @@ namespace Datadog.Trace.Debugger.Symbols
             return new SourceLocationInfo(startLine: startLine, endLine: endLine, path: sourceFile, startColumn: startColumn, endColumn: endColumn);
         }
 
-        protected virtual bool TryCreateMethodScope(TypeDefinition type, MethodDefinition method, out Model.Scope methodScope)
+        protected virtual bool TryCreateMethodScope(TypeDefinition type, MethodDefinitionHandle methodHandle, MethodDefinition method, out Model.Scope methodScope)
         {
             methodScope = default;
 
@@ -599,7 +599,7 @@ namespace Datadog.Trace.Debugger.Symbols
             var argsSymbol = GetArgsSymbol(method);
 
             // closures
-            var closureScopes = GetClosureScopes(type, method);
+            var closureScopes = GetClosureScopes(type, methodHandle, method);
             var methodAttributes = method.Attributes & StaticFinalVirtualMethod;
             var isAsyncMethod = DatadogMetadataReader.IsAsyncMethod(method.GetCustomAttributes());
             var methodLanguageSpecifics = new LanguageSpecifics
@@ -626,7 +626,7 @@ namespace Datadog.Trace.Debugger.Symbols
             return true;
         }
 
-        private Model.Scope[]? GetClosureScopes(TypeDefinition typeDef, MethodDefinition methodDef)
+        private Model.Scope[]? GetClosureScopes(TypeDefinition typeDef, MethodDefinitionHandle methodDefHandle, MethodDefinition methodDef)
         {
             Model.Scope[]? closureMethods = null;
             int index = 0;
@@ -666,13 +666,13 @@ namespace Datadog.Trace.Debugger.Symbols
                         }
 
                         var generatedMethodDef = MetadataReader.GetMethodDefinition(generatedMethodHandle);
-                        PopulateClosureMethod(generatedMethodDef, nestedType);
+                        PopulateClosureMethod(generatedMethodHandle, generatedMethodDef, nestedType);
                     }
                 }
 
                 foreach (var methodHandle in methods)
                 {
-                    if (methodHandle.IsNil || methodHandle == methodDef.Handle)
+                    if (methodHandle.IsNil || methodHandle == methodDefHandle)
                     {
                         continue;
                     }
@@ -683,7 +683,7 @@ namespace Datadog.Trace.Debugger.Symbols
                     }
 
                     var currentMethod = MetadataReader.GetMethodDefinition(methodHandle);
-                    PopulateClosureMethod(currentMethod, typeDef);
+                    PopulateClosureMethod(methodHandle, currentMethod, typeDef);
                 }
 
                 if (index == 0)
@@ -709,9 +709,9 @@ namespace Datadog.Trace.Debugger.Symbols
                 }
             }
 
-            void PopulateClosureMethod(MethodDefinition generatedMethod, TypeDefinition ownerType)
+            void PopulateClosureMethod(MethodDefinitionHandle generatedMethodHandle, MethodDefinition generatedMethod, TypeDefinition ownerType)
             {
-                if (TryCreateMethodScopeForGeneratedMethod(methodDef, generatedMethod, ownerType, out var closureMethodScope))
+                if (TryCreateMethodScopeForGeneratedMethod(methodDefHandle, methodDef, generatedMethodHandle, generatedMethod, ownerType, out var closureMethodScope))
                 {
                     // This can exceed our initial heuristic, so grow the pooled buffer on-demand to avoid dropping closure methods.
                     if (index >= closureMethods!.Length)
@@ -732,7 +732,7 @@ namespace Datadog.Trace.Debugger.Symbols
             }
         }
 
-        protected virtual bool TryCreateMethodScopeForGeneratedMethod(MethodDefinition method, MethodDefinition generatedMethod, TypeDefinition nestedType, out Model.Scope methodScope)
+        protected virtual bool TryCreateMethodScopeForGeneratedMethod(MethodDefinitionHandle methodHandle, MethodDefinition method, MethodDefinitionHandle generatedMethodHandle, MethodDefinition generatedMethod, TypeDefinition nestedType, out Model.Scope methodScope)
         {
             methodScope = default;
             return false;

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -171,7 +171,7 @@ namespace Datadog.Trace.Debugger.Symbols
                     return false;
                 }
 
-                if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(typeDefinitionHandle.RowId))
+                if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(MetadataTokens.GetToken(typeDefinitionHandle)))
                 {
                     return false;
                 }
@@ -356,7 +356,7 @@ namespace Datadog.Trace.Debugger.Symbols
                         continue;
                     }
 
-                    if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(typeHandle.RowId))
+                    if (DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(MetadataTokens.GetToken(typeHandle)))
                     {
                         continue;
                     }

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
@@ -29,14 +29,14 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
     {
     }
 
-    protected override bool TryCreateMethodScope(TypeDefinition type, MethodDefinition method, out Model.Scope methodScope)
+    protected override bool TryCreateMethodScope(TypeDefinition type, MethodDefinitionHandle methodHandle, MethodDefinition method, out Model.Scope methodScope)
     {
-        if (!base.TryCreateMethodScope(type, method, out methodScope))
+        if (!base.TryCreateMethodScope(type, methodHandle, method, out methodScope))
         {
             return false;
         }
 
-        using var memory = DatadogMetadataReader.GetMethodSequencePointsAsMemoryOwner(MetadataTokens.GetToken(method.Handle), false, out var count);
+        using var memory = DatadogMetadataReader.GetMethodSequencePointsAsMemoryOwner(MetadataTokens.GetToken(methodHandle), false, out var count);
         if (memory == null || count == 0)
         {
             return true;
@@ -61,7 +61,7 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
             methodScope.LanguageSpecifics = ls;
         }
 
-        var localScopes = GetLocalSymbols(method, sequencePoints, methodScope);
+        var localScopes = GetLocalSymbols(methodHandle, method, sequencePoints, methodScope);
         methodScope.Scopes = ConcatMethodScopes(methodScope.Scopes ?? null, localScopes);
         return true;
     }
@@ -94,7 +94,7 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
         return new SourceLocationInfo(startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn, path: typeSourceFile);
     }
 
-    protected override bool TryCreateMethodScopeForGeneratedMethod(MethodDefinition method, MethodDefinition generatedMethod, TypeDefinition nestedType, out Model.Scope closureMethodScope)
+    protected override bool TryCreateMethodScopeForGeneratedMethod(MethodDefinitionHandle methodHandle, MethodDefinition method, MethodDefinitionHandle generatedMethodHandle, MethodDefinition generatedMethod, TypeDefinition nestedType, out Model.Scope closureMethodScope)
     {
         closureMethodScope = default;
         if (method.Name.IsNil || generatedMethod.Name.IsNil)
@@ -102,7 +102,7 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
             return false;
         }
 
-        var methodToken = MetadataTokens.GetToken(generatedMethod.Handle);
+        var methodToken = MetadataTokens.GetToken(generatedMethodHandle);
         if (!DatadogMetadataReader.HasSequencePoints(methodToken))
         {
             return false;
@@ -110,9 +110,10 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
 
         var cdi = DatadogMetadataReader.GetAsyncAndClosureCustomDebugInfo(methodToken);
         string? methodName;
-        if (cdi.StateMachineHoistedLocal && MetadataTokens.GetToken(method.Handle) == cdi.StateMachineKickoffMethodToken)
+        if (cdi.StateMachineHoistedLocal && MetadataTokens.GetToken(methodHandle) == cdi.StateMachineKickoffMethodToken)
         {
-            var kickoffDef = DatadogMetadataReader.GetMethodDef(cdi.StateMachineKickoffMethodToken);
+            var kickoffDefHandle = DatadogMetadataReader.GetMethodDefHandle(cdi.StateMachineKickoffMethodToken);
+            var kickoffDef = DatadogMetadataReader.GetMethodDef(kickoffDefHandle);
             methodName = MetadataReader.GetString(kickoffDef.Name);
         }
         else
@@ -136,7 +137,7 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
             return false;
         }
 
-        if (!TryCreateMethodScope(nestedType, generatedMethod, out closureMethodScope))
+        if (!TryCreateMethodScope(nestedType, generatedMethodHandle, generatedMethod, out closureMethodScope))
         {
             return false;
         }
@@ -211,12 +212,12 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
         return true;
     }
 
-    private Model.Scope[]? GetLocalSymbols(MethodDefinition methodDefinition, ReadOnlySpan<DatadogMetadataReader.DatadogSequencePoint> sequencePoints, Model.Scope methodScope)
+    private Model.Scope[]? GetLocalSymbols(MethodDefinitionHandle methodHandle, MethodDefinition methodDefinition, ReadOnlySpan<DatadogMetadataReader.DatadogSequencePoint> sequencePoints, Model.Scope methodScope)
     {
         List<Model.Scope>? scopes = null;
         var generatedClassPrefix = GeneratedClassPrefix.AsSpan();
 
-        var methodToken = MetadataTokens.GetToken(methodDefinition.Handle);
+        var methodToken = MetadataTokens.GetToken(methodHandle);
         if (DatadogMetadataReader.GetAsyncAndClosureCustomDebugInfo(methodToken).StateMachineHoistedLocal
          && DatadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(MetadataTokens.GetToken(methodDefinition.GetDeclaringType())))
         {

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
@@ -9,8 +9,14 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Datadog.Trace.Debugger.Symbols.Model;
 using Datadog.Trace.Pdb;
-using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata; // keep vendored versions for now because we access internal members
+
+#if NETCOREAPP
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata.Ecma335;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols;
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsExtensions.cs
@@ -6,8 +6,13 @@
 #nullable enable
 
 using System.Reflection;
-using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata; // keep vendored versions for now because we access internal members
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Symbols;
+
+#if NETCOREAPP
+using System.Reflection.Metadata;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols;
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/TypeProvider.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/TypeProvider.cs
@@ -6,7 +6,12 @@
 #nullable enable
 
 using Datadog.Trace.Util;
-using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata; // keep vendored versions for now because we access internal members
+
+#if NETCOREAPP
+using System.Reflection.Metadata;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+#endif
 
 namespace Datadog.Trace.Debugger.Symbols
 {

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -28,7 +28,6 @@ using Datadog.Trace.Iast.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
-using Datadog.Trace.VendoredMicrosoftCode.System;
 using static Datadog.Trace.Configuration.ConfigurationKeys;
 using static Datadog.Trace.Telemetry.Metrics.MetricTags;
 

--- a/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
@@ -14,7 +14,6 @@ using Datadog.Trace.OpenTelemetry.Common;
 using Datadog.Trace.Processors;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Telemetry.Metrics;
-using Datadog.Trace.VendoredMicrosoftCode.System;
 using Datadog.Trace.Vendors.Datadog.Sketches;
 using Datadog.Trace.Vendors.MessagePack;
 using Datadog.Trace.Vendors.Newtonsoft.Json;

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -621,7 +621,7 @@ namespace Datadog.Trace.Pdb
             CustomDebugInfoAsyncAndClosure cdiAsyncAndClosure = default;
             if (PdbReader != null)
             {
-                var methodHandle = MethodDefinitionHandle.FromRowId(RidOf(methodToken));
+                var methodHandle = MetadataTokens.MethodDefinitionHandle(RidOf(methodToken));
                 if (methodHandle.IsNil)
                 {
                     return default;
@@ -668,7 +668,7 @@ namespace Datadog.Trace.Pdb
 
         internal bool IsCompilerGeneratedAttributeDefinedOnType(int typeToken)
         {
-            var nestedType = MetadataReader.GetTypeDefinition(TypeDefinitionHandle.FromRowId(RidOf(typeToken)));
+            var nestedType = MetadataReader.GetTypeDefinition(MetadataTokens.TypeDefinitionHandle(RidOf(typeToken)));
             var attributes = nestedType.GetCustomAttributes();
             return IsCompilerGeneratedAttributeDefine(attributes);
         }
@@ -752,7 +752,7 @@ namespace Datadog.Trace.Pdb
 
         internal MethodDefinition GetMethodDef(int methodToken)
         {
-            return MetadataReader.GetMethodDefinition(MethodDefinitionHandle.FromRowId(RidOf(methodToken)));
+            return MetadataReader.GetMethodDefinition(MetadataTokens.MethodDefinitionHandle(RidOf(methodToken)));
         }
 
         internal ImmutableArray<LocalScope>? GetLocalSymbols(int methodToken, ReadOnlySpan<DatadogSequencePoint> sequencePoints, bool searchMoveNext)

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -454,7 +454,6 @@ namespace Datadog.Trace.Pdb
                     return null;
                 }
 
-                const int methodDefTablePrefix = 0x06000000;
                 foreach (MethodDefinitionHandle methodDefinitionHandle in MetadataReader.MethodDefinitions)
                 {
                     MethodDebugInformation methodDebugInformation = PdbReader.GetMethodDebugInformation(methodDefinitionHandle);
@@ -477,7 +476,7 @@ namespace Datadog.Trace.Pdb
                             (column.HasValue == false || (sequencePoint.StartColumn <= column && sequencePoint.EndColumn >= column)))
                         {
                             byteCodeOffset = sequencePoint.Offset;
-                            return methodDefTablePrefix | methodDefinitionHandle.RowId;
+                            return MetadataTokens.GetToken(methodDefinitionHandle);
                         }
                     }
                 }

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -261,12 +261,12 @@ namespace Datadog.Trace.Pdb
             if (PdbReader != null)
             {
                 var methodDefHandle = GetMethodDefHandle(methodToken);
-                var methodDef = GetMethodDef(methodDefHandle);
                 if (methodDefHandle.IsNil)
                 {
                     return null;
                 }
 
+                var methodDef = GetMethodDef(methodDefHandle);
                 MethodDebugInformation methodDebugInformation = PdbReader.GetMethodDebugInformation(methodDefHandle.ToDebugInformationHandle());
                 if (methodDebugInformation.SequencePointsBlob.IsNil && searchMoveNext)
                 {

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -15,10 +15,15 @@ using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
 
-// keep vendored versions for now because we access internal members
+#if NETCOREAPP
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+#else
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata.Ecma335;
 using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.PortableExecutable;
+#endif
 
 namespace Datadog.Trace.Pdb
 {

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -72,6 +72,11 @@ namespace Datadog.Trace.Pdb
 
         internal static int RidOf(int metadataToken) => metadataToken & RidMask;
 
+        internal static MethodDefinitionHandle GetMethodDefHandle(int methodToken)
+        {
+            return MetadataTokens.MethodDefinitionHandle(RidOf(methodToken));
+        }
+
         internal static DatadogMetadataReader? CreatePdbReader(Assembly? assembly)
         {
             if (assembly == null || string.IsNullOrEmpty(assembly.Location))
@@ -255,16 +260,17 @@ namespace Datadog.Trace.Pdb
 
             if (PdbReader != null)
             {
-                var methodDef = GetMethodDef(methodToken);
-                if (methodDef.Handle.IsNil)
+                var methodDefHandle = GetMethodDefHandle(methodToken);
+                var methodDef = GetMethodDef(methodDefHandle);
+                if (methodDefHandle.IsNil)
                 {
                     return null;
                 }
 
-                MethodDebugInformation methodDebugInformation = PdbReader.GetMethodDebugInformation(methodDef.Handle.ToDebugInformationHandle());
+                MethodDebugInformation methodDebugInformation = PdbReader.GetMethodDebugInformation(methodDefHandle.ToDebugInformationHandle());
                 if (methodDebugInformation.SequencePointsBlob.IsNil && searchMoveNext)
                 {
-                    var moveNext = GetMoveNextMethod(methodDef);
+                    var moveNext = GetMoveNextMethod(methodDefHandle, methodDef);
                     if (moveNext.IsNil)
                     {
                         return null;
@@ -320,16 +326,17 @@ namespace Datadog.Trace.Pdb
 
             if (PdbReader != null)
             {
-                var methodDef = GetMethodDef(methodToken);
-                if (methodDef.Handle.IsNil)
+                var methodDefHandle = GetMethodDefHandle(methodToken);
+                var methodDef = GetMethodDef(methodDefHandle);
+                if (methodDefHandle.IsNil)
                 {
                     return null;
                 }
 
-                MethodDebugInformation methodDebugInformation = PdbReader.GetMethodDebugInformation(methodDef.Handle.ToDebugInformationHandle());
+                MethodDebugInformation methodDebugInformation = PdbReader.GetMethodDebugInformation(methodDefHandle.ToDebugInformationHandle());
                 if (methodDebugInformation.SequencePointsBlob.IsNil && searchMoveNext)
                 {
-                    var moveNext = GetMoveNextMethod(methodDef);
+                    var moveNext = GetMoveNextMethod(methodDefHandle, methodDef);
                     if (moveNext.IsNil)
                     {
                         return null;
@@ -360,7 +367,7 @@ namespace Datadog.Trace.Pdb
             return null;
         }
 
-        private MethodDefinitionHandle GetMoveNextMethod(MethodDefinition methodDef)
+        private MethodDefinitionHandle GetMoveNextMethod(MethodDefinitionHandle methodDefHandle, MethodDefinition methodDef)
         {
             if (methodDef.GetDeclaringType().IsNil)
             {
@@ -370,7 +377,7 @@ namespace Datadog.Trace.Pdb
             TypeDefinitionHandle nestedTypeHandle = default;
             var enclosingType = MetadataReader.GetTypeDefinition(methodDef.GetDeclaringType());
             var provider = new AsyncStateMachineAttributeTypeProvider();
-            foreach (var attributeHandle in MetadataReader.GetCustomAttributes(methodDef.Handle))
+            foreach (var attributeHandle in MetadataReader.GetCustomAttributes(methodDefHandle))
             {
                 if (attributeHandle.IsNil)
                 {
@@ -559,7 +566,8 @@ namespace Datadog.Trace.Pdb
                 return null;
             }
 
-            var method = GetMethodDef(methodToken);
+            var methodDefHandle = GetMethodDefHandle(methodToken);
+            var method = GetMethodDef(methodDefHandle);
             int localsCount = 0;
             var methodLocalsCount = GetLocalVariablesCount(method);
             if (methodLocalsCount == 0)
@@ -576,7 +584,7 @@ namespace Datadog.Trace.Pdb
                 return null;
             }
 
-            foreach (var scopeHandle in PdbReader.GetLocalScopes(method.Handle.ToDebugInformationHandle()))
+            foreach (var scopeHandle in PdbReader.GetLocalScopes(methodDefHandle.ToDebugInformationHandle()))
             {
                 var localScope = PdbReader.GetLocalScope(scopeHandle);
                 foreach (var localVarHandle in localScope.GetLocalVariables())
@@ -600,7 +608,7 @@ namespace Datadog.Trace.Pdb
 
             if (localsCount == 0 && searchMoveNext)
             {
-                var moveNext = GetMoveNextMethod(method);
+                var moveNext = GetMoveNextMethod(methodDefHandle, method);
                 if (!moveNext.IsNil)
                 {
                     return GetLocalVariableNames(MetadataTokens.GetToken(moveNext), false);
@@ -660,7 +668,8 @@ namespace Datadog.Trace.Pdb
 
         internal bool IsCompilerGeneratedAttributeDefinedOnMethod(int methodToken)
         {
-            var method = GetMethodDef(methodToken);
+            var methodDefHandle = GetMethodDefHandle(methodToken);
+            var method = GetMethodDef(methodDefHandle);
             var attributes = method.GetCustomAttributes();
             return IsCompilerGeneratedAttributeDefine(attributes);
         }
@@ -749,9 +758,9 @@ namespace Datadog.Trace.Pdb
             }
         }
 
-        internal MethodDefinition GetMethodDef(int methodToken)
+        internal MethodDefinition GetMethodDef(MethodDefinitionHandle handle)
         {
-            return MetadataReader.GetMethodDefinition(MetadataTokens.MethodDefinitionHandle(RidOf(methodToken)));
+            return MetadataReader.GetMethodDefinition(handle);
         }
 
         internal ImmutableArray<LocalScope>? GetLocalSymbols(int methodToken, ReadOnlySpan<DatadogSequencePoint> sequencePoints, bool searchMoveNext)
@@ -764,7 +773,8 @@ namespace Datadog.Trace.Pdb
             ImmutableArray<LocalScope>.Builder? localScopes = default;
             if (PdbReader != null)
             {
-                MethodDefinition method = GetMethodDef(methodToken);
+                var methodDefHandle = GetMethodDefHandle(methodToken);
+                var method = GetMethodDef(methodDefHandle);
                 var methodLocalsCount = GetLocalVariablesCount(method);
                 if (methodLocalsCount == 0)
                 {
@@ -780,7 +790,7 @@ namespace Datadog.Trace.Pdb
                 var localTypes = signature.Value.DecodeLocalSignature(new TypeProvider(false), 0);
                 localScopes = ImmutableArray.CreateBuilder<LocalScope>();
 
-                foreach (var scopeHandle in PdbReader.GetLocalScopes(method.Handle.ToDebugInformationHandle()))
+                foreach (var scopeHandle in PdbReader.GetLocalScopes(methodDefHandle.ToDebugInformationHandle()))
                 {
                     var localScope = PdbReader.GetLocalScope(scopeHandle);
                     var locals = localScope.GetLocalVariables();
@@ -888,7 +898,7 @@ namespace Datadog.Trace.Pdb
 
                 if (localScopes.Count == 0 && searchMoveNext)
                 {
-                    var moveNext = GetMoveNextMethod(method);
+                    var moveNext = GetMoveNextMethod(methodDefHandle, method);
                     return GetLocalSymbols(MetadataTokens.GetToken(moveNext), sequencePoints, false);
                 }
             }
@@ -898,7 +908,8 @@ namespace Datadog.Trace.Pdb
 
         internal bool HasMethodBody(int methodToken)
         {
-            var method = GetMethodDef(methodToken);
+            var methodDefHandle = GetMethodDefHandle(methodToken);
+            var method = GetMethodDef(methodDefHandle);
             if (method.RelativeVirtualAddress == 0)
             {
                 // Method has no RVA (typically abstract or extern method)

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.net6.0.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.net6.0.verified.txt
@@ -38,6 +38,7 @@ System.ObjectModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d
 System.Reflection.Emit, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Emit.ILGeneration, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Emit.Lightweight, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+System.Reflection.Metadata, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
@@ -42,6 +42,7 @@ System.ObjectModel, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d
 System.Reflection.Emit, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Emit.ILGeneration, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Emit.Lightweight, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+System.Reflection.Metadata, Version=1.4.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Reflection.Primitives, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Resources.ResourceManager, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Runtime, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a


### PR DESCRIPTION
## Summary of changes

Use the built-in _System.Reflection.Metadata_ types for .NET Core 3.1+

## Reason for change

In #6726, we switched from always using the vendored System.Memory and other BCL types, to using the built-in versions for .NET Core 3.1 where they're available. This was done with the goal of reducing artifact size, while also hopefully improving consistency, and potentially improving performance.

Separately, we're working on updating our vendored code to make updating it more repeatable (see #8391). This flagged a variety of modifications we'd made to the vendored System.Reflection.Metadata code to be able to use internal members.

Rather than include those modifications in the updated vendored code, this PR updates our _existing_ usages to _not_ use those internal members in any scenario. This also means we can _stop_ using the vendored code for .NET Core 3.1+.

## Implementation details

- Add pollyfil for `Hash` type used by Debugger code, which was internal to _System.Reflection.Metadata_
  - Note that although this was called `FNV1aHash`, it _isn't_ using `FNV1a`, so I chose to call it simple hash (as that's what it's doing, a simple "hash code" calculation).
  - If these hashes _should_ be using FNV1A, then that should be addressed separately
- Update namespaces to use the built-in versions where appropriate
  - These are intentionally _not_ added to `GlobalUsings.cs`, because doing so causes a variety of namespace collisions across our vendored code (Newtonsoft.Json, dnlib)
  - A couple of unused `using` statements needed removing.
- Stop using internal members on `MethodDefinition`
  - In some cases, there are simple replacements available, e.g. replacing `FromRowId`.
  - Removing usages of `MethodDefinition.Handle` was a little more painful, as it required more refactoring, but fundamentally we were always deriving a `MethodDefinition` _from_ a `MethodDefinitionHandle`, so the changes are mostly a minor inconvenience, but they now only use public APIs.

## Test coverage

Should be covered by existing tests; all these changes are just "refactorings", nothing additional.


### Assembly size comparison

| Runtime         | Before   | After    | Diff    | %
|-----------------|----------|----------|---------|-------
| `netcoreapp3.1` | 7,919.5 KB | 7,484.0 KB | -435.5 KB | -5.50%
| `net6.0`        | 8,016.5 KB | 7,581.5 KB | -435 KB | -5.43%

### Estimated size per namespace

#### Before (`net6.0`)

```
Total 7.15 MB (100.0%)
 └── Datadog 7.08 MB (99.1%)
     └── Trace 7.08 MB (99.1%)
         └── VendoredMicrosoftCode 0.54 MB (7.5%)
             └── System 0.54 MB (7.5%)
                 └── Reflection 0.52 MB (7.3%)
                     ├── Metadata 0.42 MB (5.8%)
                     ├── PortableExecutable 0.07 MB (1.0%)
                     └── Internal 0.03 MB (0.4%)
```

#### After (`net6.0`) (all gone)

```
Total 6.72 MB (100.0%)
 └── Datadog 6.66 MB (99.1%)
     └── Trace 6.66 MB (99.1%)
```

## Other details

https://datadoghq.atlassian.net/browse/APMLP-1207

Part of a stack updating our vendored system code
- https://github.com/DataDog/dd-trace-dotnet/pull/8391