### PR TITLE
Move vendored `ReadOnlySpan<T>`, `Span<T>` et. al. to System namespace

### DIFF
--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -721,16 +721,21 @@ namespace UpdateVendors
                                   "using System.Reflection;\n" +
                                   "using System.Runtime.InteropServices;\n" +
                                   "using System.Threading;\n" +
-                                  "using System.Threading.Tasks;\n\n";
+                                  "using System.Threading.Tasks;\n" +
+                                  "using Datadog.Trace.VendoredMicrosoftCode.System;\n\n"; // To give Span<T> etc access to ThrowHelper
 
             contents = contents.Insert(namespaceIndex, usings);
 
+            // Note that we leave everything in the System namespace where it is,
+            // so that the compiler can light up for things like Span<T>. It does raise the question
+            // of whether we should bother renaming _any_ of these APIs, but leaving as-is for now
+            // to avoid confusion
             contents = contents.Replace(
                                     "Datadog.Trace.VendoredMicrosoftCode.System..omponentModel.",
                                     "System.ComponentModel.")
                                .Replace(
                                     "Datadog.Trace.VendoredMicrosoftCode.System..UInt",
-                                    "Datadog.Trace.VendoredMicrosoftCode.System.NUInt")
+                                    "System.NUInt")
                                .Replace(
                                     "using Datadog.Trace.VendoredMicrosoftCode.System.ComponentModel",
                                     "using System.ComponentModel")
