### PR TITLE
add new set of benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - shared-pipeline
   - publish
   - benchmarks
-  # These benchmarks are intended to replace the legacy macrobenchmarks long term
+  # These benchmarks are running in parallel with the legacy ones
   - dotnet-aspnet-realworld-parallel
   - dotnet-aspnet-realworld-parallel-slo
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,14 @@ stages:
   - shared-pipeline
   - publish
   - benchmarks
+  - dotnet-aspnet-realworld-parallel
+  - dotnet-aspnet-realworld-parallel-slo
 
 include:
   - local: .gitlab/one-pipeline.locked.yml
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-dotnet-aspnet-realworld-parallel.yml'
+    ref: 'fayssal/integrate'
 
 variables:
   DOTNET_PACKAGE_VERSION:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-dotnet-aspnet-realworld-parallel.yml'
-    ref: 'fayssal/integrate'
+    ref: 'main'
 
 variables:
   DOTNET_PACKAGE_VERSION:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ stages:
   - shared-pipeline
   - publish
   - benchmarks
+  # These benchmarks are intended to replace the legacy macrobenchmarks long term
   - dotnet-aspnet-realworld-parallel
   - dotnet-aspnet-realworld-parallel-slo
 


### PR DESCRIPTION
## Summary of changes

Integrates new parallel macrobenchmarks from `DataDog/apm-sdks-benchmarks` via GitLab `include: project:` configuration in the CI pipeline.

## Reason for change

Centralizes macrobenchmark configurations in a single repository (`apm-sdks-benchmarks`) for consistent and unified management across all APM SDKs.

## Implementation details

Both old and new benchmarks run in parallel during the transition period to validate results. All future macrobenchmark changes should be made in the `apm-sdks-benchmarks` repository.

## Test coverage

Existing benchmark validation ensures consistency between old and new benchmark runs during the parallel execution period.

## Other details
<!-- Fixes #{issue} -->
These jobs are allowed to fail to avoid potentially impeding the workflow. 

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
