### PR TITLE
Fix ServiceStack not calling EndRequest method

### DIFF
--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -523,6 +523,11 @@ namespace Datadog.Trace.AspNet
 
             public Scope Scope { get; }
 
+            /// <summary>
+            /// Gets the inferred proxy scope. Only present when inferred proxy spans are enabled
+            /// AND necessary proxy headers were present.
+            /// </summary>
+            /// <see cref="ConfigurationKeys.FeatureFlags.InferredProxySpansEnabled"/>
             public Scope ProxyScope { get; }
         }
     }

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -40,12 +40,6 @@ namespace Datadog.Trace.AspNet
         private static bool _canReadHttpResponseHeaders = true;
 
         private readonly string _httpContextScopeKey;
-
-        /// <summary>
-        /// This key is only present when inferred proxy spans are enabled AND necessary proxy headers were present.
-        /// </summary>
-        /// <see cref="ConfigurationKeys.FeatureFlags.InferredProxySpansEnabled"/>
-        private readonly string _httpContextProxyScopeKey;
         private readonly string _requestOperationName;
 
         /// <summary>
@@ -69,7 +63,6 @@ namespace Datadog.Trace.AspNet
 
             _requestOperationName = operationName;
             _httpContextScopeKey = string.Concat("__Datadog.Trace.AspNet.TracingHttpModule-", _requestOperationName);
-            _httpContextProxyScopeKey = string.Concat(_httpContextScopeKey, ".proxy");
         }
 
         /// <inheritdoc />
@@ -218,12 +211,7 @@ namespace Datadog.Trace.AspNet
                     tracer.TracerManager.SpanContextPropagator.Inject(injectedContext, requestHeaders.Wrap());
                 }
 
-                if (inferredProxyScope is not null)
-                {
-                    httpContext.Items[_httpContextProxyScopeKey] = inferredProxyScope;
-                }
-
-                httpContext.Items[_httpContextScopeKey] = scope;
+                httpContext.Items[_httpContextScopeKey] = new ScopeContainer(scope, inferredProxyScope);
                 shouldDisposeScope = false;
 
                 tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
@@ -296,9 +284,10 @@ namespace Datadog.Trace.AspNet
                 }
 
                 if (sender is HttpApplication app &&
-                    app.Context.Items[_httpContextScopeKey] is Scope scope)
+                    app.Context.Items[_httpContextScopeKey] is ScopeContainer container)
                 {
-                    var proxyScope = app.Context.Items[_httpContextProxyScopeKey] as Scope;
+                    var scope = container.Scope;
+                    var proxyScope = container.ProxyScope;
 
                     try
                     {
@@ -474,9 +463,10 @@ namespace Datadog.Trace.AspNet
                 var httpException = exception as HttpException;
                 var is404 = httpException?.GetHttpCode() == 404;
 
-                if (httpContext?.Items[_httpContextScopeKey] is Scope scope)
+                if (httpContext?.Items[_httpContextScopeKey] is ScopeContainer container)
                 {
-                    var proxyScope = httpContext?.Items[_httpContextProxyScopeKey] as Scope;
+                    var scope = container.Scope;
+                    var proxyScope = container.ProxyScope;
                     AddHeaderTagsFromHttpResponse(httpContext, scope);
                     if (proxyScope != null)
                     {
@@ -508,12 +498,32 @@ namespace Datadog.Trace.AspNet
             try
             {
                 context.Items.Remove(_httpContextScopeKey);
-                context.Items.Remove(_httpContextProxyScopeKey);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error while clearing the HttpContext");
             }
+        }
+
+        /// <summary>
+        /// Non-disposable container for scopes stored in <see cref="HttpContext.Items"/>.
+        /// Some frameworks (e.g. ServiceStack) iterate through HttpContext.Items and dispose
+        /// all IDisposable values during their own request cleanup, which runs before IIS's
+        /// EndRequest event. Wrapping scopes in a non-disposable container prevents premature
+        /// disposal and ensures OnEndRequest can still enrich the span with resource name,
+        /// status code, and other tags.
+        /// </summary>
+        private sealed class ScopeContainer
+        {
+            public ScopeContainer(Scope scope, Scope proxyScope = null)
+            {
+                Scope = scope;
+                ProxyScope = proxyScope;
+            }
+
+            public Scope Scope { get; }
+
+            public Scope ProxyScope { get; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -513,7 +513,7 @@ namespace Datadog.Trace.AspNet
         /// disposal and ensures OnEndRequest can still enrich the span with resource name,
         /// status code, and other tags.
         /// </summary>
-        private sealed class ScopeContainer
+        internal sealed class ScopeContainer
         {
             public ScopeContainer(Scope scope, Scope proxyScope = null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
@@ -44,10 +44,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
             // AssociateWithCurrentThread can only be used when HttpContext is non-null
             var httpContext = instance.HttpContext;
             if (httpContext.Items is not null
-                && httpContext.Items[HttpContextScopeKey] is Scope scope
+                && httpContext.Items[HttpContextScopeKey] is Trace.AspNet.TracingHttpModule.ScopeContainer container
                 && Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
             {
-                rawAccess.Active = scope;
+                rawAccess.Active = container.Scope;
             }
 
             return CallTargetState.GetDefault();


### PR DESCRIPTION
## Summary of changes

Wrap scopes stored in `HttpContext.Items` in a non-disposable `ScopeContainer` to prevent premature disposal by third-party frameworks.

## Reason for change

Fixes APMS-19184. ServiceStack's `ServiceStackHost.OnEndRequest` runs before IIS's `EndRequest` pipeline event and iterates through all `HttpContext.Items` values, [disposing anything that implements `IDisposable`](https://github.com/ServiceStack/ServiceStack/blob/main/ServiceStack/src/ServiceStack/ServiceStackHost.cs#L1474) — including our `Scope`. This caused `Span.Finish()` to run before `TracingHttpModule.OnEndRequest` could set the resource name and status code, resulting in spans with `resource: aspnet.request` and no `http.status_code`.

## Implementation details

- Introduced a `ScopeContainer` nested class that holds both the request scope and the optional inferred proxy scope. It does not implement `IDisposable`, so ServiceStack's `Release()` (which does `instance as IDisposable`) skips it.
- Combined the two separate `HttpContext.Items` entries (`_httpContextScopeKey` and `_httpContextProxyScopeKey`) into a single `ScopeContainer` entry.
- Updated retrieval in `OnEndRequest` and `OnError` to unwrap from the container.

## Test coverage

Reproduced locally with a ServiceStack 5.4 sample application on IIS Express. The test confirms that `aspnet.request` spans now get proper resource names and status codes.

## Other details

This also protects against any other framework that disposes `IDisposable` objects from `HttpContext.Items` during request cleanup.