### PR TITLE
feat: enable Remote Configuration for Azure App Services

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -1372,7 +1372,6 @@ namespace Datadog.Trace.Configuration
         // NOTE: when we clean this up, see also EnvironmentHelpers.IsServerlessEnvironment()
         internal bool IsRemoteConfigurationAvailable =>
             RemoteConfigurationEnabled &&
-            !IsRunningInAzureAppService &&
             !IsRunningInAzureFunctions &&
             !IsRunningInGCPFunctions &&
             !LambdaMetadata.IsRunningInLambda;

--- a/tracer/test/Datadog.Trace.TestHelpers/PlatformHelpers/AzureAppServiceHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/PlatformHelpers/AzureAppServiceHelper.cs
@@ -25,6 +25,18 @@ public static class AzureAppServiceHelper
         return new DictionaryConfigurationSource(dict);
     }
 
+    public static IConfigurationSource CreateMinimalAzureFunctionsConfiguration(string siteName, string workerRuntime = "dotnet-isolated", string extensionVersion = "~4")
+    {
+        var dict = new Dictionary<string, string>
+        {
+            { PlatformKeys.AzureAppService.SiteNameKey, siteName },
+            { PlatformKeys.AzureFunctions.FunctionsWorkerRuntime, workerRuntime },
+            { PlatformKeys.AzureFunctions.FunctionsExtensionVersion, extensionVersion },
+        };
+
+        return new DictionaryConfigurationSource(dict);
+    }
+
     public static IConfigurationSource GetRequiredAasConfigurationValues(
         string subscriptionId,
         string deploymentId,

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -757,8 +757,8 @@ namespace Datadog.Trace.Tests.Configuration
 
             var settings = new TracerSettings(CreateConfigurationSource(configPairs.ToArray()));
 
-            // Default is "rcm is enabled" and "we're not in AAS"
-            var expected = (overrideValue ?? true) && !isRunningInAas;
+            // RC is available in AAS (agent sidecar provides RC) — isRunningInAas no longer blocks RC
+            var expected = overrideValue ?? true;
             settings.IsRemoteConfigurationAvailable.Should().Be(expected);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/TracerManagerFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerManagerFactoryTests.cs
@@ -91,9 +91,24 @@ public class TracerManagerFactoryTests : IAsyncLifetime
     }
 
     [Fact]
-    public void RemoteConfigIsDisabledInAzureAppServices()
+    public void RemoteConfigIsEnabledInAzureAppServices()
     {
         var source = AzureAppServiceHelper.CreateMinimalAzureAppServiceConfiguration("site-name");
+        var settings = new TracerSettings(source);
+
+        settings.IsRemoteConfigurationAvailable.Should().BeTrue();
+
+        _manager = CreateTracerManager(settings);
+
+        _manager.RemoteConfigurationManager.Should().BeOfType<RemoteConfigurationManager>();
+        _manager.DynamicConfigurationManager.Should().BeOfType<DynamicConfigurationManager>();
+        _manager.TracerFlareManager.Should().BeOfType<TracerFlareManager>();
+    }
+
+    [Fact]
+    public void RemoteConfigIsDisabledInAzureFunctions()
+    {
+        var source = AzureAppServiceHelper.CreateMinimalAzureFunctionsConfiguration("my-function-app");
         var settings = new TracerSettings(source);
 
         settings.IsRemoteConfigurationAvailable.Should().BeFalse();


### PR DESCRIPTION
## Summary

Re-enables Remote Configuration (RC) for Azure App Services in the .NET tracer. Prior to this change, `IsRemoteConfigurationAvailable` returned `false` for both Azure App Services and Azure Functions. This PR removes the App Services block while keeping the Azure Functions block intact.

**Before:** `RemoteConfigurationEnabled && !IsRunningInAzureFunctions && !IsRunningInAzureAppService && ...`
**After:** `RemoteConfigurationEnabled && !IsRunningInAzureFunctions && ...`

When a customer runs the Datadog Agent as a sidecar in their App Services deployment and sets `DD_DYNAMIC_INSTRUMENTATION_ENABLED=true`, the existing DI infrastructure (`DebuggerManager.cs:551`, `DynamicInstrumentation.cs:85`) will now activate.

## Changes

- `tracer/src/Datadog.Trace/Configuration/TracerSettings.cs`: Remove `!IsRunningInAzureAppService &&` from `IsRemoteConfigurationAvailable` predicate (1-line change)
- `tracer/test/Datadog.Trace.TestHelpers/PlatformHelpers/AzureAppServiceHelper.cs`: Add `CreateMinimalAzureFunctionsConfiguration()` helper for test setup
- `tracer/test/Datadog.Trace.Tests/TracerManagerFactoryTests.cs`: Rename `RemoteConfigIsDisabledInAzureAppServices` → `RemoteConfigIsEnabledInAzureAppServices` (flipped assertions); add new `RemoteConfigIsDisabledInAzureFunctions` regression test
- `tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs`: Update `IsRemoteConfigurationAvailable_AzureAppService` assertion

## Decisions

- Azure Functions block (`!IsRunningInAzureFunctions`) is intentionally preserved — Functions Consumption plan has no agent sidecar path
- `RemoteConfigIsDisabledInAzureFunctions` regression test added to prevent future silent removal (mirrors Lambda and GCP patterns)

## Testing

- New `RemoteConfigIsEnabledInAzureAppServices` test: asserts `IsRemoteConfigurationAvailable=true`
- New `RemoteConfigIsDisabledInAzureFunctions` test: asserts `IsRemoteConfigurationAvailable=false` (regression guard)
- dotnet SDK not available on dev machine — CI will run full `Datadog.Trace.Tests` suite

## Context

Phase 1 of Live Debugger on Azure. App Services only. Azure Functions Consumption deferred (requires agent-less RC delivery mechanism).