### PR TITLE
fix(netfx): Prevent startup deadlock in console apps using ConfigurationManager config builders

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
@@ -31,6 +31,14 @@ public static class CallTargetInvoker
     private static readonly bool IsRunningInPartialTrust;
     private static bool _isIisPreStartInitComplete;
 
+    // Guard to prevent CallTarget integrations from running while ConfigurationManager.AppSettings
+    // is being loaded. On .NET Framework, config builders (like Azure App Configuration) can make
+    // outbound HTTP calls during AppSettings initialization. If those HTTP calls are instrumented,
+    // the instrumentation may try to access GlobalConfigurationSource (which is still initializing),
+    // causing a cross-thread deadlock on the type initializer lock.
+    // Set by GlobalConfigurationSource before reading ConfigurationManager.AppSettings.
+    private static volatile bool _isLoadingConfigurationManagerAppSettings;
+
     static CallTargetInvoker()
     {
         // Check if IIS automatic instrumentation has set the AppDomain property to indicate the PreStartInit state
@@ -91,6 +99,12 @@ public static class CallTargetInvoker
                 _isIisPreStartInitComplete = true;
             }
         }
+    }
+
+    internal static bool IsLoadingConfigurationManagerAppSettings
+    {
+        get => _isLoadingConfigurationManagerAppSettings;
+        set => _isLoadingConfigurationManagerAppSettings = value;
     }
 #endif
 
@@ -683,7 +697,7 @@ public static class CallTargetInvoker
         // in some scenarios that we definitely _shouldn't_ be running here, so
         // strictly checking _isIisPreStartInitComplete instead.
 #if NETFRAMEWORK
-        if (!IsRunningInPartialTrust && _isIisPreStartInitComplete)
+        if (!IsRunningInPartialTrust && !IsLoadingConfigurationManagerAppSettings && _isIisPreStartInitComplete)
 #endif
         {
             IntegrationOptions<TIntegration, TTarget>.LogException(exception);
@@ -716,6 +730,15 @@ public static class CallTargetInvoker
         if (IsRunningInPartialTrust)
         {
             // Never run any call target integrations
+            return false;
+        }
+
+        // Block all integrations while ConfigurationManager.AppSettings is being loaded.
+        // Config builders (e.g. Azure App Configuration) can make outbound HTTP calls during
+        // AppSettings initialization. If we instrument those calls, the integration would try
+        // to access GlobalConfigurationSource (still initializing), causing a deadlock.
+        if (IsLoadingConfigurationManagerAppSettings)
+        {
             return false;
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/GlobalConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/GlobalConfigurationSource.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
+using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration.ConfigurationSources;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.LibDatadog.HandsOffConfiguration;
@@ -79,7 +80,20 @@ internal static class GlobalConfigurationSource
 
 #if NETFRAMEWORK
         // on .NET Framework only, also read from app.config/web.config
-        configurationSource.Add(new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings, ConfigurationOrigins.AppConfig));
+        // Guard: config builders (like Azure App Configuration) may make outbound HTTP calls
+        // during AppSettings initialization. Those calls could be instrumented by CallTarget,
+        // which would try to access GlobalConfigurationSource before it finishes initializing,
+        // causing a cross-thread deadlock. Setting this flag tells CallTargetInvoker to skip
+        // instrumenting any methods during this window.
+        try
+        {
+            CallTargetInvoker.IsLoadingConfigurationManagerAppSettings = true;
+            configurationSource.Add(new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings, ConfigurationOrigins.AppConfig));
+        }
+        finally
+        {
+            CallTargetInvoker.IsLoadingConfigurationManagerAppSettings = false;
+        }
 #endif
 
         // datadog.json

--- a/tracer/test/Datadog.Trace.Tests/Configuration/GlobalConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/GlobalConfigurationSourceTests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources;
 using Datadog.Trace.Configuration.Telemetry;
@@ -52,4 +53,54 @@ public class GlobalConfigurationSourceTests
         localConfigSource.GetString("KEY4", NullConfigurationTelemetry.Instance, null, false).Result.Should().Be("true");
         localConfigSource.GetBool("KEY2", NullConfigurationTelemetry.Instance, null).Result.Should().Be(false);
     }
