### PR TITLE
Expand http.route tag when DD_TRACE_EXPAND_ROUTE_TEMPLATES_ENABLED is true

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -97,11 +97,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     }
 
                     string routeUrl = route?.Url;
+                    string httpRouteValue = routeUrl;
                     string areaName;
                     string controllerName;
                     string actionName;
                     if ((wasAttributeRouted || newResourceNamesEnabled) && string.IsNullOrEmpty(resourceName) && !string.IsNullOrEmpty(routeUrl))
                     {
+                        var expandRouteTemplates = newResourceNamesEnabled && tracer.Settings.ExpandRouteTemplatesEnabled;
                         resourceName = AspNetResourceNameHelper.CalculateResourceName(
                             httpMethod: httpMethod,
                             routeTemplate: routeUrl,
@@ -110,7 +112,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                             out areaName,
                             out controllerName,
                             out actionName,
-                            expandRouteTemplates: newResourceNamesEnabled && tracer.Settings.ExpandRouteTemplatesEnabled);
+                            expandRouteTemplates: expandRouteTemplates);
+
+                        // When route templates are expanded, the http.route tag should
+                        // reflect the expanded route to stay consistent with resource_name.
+                        // Extract the route path from the resource name (strip the HTTP method prefix).
+                        if (expandRouteTemplates && resourceName != null)
+                        {
+                            var spaceIndex = resourceName.IndexOf(' ');
+                            if (spaceIndex >= 0 && spaceIndex + 1 < resourceName.Length)
+                            {
+                                httpRouteValue = resourceName.Substring(spaceIndex + 1);
+                            }
+                        }
                     }
                     else
                     {
@@ -201,12 +215,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     {
                         if (string.IsNullOrEmpty(rootAspNetTags.HttpRoute))
                         {
-                            rootAspNetTags.HttpRoute = routeUrl;
+                            rootAspNetTags.HttpRoute = httpRouteValue;
                         }
                     }
                     else if (string.IsNullOrEmpty(rootspanTags.GetTag(Tags.HttpRoute)))
                     {
-                        span.Context.TraceContext?.RootSpan.Tags.SetTag(Tags.HttpRoute, routeUrl);
+                        span.Context.TraceContext?.RootSpan.Tags.SetTag(Tags.HttpRoute, httpRouteValue);
                     }
 
                     tags.SetAnalyticsSampleRate(IntegrationId, tracer.CurrentTraceSettings.Settings, enabledWithGlobalSetting: true);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -149,12 +149,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 }
 
                 string resourceName;
+                string httpRouteValue = route;
 
                 string controller = string.Empty;
                 string action = string.Empty;
                 string area = string.Empty;
                 if (route is not null && routeValues is not null)
                 {
+                    var expandRouteTemplates = newResourceNamesEnabled && tracer.Settings.ExpandRouteTemplatesEnabled;
                     resourceName = AspNetResourceNameHelper.CalculateResourceName(
                         httpMethod: method,
                         routeTemplate: route,
@@ -164,7 +166,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         out controller,
                         out action,
                         addSlashPrefix: newResourceNamesEnabled,
-                        expandRouteTemplates: newResourceNamesEnabled && tracer.Settings.ExpandRouteTemplatesEnabled);
+                        expandRouteTemplates: expandRouteTemplates);
+
+                    // When route templates are expanded, the http.route tag should
+                    // reflect the expanded route to stay consistent with resource_name.
+                    // Extract the route path from the resource name (strip the HTTP method prefix).
+                    if (expandRouteTemplates && resourceName != null)
+                    {
+                        var spaceIndex = resourceName.IndexOf(' ');
+                        if (spaceIndex >= 0 && spaceIndex + 1 < resourceName.Length)
+                        {
+                            httpRouteValue = resourceName.Substring(spaceIndex + 1);
+                        }
+                    }
                 }
                 else if (requestUri != null)
                 {
@@ -209,11 +223,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     tags.AspNetRoute = route;
                     if (span.Context.TraceContext.RootSpan.Tags is AspNetTags rootAspNetTags)
                     {
-                        rootAspNetTags.HttpRoute = route;
+                        rootAspNetTags.HttpRoute = httpRouteValue;
                     }
                     else
                     {
-                        span.Context.TraceContext.RootSpan?.SetTag(Tags.HttpRoute, route);
+                        span.Context.TraceContext.RootSpan?.SetTag(Tags.HttpRoute, httpRouteValue);
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -383,7 +383,11 @@ namespace Datadog.Trace.DiagnosticListeners
 
                     resourceName = $"{rootSpanTags.HttpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
 
-                    aspNetRoute = routeTemplate?.TemplateText.ToLowerInvariant();
+                    // When route templates are expanded, use the expanded route for http.route
+                    // to stay consistent with resource_name
+                    aspNetRoute = tracer.Settings.ExpandRouteTemplatesEnabled
+                        ? resourcePathName
+                        : routeTemplate?.TemplateText.ToLowerInvariant();
                 }
             }
 