@@ -745,14 +750,15 @@ namespace UpdateVendors
                                     "using System.Runtime.CompilerServices")
                                .Replace(
                                     "using Datadog.Trace.VendoredMicrosoftCode.System.Text",
-                                    "using System.Text")
-                               .Replace(
-                                    "namespace System\r\n",
-                                    "namespace System\n")
-                                // TODO: We should consider _not_ making this change in the future
-                               .Replace(
-                                    "namespace System\n",
-                                    "namespace Datadog.Trace.VendoredMicrosoftCode.System\n");
+                                    "using System.Text");
+
+            // Leave this one in the vendored namespace to avoid naming conflicts with various _other_ ThrowHelper files
+            if (string.Equals(Path.GetFileName(filePath), "ThrowHelper.cs"))
+            {
+                contents = contents.Replace(
+                    "namespace System",
+                    "namespace Datadog.Trace.VendoredMicrosoftCode.System");
+            }
 
             var resourceReplacements = new List<KeyValuePair<string, string>>
             {

--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -725,8 +725,11 @@ namespace UpdateVendors
 
             contents = contents.Insert(namespaceIndex, usings);
 
-            // Leave this one in the vendored namespace to avoid naming conflicts with various _other_ ThrowHelper files
-            if (string.Equals(Path.GetFileName(filePath), "ThrowHelper.cs"))
+            // Leave these in the vendored namespace to avoid naming conflicts with various _other_ ThrowHelper files,
+            // and MemoryExtensions causes conflicts in the test projects - it's extension methods, so doesn't matter too much where it is
+            if (string.Equals(Path.GetFileName(filePath), "ThrowHelper.cs")
+             || string.Equals(Path.GetFileName(filePath), "MemoryExtensions.cs")
+             || string.Equals(Path.GetFileName(filePath), "MemoryExtensions.Portable.cs"))
             {
                 contents = contents.Replace(
                     "namespace System",

--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -721,10 +721,17 @@ namespace UpdateVendors
                                   "using System.Reflection;\n" +
                                   "using System.Runtime.InteropServices;\n" +
                                   "using System.Threading;\n" +
-                                  "using System.Threading.Tasks;\n" +
-                                  "using Datadog.Trace.VendoredMicrosoftCode.System;\n\n"; // To give Span<T> etc access to ThrowHelper
+                                  "using System.Threading.Tasks;\n\n";
 
             contents = contents.Insert(namespaceIndex, usings);
+
+            // Leave this one in the vendored namespace to avoid naming conflicts with various _other_ ThrowHelper files
+            if (string.Equals(Path.GetFileName(filePath), "ThrowHelper.cs"))
+            {
+                contents = contents.Replace(
+                    "namespace System",
+                    "namespace Datadog.Trace.VendoredMicrosoftCode.System");
+            }
 
             // Note that we leave everything in the System namespace where it is,
             // so that the compiler can light up for things like Span<T>. It does raise the question
@@ -750,15 +757,10 @@ namespace UpdateVendors
                                     "using System.Runtime.CompilerServices")
                                .Replace(
                                     "using Datadog.Trace.VendoredMicrosoftCode.System.Text",
-                                    "using System.Text");
-
-            // Leave this one in the vendored namespace to avoid naming conflicts with various _other_ ThrowHelper files
-            if (string.Equals(Path.GetFileName(filePath), "ThrowHelper.cs"))
-            {
-                contents = contents.Replace(
-                    "namespace System",
-                    "namespace Datadog.Trace.VendoredMicrosoftCode.System");
-            }
+                                    "using System.Text")
+                               .Replace(
+                                    "ThrowHelper.",
+                                    "global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.");
 
             var resourceReplacements = new List<KeyValuePair<string, string>>
             {

--- a/tracer/src/Datadog.Trace/ExtensionMethods/StringBuilderExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/StringBuilderExtensions.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using System;
 using System.Text;
 
 #if !NETCOREAPP3_1_OR_GREATER

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -269,7 +269,6 @@ namespace Datadog.Trace.Propagators
             string rawTraceId;
             string rawSpanId;
 
-#if NETCOREAPP
             var w3cTraceId = header.AsSpan(start: 3, length: 32);
             var w3cSpanId = header.AsSpan(start: 36, length: 16);
 
@@ -295,31 +294,6 @@ namespace Datadog.Trace.Propagators
             {
                 return false;
             }
-#else
-            rawTraceId = header.Substring(startIndex: 3, length: 32);
-            rawSpanId = header.Substring(startIndex: 36, length: 16);
-
-            if (!HexString.TryParseTraceId(rawTraceId, out traceId) || traceId == TraceId.Zero)
-            {
-                return false;
-            }
-
-            if (!HexString.TryParseUInt64(rawSpanId, out parentId) || parentId == 0)
-            {
-                return false;
-            }
-
-            bool sampled;
-
-            if (HexString.TryParseByte(header.Substring(53, 2), out var traceFlags))
-            {
-                sampled = ((TraceFlags)traceFlags).HasFlagFast(TraceFlags.Sampled);
-            }
-            else
-            {
-                return false;
-            }
-#endif
 
             traceParent = new W3CTraceParent(
                 traceId: traceId,

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                     T[] array = _array;
                     if (array == null)
                     {
-                        ThrowHelper.ThrowObjectDisposedException_ArrayMemoryPoolBuffer();
+                        global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowObjectDisposedException_ArrayMemoryPoolBuffer();
                     }
 
                     return new Memory<T>(array);

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ArrayMemoryPool.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ArrayMemoryPool.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             if (minimumBufferSize == -1)
                 minimumBufferSize = 1 + (4095 / Unsafe.SizeOf<T>());
             else if (((uint)minimumBufferSize) > s_maxBufferSize)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumBufferSize);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumBufferSize);
 
             return new ArrayMemoryPoolBuffer(minimumBufferSize);
         }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/BuffersExtensions.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/BuffersExtensions.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
         public static void CopyTo<T>(in this ReadOnlySequence<T> source, Span<T> destination)
         {
             if (source.Length > destination.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
 
             if (source.IsSingleSegment)
             {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ReadOnlySequence.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ReadOnlySequence.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                 (uint)startSegment.Memory.Length < (uint)startIndex ||
                 (uint)endSegment.Memory.Length < (uint)endIndex ||
                 (startSegment == endSegment && endIndex < startIndex))
-                ThrowHelper.ThrowArgumentValidationException(startSegment, startIndex, endSegment);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentValidationException(startSegment, startIndex, endSegment);
 
             _sequenceStart = new SequencePosition(startSegment, ReadOnlySequence.SegmentToSequenceStart(startIndex));
             _sequenceEnd = new SequencePosition(endSegment, ReadOnlySequence.SegmentToSequenceEnd(endIndex));
@@ -109,7 +109,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
         public ReadOnlySequence(T[] array)
         {
             if (array == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
 
             _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(0));
             _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(array.Length));
@@ -123,7 +123,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             if (array == null ||
                 (uint)start > (uint)array.Length ||
                 (uint)length > (uint)(array.Length - start))
-                ThrowHelper.ThrowArgumentValidationException(array, start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentValidationException(array, start);
 
             _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(start));
             _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(start + length));
@@ -150,7 +150,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             else if (typeof(T) == typeof(char))
             {
                 if (!MemoryMarshal.TryGetString(((ReadOnlyMemory<char>)(object)memory), out string text, out int start, out length))
-                    ThrowHelper.ThrowInvalidOperationException();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowInvalidOperationException();
 
                 _sequenceStart = new SequencePosition(text, ReadOnlySequence.StringToSequenceStart(start));
                 _sequenceEnd = new SequencePosition(text, ReadOnlySequence.StringToSequenceEnd(start + length));
@@ -158,7 +158,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             else
             {
                 // Should never be reached
-                ThrowHelper.ThrowInvalidOperationException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowInvalidOperationException();
                 _sequenceStart = default;
                 _sequenceEnd = default;
             }
@@ -172,7 +172,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
         public ReadOnlySequence<T> Slice(long start, long length)
         {
             if (start < 0 || length < 0)
-                ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
 
             SequencePosition begin;
             SequencePosition end;
@@ -201,7 +201,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                 else
                 {
                     if (currentLength < 0)
-                        ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                        global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
 
                     begin = SeekMultiSegment(startSegment.Next, endObject, endIndex, start - currentLength, ExceptionArgument.start);
 
@@ -216,7 +216,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                     else
                     {
                         if (endIndex - beginIndex < length)
-                            ThrowHelper.ThrowStartOrEndArgumentValidationException(0);  // Passing value >= 0 means throw exception on length argument
+                            global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(0);  // Passing value >= 0 means throw exception on length argument
 
                         end = new SequencePosition(beginObject, beginIndex + (int)length);
                     }
@@ -225,13 +225,13 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             else
             {
                 if (endIndex - startIndex < start)
-                    ThrowHelper.ThrowStartOrEndArgumentValidationException(-1); // Passing value < 0 means throw exception on start argument
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(-1); // Passing value < 0 means throw exception on start argument
 
                 startIndex += (int)start;
                 begin = new SequencePosition(startObject, startIndex);
 
                 if (endIndex - startIndex < length)
-                    ThrowHelper.ThrowStartOrEndArgumentValidationException(0);  // Passing value >= 0 means throw exception on length argument
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(0);  // Passing value >= 0 means throw exception on length argument
 
                 end = new SequencePosition(startObject, startIndex + (int)length);
             }
@@ -247,7 +247,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
         public ReadOnlySequence<T> Slice(long start, SequencePosition end)
         {
             if (start < 0)
-                ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
 
             uint sliceEndIndex = (uint)GetIndex(end);
             object sliceEndObject = end.GetObject();
@@ -263,11 +263,11 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             {
                 if (!InRange(sliceEndIndex, startIndex, endIndex))
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
                 }
 
                 if (sliceEndIndex - startIndex < start)
-                    ThrowHelper.ThrowStartOrEndArgumentValidationException(-1); // Passing value < 0 means throw exception on start argument
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(-1); // Passing value < 0 means throw exception on start argument
 
                 goto FoundInFirstSegment;
             }
@@ -284,12 +284,12 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                 startRange,
                 (ulong)(((ReadOnlySequenceSegment<T>)endObject).RunningIndex + endIndex)))
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
             }
 
             if (startRange + (ulong)start > sliceRange)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
             int currentLength = startSegment.Memory.Length - (int)startIndex;
@@ -298,7 +298,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             if (currentLength <= start)
             {
                 if (currentLength < 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
 
                 // End of segment. Move to start of next.
                 SequencePosition begin = SeekMultiSegment(startSegment.Next, sliceEndObject, (int)sliceEndIndex, start - currentLength, ExceptionArgument.start);
@@ -333,15 +333,15 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             {
                 if (!InRange(sliceStartIndex, startIndex, endIndex))
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
                 }
 
                 if (length < 0)
                     // Passing value >= 0 means throw exception on length argument
-                    ThrowHelper.ThrowStartOrEndArgumentValidationException(0);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(0);
 
                 if (endIndex - sliceStartIndex < length)
-                    ThrowHelper.ThrowStartOrEndArgumentValidationException(0);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(0);
 
                 goto FoundInFirstSegment;
             }
@@ -356,16 +356,16 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             Debug.Assert(sliceStartIndex >= 0 && startIndex >= 0 && endIndex >= 0);
             if (!InRange(sliceRange, startRange, endRange))
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
             }
 
             if (length < 0)
                 // Passing value >= 0 means throw exception on length argument
-                ThrowHelper.ThrowStartOrEndArgumentValidationException(0);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(0);
 
             if (sliceRange + (ulong)length > endRange)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
 
             int currentLength = sliceStartSegment.Memory.Length - (int)sliceStartIndex;
@@ -374,7 +374,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             if (currentLength < length)
             {
                 if (currentLength < 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
 
                 // End of segment. Move to start of next.
                 SequencePosition end = SeekMultiSegment(sliceStartSegment.Next, endObject, (int)endIndex, length - currentLength, ExceptionArgument.length);
@@ -438,7 +438,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
         public ReadOnlySequence<T> Slice(long start)
         {
             if (start < 0)
-                ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
 
             if (start == 0)
                 return this;
@@ -485,7 +485,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
         public SequencePosition GetPosition(long offset, SequencePosition origin)
         {
             if (offset < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
 
             return Seek(origin, _sequenceEnd, offset, ExceptionArgument.offset);
         }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ReadOnlySequence_helpers.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/ReadOnlySequence_helpers.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                     ReadOnlySequenceSegment<T> nextSegment = startSegment.Next;
 
                     if (nextSegment == null)
-                        ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+                        global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
                     next = new SequencePosition(nextSegment, 0);
                     memory = startSegment.Memory.Slice(startIndex);
@@ -65,7 +65,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             else
             {
                 if (positionObject != endObject)
-                    ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
                 if (type == SequenceType.Array)
                 {
@@ -132,7 +132,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                 else // endIndex < 0, SequenceType.Array
                 {
                     if (isMultiSegment)
-                        ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+                        global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
                     return new ReadOnlyMemory<T>((T[])startObject, startIndex, (endIndex & ReadOnlySequence.IndexBitMask) - startIndex);
                 }
@@ -140,7 +140,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             else // startIndex < 0
             {
                 if (isMultiSegment)
-                    ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
 
                 // A == 1 && B == 1 means SequenceType.String
                 // A == 1 && B == 0 means SequenceType.MemoryManager
@@ -181,7 +181,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                     goto IsSingleSegment;
 
                 if (currentLength < 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
 
                 // End of segment. Move to start of next.
                 return SeekMultiSegment(startSegment.Next, endObject, endIndex, offset - currentLength, argument);
@@ -190,7 +190,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             Debug.Assert(startObject == endObject);
 
             if (endIndex - startIndex < offset)
-                ThrowHelper.ThrowArgumentOutOfRangeException(argument);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(argument);
 
         // Single segment Seek
         IsSingleSegment:
@@ -218,7 +218,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
 
             // Hit the end of the segments but didn't reach the count
             if (currentSegment == null || endIndex < offset)
-                ThrowHelper.ThrowArgumentOutOfRangeException(argument);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(argument);
 
         FoundSegment:
             return new SequencePosition(currentSegment, (int)offset);
@@ -238,7 +238,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             {
                 if (!InRange(sliceStartIndex, startIndex, endIndex))
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
                 }
             }
             else
@@ -251,7 +251,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                     startRange,
                     (ulong)(((ReadOnlySequenceSegment<T>)endObject).RunningIndex + endIndex)))
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
                 }
             }
         }
@@ -273,7 +273,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                     sliceStartIndex < startIndex ||
                     sliceEndIndex > endIndex)
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
                 }
             }
             else
