### PR TITLE
[Profiler] Fix UB in DebugInfoStore::Get(): re-acquire iterator after map insertion

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
@@ -45,6 +45,7 @@ SymbolDebugInfo DebugInfoStore::Get(ModuleID moduleId, mdMethodDef methodDef)
     if (it == _modulesInfo.cend())
     {
         ParseModuleDebugInfo(moduleId);
+        it = _modulesInfo.find(moduleId);
     }
 
     ModuleDebugInfo& info = (it == _modulesInfo.cend()) ? _modulesInfo[moduleId] : it->second;


### PR DESCRIPTION
## Summary of changes
Inspired by https://github.com/DataDog/dd-trace-dotnet/pull/8283#pullrequestreview-4120625532

## Reason for change
In `DebugInfoStore::Get()`, `ParseModuleDebugInfo(moduleId)` inserts into the `_modulesInfo` unordered_map via `_modulesInfo[moduleId]`, which may trigger a rehash that invalidates all iterators. The old code reused a stale iterator obtained before the insertion — undefined behavior per the C++ standard. Fix: re-acquire the iterator via find() after insertion, and simplify the now-unnecessary ternary.

## Implementation details

re-acquire the iterator

## Test coverage


## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
