### PR TITLE
fix: 'occured' -> 'occurred' across 10 files in tracer, profiler, shared

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/OpenLdapCrash.cs
+++ b/profiler/src/Demos/Samples.Computer01/OpenLdapCrash.cs
@@ -55,7 +55,7 @@ namespace Samples.Computer01
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[Error] An error occured while trying to connect to the LDAP server `{_serverHostname}:{_serverPort}`. Message: " + e.Message);
+                Console.WriteLine($"[Error] An error occurred while trying to connect to the LDAP server `{_serverHostname}:{_serverPort}`. Message: " + e.Message);
             }
         }
     }

--- a/shared/src/native-src/dynamic_com_library.cpp
+++ b/shared/src/native-src/dynamic_com_library.cpp
@@ -17,7 +17,7 @@ HRESULT datadog::shared::DynamicCOMLibrary::DllGetClassObject(REFCLSID clsid, RE
         return _dllGetClassObjectFn(clsid, iid, ptr);
     }
 
-    _logger->Warn("DynamicCOMLibrary::DllGetClassObject: cannot call to DllGetClassObject. An issue might have occured "
+    _logger->Warn("DynamicCOMLibrary::DllGetClassObject: cannot call to DllGetClassObject. An issue might have occurred "
                   "and we were enable to get a pointer to this function");
     return E_FAIL;
 }
@@ -29,7 +29,7 @@ HRESULT datadog::shared::DynamicCOMLibrary::DllCanUnloadNow()
         return _dllCanUnloadNowFn();
     }
 
-    _logger->Warn("DynamicCOMLibrary::DllCanUnloadNow: cannot call to DllCanUnloadNow. An issue might have occured "
+    _logger->Warn("DynamicCOMLibrary::DllCanUnloadNow: cannot call to DllCanUnloadNow. An issue might have occurred "
                   "and we were enable to get a pointer to this function");
     return E_FAIL;
 }

--- a/shared/src/native-src/dynamic_library_base.cpp
+++ b/shared/src/native-src/dynamic_library_base.cpp
@@ -97,7 +97,7 @@ bool DynamicLibraryBase::Unload()
     if (_instance == nullptr)
     {
         _logger->Warn("Unload: Unable to unload dynamic library '", _filePath,
-                      ". Reason: An issue occured while loading it. See previous message.");
+                      ". Reason: An issue occurred while loading it. See previous message.");
         return false;
     }
 

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -381,7 +381,7 @@ partial class Build
         finally
         {
             CopyDumpsTo(ProfilerBuildDataDirectory);
-            // A crashed occured on linux and the memory dump copy failed due a lack of permission.
+            // A crashed occurred on linux and the memory dump copy failed due a lack of permission.
             Chmod.Value.Invoke("-R 777 " + ProfilerBuildDataDirectory);
         }
     }

--- a/tracer/src/Datadog.Trace.Tools.Shared/ProcessInfo.cs
+++ b/tracer/src/Datadog.Trace.Tools.Shared/ProcessInfo.cs
@@ -117,7 +117,7 @@ public class ProcessInfo
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"An error occured while parsing the configuration file {configPath}: {ex.Message}", ex);
+            throw new InvalidOperationException($"An error occurred while parsing the configuration file {configPath}: {ex.Message}", ex);
         }
     }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -582,7 +582,7 @@ namespace Datadog.Trace.Agent
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "An error occured in the serialization thread");
+                    Log.Error(ex, "An error occurred in the serialization thread");
                 }
 
                 if (_processExit.Task.IsCompleted)