@@ -286,12 +286,12 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
                 ulong sliceEndRange = (ulong)(((ReadOnlySequenceSegment<T>)sliceEndObject).RunningIndex + sliceEndIndex);
 
                 if (sliceStartRange > sliceEndRange)
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
 
                 if (sliceStartRange < (ulong)(((ReadOnlySequenceSegment<T>)startObject).RunningIndex + startIndex)
                     || sliceEndRange > (ulong)(((ReadOnlySequenceSegment<T>)endObject).RunningIndex + endIndex))
                 {
-                    ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
                 }
             }
         }
@@ -306,7 +306,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
             }
 
             if (currentLength < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PositionOutOfRange();
 
             return SeekMultiSegment(startSegment.Next, endObject, endIndex, length - currentLength, ExceptionArgument.length);
         }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/StandardFormat.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/StandardFormat.cs
@@ -68,9 +68,9 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers
         public StandardFormat(char symbol, byte precision = NoPrecision)
         {
             if (precision != NoPrecision && precision > MaxPrecision)
-                ThrowHelper.ThrowArgumentOutOfRangeException_PrecisionTooLarge();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_PrecisionTooLarge();
             if (symbol != (byte)symbol)
-                ThrowHelper.ThrowArgumentOutOfRangeException_SymbolDoesNotFit();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException_SymbolDoesNotFit();
 
             _format = (byte)symbol;
             _precision = precision;

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Base64Decoder.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Base64Decoder.cs
@@ -191,7 +191,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
         public static int GetMaxDecodedFromUtf8Length(int length)
         {
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
 
             return (length >> 2) * 3;
         }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Base64Encoder.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Base64Encoder.cs
@@ -120,7 +120,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
         public static int GetMaxEncodedToUtf8Length(int length)
         {
             if ((uint)length > MaximumEncodeLength)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
 
             return (((length + 2) / 3) * 4);
         }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Boolean.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Boolean.cs
@@ -114,7 +114,7 @@ BufferTooSmall:
             return false;
 
 BadFormat:
-            return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+            return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.cs
@@ -135,7 +135,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryFormatDateTimeG(value.DateTime, offset, destination, out bytesWritten);
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
         }
 
