### PR TITLE
[Profiler] Prevent profiler from interrupted thread while executing  handler `SIGSEGV` handler

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -673,6 +673,47 @@ pid_t fork()
 }
 #endif
 #endif
+
+// https://github.com/DataDog/dd-trace-dotnet/pull/8162
+// There is a stack overflow on the altstack when coreclr's SIGSEGV handler is interrupted by
+// SIGPROF/SIGUSR1 signals.
+//
+// * sigaction is wrapped to mask SIGPROF/SIGUSR1 to make sure that the thread is not interrupted
+// while executing the SIGSEGV handler.
+//
+// * pthread_sigmask is called by the runtime to unblock SIGSEGV. The CLR never returns from SIGSEGV handler,
+// instead it jumps back from the altstack to the main stack, unblocks SIGSEGV and continues execution.
+// We need to unblock SIGPROF/SIGUSR1 as well to allow the profiler continue working.
+
+static int (*__real_sigaction)(int signum, const struct sigaction* act, struct sigaction* oldact) = NULL;
+static int (*__real_pthread_sigmask)(int how, const sigset_t *set, sigset_t *oldset) = NULL;
+
+int sigaction(int signum, const struct sigaction* act, struct sigaction* oldact)
+{
+    check_init();
+    if (signum == SIGSEGV && act != NULL)
+    {
+        struct sigaction new_act = *act;
+        sigaddset(&new_act.sa_mask, SIGPROF);
+        sigaddset(&new_act.sa_mask, SIGUSR1);
+        return __real_sigaction(signum, &new_act, oldact);
+    }
+    return __real_sigaction(signum, act, oldact);
+}
+
+int pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset)
+{
+    check_init();
+    if (how == SIG_UNBLOCK && set != NULL && 1 == sigismember(set, SIGSEGV))
+    {
+        sigset_t new_set = *set;
+        sigaddset(&new_set, SIGPROF);
+        sigaddset(&new_set, SIGUSR1);
+        return __real_pthread_sigmask(how, &new_set, oldset);
+    }
+    return __real_pthread_sigmask(how, set, oldset);
+}
+
 static pthread_once_t once_control = PTHREAD_ONCE_INIT;
 
 static void init()
@@ -682,6 +723,8 @@ static void init()
     __real_dlclose = __dd_dlsym(RTLD_NEXT, "dlclose");
     __real_dladdr = __dd_dlsym(RTLD_NEXT, "dladdr");
     __real_execve = __dd_dlsym(RTLD_NEXT, "execve");
+    __real_sigaction = __dd_dlsym(RTLD_NEXT, "sigaction");
+    __real_pthread_sigmask = __dd_dlsym(RTLD_NEXT, "pthread_sigmask");
 #ifdef DD_ALPINE
     __real_pthread_create = __dd_dlsym(RTLD_NEXT, "pthread_create");
     __real_pthread_attr_init = __dd_dlsym(RTLD_NEXT, "pthread_attr_init");


### PR DESCRIPTION
## Summary of changes

This PR is inspired from https://github.com/DataDog/dd-trace-dotnet/pull/8162

## Reason for change
There is a stack overflow on the altstack when coreclr's `SIGSEGV` handler is interrupted by `SIGPROF` signal.