@@ -539,7 +543,6 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 // Have to pass this value through to the MVC span, as not available there
                 var normalizedRoute = routePattern.RawText?.ToLowerInvariant();
-                trackingFeature.Route = normalizedRoute;
 
                 var request = httpContext.Request.DuckCast<HttpRequestStruct>();
                 RouteValueDictionary routeValues = request.RouteValues;
@@ -566,16 +569,23 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 var resourceName = $"{tags.HttpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
 
+                // When route templates are expanded, use the expanded route for http.route
+                // to stay consistent with resource_name
+                var routeTagValue = _tracer.Settings.ExpandRouteTemplatesEnabled
+                    ? resourcePathName
+                    : normalizedRoute;
+
                 // NOTE: We could set the controller/action/area tags on the parent span
                 // But instead we re-extract them in the MVC endpoint as these are MVC
                 // constructs. this is likely marginally less efficient, but simplifies the
                 // already complex logic in the MVC handler
+                trackingFeature.Route = routeTagValue;
                 trackingFeature.ResourceName = resourceName;
                 if (isFirstExecution)
                 {
                     // Overwrite the route in the parent span
                     rootSpan.ResourceName = resourceName;
-                    tags.AspNetCoreRoute = normalizedRoute;
+                    tags.AspNetCoreRoute = routeTagValue;
                 }
 
                 _security.CheckPathParamsAndSessionId(httpContext, rootSpan, routeValues);

--- a/tracer/test/Datadog.Trace.Tests/AspNet/AspNetResourceNameHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AspNet/AspNetResourceNameHelperTests.cs
@@ -171,6 +171,119 @@ namespace Datadog.Trace.Tests.AspNet
             using var a = new AssertionScope();
             resource.Should().Be($"{method} {expected}");
         }
