### PR TITLE
[SINT-5051] Update CI identities client version and Windows code signer to latest release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ variables:
   GITLAB_GROUP_OSS: DataDog
   # GitHub org for internal repos (used in git insteadOf redirects) - update to new org after the split
   GITHUB_ORG_INTERNAL: DataDog
-  CI_IDENTITIES_CLIENT_URL: s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/v0.2.0/ci-identities-gitlab-job-client-windows-amd64.exe
+  CI_IDENTITIES_CLIENT_URL: s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/v0.6.3/ci-identities-gitlab-job-client-windows-amd64.exe
   SUPPORTED_CONFIG_PATH: "tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml"
   OCI_PACKAGE_MAX_SIZE_BYTES: 40000000
   LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 40000000
@@ -49,6 +49,7 @@ build:
         -e NUGET_CERT_REVOCATION_MODE=offline `
         -e CI_IDENTITIES_GITLAB_ID_TOKEN `
         -e CI_PROJECT_NAME `
+        -e CI_JOB_NAME_SLUG `
         registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:ci-identities `
         Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi DownloadWinSsiTelemetryForwarder
     - mkdir artifacts-out

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ variables:
   GITLAB_GROUP_OSS: DataDog
   # GitHub org for internal repos (used in git insteadOf redirects) - update to new org after the split
   GITHUB_ORG_INTERNAL: DataDog
-  CI_IDENTITIES_CLIENT_URL: s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/v0.2.0/ci-identities-gitlab-job-client-windows-amd64.exe
+  CI_IDENTITIES_CLIENT_URL: s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/v0.6.3/ci-identities-gitlab-job-client-windows-amd64.exe
   SUPPORTED_CONFIG_PATH: "tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml"
   OCI_PACKAGE_MAX_SIZE_BYTES: 43000000
   LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 43000000
@@ -113,6 +113,7 @@ build:
         -e NUGET_CERT_REVOCATION_MODE=offline `
         -e CI_IDENTITIES_GITLAB_ID_TOKEN `
         -e CI_PROJECT_NAME `
+        -e CI_JOB_NAME_SLUG `
         $env:WINDOWS_BUILD_IMAGE `
         Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi DownloadWinSsiTelemetryForwarder
     - mkdir artifacts-out

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -52,7 +52,7 @@ COPY helpers.ps1 install_java.ps1 ./
 RUN powershell -Command .\install_java.ps1
 
 # Install Windows Code Signer
-COPY --from=registry.ddbuild.io/windows-code-signer/go:v0.6.0-ltsc2019 c:/windows-code-signer/windows-code-signer.exe c:/devtools/windows-code-signer.exe
+COPY --from=registry.ddbuild.io/windows-code-signer/go:v0.7.0-ltsc2019 c:/windows-code-signer/windows-code-signer.exe c:/devtools/windows-code-signer.exe
 
 # Copy everything else
 COPY . .

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -52,7 +52,7 @@ COPY helpers.ps1 install_java.ps1 ./
 RUN powershell -Command .\install_java.ps1
 
 # Install Windows Code Signer
-COPY --from=registry.ddbuild.io/windows-code-signer/go:v0.6.0 c:/windows-code-signer/windows-code-signer.exe c:/devtools/windows-code-signer.exe
+COPY --from=registry.ddbuild.io/windows-code-signer/go:v0.7.0 c:/windows-code-signer/windows-code-signer.exe c:/devtools/windows-code-signer.exe
 
 # Copy everything else
 COPY . .


### PR DESCRIPTION
## Summary of changes
- Update Windows code signing image to v0.7.0. This version uses the latest version of the CI Identities client
- Forward the CI Job Name Env Variable for better observability.
- Update the ci-identities client version to the latest one

## Reason for change
Mostly for better observability
See changelog : [link](https://github.com/ddoghq/ci-identities/blob/main/apps/ci-identities-gitlab-job-client/CHANGELOG.md)