Here is the trace from kernel (obtained with this vibecoded ebpf tracer https://github.com/korniltsev-grafanista/signalsnoop ):
```
rsp: 0x00007ee895e36b30
get_sigframe for tgid=974490 tid=974548 (.NET TP Worker), ret=0x7ee895e35f38
x64_setup_rt_frame failed for tgid=974490 tid=974548 (.NET TP Worker), sig=27, ret=-14
7ee895e36000-7ee895e39000 rw-p 00000000 00:00 0 // altstack
```

<details>

```
get_sigframe for tgid=974490 tid=974548 (.NET TP Worker), ret=0x7ee895e35f38
        x64_setup_rt_frame
        arch_do_signal_or_restart
        irqentry_exit_to_user_mode
        asm_sysvec_apic_timer_interrupt
    Userspace registers:
        rip: 0x00007f2a70c16874  rsp: 0x00007ee895e36b30  flags: 0x0000000000000202
        rax: 0x00007ee895e37800  rbx: 0x00007ee87fbfdd68  rcx:   0x00007f2a70c16972
        rdx: 0x00007ee895e36b70  rsi: 0x0000000000000000  rdi:   0x00007ee895e36b90
        rbp: 0x00007ee895e377e0  r8:  0x00007ee895e37800  r9:    0x00007ee87418b629
        r10: 0x00000000000000f5  r11: 0x00007f2a714c1000  r12:   0x00007ee87fbfdd70
        r13: 0x00007ee895e36b90  r14: 0x00007ee895e38480  r15:   0x00007ee87fbfde00

x64_setup_rt_frame failed for tgid=974490 tid=974548 (.NET TP Worker), sig=27, ret=-14
    sa_flags: 0x14000004 (SA_RESTORER=true)
        arch_do_signal_or_restart
        irqentry_exit_to_user_mode
        asm_sysvec_apic_timer_interrupt
    Userspace registers:
        rip: 0x00007f2a70c16874  rsp: 0x00007ee895e36b30  flags: 0x0000000000000202
        rax: 0x00007ee895e37800  rbx: 0x00007ee87fbfdd68  rcx:   0x00007f2a70c16972
        rdx: 0x00007ee895e36b70  rsi: 0x0000000000000000  rdi:   0x00007ee895e36b90
        rbp: 0x00007ee895e377e0  r8:  0x00007ee895e37800  r9:    0x00007ee87418b629
        r10: 0x00000000000000f5  r11: 0x00007f2a714c1000  r12:   0x00007ee87fbfdd70
        r13: 0x00007ee895e36b90  r14: 0x00007ee895e38480  r15:   0x00007ee87fbfde00
    Stack probe:
        [sp+0] 0x00007ee895e36b30: 0x00007f2a70be4ad0
        [sp-128] 0x00007ee895e36ab0: 0x0000000000000000
        [sp-568] 0x00007ee895e368f8: 0x0000000000000000
        [sp-700] 0x00007ee895e36874: 0x0000000000000000

signal_setup_done failed for tgid=974490 tid=974548 (.NET TP Worker), sig=27, ret=1
        signal_setup_done
        arch_do_signal_or_restart
        irqentry_exit_to_user_mode
        asm_sysvec_apic_timer_interrupt
    Userspace registers:
        rip: 0x00007f2a70c16874  rsp: 0x00007ee895e36b30  flags: 0x0000000000000202
        rax: 0x00007ee895e37800  rbx: 0x00007ee87fbfdd68  rcx:   0x00007f2a70c16972
        rdx: 0x00007ee895e36b70  rsi: 0x0000000000000000  rdi:   0x00007ee895e36b90
        rbp: 0x00007ee895e377e0  r8:  0x00007ee895e37800  r9:    0x00007ee87418b629
        r10: 0x00000000000000f5  r11: 0x00007f2a714c1000  r12:   0x00007ee87fbfdd70
        r13: 0x00007ee895e36b90  r14: 0x00007ee895e38480  r15:   0x00007ee87fbfde00
    Stack probe:
        [sp+0] 0x00007ee895e36b30: 0x00007f2a70be4ad0
        [sp-128] 0x00007ee895e36ab0: 0x0000000000000000
        [sp-568] 0x00007ee895e368f8: 0x0000000000000000
        [sp-700] 0x00007ee895e36874: 0x0000000000000000

vfs_coredump for tgid=974490 tid=974548 (.NET TP Worker)
        vfs_coredump
        get_signal
        arch_do_signal_or_restart
        irqentry_exit_to_user_mode
        asm_sysvec_apic_timer_interrupt
    Userspace registers:
        rip: 0x00007f2a70c16874  rsp: 0x00007ee895e36b30  flags: 0x0000000000000202
        rax: 0x00007ee895e37800  rbx: 0x00007ee87fbfdd68  rcx:   0x00007f2a70c16972
        rdx: 0x00007ee895e36b70  rsi: 0x0000000000000000  rdi:   0x00007ee895e36b90
        rbp: 0x00007ee895e377e0  r8:  0x00007ee895e37800  r9:    0x00007ee87418b629
        r10: 0x00000000000000f5  r11: 0x00007f2a714c1000  r12:   0x00007ee87fbfdd70
        r13: 0x00007ee895e36b90  r14: 0x00007ee895e38480  r15:   0x00007ee87fbfde00
    Stack probe:
        [sp+0] 0x00007ee895e36b30: 0x00007f2a70be4ad0
        [sp-128] 0x00007ee895e36ab0: 0x0000000000000000
        [sp-568] 0x00007ee895e368f8: 0x0000000000000000
        [sp-700] 0x00007ee895e36874: 0x0000000000000000
    Process maps:
    
    
7ee895e36000-7ee895e39000 rw-p 00000000 00:00 0   <-- rsp=0x7ee895e36b30, rbp=0x7ee895e377e0, rax=0x7ee895e37800, rdx=0x7ee895e36b70, rdi=0x7ee895e36b90, r8=0x7ee895e37800, r13=0x7ee895e36b90, r14=0x7ee895e38480
7ee895e35f38


```
</details>

## Implementation details


This PR adds wrappers to `sigaction` and `pthread_sigmask`.

`sigaction` masks `SIGPROF` if the signal is `SIGSEGV` - to prevent SIGSEGV stack overflow during signal delivering.
`pthread_sigmask` unblocks `SIGPROF` if we are unblocking `SIGSEGV` - the runtime unblocks SIGSEGV, and we should unblock `SIGPROF` as well to allow the profiler continue working and delivering `SIGPROF` signals.

## Test coverage

This is the code I used to simplify reproducing - triggering null deref in managed code in a busy loop. https://github.com/grafana/pyroscope-dotnet/pull/177/files#diff-75c68efd0775648bc723a9557e3cc83a294c79852dc5dc2c733e8bb80e15a9fcR18

## Other details

Disclaimer: the problem was initially reported by grafana user(using the fork https://github.com/grafana/pyroscope-dotnet) we then confirmed the same problem with the genuine (not fork) dd-trace-dotnet v0.34.0. 