### PR TITLE
[Profiler] Fix bug in ManagedCodeCache

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
@@ -181,18 +181,15 @@ bool ManagedCodeCache::IsManaged(std::uintptr_t ip) const noexcept
         // Level 1: Find the page (shared lock on map structure)
         std::shared_lock<std::shared_mutex> mapLock(_pagesMutex);
         auto pageIt = _pagesMap.find(page);
-        if (pageIt == _pagesMap.end())
-        {
-            return false;  // No code on this page
-        }
-        
-        // Level 2: Binary search within the page's ranges (shared lock on page)
-   
-        std::shared_lock<std::shared_mutex> pageLock(pageIt->second.lock);
-        auto range = FindRange(pageIt->second.ranges, static_cast<UINT_PTR>(ip));
-        if (range.has_value())
-        {
-            return true;
+        if (pageIt != _pagesMap.end())
+        {   
+            // Level 2: Binary search within the page's ranges (shared lock on page)
+            std::shared_lock<std::shared_mutex> pageLock(pageIt->second.lock);
+            auto range = FindRange(pageIt->second.ranges, static_cast<UINT_PTR>(ip));
+            if (range.has_value())
+            {
+                return true;
+            }
         }
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
@@ -134,7 +134,13 @@ private:
     // Append new ranges to the cache (accumulative - never removes old ranges)
     // This preserves old tier code that might still be on the stack
     void AddFunctionRangesToCache(std::vector<CodeRange> newRanges);
+#ifdef DD_TEST
+public:
+#endif
     void AddModuleRangesToCache(std::vector<ModuleCodeRange> moduleCodeRanges);
+#ifdef DD_TEST
+private:
+#endif
     void AddModuleCodeRangesAsync(std::vector<ModuleCodeRange> moduleCodeRanges);
     void AddFunctionCodeRangesAsync(std::vector<CodeRange> ranges);
     std::vector<ModuleCodeRange> GetModuleCodeRanges(ModuleID moduleId);

--- a/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
@@ -296,3 +296,24 @@ TEST_F(ManagedCodeCacheTest, AddFunction_GetCodeInfo2Fails_HandledGracefully) {
     // Should not crash
     EXPECT_FALSE(cache->GetFunctionId(0x1000).has_value());
 }
+
+// Test: IsManaged falls back to R2R module check when IP is not in the JIT page map
+TEST_F(ManagedCodeCacheTest, IsManaged_IPInR2RModule_NotInPageMap_ReturnsTrue) {
+    // Register an R2R module range directly (bypassing PE parsing)
+    // Use an address that has no JIT-compiled code registered on its page
+    uintptr_t r2rCodeStart = 0xA0000000;
+    uintptr_t r2rCodeEnd   = 0xA000FFFF;
+
+    std::vector<ModuleCodeRange> moduleRanges;
+    moduleRanges.emplace_back(r2rCodeStart, r2rCodeEnd);
+
+    cache->AddModuleRangesToCache(std::move(moduleRanges));
+
+    // An IP within the R2R range but with no JIT page entry should still be detected as managed
+    uintptr_t ipInR2R = r2rCodeStart + 0x500;
+    EXPECT_TRUE(cache->IsManaged(ipInR2R))
+        << "IsManaged should return true for an IP in an R2R module even when the JIT page map has no entry for that page";
+
+    // An IP outside both the JIT page map and any R2R module should still be false
+    EXPECT_FALSE(cache->IsManaged(0xDEADBEEF));
+}


### PR DESCRIPTION
## Summary of changes

Method `IsManaged` has a bug when the instruction pointer is in the R2R segments.
## Reason for change

## Implementation details

Make it right :)
If we do not find the instruction pointers in JIT Code cache, we look into the module code cache.

## Test coverage
New test added 
## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