+
+        /// <summary>
+        /// Verifies that when expandRouteTemplates is true, the route path extracted
+        /// from the resource name is consistent and can be used as the http.route tag value.
+        /// This is the pattern used by AspNetMvcIntegration and AspNetWebApi2Integration
+        /// to keep http.route consistent with resource_name.
+        /// </summary>
+        [Theory]
+        [InlineData("{tenantId}/{controller}/{id}", "/home/index/{id}", false, "{tenantId}/{controller}/{id}")]
+        [InlineData("{tenantId}/{controller}/{id}", "/home/index/{id}", true, "/{tenantid}/home/{id}")]
+        [InlineData("{controller}/{action}/{nonid}", "/home/index/{nonid}", false, "{controller}/{action}/{nonid}")]
+        [InlineData("{controller}/{action}/{nonid}", "/home/index/oops", true, "/home/index/oops")]
+        [InlineData("{controller}", "/home", false, "{controller}")]
+        [InlineData("{controller}", "/home", true, "/home")]
+        public void ExpandedRoute_ExtractedFromResourceName_IsConsistentWithResourceName(
+            string template, string expectedRoute, bool expandRouteTemplates, string expectedHttpRouteWhenNotExpanded)
+        {
+            const string method = "GET";
+
+            var routeValues = new RouteValueDictionary
+            {
+                { "controller", "Home" },
+                { "action", "Index" },
+                { "tenantId", "abc123" },
+                { "nonid", "oops" },
+                { "id", 42 },
+            };
+
+            var resource = AspNetResourceNameHelper.CalculateResourceName(
+                httpMethod: method,
+                routeTemplate: template,
+                routeValues: routeValues,
+                defaults: null,
+                out _,
+                out _,
+                out _,
+                expandRouteTemplates);
+
+            // Extract route from resource name (same pattern used in the integration code)
+            string httpRouteValue = template;
+            if (expandRouteTemplates && resource != null)
+            {
+                var spaceIndex = resource.IndexOf(' ');
+                if (spaceIndex >= 0 && spaceIndex + 1 < resource.Length)
+                {
+                    httpRouteValue = resource.Substring(spaceIndex + 1);
+                }
+            }
+
+            using var a = new AssertionScope();
+            resource.Should().Be($"{method} {expectedRoute}");
+
+            if (expandRouteTemplates)
+            {
+                // When expanding, http.route should match the route part of resource_name
+                httpRouteValue.Should().Be(expectedRoute,
+                    "http.route should be consistent with resource_name when expandRouteTemplates is true");
+            }
+            else
+            {
+                // When not expanding, http.route stays as the raw template
+                httpRouteValue.Should().Be(template,
+                    "http.route should remain as the raw route template when expandRouteTemplates is false");
+            }
+        }
+
+        /// <summary>
+        /// Regression test: verifies that with a generic {controller} route template,
+        /// multiple different controllers produce distinct http.route values when
+        /// expandRouteTemplates is true, preventing duplicate endpoints in the UI.
+        /// </summary>
+        [Fact]
+        public void ExpandedRoute_DifferentControllers_ProduceDifferentHttpRoutes()
+        {
+            const string method = "GET";
+            const string template = "api/{controller}/{id}";
+
+            var controllers = new[] { "users", "orders", "products", "settings" };
+            var httpRoutes = new System.Collections.Generic.HashSet<string>();
+
+            foreach (var controllerName in controllers)
+            {
+                var routeValues = new RouteValueDictionary
+                {
+                    { "controller", controllerName },
+                    { "id", 42 },
+                };
+
+                var resource = AspNetResourceNameHelper.CalculateResourceName(
+                    httpMethod: method,
+                    routeTemplate: template,
+                    routeValues: routeValues,
+                    defaults: null,
+                    out _,
+                    out _,
+                    out _,
+                    expandRouteTemplates: true);
+
+                // Extract the route from the resource name
+                var spaceIndex = resource.IndexOf(' ');
+                var httpRouteValue = resource.Substring(spaceIndex + 1);
+
+                httpRoutes.Add(httpRouteValue);
+
+                // Each controller should produce a unique route containing the controller name
+                httpRouteValue.Should().Contain(controllerName,
+                    $"http.route should contain the expanded controller name '{controllerName}'");
+            }
+
+            // All routes should be distinct (no duplicates)
+            httpRoutes.Should().HaveCount(controllers.Length,
+                "each controller should produce a distinct http.route value");
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
NOTE: This is coming from Tahir's PR which is from a fork: https://github.com/DataDog/dd-trace-dotnet/pull/8320
Making this not from a fork to help reduce turn around time on this

- When `DD_TRACE_EXPAND_ROUTE_TEMPLATES_ENABLED=true`, the `http.route` span tag now reflects the expanded route template, consistent with `resource_name`
- Previously, `resource_name` was expanded (e.g., `GET /api/users/{id}`) but `http.route` retained the raw template (e.g., `api/{controller}/{id}`), causing the Datadog endpoints page to show duplicate entries
- Fix covers ASP.NET MVC, Web API 2 (.NET Framework), and ASP.NET Core (both endpoint and non-endpoint routing)

## Changes

- **`AspNetMvcIntegration.cs`**: Extract expanded route from computed resource name and use it for `HttpRoute` tag
- **`AspNetWebApi2Integration.cs`**: Same pattern as MVC integration
- **`AspNetCoreDiagnosticObserver.cs`**: Use `resourcePathName` (already expanded by `SimplifyRoutePattern`) for `AspNetCoreRoute`/`trackingFeature.Route` instead of raw template text
- **`AspNetResourceNameHelperTests.cs`**: Added tests verifying expanded route extraction is consistent with resource name, and that different controllers produce distinct http.route values

## Test plan

- [x] Unit tests added for route expansion consistency
- [x] Regression test: multiple controllers sharing a `{controller}` template produce distinct `http.route` values when expand is enabled
- [ ] Verify existing `CalculateResourceName` tests still pass (no behavioral change when `expandRouteTemplates=false`)
- [ ] Integration test with ASP.NET MVC app using generic `{controller}` routes

Fixes #8319

🤖 Generated with [Claude Code](https://claude.com/claude-code)