### PR TITLE
test(tracecontext): verify KSR tag formatting is locale-independent

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests_KnuthSamplingRate.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests_KnuthSamplingRate.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Globalization;
+using System.Threading;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Tests.Util;
 using FluentAssertions;
@@ -106,5 +108,36 @@ public class TraceContextTests_KnuthSamplingRate
             traceContext.SetSamplingPriority(SamplingPriorityValues.AutoKeep, SamplingMechanism.AgentRate, rate);
 
             traceContext.Tags.GetTag(Tags.Propagated.KnuthSamplingRate).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(0.3f, "0.3")]
+        [InlineData(1.0f, "1")]
+        [InlineData(0.000001f, "0.000001")]
+        [InlineData(0.5f, "0.5")]
+        [InlineData(0.0f, "0")]
+        public void KsrTag_FormattedIndependentOfThreadCulture(float rate, string expected)
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // German culture uses comma as decimal separator
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+                var tracer = new StubDatadogTracer();
+                var traceContext = new TraceContext(tracer);
+
+                traceContext.SetSamplingPriority(
+                    SamplingPriorityValues.AutoKeep,
+                    SamplingMechanism.AgentRate,
+                    rate);
+
+                traceContext.Tags.GetTag(Tags.Propagated.KnuthSamplingRate)
+                    .Should().Be(expected, "KSR formatting must use '.' as decimal separator regardless of thread culture");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 }


### PR DESCRIPTION
## Summary of changes

Add a unit test that verifies KSR (Knuth Sampling Rate) tag formatting produces locale-independent output (always uses '.' as the decimal separator, never ',').

## Reason for change

If `float.ToString()` is called without an explicit `CultureInfo.InvariantCulture`, threads running under cultures that use comma as a decimal separator (e.g. `de-DE`) would produce malformed KSR tags like `0,5` instead of `0.5`. This test guards against that regression.

## Implementation details

New `[Theory]` test `KsrTag_FormattedIndependentOfThreadCulture` in `TraceContextTests_KnuthSamplingRate`:
- Sets `Thread.CurrentThread.CurrentCulture` to `de-DE` (comma decimal separator)
- Calls `SetSamplingPriority` with various rates
- Asserts the KSR tag always uses '.' as the decimal separator
- Restores the original culture in a `finally` block

## Test coverage

The new test itself is the test coverage. It exercises the same `SetSamplingPriority` -> KSR tag path as existing tests but under a non-invariant culture.

## Other details

None.