@@ -179,7 +179,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryFormatDateTimeG(value, Utf8Constants.s_nullUtcOffset, destination, out bytesWritten);
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
@@ -120,7 +120,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     }
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     break;
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
 
             string formatString = format.ToString();

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     break;
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
 
             // At this point, the low byte of flags contains the minimum required length

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryFormatUInt64X((ulong)value & mask, format.Precision, false, destination, out bytesWritten);
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Unsigned.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryFormatUInt64X(value, format.Precision, false /* useLower */, destination, out bytesWritten);
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.TimeSpan.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Formatter/Utf8Formatter.TimeSpan.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     break;
 
                 default:
-                    return ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryFormatThrowFormatException(out bytesWritten);
             }
 
             // First, calculate how large an output buffer is needed to hold the entire output.

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Boolean.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Boolean.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
         public static bool TryParse(ReadOnlySpan<byte> source, out bool value, out int bytesConsumed, char standardFormat = default)
         {
             if (!(standardFormat == default(char) || standardFormat == 'G' || standardFormat == 'l'))
-                return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
 
             if (source.Length >= 4)
             {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
@@ -109,7 +109,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseDateTimeG(source, out value, out _, out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 
@@ -154,7 +154,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseDateTimeG(source, out DateTime _, out value, out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Decimal.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Decimal.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     break;
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
 
             NumberBuffer number = default;

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Float.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Float.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     break;
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
 
             NumberBuffer number = default;

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Guid.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Guid.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                 case 'N':
                     return TryParseGuidN(source, out value, out bytesConsumed);
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseByteX(source, out Unsafe.As<sbyte, byte>(ref value), out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 
@@ -115,7 +115,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseUInt16X(source, out Unsafe.As<short, ushort>(ref value), out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 
@@ -161,7 +161,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseUInt32X(source, out Unsafe.As<int, uint>(ref value), out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 
@@ -207,7 +207,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseUInt64X(source, out Unsafe.As<long, ulong>(ref value), out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseByteX(source, out value, out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 
@@ -108,7 +108,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseUInt16X(source, out value, out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 
@@ -154,7 +154,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseUInt32X(source, out value, out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 
@@ -200,7 +200,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseUInt64X(source, out value, out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpan.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpan.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text
                     return TryParseTimeSpanLittleG(source, out value, out bytesConsumed);
 
                 default:
-                    return ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
+                    return global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.TryParseThrowFormatException(out value, out bytesConsumed);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Memory.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Memory.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// Memory represents a contiguous region of arbitrary memory similar to <see cref="Span{T}"/>.
@@ -66,7 +66,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
                 return; // returns default
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArrayTypeMismatchException();
 
             _object = array;
             _index = 0;
@@ -79,14 +79,14 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (array == null)
             {
                 if (start != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
                 this = default;
                 return; // returns default
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArrayTypeMismatchException();
             if ((uint)start > (uint)array.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
 
             _object = array;
             _index = start;
@@ -111,14 +111,14 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (array == null)
             {
                 if (start != 0 || length != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
                 this = default;
                 return; // returns default
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArrayTypeMismatchException();
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
 
             _object = array;
             _index = start;
@@ -141,7 +141,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             Debug.Assert(manager != null);
 
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
 
             _object = manager;
             _index = (1 << 31); // Mark as MemoryManager type
@@ -166,7 +166,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             Debug.Assert(manager != null);
 
             if (length < 0 || start < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
 
             _object = manager;
             _index = start | (1 << 31); // Mark as MemoryManager type
@@ -242,7 +242,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             int actualLength = capturedLength & RemoveFlagsBitMask;
             if ((uint)start > (uint)actualLength)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
             // It is expected for (capturedLength - start) to be negative if the memory is already pre-pinned.
@@ -265,7 +265,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             int actualLength = capturedLength & RemoveFlagsBitMask;
             if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
             }
 
             // Set the high-bit to match the this._length high bit (1 for pre-pinned, 0 for unpinned).

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryDebugView.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryDebugView.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal sealed class MemoryDebugView<T>
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.Portable.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.Portable.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace System
+namespace Datadog.Trace.VendoredMicrosoftCode.System
 {
     /// <summary>
     /// Extension methods for Span{T}, Memory{T}, and friends.

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.Portable.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.Portable.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// Extension methods for Span{T}, Memory{T}, and friends.
@@ -173,7 +173,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public static int ToLower(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
         {
             if (culture == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
 
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
@@ -213,7 +213,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public static int ToUpper(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo culture)
         {
             if (culture == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument.culture);
 
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
@@ -311,11 +311,11 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (text == null)
             {
                 if (start != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
                 return default;
             }
             if ((uint)start > (uint)text.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), StringAdjustment + start * sizeof(char), text.Length - start);
         }
@@ -336,11 +336,11 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (text == null)
             {
                 if (start != 0 || length != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
                 return default;
             }
             if ((uint)start > (uint)text.Length || (uint)length > (uint)(text.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), StringAdjustment + start * sizeof(char), length);
         }
@@ -368,11 +368,11 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (text == null)
             {
                 if (start != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
                 return default;
             }
             if ((uint)start > (uint)text.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new ReadOnlyMemory<char>(text, start, text.Length - start);
         }
@@ -390,11 +390,11 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (text == null)
             {
                 if (start != 0 || length != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
                 return default;
             }
             if ((uint)start > (uint)text.Length || (uint)length > (uint)(text.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new ReadOnlyMemory<char>(text, start, length);
         }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace System
+namespace Datadog.Trace.VendoredMicrosoftCode.System
 {
     /// <summary>
     /// Extension methods for Span{T}, Memory{T}, and friends.

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MemoryExtensions.cs
@@ -11,7 +11,7 @@ using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices;
 
-using nuint = Datadog.Trace.VendoredMicrosoftCode.System.NUInt;
+using nuint = System.NUInt;
 
 using System;
 using System.Collections;
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// Extension methods for Span{T}, Memory{T}, and friends.
@@ -838,7 +838,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public static Span<T> AsSpan<T>(this ArraySegment<T> segment, int start)
         {
             if (((uint)start) > segment.Count)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new Span<T>(segment.Array, segment.Offset + start, segment.Count - start);
         }
@@ -859,9 +859,9 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public static Span<T> AsSpan<T>(this ArraySegment<T> segment, int start, int length)
         {
             if (((uint)start) > segment.Count)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             if (((uint)length) > segment.Count - start)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
 
             return new Span<T>(segment.Array, segment.Offset + start, length);
         }
@@ -917,7 +917,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public static Memory<T> AsMemory<T>(this ArraySegment<T> segment, int start)
         {
             if (((uint)start) > segment.Count)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new Memory<T>(segment.Array, segment.Offset + start, segment.Count - start);
         }
@@ -937,9 +937,9 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public static Memory<T> AsMemory<T>(this ArraySegment<T> segment, int start, int length)
         {
             if (((uint)start) > segment.Count)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             if (((uint)length) > segment.Count - start)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
 
             return new Memory<T>(segment.Array, segment.Offset + start, length);
         }
@@ -1171,7 +1171,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
                     (uint)byteOffset > (uint)-(other.Length * Unsafe.SizeOf<T>()))
                 {
                     if ((int)byteOffset % Unsafe.SizeOf<T>() != 0)
-                        ThrowHelper.ThrowArgumentException_OverlapAlignmentMismatch();
+                        global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_OverlapAlignmentMismatch();
 
                     elementOffset = (int)byteOffset / Unsafe.SizeOf<T>();
                     return true;
@@ -1188,7 +1188,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
                     (ulong)byteOffset > (ulong)-((long)other.Length * Unsafe.SizeOf<T>()))
                 {
                     if ((long)byteOffset % Unsafe.SizeOf<T>() != 0)
-                        ThrowHelper.ThrowArgumentException_OverlapAlignmentMismatch();
+                        global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_OverlapAlignmentMismatch();
 
                     elementOffset = (int)((long)byteOffset / Unsafe.SizeOf<T>());
                     return true;
@@ -1347,7 +1347,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             where TComparer : IComparer<T>
         {
             if (comparer == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparer);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparer);
 
             var comparable = new SpanHelpers.ComparerComparable<T, TComparer>(
                 value, comparer);

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MutableDecimal.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/MutableDecimal.cs
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     //
     // Some of the Number code ported from CoreRT used internal Decimal methods that did in-place modifications on Decimal. So as to not

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/NUint.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/NUint.cs
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     //
     // A makeshift native uint type for build configurations that don't build 32/64-bit specific binaries (and hence, can't alias them to UInt32/UInt64 via an ifdef.)

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Decimal.DecCalc.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Decimal.DecCalc.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static class DecimalDecCalc
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Number.FormatAndParse.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Number.FormatAndParse.cs
@@ -25,7 +25,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static partial class Number
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Number.NumberBuffer.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Number.NumberBuffer.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     //
     // This is a port of the Number/NumberBuffer structure from CoreRT (which in turn was a C#-ized port of the NUMBER struct inside CoreCLR.)

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Number.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Number/Number.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static partial class Number
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Pinnable.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Pinnable.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     //
     // This class exists solely so that arbitrary objects can be Unsafe-casted to it to get a ref to the start of the user data.

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ReadOnlyMemory.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ReadOnlyMemory.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// Represents a contiguous region of memory, similar to <see cref="ReadOnlySpan{T}"/>.
@@ -86,12 +86,12 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (array == null)
             {
                 if (start != 0 || length != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
                 this = default;
                 return; // returns default
             }
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
 
             _object = array;
             _index = start;
@@ -164,7 +164,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             int actualLength = capturedLength & RemoveFlagsBitMask;
             if ((uint)start > (uint)actualLength)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
             // It is expected for (capturedLength - start) to be negative if the memory is already pre-pinned.
@@ -187,7 +187,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             int actualLength = _length & RemoveFlagsBitMask;
             if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
             // Set the high-bit to match the this._length high bit (1 for pre-pinned, 0 for unpinned).

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ReadOnlySpan.Portable.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ReadOnlySpan.Portable.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// ReadOnlySpan represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
@@ -70,12 +70,12 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (array == null)
             {
                 if (start != 0 || length != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
                 this = default;
                 return; // returns default
             }
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             _length = length;
             _pinnable = Unsafe.As<Pinnable<T>>(array);
@@ -101,9 +101,9 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public unsafe ReadOnlySpan(void* pointer, int length)
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             _length = length;
             _pinnable = null;
@@ -135,7 +135,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             get
             {
                 if ((uint)index >= ((uint)_length))
-                    ThrowHelper.ThrowIndexOutOfRangeException();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowIndexOutOfRangeException();
 
                 if (_pinnable == null)
                     unsafe { return ref Unsafe.Add<T>(ref Unsafe.AsRef<T>(_byteOffset.ToPointer()), index); }
@@ -175,7 +175,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public void CopyTo(Span<T> destination)
         {
             if (!TryCopyTo(destination))
-                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_DestinationTooShort();
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public ReadOnlySpan<T> Slice(int start)
         {
             if ((uint)start > (uint)_length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             IntPtr newOffset = _byteOffset.Add<T>(start);
             int length = _length - start;
@@ -271,7 +271,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public ReadOnlySpan<T> Slice(int start, int length)
         {
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             IntPtr newOffset = _byteOffset.Add<T>(start);
             return new ReadOnlySpan<T>(_pinnable, newOffset, length);

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ReadOnlySpan.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ReadOnlySpan.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// ReadOnlySpan represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Runtime/InteropServices/MemoryMarshal.Portable.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Runtime/InteropServices/MemoryMarshal.Portable.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
             where T : struct
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
 
             int newLength = checked(span.Length * Unsafe.SizeOf<T>());
             return new Span<byte>(Unsafe.As<Pinnable<byte>>(span.Pinnable), span.ByteOffset, newLength);
@@ -65,7 +65,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
             where T : struct
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
 
             int newLength = checked(span.Length * Unsafe.SizeOf<T>());
             return new ReadOnlySpan<byte>(Unsafe.As<Pinnable<byte>>(span.Pinnable), span.ByteOffset, newLength);
@@ -123,10 +123,10 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
             where TTo : struct
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
 
             if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
 
             int newLength = checked((int)((long)span.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
             return new Span<TTo>(Unsafe.As<Pinnable<TTo>>(span.Pinnable), span.ByteOffset, newLength);
@@ -148,10 +148,10 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
             where TTo : struct
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TFrom));
 
             if (SpanHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(TTo));
 
             int newLength = checked((int)((long)span.Length * Unsafe.SizeOf<TFrom>() / Unsafe.SizeOf<TTo>()));
             return new ReadOnlySpan<TTo>(Unsafe.As<Pinnable<TTo>>(span.Pinnable), span.ByteOffset, newLength);

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -156,11 +156,11 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
             if (Unsafe.SizeOf<T>() > source.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
             return Unsafe.ReadUnaligned<T>(ref GetReference(source));
         }
@@ -175,7 +175,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
             if (Unsafe.SizeOf<T>() > (uint)source.Length)
             {
@@ -195,11 +195,11 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
             if ((uint)Unsafe.SizeOf<T>() > (uint)destination.Length)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
             Unsafe.WriteUnaligned<T>(ref GetReference(destination), value);
         }
@@ -214,7 +214,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             }
             if (Unsafe.SizeOf<T>() > (uint)destination.Length)
             {
@@ -245,13 +245,13 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices
             if (array == null)
             {
                 if (start != 0 || length != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
                 return default;
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArrayTypeMismatchException();
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException();
 
             // Before using _length, check if _length < 0, then 'and' it with RemoveFlagsBitMask
             return new Memory<T>((object)array, start, length | (1 << 31));

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SequencePosition.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SequencePosition.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// Represents position in non-contiguous set of memory.

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Span.Portable.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Span.Portable.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// Span represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed
@@ -49,7 +49,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
                 return; // returns default
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArrayTypeMismatchException();
 
             _length = array.Length;
             _pinnable = Unsafe.As<Pinnable<T>>(array);
@@ -65,13 +65,13 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (array == null)
             {
                 if (start != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
                 return default;
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArrayTypeMismatchException();
             if ((uint)start > (uint)array.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             IntPtr byteOffset = SpanHelpers.PerTypeValues<T>.ArrayAdjustment.Add<T>(start);
             int length = array.Length - start;
@@ -96,14 +96,14 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             if (array == null)
             {
                 if (start != 0 || length != 0)
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
                 this = default;
                 return; // returns default
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
-                ThrowHelper.ThrowArrayTypeMismatchException();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArrayTypeMismatchException();
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             _length = length;
             _pinnable = Unsafe.As<Pinnable<T>>(array);
@@ -129,9 +129,9 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public unsafe Span(void* pointer, int length)
         {
             if (SpanHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_InvalidTypeWithPointersNotSupported(typeof(T));
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             _length = length;
             _pinnable = null;
@@ -163,7 +163,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             get
             {
                 if ((uint)index >= ((uint)_length))
-                    ThrowHelper.ThrowIndexOutOfRangeException();
+                    global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowIndexOutOfRangeException();
 
                 if (_pinnable == null)
                     unsafe { return ref Unsafe.Add<T>(ref Unsafe.AsRef<T>(_byteOffset.ToPointer()), index); }
@@ -306,7 +306,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public void CopyTo(Span<T> destination)
         {
             if (!TryCopyTo(destination))
-                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentException_DestinationTooShort();
         }
 
         /// <summary>
@@ -377,7 +377,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public Span<T> Slice(int start)
         {
             if ((uint)start > (uint)_length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             IntPtr newOffset = _byteOffset.Add<T>(start);
             int length = _length - start;
@@ -396,7 +396,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public Span<T> Slice(int start, int length)
         {
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             IntPtr newOffset = _byteOffset.Add<T>(start);
             return new Span<T>(_pinnable, newOffset, length);

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Span.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/Span.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     /// <summary>
     /// Span represents a contiguous region of arbitrary memory. Unlike arrays, it can point to either managed

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanDebugView.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanDebugView.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal sealed class SpanDebugView<T>
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.BinarySearch.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.BinarySearch.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static partial class SpanHelpers
     {
@@ -31,7 +31,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
             where TComparable : IComparable<T>
         {
             if (comparable == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparable);
+                global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument.comparable);
 
             return BinarySearch(ref MemoryMarshal.GetReference(span), span.Length, comparable);
         }

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.Byte.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.Byte.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 using Datadog.Trace.VendoredMicrosoftCode.System.Numerics;
 using System.Runtime.CompilerServices;
 
-using nuint = Datadog.Trace.VendoredMicrosoftCode.System.NUInt;
+using nuint = System.NUInt;
 
 using System;
 using System.Collections;
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static partial class SpanHelpers
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.Char.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.Char.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static partial class SpanHelpers
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.T.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.T.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static partial class SpanHelpers
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/SpanHelpers.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Datadog.Trace.VendoredMicrosoftCode.System
+namespace System
 {
     internal static partial class SpanHelpers
     {

--- a/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ThrowHelper.cs
+++ b/tracer/src/Datadog.Trace/Vendors/System.Memory/System/ThrowHelper.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         public static bool TryFormatThrowFormatException(out int bytesWritten)
         {
             bytesWritten = 0;
-            ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+            global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowFormatException_BadFormatSpecifier();
             return false;
         }
 
@@ -132,7 +132,7 @@ namespace Datadog.Trace.VendoredMicrosoftCode.System
         {
             value = default;
             bytesConsumed = 0;
-            ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+            global::Datadog.Trace.VendoredMicrosoftCode.System.ThrowHelper.ThrowFormatException_BadFormatSpecifier();
             return false;
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -243,10 +243,11 @@ public class DatadogLoggingFactoryTests
 
         // Should contain "ProgramData" or "Program Data" (for localized versions)
         // or be the fallback C:\ProgramData
-        (result.Contains("ProgramData", StringComparison.OrdinalIgnoreCase) ||
-         result.Contains("Program Data", StringComparison.OrdinalIgnoreCase) ||
+        (System.MemoryExtensions.Contains(result, "ProgramData", StringComparison.OrdinalIgnoreCase) ||
+         System.MemoryExtensions.Contains(result, "Program Data", StringComparison.OrdinalIgnoreCase) ||
          result.Equals(@"C:\ProgramData", StringComparison.OrdinalIgnoreCase))
-            .Should().BeTrue();
+           .Should()
+           .BeTrue();
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
@@ -24,7 +24,7 @@ public class TracerFlareManagerTests
     private const string ConfigPath = "/some/path";
     private readonly string _requestId = Guid.NewGuid().ToString();
     private readonly string _logsDir;
-    private readonly byte[] _validConfigBytes = """{ "task_type": "tracer_flare", "args": { "case_id": "abc123","hostname": "my.hostname", "user_handle": "its.me@datadoghq.com" } }"""u8.ToArray();
+    private readonly byte[] _validConfigBytes = Encoding.UTF8.GetBytes("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123","hostname": "my.hostname", "user_handle": "its.me@datadoghq.com" } }""");
 
     public TracerFlareManagerTests()
     {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallSite.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallSite.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
 using System.Text;
-using Datadog.Trace.ClrProfiler;
+using DatadogTrace::Datadog.Trace.ClrProfiler;
 
 namespace CallTargetNativeTest;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetBubbleUpExceptions.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetBubbleUpExceptions.cs
@@ -1,6 +1,8 @@
+extern alias DatadogTrace;
+
 using System;
 using System.Threading.Tasks;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Aliases="DatadogTrace" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Categories.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Categories.cs
@@ -1,7 +1,8 @@
+extern alias DatadogTrace;
 using System;
 using System.Text;
 using CallTargetNativeTest.NoOp;
-using Datadog.Trace.ClrProfiler;
+using DatadogTrace::Datadog.Trace.ClrProfiler;
 
 namespace CallTargetNativeTest;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/InstrumentationExceptions.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/InstrumentationExceptions.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
 using System.Threading.Tasks;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Interface.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Interface.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
 using CallTargetNativeTest.NoOp;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/CallTargetBubbleUpExceptionsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/CallTargetBubbleUpExceptionsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/CallTargetRefStructExtensions.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/CallTargetRefStructExtensions.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericOutModificationVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericOutModificationVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericRefModificationVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericRefModificationVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/InstrumentationExceptionsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/InstrumentationExceptionsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 ﻿using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsIntegration.cs
@@ -1,6 +1,7 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.DuckTyping;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.DuckTyping;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructFourParametersVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructFourParametersVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructOneParametersVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructOneParametersVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructTwoParametersVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructTwoParametersVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp;
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntOutVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntOutVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntRefModificationVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntRefModificationVoidIntegration.cs
@@ -1,5 +1,6 @@
+extern alias DatadogTrace;
 using System;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest.NoOp
 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
@@ -1,3 +1,4 @@
+extern alias DatadogTrace;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -7,8 +8,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using CallTargetNativeTest.NoOp;
-using Datadog.Trace.ClrProfiler;
-using Datadog.Trace.ClrProfiler.CallTarget;
+using DatadogTrace::Datadog.Trace.ClrProfiler;
+using DatadogTrace::Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest
 {


### PR DESCRIPTION
## Summary of changes

Updates the System.Memory vendoring code to move types like `ReadOnlySpan<T>`, `Span<T>` into `System` instead of `Datadog.Trace.VendoredMicrosoftCode.System`

## Reason for change

The compiler has various functionality that relies on the `Span<T>` (and `ReadOnlySpan<T>`) being available in the `System` namespace. By making this change, we get the advantage of those types being available. 

A separate PR will actually update code to use those types, except where changes were required to make it compile in this PR.

## Implementation details

Update the vendoring code to stop changing the namespace.

## Test coverage

This is the test, if the tests pass, we should be fine.

## Other details


Depends on a stack updating our vendored system code

- https://github.com/DataDog/dd-trace-dotnet/pull/8391
- https://github.com/DataDog/dd-trace-dotnet/pull/8454
- https://github.com/DataDog/dd-trace-dotnet/pull/8455
- https://github.com/DataDog/dd-trace-dotnet/pull/8459
- https://github.com/DataDog/dd-trace-dotnet/pull/8461
- https://github.com/DataDog/dd-trace-dotnet/pull/8469