+
+#if NETFRAMEWORK
+    [Fact]
+    public void CreateDefaultConfigurationSource_SetsAndClearsAppSettingsLoadingGuard()
+    {
+        // The guard must be cleared after CreateDefaultConfigurationSource completes,
+        // so that CallTarget integrations resume normally after initialization.
+        CallTargetInvoker.IsLoadingConfigurationManagerAppSettings.Should().BeFalse(
+            "the guard should not be active outside of ConfigurationManager.AppSettings loading");
+
+        // Verify that after creating the configuration source, the guard is cleared
+        var result = GlobalConfigurationSource.CreateDefaultConfigurationSource(
+            isLibdatadogAvailable: false);
+
+        result.ConfigurationSource.Should().NotBeNull();
+        CallTargetInvoker.IsLoadingConfigurationManagerAppSettings.Should().BeFalse(
+            "the guard should be cleared after CreateDefaultConfigurationSource completes");
+    }
+
+    [Fact]
+    public void AppSettingsLoadingGuard_BlocksCallTargetIntegrations()
+    {
+        // Verify the guard's default state is false (not blocking)
+        CallTargetInvoker.IsLoadingConfigurationManagerAppSettings.Should().BeFalse();
+
+        try
+        {
+            // When the guard is set, BeginMethod should return the default state
+            // (i.e., no instrumentation runs) because CanExecuteCallTargetIntegration returns false
+            CallTargetInvoker.IsLoadingConfigurationManagerAppSettings = true;
+
+            // BeginMethod should return default (no-op) when the guard is active
+            var result = CallTargetInvoker.BeginMethod<ConfigLoadingGuardTestIntegration, object>(new object());
+            result.Should().Be(CallTargetState.GetDefault());
+        }
+        finally
+        {
+            CallTargetInvoker.IsLoadingConfigurationManagerAppSettings = false;
+        }
+
+        CallTargetInvoker.IsLoadingConfigurationManagerAppSettings.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Dummy integration type used only for testing the configuration loading guard.
+    /// </summary>
+    internal class ConfigLoadingGuardTestIntegration
+    {
+    }
+#endif
 }


### PR DESCRIPTION
## Summary of changes

Add a volatile boolean guard (`IsLoadingConfigurationManagerAppSettings`) to `CallTargetInvoker` that temporarily blocks all CallTarget integrations while `ConfigurationManager.AppSettings` is being loaded in `GlobalConfigurationSource`.

## Reason for change

On .NET Framework, **console applications hang on startup** (before `Main()` runs) when:

1. `app.config` uses **config builders** (e.g., Azure App Configuration, Azure Key Vault) on `<appSettings>` or `<connectionStrings>`
2. The Datadog .NET tracer is enabled

The config builder makes **outbound HTTPS calls** during `ConfigurationManager.AppSettings` initialization. Those calls are intercepted by CallTarget HTTP instrumentation, which tries to access `GlobalConfigurationSource` — but its type initializer is still running on the main thread. This creates a **cross-thread type-initializer deadlock**:

- **Thread A** (main): holds `GlobalConfigurationSource`'s `.cctor` lock, waiting for HTTP response
- **Thread B** (I/O completion): has the HTTP response, but blocks on the `.cctor` lock when instrumentation accesses `Tracer.Instance`

PR #6147 solved this for **IIS** by gating integrations during `PreStartInit`. Console apps had no equivalent protection.

## Implementation details

- **`CallTargetInvoker.cs`**: Added `IsLoadingConfigurationManagerAppSettings` volatile boolean. When `true`, `CanExecuteCallTargetIntegration()` returns `false` (same pattern as the IIS `PreStartInit` guard). Also guards the `LogException` path.
- **`GlobalConfigurationSource.cs`**: Wraps `ConfigurationManager.AppSettings` access in `try/finally` that sets/clears the guard.

The guard window is very narrow (only the duration of AppSettings loading). The only integrations blocked are those intercepting the config builder's internal infrastructure HTTP calls, which happen before user code runs.

See [`docs/development/for-ai/ConsoleLock.md`](docs/development/for-ai/ConsoleLock.md) for a detailed architectural explanation with diagrams.

## Test coverage

- `CreateDefaultConfigurationSource_SetsAndClearsAppSettingsLoadingGuard` — Verifies the guard is cleared after `CreateDefaultConfigurationSource` completes
- `AppSettingsLoadingGuard_BlocksCallTargetIntegrations` — Verifies `BeginMethod` returns a no-op `CallTargetState` when the guard is active

Both tests are `#if NETFRAMEWORK` only (the guard doesn't apply to .NET Core).

## Other details

- No effect on .NET Core (guard and `AppSettings` read are both inside `#if NETFRAMEWORK`)
- No effect on IIS (the existing `PreStartInit` guard is unchanged; the new guard is checked before it)
- `volatile` ensures cross-thread visibility; `finally` ensures the guard is always cleared
- Resolves APMS-19239

<!-- Fixes APMS-19239 -->