--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -278,7 +278,7 @@ namespace Datadog.Trace
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "Error occured in keep-alive for {Process}.", path);
+                        Log.Error(ex, "Error occurred in keep-alive for {Process}.", path);
                     }
                     finally
                     {

--- a/tracer/src/Datadog.Trace/Telemetry/ITelemetryTransport.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/ITelemetryTransport.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Telemetry
         /// </summary>
         /// <param name="data">The data to send</param>
         /// <returns><c>true</c> if the data was sent successfully, or a non-fatal error occurred
-        /// <c>false</c> if a fatal error occured, and no further telemetry should be sent.</returns>
+        /// <c>false</c> if a fatal error occurred, and no further telemetry should be sent.</returns>
         Task<TelemetryPushResult> PushTelemetry(TelemetryData data);
 
         string GetTransportInfo();

--- a/tracer/src/Datadog.Trace/Util/EnvironmentHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/EnvironmentHelpers.cs
@@ -41,7 +41,7 @@ internal static class EnvironmentHelpers
     /// <summary>
     /// Safe wrapper around Environment.MachineName
     /// </summary>
-    /// <returns>The value of <see cref="Environment.MachineName"/>, or null if an error occured</returns>
+    /// <returns>The value of <see cref="Environment.MachineName"/>, or null if an error occurred</returns>
     public static string? GetMachineName()
     {
         try
@@ -62,7 +62,7 @@ internal static class EnvironmentHelpers
     /// </summary>
     /// <param name="key">Name of the environment variable to fetch</param>
     /// <param name="defaultValue">Value to return in case of error</param>
-    /// <returns>The value of the environment variable, or the default value if an error occured</returns>
+    /// <returns>The value of the environment variable, or the default value if an error occurred</returns>
     public static string? GetEnvironmentVariable(string key, string? defaultValue = null)
     {
         try
@@ -83,7 +83,7 @@ internal static class EnvironmentHelpers
     /// <summary>
     /// Safe wrapper around Environment.GetEnvironmentVariables
     /// </summary>
-    /// <returns>A dictionary that contains all environment variables or an empty dictionary if an error occured</returns>
+    /// <returns>A dictionary that contains all environment variables or an empty dictionary if an error occurred</returns>
     public static IDictionary GetEnvironmentVariables()
     {
         try

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3573,13 +3573,13 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Create a string representing "An error occured in the managed loader: "
+    // Create a string representing "An error occurred in the managed loader: "
 
 #ifdef _WIN32
-    LPCWSTR error_str = L"An error occured in the managed loader: ";
+    LPCWSTR error_str = L"An error occurred in the managed loader: ";
     auto error_str_size = wcslen(error_str);
 #else
-    char16_t error_str[] = u"An error occured in the managed loader: ";
+    char16_t error_str[] = u"An error occurred in the managed loader: ";
     auto error_str_size = std::char_traits<char16_t>::length(error_str);
 #endif
 
@@ -3777,7 +3777,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
         // Catch block
         // catch (Exception ex)
         // {
-        //      var message = "An error occured in the managed loader: " + ex.ToString();
+        //      var message = "An error occurred in the managed loader: " + ex.ToString();
         //      var chars = message.ToCharArray();
         //
         //      fixed (char* p = chars)


### PR DESCRIPTION
## Summary

Fix 16 instances of `occured` → `occurred` across 10 files in the tracer, profiler, and shared native libraries. All are log messages, XML doc comments, and inline comments. No logic or API change.

## Files

| File | Instances | Kind |
|------|-----------|------|
| `tracer/src/Datadog.Tracer.Native/cor_profiler.cpp` | 4 | Log messages |
| `tracer/src/Datadog.Trace/Util/EnvironmentHelpers.cs` | 3 | XML doc |
| `shared/src/native-src/dynamic_com_library.cpp` | 2 | Log messages |
| `tracer/src/Datadog.Trace/Telemetry/ITelemetryTransport.cs` | 1 | XML doc |
| `profiler/src/Demos/Samples.Computer01/OpenLdapCrash.cs` | 1 | Comment |
| `shared/src/native-src/dynamic_library_base.cpp` | 1 | Log message |
| `tracer/src/Datadog.Trace.Tools.Shared/ProcessInfo.cs` | 1 | Comment |
| `tracer/build/_build/Build.Profiler.Steps.cs` | 1 | Build script comment |
| `tracer/src/Datadog.Trace/Agent/AgentWriter.cs` | 1 | Comment |
| `tracer/src/Datadog.Trace/AgentProcessManager.cs` | 1 | Comment |

## Testing

String-literal/comment change; no tests impacted. Follows the same pattern as #3799 (dd-trace-php, merged).