### PR TITLE
[Debugger] Add global rate limiter

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -282,7 +282,6 @@ src/Datadog.Trace/Debugger/PInvoke/ProbeStatus.cs
 src/Datadog.Trace/Debugger/ProbeStatuses/FetchProbeStatus.cs
 src/Datadog.Trace/Debugger/ProbeStatuses/IProbeStatusPoller.cs
 src/Datadog.Trace/Debugger/ProbeStatuses/ProbeStatusPoller.cs
-src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
 src/Datadog.Trace/Debugger/RateLimiting/AtomicInt64.cs
 src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
 src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
 
@@ -20,20 +21,35 @@ namespace Datadog.Trace.Debugger.Configurations
         private readonly string? _env;
         private readonly string? _version;
         private readonly int _maxProbesPerType;
+        private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
 
         private ProbeConfiguration _currentConfiguration;
 
-        private ConfigurationUpdater(string? env, string? version, int maxProbesPerType)
+        private ConfigurationUpdater(string? env, string? version, int maxProbesPerType, IDebuggerGlobalRateLimiter? globalRateLimiter)
         {
             _env = env;
             _version = version;
             _maxProbesPerType = maxProbesPerType;
+            _globalRateLimiter = globalRateLimiter ?? DebuggerGlobalRateLimiter.Instance;
             _currentConfiguration = new ProbeConfiguration();
         }
 
-        public static ConfigurationUpdater Create(string? environment, string? serviceVersion, int maxProbesPerType)
+        public static ConfigurationUpdater Create(string? environment, string? serviceVersion, int maxProbesPerType, IDebuggerGlobalRateLimiter? globalRateLimiter = null)
         {
-            return new ConfigurationUpdater(environment, serviceVersion, maxProbesPerType);
+            return new ConfigurationUpdater(environment, serviceVersion, maxProbesPerType, globalRateLimiter);
+        }
+
+        private static bool IsProbeConfigurationPath(RemoteConfigurationPath path)
+        {
+            return path.Id.StartsWith(DefinitionPaths.LogProbe)
+                || path.Id.StartsWith(DefinitionPaths.MetricProbe)
+                || path.Id.StartsWith(DefinitionPaths.SpanProbe)
+                || path.Id.StartsWith(DefinitionPaths.SpanDecorationProbe);
+        }
+
+        private static bool IsServiceConfigurationPath(RemoteConfigurationPath path)
+        {
+            return path.Id.StartsWith(DefinitionPaths.ServiceConfiguration);
         }
 
         public List<UpdateResult> AcceptAdded(ProbeConfiguration configuration)
@@ -49,7 +65,7 @@ namespace Datadog.Trace.Debugger.Configurations
 
             if (comparer.HasRateLimitChanged)
             {
-                HandleRateLimitChanged(comparer);
+                HandleRateLimitChanged(filteredConfiguration);
             }
 
             _currentConfiguration = configuration;
@@ -61,7 +77,17 @@ namespace Datadog.Trace.Debugger.Configurations
         {
             try
             {
-                HandleRemovedProbesChanges(paths);
+                if (paths.Any(IsServiceConfigurationPath))
+                {
+                    _currentConfiguration.ServiceConfiguration = null;
+                    _globalRateLimiter.ResetRate();
+                }
+
+                var probePaths = paths.Where(IsProbeConfigurationPath).ToList();
+                if (probePaths.Count > 0)
+                {
+                    HandleRemovedProbesChanges(probePaths);
+                }
             }
             catch (Exception ex)
             {
@@ -127,9 +153,9 @@ namespace Datadog.Trace.Debugger.Configurations
             DebuggerManager.Instance.DynamicInstrumentation?.UpdateRemovedProbeInstrumentations(paths);
         }
 
-        private void HandleRateLimitChanged(ProbeConfigurationComparer comparer)
+        private void HandleRateLimitChanged(ProbeConfiguration configuration)
         {
-            // todo handle rate limited changes
+            _globalRateLimiter.SetRate(configuration.ServiceConfiguration?.Sampling?.SnapshotsPerSecond);
         }
 
         internal sealed record UpdateResult(string Id, string? Error);

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
 
@@ -20,6 +21,7 @@ namespace Datadog.Trace.Debugger.Configurations
         private readonly string? _env;
         private readonly string? _version;
         private readonly int _maxProbesPerType;
+        private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
         private readonly HashSet<string> _removedRcmProbeIds = new();
         private Func<IReadOnlyList<ProbeDefinition>, List<UpdateResult>>? _handleAddedProbesChanges;
         private Action<string[]>? _handleRemovedProbesChanges;
@@ -28,18 +30,19 @@ namespace Datadog.Trace.Debugger.Configurations
         private ProbeConfiguration? _fileConfiguration;
         private ProbeConfiguration _rcmConfiguration;
 
-        private ConfigurationUpdater(string? env, string? version, int maxProbesPerType)
+        private ConfigurationUpdater(string? env, string? version, int maxProbesPerType, IDebuggerGlobalRateLimiter? globalRateLimiter)
         {
             _env = env;
             _version = version;
             _maxProbesPerType = maxProbesPerType;
+            _globalRateLimiter = globalRateLimiter ?? DebuggerGlobalRateLimiter.Instance;
             _currentConfiguration = new ProbeConfiguration();
             _rcmConfiguration = new ProbeConfiguration();
         }
 
-        public static ConfigurationUpdater Create(string? environment, string? serviceVersion, int maxProbesPerType)
+        public static ConfigurationUpdater Create(string? environment, string? serviceVersion, int maxProbesPerType, IDebuggerGlobalRateLimiter? globalRateLimiter = null)
         {
-            return new ConfigurationUpdater(environment, serviceVersion, maxProbesPerType);
+            return new ConfigurationUpdater(environment, serviceVersion, maxProbesPerType, globalRateLimiter);
         }
 
         public void SetProbeInstrumentationHandlers(Func<IReadOnlyList<ProbeDefinition>, List<UpdateResult>> handleAddedProbesChanges, Action<string[]> handleRemovedProbesChanges)
@@ -108,7 +111,7 @@ namespace Datadog.Trace.Debugger.Configurations
 
             if (comparer.HasRateLimitChanged)
             {
-                HandleRateLimitChanged(comparer);
+                HandleRateLimitChanged(filteredConfiguration);
             }
 
             _currentConfiguration = filteredConfiguration;
@@ -195,9 +198,9 @@ namespace Datadog.Trace.Debugger.Configurations
             _handleRemovedProbesChanges?.Invoke(probeIds);
         }
 
-        private void HandleRateLimitChanged(ProbeConfigurationComparer comparer)
+        private void HandleRateLimitChanged(ProbeConfiguration configuration)
         {
-            // todo handle rate limited changes
+            _globalRateLimiter.SetRate(configuration.ServiceConfiguration?.Sampling?.SnapshotsPerSecond);
         }
 
         internal sealed record UpdateResult(string Id, string? Error);

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ConfigurationUpdater.cs
@@ -104,14 +104,15 @@ namespace Datadog.Trace.Debugger.Configurations
             var filteredConfiguration = ApplyConfigurationFilters(GetEffectiveConfiguration());
             var comparer = new ProbeConfigurationComparer(_currentConfiguration, filteredConfiguration);
 
-            if (comparer.HasProbeRelatedChanges)
-            {
-                result = HandleAddedProbesChanges(comparer);
-            }
-
+            // Apply the global limiter before making new probes live.
             if (comparer.HasRateLimitChanged)
             {
                 HandleRateLimitChanged(filteredConfiguration);
+            }
+
+            if (comparer.HasProbeRelatedChanges)
+            {
+                result = HandleAddedProbesChanges(comparer);
             }
 
             _currentConfiguration = filteredConfiguration;

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationComparer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/ProbeConfigurationComparer.cs
@@ -33,8 +33,7 @@ namespace Datadog.Trace.Debugger.Configurations
 
             HasProbeRelatedChanges = AddedDefinitions.Any() || isFilteredListChanged;
             HasRateLimitChanged =
-                (!currentConfiguration.ServiceConfiguration?.Sampling?.Equals(incomingConfiguration.ServiceConfiguration?.Sampling) ?? incomingConfiguration.ServiceConfiguration?.Sampling != null)
-             || HasProbeRelatedChanges;
+                (!currentConfiguration.ServiceConfiguration?.Sampling?.Equals(incomingConfiguration.ServiceConfiguration?.Sampling) ?? incomingConfiguration.ServiceConfiguration?.Sampling != null);
         }
 
         public IReadOnlyList<ProbeDefinition> AddedDefinitions { get; }

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.ProbeStatuses;
+using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Debugger.Symbols;
@@ -29,6 +30,7 @@ internal sealed class DebuggerFactory
 
     internal static DynamicInstrumentation CreateDynamicInstrumentation(IDiscoveryService discoveryService, IRcmSubscriptionManager remoteConfigurationManager, TracerSettings tracerSettings, Func<string> serviceNameProvider, DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider)
     {
+        var globalRateLimiter = DebuggerGlobalRateLimiter.Instance;
         var snapshotSlicer = SnapshotSlicer.Create(debuggerSettings);
         var snapshotSink = SnapshotSink.Create(debuggerSettings, snapshotSlicer);
         var logSink = SnapshotSink.Create(debuggerSettings, snapshotSlicer);
@@ -39,7 +41,7 @@ internal sealed class DebuggerFactory
         var diagnosticsUploader = CreateDiagnosticsUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, true), diagnosticsSink);
         var lineProbeResolver = LineProbeResolver.Create(debuggerSettings.ThirdPartyDetectionExcludes, debuggerSettings.ThirdPartyDetectionIncludes);
         var probeStatusPoller = ProbeStatusPoller.Create(diagnosticsSink, debuggerSettings);
-        var configurationUpdater = ConfigurationUpdater.Create(tracerSettings.Manager.InitialMutableSettings.Environment, tracerSettings.Manager.InitialMutableSettings.ServiceVersion, debuggerSettings.MaxProbesPerType);
+        var configurationUpdater = ConfigurationUpdater.Create(tracerSettings.Manager.InitialMutableSettings.Environment, tracerSettings.Manager.InitialMutableSettings.ServiceVersion, debuggerSettings.MaxProbesPerType, globalRateLimiter);
 
         var statsd = GetDogStatsd(tracerSettings);
 
@@ -53,7 +55,8 @@ internal sealed class DebuggerFactory
             diagnosticsUploader: diagnosticsUploader,
             probeStatusPoller: probeStatusPoller,
             configurationUpdater: configurationUpdater,
-            dogStats: statsd);
+            dogStats: statsd,
+            globalRateLimiter: globalRateLimiter);
     }
 
     private static IDogStatsd GetDogStatsd(TracerSettings tracerSettings)

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.ExceptionAutoInstrumentation;
 using Datadog.Trace.Debugger.Helpers;
+using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Debugger.Symbols;
@@ -851,6 +852,7 @@ namespace Datadog.Trace.Debugger
                         .Add(Volatile.Read(ref _symDbRemoteConfig))
                         .Add(_dynamicInstrumentation)
                         .Add(ExceptionReplay)
+                        .Execute(DebuggerGlobalRateLimiter.TryDisposeInstance, "disposing global debugger rate limiter")
                         .DisposeAll();
         }
     }

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -47,6 +47,7 @@ namespace Datadog.Trace.Debugger
         private readonly ConfigurationUpdater _configurationUpdater;
         private readonly IDogStatsd _dogStats;
         private readonly DebuggerSettings _settings;
+        private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
         private readonly object _instanceLock = new();
         private int _disposeState;
 
@@ -60,7 +61,8 @@ namespace Datadog.Trace.Debugger
             IDebuggerUploader diagnosticsUploader,
             IProbeStatusPoller probeStatusPoller,
             ConfigurationUpdater configurationUpdater,
-            IDogStatsd dogStats)
+            IDogStatsd dogStats,
+            IDebuggerGlobalRateLimiter? globalRateLimiter = null)
         {
             Log.Information("Initializing Dynamic Instrumentation");
             _settings = settings;
@@ -74,7 +76,9 @@ namespace Datadog.Trace.Debugger
             _subscriptionManager = remoteConfigurationManager;
             _configurationUpdater = configurationUpdater;
             _dogStats = dogStats;
+            _globalRateLimiter = globalRateLimiter ?? DebuggerGlobalRateLimiter.Instance;
             _unboundProbes = new List<ProbeDefinition>();
+            _globalRateLimiter.ResetRate();
             _subscription = new Subscription(
                 (updates, removals) =>
                 {
@@ -744,6 +748,7 @@ namespace Datadog.Trace.Debugger
             // On master, _dogStats was disposed via SafeDisposal.Add() which called sync
             // Dispose() — itself fire-and-forget internally via Task.Run().
             _dogStats?.DisposeAsync().ContinueWith(t => Log.Error(t.Exception, "Error waiting for StatsD disposal"), TaskContinuationOptions.OnlyOnFaulted);
+            _globalRateLimiter.Dispose();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Debugger
             _unboundProbes = new List<ProbeDefinition>();
             _lastReportedUnboundProbeErrors = new Dictionary<string, LineProbeResolveErrorKey>();
 			_globalRateLimiter = globalRateLimiter ?? DebuggerGlobalRateLimiter.Instance;
-			_globalRateLimiter.ResetRate();
+			_globalRateLimiter.Initialize();
             _subscription = new Subscription(
                 (updates, removals) =>
                 {
@@ -233,6 +233,11 @@ namespace Datadog.Trace.Debugger
 
             lock (_instanceLock)
             {
+                if (IsDisposed)
+                {
+                    return [];
+                }
+
                 if (addedProbes.Count == 0)
                 {
                     return [];
@@ -241,108 +246,105 @@ namespace Datadog.Trace.Debugger
                 Log.Information<int>("Dynamic Instrumentation.InstrumentProbes: Request to instrument {Count} probes definitions", addedProbes.Count);
                 var result = new List<ConfigurationUpdater.UpdateResult>(addedProbes.Count);
 
-                lock (_instanceLock)
+                var methodProbes = new List<NativeMethodProbeDefinition>();
+                var lineProbes = new List<NativeLineProbeDefinition>();
+                var spanProbes = new List<NativeSpanProbeDefinition>();
+
+                var fetchProbeStatus = new List<FetchProbeStatus>();
+                var lineProbeDiagnosticLevel = Log.IsEnabled(LogEventLevel.Debug) ? LineProbeDiagnosticLevel.Full : LineProbeDiagnosticLevel.Minimal;
+
+                foreach (var addedProbe in addedProbes)
                 {
-                    var methodProbes = new List<NativeMethodProbeDefinition>();
-                    var lineProbes = new List<NativeLineProbeDefinition>();
-                    var spanProbes = new List<NativeSpanProbeDefinition>();
-
-                    var fetchProbeStatus = new List<FetchProbeStatus>();
-                    var lineProbeDiagnosticLevel = Log.IsEnabled(LogEventLevel.Debug) ? LineProbeDiagnosticLevel.Full : LineProbeDiagnosticLevel.Minimal;
-
-                    foreach (var addedProbe in addedProbes)
+                    try
                     {
-                        try
+                        switch (GetProbeLocationType(addedProbe))
                         {
-                            switch (GetProbeLocationType(addedProbe))
-                            {
-                                case ProbeLocationType.Line:
-                                    {
-                                        var lineProbeResult = _lineProbeResolver.TryResolveLineProbe(addedProbe, out var location, lineProbeDiagnosticLevel);
-                                        var status = lineProbeResult.Status;
+                            case ProbeLocationType.Line:
+                                {
+                                    var lineProbeResult = _lineProbeResolver.TryResolveLineProbe(addedProbe, out var location, lineProbeDiagnosticLevel);
+                                    var status = lineProbeResult.Status;
 
-                                        LogLineProbeResolution(addedProbe.Id, lineProbeResult, "initial resolution");
-                                        switch (status)
-                                        {
-                                            case LiveProbeResolveStatus.Bound:
-                                                lineProbes.Add(new NativeLineProbeDefinition(location!.ProbeDefinition.Id, location.Mvid, location.MethodToken, (int)location.BytecodeOffset, location.LineNumber, location.ProbeDefinition.Where.SourceFile));
-                                                fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0));
+                                    LogLineProbeResolution(addedProbe.Id, lineProbeResult, "initial resolution");
+                                    switch (status)
+                                    {
+                                        case LiveProbeResolveStatus.Bound:
+                                            lineProbes.Add(new NativeLineProbeDefinition(location!.ProbeDefinition.Id, location.Mvid, location.MethodToken, (int)location.BytecodeOffset, location.LineNumber, location.ProbeDefinition.Where.SourceFile));
+                                            fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0));
                                                 _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
-                                                ProbeExpressionsProcessor.Instance.AddProbeProcessor(addedProbe);
-                                                SetRateLimit(addedProbe);
-                                                break;
-                                            case LiveProbeResolveStatus.Unbound:
+                                            ProbeExpressionsProcessor.Instance.AddProbeProcessor(addedProbe);
+                                            SetRateLimit(addedProbe);
+                                            break;
+                                        case LiveProbeResolveStatus.Unbound:
                                                 // Unbound line probes remain retryable on future assembly loads. Some retryable
                                                 // outcomes are still reported as ERROR so the backend can show actionable user
                                                 // feedback while the tracer keeps looking for a later exact/unique match.
                                                 Log.Information("ProbeID {ProbeID} is unbound. It will be retried when new assemblies are loaded.", addedProbe.Id);
-                                                _unboundProbes.Add(addedProbe);
+                                            _unboundProbes.Add(addedProbe);
                                                 var unboundProbeStatus = lineProbeResult.ReportError
                                                                              ? new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: GetLineProbeResolveMessage(lineProbeResult))
                                                                              : new ProbeStatus(addedProbe.Id, Sink.Models.Status.RECEIVED, errorMessage: null);
                                                 UpdateLastReportedUnboundProbeError(addedProbe.Id, lineProbeResult);
                                                 fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, unboundProbeStatus));
-                                                break;
-                                            case LiveProbeResolveStatus.Error:
-                                                Log.Warning("ProbeID {ProbeID} error resolving live. Error: {Error}", addedProbe.Id, lineProbeResult.Message);
+                                            break;
+                                        case LiveProbeResolveStatus.Error:
+                                            Log.Warning("ProbeID {ProbeID} error resolving live. Error: {Error}", addedProbe.Id, lineProbeResult.Message);
                                                 _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
-                                                fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: lineProbeResult.Message)));
-                                                break;
-                                        }
-
-                                        break;
+                                            fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: lineProbeResult.Message)));
+                                            break;
                                     }
 
-                                case ProbeLocationType.Method:
-                                    {
-                                        var signature = SignatureParser.TryParse(addedProbe.Where.Signature, out var s) ? s : null;
-
-                                        fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0));
-                                        if (addedProbe is SpanProbe)
-                                        {
-                                            var spanDefinition = new NativeSpanProbeDefinition(addedProbe.Id, addedProbe.Where.TypeName, addedProbe.Where.MethodName, signature);
-                                            spanProbes.Add(spanDefinition);
-                                        }
-                                        else
-                                        {
-                                            var nativeDefinition = new NativeMethodProbeDefinition(addedProbe.Id, addedProbe.Where.TypeName, addedProbe.Where.MethodName, signature);
-                                            methodProbes.Add(nativeDefinition);
-                                            ProbeExpressionsProcessor.Instance.AddProbeProcessor(addedProbe);
-                                            SetRateLimit(addedProbe);
-                                        }
-
-                                        break;
-                                    }
-
-                                case ProbeLocationType.Unrecognized:
-                                    fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: "Unknown probe type")));
-                                    result.Add(new ConfigurationUpdater.UpdateResult(addedProbe.Id, "Unknown probe type"));
                                     break;
-                            }
+                                }
 
-                            result.Add(new ConfigurationUpdater.UpdateResult(addedProbe.Id, null));
+                            case ProbeLocationType.Method:
+                                {
+                                    var signature = SignatureParser.TryParse(addedProbe.Where.Signature, out var s) ? s : null;
+
+                                    fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0));
+                                    if (addedProbe is SpanProbe)
+                                    {
+                                        var spanDefinition = new NativeSpanProbeDefinition(addedProbe.Id, addedProbe.Where.TypeName, addedProbe.Where.MethodName, signature);
+                                        spanProbes.Add(spanDefinition);
+                                    }
+                                    else
+                                    {
+                                        var nativeDefinition = new NativeMethodProbeDefinition(addedProbe.Id, addedProbe.Where.TypeName, addedProbe.Where.MethodName, signature);
+                                        methodProbes.Add(nativeDefinition);
+                                        ProbeExpressionsProcessor.Instance.AddProbeProcessor(addedProbe);
+                                        SetRateLimit(addedProbe);
+                                    }
+
+                                    break;
+                                }
+
+                            case ProbeLocationType.Unrecognized:
+                                fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: "Unknown probe type")));
+                                result.Add(new ConfigurationUpdater.UpdateResult(addedProbe.Id, "Unknown probe type"));
+                                break;
                         }
-                        catch (Exception e)
-                        {
-                            result.Add(new ConfigurationUpdater.UpdateResult(addedProbe.Id, e.Message));
-                        }
+
+                        result.Add(new ConfigurationUpdater.UpdateResult(addedProbe.Id, null));
                     }
-
-                    using var disposableMethodProbes = new DisposableEnumerable<NativeMethodProbeDefinition>(methodProbes);
-                    using var disposableSpanProbes = new DisposableEnumerable<NativeSpanProbeDefinition>(spanProbes);
-                    if (methodProbes.Count != 0 || lineProbes.Count != 0 || spanProbes.Count != 0)
+                    catch (Exception e)
                     {
-                        _instrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
+                        result.Add(new ConfigurationUpdater.UpdateResult(addedProbe.Id, e.Message));
                     }
-
-                    var probeIds = fetchProbeStatus.Select(fp => fp.ProbeId).ToArray();
-                    _probeStatusPoller.UpdateProbes(probeIds, fetchProbeStatus.ToArray());
-
-                    // This log entry is being checked in integration test
-                    Log.Information("Dynamic Instrumentation.InstrumentProbes: Request to instrument added probes definitions completed.");
-
-                    return result;
                 }
+
+                using var disposableMethodProbes = new DisposableEnumerable<NativeMethodProbeDefinition>(methodProbes);
+                using var disposableSpanProbes = new DisposableEnumerable<NativeSpanProbeDefinition>(spanProbes);
+                if (methodProbes.Count != 0 || lineProbes.Count != 0 || spanProbes.Count != 0)
+                {
+                        _instrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
+                }
+
+                var probeIds = fetchProbeStatus.Select(fp => fp.ProbeId).ToArray();
+                _probeStatusPoller.UpdateProbes(probeIds, fetchProbeStatus.ToArray());
+
+                // This log entry is being checked in integration test
+                Log.Information("Dynamic Instrumentation.InstrumentProbes: Request to instrument added probes definitions completed.");
+
+                return result;
             }
         }
 
@@ -430,6 +432,11 @@ namespace Datadog.Trace.Debugger
 
             lock (_instanceLock)
             {
+                if (IsDisposed)
+                {
+                    return;
+                }
+
                 var boundedProbes = _probeStatusPoller.GetBoundedProbes();
                 var probesToRemoveFromNative = new List<string>();
                 _probeStatusPoller.RemoveProbes(removedProbesIds);
@@ -571,6 +578,11 @@ namespace Datadog.Trace.Debugger
             // A new assembly was loaded, so re-examine whether the probe can now be resolved.
             lock (_instanceLock)
             {
+				if (IsDisposed)
+                {
+                    return;
+                }
+				
                 if (_unboundProbes.Count == 0)
                 {
                     return;
@@ -670,7 +682,7 @@ namespace Datadog.Trace.Debugger
 
         private ApplyDetails[] AcceptAddedConfiguration(List<RemoteConfiguration>? configs)
         {
-            if (configs == null)
+            if (configs == null || IsDisposed)
             {
                 return [];
             }
@@ -749,7 +761,17 @@ namespace Datadog.Trace.Debugger
 
             try
             {
-                var updateResults = _configurationUpdater.AcceptAdded(rcmUpdate);
+                List<ConfigurationUpdater.UpdateResult> updateResults;
+                lock (_instanceLock)
+                {
+                    if (IsDisposed)
+                    {
+                        return [];
+                    }
+
+                    updateResults = _configurationUpdater.AcceptAdded(rcmUpdate);
+                }
+
                 foreach (var updateResult in updateResults)
                 {
                     var config = configs.FirstOrDefault(c => ProbeConfigurationUtils.IsProbeId(c.Path, updateResult.Id));
@@ -772,12 +794,20 @@ namespace Datadog.Trace.Debugger
 
         private void AcceptRemovedConfiguration(List<RemoteConfigurationPath>? paths)
         {
-            if (paths == null)
+            if (paths == null || IsDisposed)
             {
                 return;
             }
 
-            _configurationUpdater.AcceptRemoved(paths);
+            lock (_instanceLock)
+            {
+                if (IsDisposed)
+                {
+                    return;
+                }
+
+                _configurationUpdater.AcceptRemoved(paths);
+            }
         }
 
         internal void AddSnapshot(ProbeInfo probe, string snapshot)
@@ -915,18 +945,22 @@ namespace Datadog.Trace.Debugger
 
             _processExit.TrySetResult(true);
             AppDomain.CurrentDomain.AssemblyLoad -= CheckUnboundProbes;
-            SafeDisposal.New()
-                        .Execute(() => _subscriptionManager.Unsubscribe(_subscription), "unsubscribing from RCM")
-                        .Add(_snapshotUploader)
-                        .Add(_diagnosticsUploader)
-                        .Add(_probeStatusPoller)
-                        .DisposeAll();
+            lock (_instanceLock)
+            {
+                SafeDisposal.New()
+                            .Execute(() => _subscriptionManager.Unsubscribe(_subscription), "unsubscribing from RCM")
+                            .Add(_snapshotUploader)
+                            .Add(_logUploader)
+                            .Add(_diagnosticsUploader)
+                            .Add(_probeStatusPoller)
+                            .DisposeAll();
+                _globalRateLimiter.Dispose();
+            }
 
             // Cannot await here because Dispose() is synchronous and callers hold locks.
             // On master, _dogStats was disposed via SafeDisposal.Add() which called sync
             // Dispose() — itself fire-and-forget internally via Task.Run().
             _dogStats?.DisposeAsync().ContinueWith(t => Log.Error(t.Exception, "Error waiting for StatsD disposal"), TaskContinuationOptions.OnlyOnFaulted);
-            _globalRateLimiter.Dispose();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -54,7 +54,8 @@ namespace Datadog.Trace.Debugger
         private readonly ConfigurationUpdater _configurationUpdater;
         private readonly IDogStatsd _dogStats;
         private readonly DebuggerSettings _settings;
-        private readonly NativeProbeInstrumentationRequester _instrumentProbes;
+        private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
+		private readonly NativeProbeInstrumentationRequester _instrumentProbes;
         private readonly object _instanceLock = new();
         private int _disposeState;
         private int _initializationState;
@@ -71,7 +72,8 @@ namespace Datadog.Trace.Debugger
             IProbeStatusPoller probeStatusPoller,
             ConfigurationUpdater configurationUpdater,
             IDogStatsd dogStats,
-            NativeProbeInstrumentationRequester? instrumentProbes = null)
+            IDebuggerGlobalRateLimiter? globalRateLimiter = null,
+			NativeProbeInstrumentationRequester? instrumentProbes = null)
         {
             Log.Information("Initializing Dynamic Instrumentation");
             _settings = settings;
@@ -89,6 +91,8 @@ namespace Datadog.Trace.Debugger
             _instrumentProbes = instrumentProbes ?? DebuggerNativeMethods.InstrumentProbes;
             _unboundProbes = new List<ProbeDefinition>();
             _lastReportedUnboundProbeErrors = new Dictionary<string, LineProbeResolveErrorKey>();
+			_globalRateLimiter = globalRateLimiter ?? DebuggerGlobalRateLimiter.Instance;
+			_globalRateLimiter.ResetRate();
             _subscription = new Subscription(
                 (updates, removals) =>
                 {
@@ -922,6 +926,7 @@ namespace Datadog.Trace.Debugger
             // On master, _dogStats was disposed via SafeDisposal.Add() which called sync
             // Dispose() — itself fire-and-forget internally via Task.Run().
             _dogStats?.DisposeAsync().ContinueWith(t => Log.Error(t.Exception, "Error waiting for StatsD disposal"), TaskContinuationOptions.OnlyOnFaulted);
+            _globalRateLimiter.Dispose();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -54,8 +54,7 @@ namespace Datadog.Trace.Debugger
         private readonly ConfigurationUpdater _configurationUpdater;
         private readonly IDogStatsd _dogStats;
         private readonly DebuggerSettings _settings;
-        private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
-		private readonly NativeProbeInstrumentationRequester _instrumentProbes;
+        private readonly NativeProbeInstrumentationRequester _instrumentProbes;
         private readonly object _instanceLock = new();
         private int _disposeState;
         private int _initializationState;
@@ -73,7 +72,7 @@ namespace Datadog.Trace.Debugger
             ConfigurationUpdater configurationUpdater,
             IDogStatsd dogStats,
             IDebuggerGlobalRateLimiter? globalRateLimiter = null,
-			NativeProbeInstrumentationRequester? instrumentProbes = null)
+            NativeProbeInstrumentationRequester? instrumentProbes = null)
         {
             Log.Information("Initializing Dynamic Instrumentation");
             _settings = settings;
@@ -91,8 +90,7 @@ namespace Datadog.Trace.Debugger
             _instrumentProbes = instrumentProbes ?? DebuggerNativeMethods.InstrumentProbes;
             _unboundProbes = new List<ProbeDefinition>();
             _lastReportedUnboundProbeErrors = new Dictionary<string, LineProbeResolveErrorKey>();
-			_globalRateLimiter = globalRateLimiter ?? DebuggerGlobalRateLimiter.Instance;
-			_globalRateLimiter.Initialize();
+            (globalRateLimiter ?? DebuggerGlobalRateLimiter.Instance).Initialize();
             _subscription = new Subscription(
                 (updates, removals) =>
                 {
@@ -270,25 +268,25 @@ namespace Datadog.Trace.Debugger
                                         case LiveProbeResolveStatus.Bound:
                                             lineProbes.Add(new NativeLineProbeDefinition(location!.ProbeDefinition.Id, location.Mvid, location.MethodToken, (int)location.BytecodeOffset, location.LineNumber, location.ProbeDefinition.Where.SourceFile));
                                             fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0));
-                                                _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
+                                            _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
                                             ProbeExpressionsProcessor.Instance.AddProbeProcessor(addedProbe);
                                             SetRateLimit(addedProbe);
                                             break;
                                         case LiveProbeResolveStatus.Unbound:
-                                                // Unbound line probes remain retryable on future assembly loads. Some retryable
-                                                // outcomes are still reported as ERROR so the backend can show actionable user
-                                                // feedback while the tracer keeps looking for a later exact/unique match.
-                                                Log.Information("ProbeID {ProbeID} is unbound. It will be retried when new assemblies are loaded.", addedProbe.Id);
+                                            // Unbound line probes remain retryable on future assembly loads. Some retryable
+                                            // outcomes are still reported as ERROR so the backend can show actionable user
+                                            // feedback while the tracer keeps looking for a later exact/unique match.
+                                            Log.Information("ProbeID {ProbeID} is unbound. It will be retried when new assemblies are loaded.", addedProbe.Id);
                                             _unboundProbes.Add(addedProbe);
-                                                var unboundProbeStatus = lineProbeResult.ReportError
-                                                                             ? new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: GetLineProbeResolveMessage(lineProbeResult))
-                                                                             : new ProbeStatus(addedProbe.Id, Sink.Models.Status.RECEIVED, errorMessage: null);
-                                                UpdateLastReportedUnboundProbeError(addedProbe.Id, lineProbeResult);
-                                                fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, unboundProbeStatus));
+                                            var unboundProbeStatus = lineProbeResult.ReportError
+                                                                         ? new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: GetLineProbeResolveMessage(lineProbeResult))
+                                                                         : new ProbeStatus(addedProbe.Id, Sink.Models.Status.RECEIVED, errorMessage: null);
+                                            UpdateLastReportedUnboundProbeError(addedProbe.Id, lineProbeResult);
+                                            fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, unboundProbeStatus));
                                             break;
                                         case LiveProbeResolveStatus.Error:
                                             Log.Warning("ProbeID {ProbeID} error resolving live. Error: {Error}", addedProbe.Id, lineProbeResult.Message);
-                                                _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
+                                            _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
                                             fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: lineProbeResult.Message)));
                                             break;
                                     }
@@ -335,7 +333,7 @@ namespace Datadog.Trace.Debugger
                 using var disposableSpanProbes = new DisposableEnumerable<NativeSpanProbeDefinition>(spanProbes);
                 if (methodProbes.Count != 0 || lineProbes.Count != 0 || spanProbes.Count != 0)
                 {
-                        _instrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
+                    _instrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
                 }
 
                 var probeIds = fetchProbeStatus.Select(fp => fp.ProbeId).ToArray();
@@ -578,11 +576,11 @@ namespace Datadog.Trace.Debugger
             // A new assembly was loaded, so re-examine whether the probe can now be resolved.
             lock (_instanceLock)
             {
-				if (IsDisposed)
+                if (IsDisposed)
                 {
                     return;
                 }
-				
+
                 if (_unboundProbes.Count == 0)
                 {
                     return;
@@ -954,7 +952,6 @@ namespace Datadog.Trace.Debugger
                             .Add(_diagnosticsUploader)
                             .Add(_probeStatusPoller)
                             .DisposeAll();
-                _globalRateLimiter.Dispose();
             }
 
             // Cannot await here because Dispose() is synchronous and callers hold locks.

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -28,6 +28,10 @@ namespace Datadog.Trace.Debugger.Expressions
         private const string DynamicPrefix = "_dd.di.";
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProbeProcessor));
 
+        private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
+        private string _probeId = string.Empty;
+        private ProbeType _probeType;
+        private bool _shouldApplyGlobalRateLimit;
         private ProbeExpressionEvaluator? _evaluator;
         private DebuggerExpression?[]? _templates;
         private DebuggerExpression? _condition;
@@ -41,7 +45,13 @@ namespace Datadog.Trace.Debugger.Expressions
         /// <exception cref="ArgumentOutOfRangeException">If probe type or probe location is from unsupported type</exception>
         /// <remarks>Exceptions should be caught and logged by the caller</remarks>
         internal ProbeProcessor(ProbeDefinition probe)
+            : this(probe, DebuggerGlobalRateLimiter.Instance)
         {
+        }
+
+        internal ProbeProcessor(ProbeDefinition probe, IDebuggerGlobalRateLimiter globalRateLimiter)
+        {
+            _globalRateLimiter = globalRateLimiter ?? throw new ArgumentNullException(nameof(globalRateLimiter));
             InitializeProbeProcessor(probe);
         }
 
@@ -73,6 +83,9 @@ namespace Datadog.Trace.Debugger.Expressions
             };
 
             SetExpressions(probe);
+            _probeId = probe.Id;
+            _probeType = probeType;
+            _shouldApplyGlobalRateLimit = probeType is ProbeType.Snapshot or ProbeType.Log;
 
             var capture = (probe as LogProbe)?.Capture;
             var maxInfo = capture != null
@@ -164,9 +177,15 @@ namespace Datadog.Trace.Debugger.Expressions
             return _evaluator;
         }
 
+        private bool SamplePayload(IAdaptiveSampler sampler)
+        {
+            return (!_shouldApplyGlobalRateLimit || _globalRateLimiter.ShouldSample(_probeType, _probeId))
+                && sampler.Sample();
+        }
+
         public bool ShouldProcess(in ProbeData probeData)
         {
-            return HasCondition() || probeData.Sampler.Sample();
+            return HasCondition() || SamplePayload(probeData.Sampler);
         }
 
         public bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator inSnapshotCreator, in ProbeData probeData)
@@ -382,10 +401,24 @@ namespace Datadog.Trace.Debugger.Expressions
             }
 
             if (evaluationResult.Condition != null && // i.e. not a metric, span probe, or span decoration
-                (evaluationResult.Condition is false ||
-                !sampler.Sample()))
+                evaluationResult.Condition is false)
             {
                 // if the expression evaluated to false, or there is a rate limit, stop capture
+                shouldStopCapture = true;
+                return evaluationResult;
+            }
+
+            if (evaluationResult.Condition != null &&
+                _shouldApplyGlobalRateLimit &&
+                !_globalRateLimiter.ShouldSample(_probeType, _probeId))
+            {
+                shouldStopCapture = true;
+                return evaluationResult;
+            }
+
+            if (evaluationResult.Condition != null &&
+                !sampler.Sample())
+            {
                 shouldStopCapture = true;
                 return evaluationResult;
             }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.Debugger.Expressions
         private const string DynamicPrefix = "_dd.di.";
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProbeProcessor));
 
+        private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
         private volatile ProbeProcessorState _state;
 
         /// <summary>
@@ -37,7 +38,13 @@ namespace Datadog.Trace.Debugger.Expressions
         /// <exception cref="ArgumentOutOfRangeException">If probe type or probe location is from unsupported type</exception>
         /// <remarks>Exceptions should be caught and logged by the caller</remarks>
         internal ProbeProcessor(ProbeDefinition probe)
+            : this(probe, DebuggerGlobalRateLimiter.Instance)
         {
+        }
+
+        internal ProbeProcessor(ProbeDefinition probe, IDebuggerGlobalRateLimiter globalRateLimiter)
+        {
+            _globalRateLimiter = globalRateLimiter ?? throw new ArgumentNullException(nameof(globalRateLimiter));
             _state = ProbeProcessorState.Create(probe);
         }
 
@@ -99,7 +106,7 @@ namespace Datadog.Trace.Debugger.Expressions
         public bool TryBeginProcess(in ProbeData probeData, [NotNullWhen(true)] out IDebuggerSnapshotCreator? snapshotCreator)
         {
             var state = _state;
-            if (!state.HasCondition && !probeData.Sampler.Sample())
+            if (!state.HasCondition && !SamplePayload(state.ProbeInfo, probeData.Sampler))
             {
                 snapshotCreator = null;
                 return false;
@@ -107,6 +114,12 @@ namespace Datadog.Trace.Debugger.Expressions
 
             snapshotCreator = new DebuggerSnapshotCreator(state);
             return true;
+        }
+
+        private bool SamplePayload(in ProbeInfo probeInfo, IAdaptiveSampler sampler)
+        {
+            return (probeInfo.ProbeType is not (ProbeType.Snapshot or ProbeType.Log) || _globalRateLimiter.ShouldSample(probeInfo.ProbeType, probeInfo.ProbeId))
+                && sampler.Sample();
         }
 
         public bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator inSnapshotCreator, in ProbeData probeData)
@@ -356,7 +369,7 @@ namespace Datadog.Trace.Debugger.Expressions
             {
                 // Probes with conditions defer sampling until after the condition is evaluated,
                 // so evaluation errors must honor that same sampler before emitting a snapshot.
-                if (probeInfo.HasCondition && !sampler.Sample())
+                if (probeInfo.HasCondition && !SamplePayload(in probeInfo, sampler))
                 {
                     shouldStopCapture = true;
                 }
@@ -371,7 +384,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (evaluationResult.Condition != null && // i.e. not a metric, span probe, or span decoration
                 (evaluationResult.Condition is false ||
-                !sampler.Sample()))
+                !SamplePayload(in probeInfo, sampler)))
             {
                 // if the expression evaluated to false, or there is a rate limit, stop capture
                 shouldStopCapture = true;

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -118,8 +118,8 @@ namespace Datadog.Trace.Debugger.Expressions
 
         private bool SamplePayload(in ProbeInfo probeInfo, IAdaptiveSampler sampler)
         {
-            return (probeInfo.ProbeType is not (ProbeType.Snapshot or ProbeType.Log) || _globalRateLimiter.ShouldSample(probeInfo.ProbeType, probeInfo.ProbeId))
-                && sampler.Sample();
+            return sampler.Sample()
+                && (probeInfo.ProbeType != ProbeType.Snapshot || _globalRateLimiter.ShouldSampleSnapshot(probeInfo.ProbeId));
         }
 
         public bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator inSnapshotCreator, in ProbeData probeData)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -118,8 +118,13 @@ namespace Datadog.Trace.Debugger.Expressions
 
         private bool SamplePayload(in ProbeInfo probeInfo, IAdaptiveSampler sampler)
         {
-            return sampler.Sample()
-                && (probeInfo.ProbeType != ProbeType.Snapshot || _globalRateLimiter.ShouldSampleSnapshot(probeInfo.ProbeId));
+            // Global-first matches Java; it can affect per-probe fairness and may be improved later.
+            if (probeInfo.ProbeType == ProbeType.Snapshot && !_globalRateLimiter.ShouldSampleSnapshot(probeInfo.ProbeId))
+            {
+                return false;
+            }
+
+            return sampler.Sample();
         }
 
         public bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator inSnapshotCreator, in ProbeData probeData)

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Threading;
 using Datadog.Trace.Logging;
@@ -64,15 +66,16 @@ namespace Datadog.Trace.Debugger.RateLimiting
         private int _countsSlotIndex;
         private Counts[] _countsSlots;
 
-        private Timer _timer;
-        private Action _rollWindowCallback;
+        private Timer? _timer;
+        private Action? _rollWindowCallback;
+        private int _disposeState;
 
         internal AdaptiveSampler(
             TimeSpan windowDuration,
             int samplesPerWindow,
             int averageLookback,
             int budgetLookback,
-            Action rollWindowCallback)
+            Action? rollWindowCallback)
         {
             _timer = new Timer(state => RollWindow(), state: null, windowDuration, windowDuration);
             _totalCountRunningAverage = 0;
@@ -134,6 +137,17 @@ namespace Datadog.Trace.Debugger.RateLimiting
             return ThreadSafeRandom.Shared.NextDouble();
         }
 
+        public void Dispose()
+        {
+            if (Interlocked.CompareExchange(ref _disposeState, 1, 0) != 0)
+            {
+                return;
+            }
+
+            Interlocked.Exchange(ref _timer, null)?.Dispose();
+            _rollWindowCallback = null;
+        }
+
         private double ComputeIntervalAlpha(int lookback)
         {
             return 1 - Math.Pow(lookback, -1.0 / lookback);
@@ -191,10 +205,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
                 counts.Reset();
 
-                if (_rollWindowCallback != null)
-                {
-                    _rollWindowCallback();
-                }
+                _rollWindowCallback?.Invoke();
             }
             catch (Exception e)
             {

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Threading;
 using Datadog.Trace.Logging;
@@ -32,7 +34,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
     /// to compensate for too rapid changes in the incoming events rate and maintain the target average
     /// number of samples per window.
     /// </summary>
-    internal sealed class AdaptiveSampler : IAdaptiveSampler, IDisposable
+    internal sealed class AdaptiveSampler : IAdaptiveSampler
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AdaptiveSampler>();
 
@@ -65,15 +67,16 @@ namespace Datadog.Trace.Debugger.RateLimiting
         private int _countsSlotIndex;
         private Counts[] _countsSlots;
 
-        private Timer _timer;
-        private Action _rollWindowCallback;
+        private Timer? _timer;
+        private Action? _rollWindowCallback;
+        private int _disposeState;
 
         internal AdaptiveSampler(
             TimeSpan windowDuration,
             int samplesPerWindow,
             int averageLookback,
             int budgetLookback,
-            Action rollWindowCallback)
+            Action? rollWindowCallback)
         {
             _timer = new Timer(state => RollWindow(), state: null, windowDuration, windowDuration);
             _totalCountRunningAverage = 0;
@@ -141,7 +144,13 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         public void Dispose()
         {
-            _timer?.Dispose();
+            if (Interlocked.CompareExchange(ref _disposeState, 1, 0) != 0)
+            {
+                return;
+            }
+
+            Interlocked.Exchange(ref _timer, null)?.Dispose();
+            _rollWindowCallback = null;
         }
 
         private double ComputeIntervalAlpha(int lookback)
@@ -172,7 +181,12 @@ namespace Datadog.Trace.Debugger.RateLimiting
         {
             try
             {
-                Action rollWindowCallback;
+                if (Volatile.Read(ref _disposeState) != 0)
+                {
+                    return;
+                }
+
+                Action? rollWindowCallback;
 
                 lock (_maintenanceLock)
                 {

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSamplerLifetime.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSamplerLifetime.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Threading;
 

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSamplerLifetime.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSamplerLifetime.cs
@@ -1,0 +1,41 @@
+// <copyright file="AdaptiveSamplerLifetime.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading;
+
+namespace Datadog.Trace.Debugger.RateLimiting
+{
+    internal static class AdaptiveSamplerLifetime
+    {
+        private const int AverageLookback = 180;
+        private const int BudgetLookback = 16;
+
+        private static readonly TimeSpan WindowDuration = TimeSpan.FromSeconds(1);
+
+        public static IAdaptiveSampler Create(int samplesPerSecond)
+        {
+            return new AdaptiveSampler(WindowDuration, samplesPerSecond, AverageLookback, BudgetLookback, rollWindowCallback: null);
+        }
+
+        public static void Replace(ref IAdaptiveSampler sampler, IAdaptiveSampler replacement)
+        {
+            Dispose(Interlocked.Exchange(ref sampler, replacement));
+        }
+
+        public static void Dispose(ref IAdaptiveSampler sampler)
+        {
+            Dispose(Interlocked.Exchange(ref sampler, NopAdaptiveSampler.Instance));
+        }
+
+        public static void Dispose(IAdaptiveSampler sampler)
+        {
+            if (!ReferenceEquals(sampler, NopAdaptiveSampler.Instance))
+            {
+                sampler.Dispose();
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
@@ -1,0 +1,114 @@
+// <copyright file="DebuggerGlobalRateLimiter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Runtime.CompilerServices;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Debugger.RateLimiting
+{
+    internal sealed class DebuggerGlobalRateLimiter : IDebuggerGlobalRateLimiter
+    {
+        internal const int DefaultSnapshotSamplesPerSecond = 100;
+        internal const int DefaultLogSamplesPerSecond = 5000;
+
+        private const int LogCooldownSeconds = 60;
+
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebuggerGlobalRateLimiter));
+
+        private readonly Func<int, IAdaptiveSampler> _samplerFactory;
+        private readonly ILogRateLimiter _logRateLimiter;
+
+        private IAdaptiveSampler _snapshotSampler;
+        private IAdaptiveSampler _logSampler;
+
+        internal DebuggerGlobalRateLimiter()
+            : this(AdaptiveSamplerLifetime.Create, new LogRateLimiter(LogCooldownSeconds))
+        {
+        }
+
+        internal DebuggerGlobalRateLimiter(Func<int, IAdaptiveSampler> samplerFactory, ILogRateLimiter logRateLimiter)
+        {
+            _samplerFactory = samplerFactory ?? throw new ArgumentNullException(nameof(samplerFactory));
+            _logRateLimiter = logRateLimiter ?? throw new ArgumentNullException(nameof(logRateLimiter));
+            _snapshotSampler = NopAdaptiveSampler.Instance;
+            _logSampler = NopAdaptiveSampler.Instance;
+            ResetRate();
+        }
+
+        internal static DebuggerGlobalRateLimiter Instance { get; } = new();
+
+        public bool ShouldSample(ProbeType probeType, string probeId)
+        {
+            var sampler = probeType switch
+            {
+                ProbeType.Snapshot => _snapshotSampler,
+                ProbeType.Log => _logSampler,
+                _ => null
+            };
+
+            if (sampler == null || sampler.Sample())
+            {
+                return true;
+            }
+
+            LogDrop(probeType, probeId);
+            return false;
+        }
+
+        public void SetRate(double? samplesPerSecond)
+        {
+            if (!samplesPerSecond.HasValue)
+            {
+                ResetRate();
+                return;
+            }
+
+            var configuredRate = Math.Max((int)samplesPerSecond.Value, 0);
+            ReplaceSamplers(configuredRate, configuredRate);
+        }
+
+        public void ResetRate()
+        {
+            ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+        }
+
+        public void Dispose()
+        {
+            AdaptiveSamplerLifetime.Dispose(ref _snapshotSampler);
+            AdaptiveSamplerLifetime.Dispose(ref _logSampler);
+        }
+
+        private void ReplaceSamplers(int snapshotSamplesPerSecond, int logSamplesPerSecond)
+        {
+            AdaptiveSamplerLifetime.Replace(ref _snapshotSampler, _samplerFactory(snapshotSamplesPerSecond));
+            AdaptiveSamplerLifetime.Replace(ref _logSampler, _samplerFactory(logSamplesPerSecond));
+        }
+
+        private void LogDrop(ProbeType probeType, string probeId, [CallerFilePath] string sourceFile = "", [CallerLineNumber] int sourceLine = 0)
+        {
+            if (!_logRateLimiter.ShouldLog(sourceFile, sourceLine, out var skipCount))
+            {
+                return;
+            }
+
+            var probeTypeName = probeType == ProbeType.Snapshot ? "snapshot" : "log";
+            const string message = "Global debugger rate limit reached for {ProbeType} probes. Dropping capture for ProbeId={ProbeId}";
+            const string messageWithSkipCount = "Global debugger rate limit reached for {ProbeType} probes. Dropping capture for ProbeId={ProbeId}, {SkipCount} additional messages skipped";
+
+            if (skipCount > 0)
+            {
+                Log.Warning(messageWithSkipCount, probeTypeName, probeId, skipCount);
+            }
+            else
+            {
+                Log.Warning(message, probeTypeName, probeId);
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Logging;
 
@@ -23,9 +24,11 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         private readonly Func<int, IAdaptiveSampler> _samplerFactory;
         private readonly ILogRateLimiter _logRateLimiter;
+        private readonly object _lifetimeLock = new();
 
         private IAdaptiveSampler _snapshotSampler;
         private IAdaptiveSampler _logSampler;
+        private bool _disposed;
 
         internal DebuggerGlobalRateLimiter()
             : this(AdaptiveSamplerLifetime.Create, new LogRateLimiter(LogCooldownSeconds))
@@ -47,8 +50,8 @@ namespace Datadog.Trace.Debugger.RateLimiting
         {
             var sampler = probeType switch
             {
-                ProbeType.Snapshot => _snapshotSampler,
-                ProbeType.Log => _logSampler,
+                ProbeType.Snapshot => Volatile.Read(ref _snapshotSampler),
+                ProbeType.Log => Volatile.Read(ref _logSampler),
                 _ => null
             };
 
@@ -61,27 +64,61 @@ namespace Datadog.Trace.Debugger.RateLimiting
             return false;
         }
 
+        public void Initialize()
+        {
+            lock (_lifetimeLock)
+            {
+                _disposed = false;
+                ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+            }
+        }
+
         public void SetRate(double? samplesPerSecond)
         {
-            if (!samplesPerSecond.HasValue)
+            lock (_lifetimeLock)
             {
-                ResetRate();
-                return;
-            }
+                if (_disposed)
+                {
+                    return;
+                }
 
-            var configuredRate = Math.Max((int)samplesPerSecond.Value, 0);
-            ReplaceSamplers(configuredRate, configuredRate);
+                if (!samplesPerSecond.HasValue)
+                {
+                    ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+                    return;
+                }
+
+                var configuredRate = Math.Max((int)samplesPerSecond.Value, 0);
+                ReplaceSamplers(configuredRate, configuredRate);
+            }
         }
 
         public void ResetRate()
         {
-            ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+            lock (_lifetimeLock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+            }
         }
 
         public void Dispose()
         {
-            AdaptiveSamplerLifetime.Dispose(ref _snapshotSampler);
-            AdaptiveSamplerLifetime.Dispose(ref _logSampler);
+            lock (_lifetimeLock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                AdaptiveSamplerLifetime.Dispose(ref _snapshotSampler);
+                AdaptiveSamplerLifetime.Dispose(ref _logSampler);
+            }
         }
 
         private void ReplaceSamplers(int snapshotSamplesPerSecond, int logSamplesPerSecond)

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Debugger.RateLimiting
@@ -16,7 +15,6 @@ namespace Datadog.Trace.Debugger.RateLimiting
     internal sealed class DebuggerGlobalRateLimiter : IDebuggerGlobalRateLimiter
     {
         internal const int DefaultSnapshotSamplesPerSecond = 100;
-        internal const int DefaultLogSamplesPerSecond = 5000;
 
         private const int LogCooldownSeconds = 60;
 
@@ -27,7 +25,6 @@ namespace Datadog.Trace.Debugger.RateLimiting
         private readonly object _lifetimeLock = new();
 
         private IAdaptiveSampler _snapshotSampler;
-        private IAdaptiveSampler _logSampler;
         private bool _disposed;
 
         internal DebuggerGlobalRateLimiter()
@@ -40,27 +37,21 @@ namespace Datadog.Trace.Debugger.RateLimiting
             _samplerFactory = samplerFactory ?? throw new ArgumentNullException(nameof(samplerFactory));
             _logRateLimiter = logRateLimiter ?? throw new ArgumentNullException(nameof(logRateLimiter));
             _snapshotSampler = NopAdaptiveSampler.Instance;
-            _logSampler = NopAdaptiveSampler.Instance;
             ResetRate();
         }
 
         internal static DebuggerGlobalRateLimiter Instance { get; } = new();
 
-        public bool ShouldSample(ProbeType probeType, string probeId)
+        public bool ShouldSampleSnapshot(string probeId)
         {
-            var sampler = probeType switch
-            {
-                ProbeType.Snapshot => Volatile.Read(ref _snapshotSampler),
-                ProbeType.Log => Volatile.Read(ref _logSampler),
-                _ => null
-            };
+            var sampler = Volatile.Read(ref _snapshotSampler);
 
-            if (sampler == null || sampler.Sample())
+            if (sampler.Sample())
             {
                 return true;
             }
 
-            LogDrop(probeType, probeId);
+            LogDrop(probeId);
             return false;
         }
 
@@ -69,7 +60,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
             lock (_lifetimeLock)
             {
                 _disposed = false;
-                ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+                ReplaceSampler(DefaultSnapshotSamplesPerSecond);
             }
         }
 
@@ -84,12 +75,12 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
                 if (!samplesPerSecond.HasValue)
                 {
-                    ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+                    ReplaceSampler(DefaultSnapshotSamplesPerSecond);
                     return;
                 }
 
                 var configuredRate = Math.Max((int)samplesPerSecond.Value, 0);
-                ReplaceSamplers(configuredRate, configuredRate);
+                ReplaceSampler(configuredRate);
             }
         }
 
@@ -102,7 +93,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
                     return;
                 }
 
-                ReplaceSamplers(DefaultSnapshotSamplesPerSecond, DefaultLogSamplesPerSecond);
+                ReplaceSampler(DefaultSnapshotSamplesPerSecond);
             }
         }
 
@@ -117,34 +108,31 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
                 _disposed = true;
                 AdaptiveSamplerLifetime.Dispose(ref _snapshotSampler);
-                AdaptiveSamplerLifetime.Dispose(ref _logSampler);
             }
         }
 
-        private void ReplaceSamplers(int snapshotSamplesPerSecond, int logSamplesPerSecond)
+        private void ReplaceSampler(int snapshotSamplesPerSecond)
         {
             AdaptiveSamplerLifetime.Replace(ref _snapshotSampler, _samplerFactory(snapshotSamplesPerSecond));
-            AdaptiveSamplerLifetime.Replace(ref _logSampler, _samplerFactory(logSamplesPerSecond));
         }
 
-        private void LogDrop(ProbeType probeType, string probeId, [CallerFilePath] string sourceFile = "", [CallerLineNumber] int sourceLine = 0)
+        private void LogDrop(string probeId, [CallerFilePath] string sourceFile = "", [CallerLineNumber] int sourceLine = 0)
         {
             if (!_logRateLimiter.ShouldLog(sourceFile, sourceLine, out var skipCount))
             {
                 return;
             }
 
-            var probeTypeName = probeType == ProbeType.Snapshot ? "snapshot" : "log";
-            const string message = "Global debugger rate limit reached for {ProbeType} probes. Dropping capture for ProbeId={ProbeId}";
-            const string messageWithSkipCount = "Global debugger rate limit reached for {ProbeType} probes. Dropping capture for ProbeId={ProbeId}, {SkipCount} additional messages skipped";
+            const string message = "Global debugger rate limit reached for snapshot probes. Dropping capture for ProbeId={ProbeId}";
+            const string messageWithSkipCount = "Global debugger rate limit reached for snapshot probes. Dropping capture for ProbeId={ProbeId}, {SkipCount} additional messages skipped";
 
             if (skipCount > 0)
             {
-                Log.Warning(messageWithSkipCount, probeTypeName, probeId, skipCount);
+                Log.Warning(messageWithSkipCount, probeId, skipCount);
             }
             else
             {
-                Log.Warning(message, probeTypeName, probeId);
+                Log.Warning(message, probeId);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/DebuggerGlobalRateLimiter.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
         private const int LogCooldownSeconds = 60;
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebuggerGlobalRateLimiter));
+        private static readonly Lazy<DebuggerGlobalRateLimiter> InstanceLazy = new(() => new DebuggerGlobalRateLimiter());
 
         private readonly Func<int, IAdaptiveSampler> _samplerFactory;
         private readonly ILogRateLimiter _logRateLimiter;
@@ -40,7 +41,15 @@ namespace Datadog.Trace.Debugger.RateLimiting
             ResetRate();
         }
 
-        internal static DebuggerGlobalRateLimiter Instance { get; } = new();
+        internal static DebuggerGlobalRateLimiter Instance => InstanceLazy.Value;
+
+        internal static void TryDisposeInstance()
+        {
+            if (InstanceLazy.IsValueCreated)
+            {
+                InstanceLazy.Value.Dispose();
+            }
+        }
 
         public bool ShouldSampleSnapshot(string probeId)
         {

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
@@ -1,4 +1,4 @@
-// <copyright file="IAdaptiveSampler.cs" company="Datadog">
+// <copyright file="IDebuggerGlobalRateLimiter.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -6,17 +6,16 @@
 #nullable enable
 
 using System;
+using Datadog.Trace.Debugger.Expressions;
 
 namespace Datadog.Trace.Debugger.RateLimiting
 {
-    internal interface IAdaptiveSampler : IDisposable
+    internal interface IDebuggerGlobalRateLimiter : IDisposable
     {
-        bool Sample();
+        bool ShouldSample(ProbeType probeType, string probeId);
 
-        bool Keep();
+        void SetRate(double? samplesPerSecond);
 
-        bool Drop();
-
-        double NextDouble();
+        void ResetRate();
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
@@ -14,6 +14,8 @@ namespace Datadog.Trace.Debugger.RateLimiting
     {
         bool ShouldSample(ProbeType probeType, string probeId);
 
+        void Initialize();
+
         void SetRate(double? samplesPerSecond);
 
         void ResetRate();

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
@@ -6,13 +6,12 @@
 #nullable enable
 
 using System;
-using Datadog.Trace.Debugger.Expressions;
 
 namespace Datadog.Trace.Debugger.RateLimiting
 {
     internal interface IDebuggerGlobalRateLimiter : IDisposable
     {
-        bool ShouldSample(ProbeType probeType, string probeId);
+        bool ShouldSampleSnapshot(string probeId);
 
         void Initialize();
 

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/IDebuggerGlobalRateLimiter.cs
@@ -1,0 +1,21 @@
+// <copyright file="IDebuggerGlobalRateLimiter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.Debugger.Expressions;
+
+namespace Datadog.Trace.Debugger.RateLimiting
+{
+    internal interface IDebuggerGlobalRateLimiter : IDisposable
+    {
+        bool ShouldSample(ProbeType probeType, string probeId);
+
+        void SetRate(double? samplesPerSecond);
+
+        void ResetRate();
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/NopAdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/NopAdaptiveSampler.cs
@@ -29,5 +29,9 @@ namespace Datadog.Trace.Debugger.RateLimiting
         {
             return 1.0;
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
@@ -22,7 +22,18 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         private static ProbeRateLimiter _instance;
 
+        private readonly Func<int, IAdaptiveSampler> _samplerFactory;
         private readonly ConcurrentDictionary<string, IAdaptiveSampler> _samplers = new();
+
+        internal ProbeRateLimiter()
+            : this(AdaptiveSamplerLifetime.Create)
+        {
+        }
+
+        internal ProbeRateLimiter(Func<int, IAdaptiveSampler> samplerFactory)
+        {
+            _samplerFactory = samplerFactory ?? throw new ArgumentNullException(nameof(samplerFactory));
+        }
 
         internal static ProbeRateLimiter Instance
         {
@@ -35,17 +46,34 @@ namespace Datadog.Trace.Debugger.RateLimiting
             }
         }
 
-        private static AdaptiveSampler CreateSampler(int samplesPerSecond = DefaultSamplesPerSecond) =>
-            new(TimeSpan.FromSeconds(1), samplesPerSecond, 180, 16, null);
-
         public IAdaptiveSampler GerOrAddSampler(string probeId)
         {
-            return _samplers.GetOrAdd(probeId, _ => CreateSampler(1));
+            while (true)
+            {
+                if (_samplers.TryGetValue(probeId, out var sampler))
+                {
+                    return sampler;
+                }
+
+                var createdSampler = _samplerFactory(DefaultSamplesPerSecond);
+                if (_samplers.TryAdd(probeId, createdSampler))
+                {
+                    return createdSampler;
+                }
+
+                AdaptiveSamplerLifetime.Dispose(createdSampler);
+            }
         }
 
         public bool TryAddSampler(string probeId, IAdaptiveSampler sampler)
         {
-            return _samplers.TryAdd(probeId, sampler);
+            if (_samplers.TryAdd(probeId, sampler))
+            {
+                return true;
+            }
+
+            AdaptiveSamplerLifetime.Dispose(sampler);
+            return false;
         }
 
         public void SetRate(string probeId, int samplesPerSecond)
@@ -58,16 +86,20 @@ namespace Datadog.Trace.Debugger.RateLimiting
                 return;
             }
 
-            var adaptiveSampler = CreateSampler(samplesPerSecond);
+            var adaptiveSampler = _samplerFactory(samplesPerSecond);
             if (!_samplers.TryAdd(probeId, adaptiveSampler))
             {
+                AdaptiveSamplerLifetime.Dispose(adaptiveSampler);
                 Log.Information("Adaptive sampler already exist for {ProbeID}", probeId);
             }
         }
 
         public void ResetRate(string probeId)
         {
-            _samplers.TryRemove(probeId, out _);
+            if (_samplers.TryRemove(probeId, out var sampler))
+            {
+                AdaptiveSamplerLifetime.Dispose(sampler);
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
@@ -22,7 +22,18 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         private static ProbeRateLimiter _instance;
 
+        private readonly Func<int, IAdaptiveSampler> _samplerFactory;
         private readonly ConcurrentDictionary<string, IAdaptiveSampler> _samplers = new();
+
+        internal ProbeRateLimiter()
+            : this(AdaptiveSamplerLifetime.Create)
+        {
+        }
+
+        internal ProbeRateLimiter(Func<int, IAdaptiveSampler> samplerFactory)
+        {
+            _samplerFactory = samplerFactory ?? throw new ArgumentNullException(nameof(samplerFactory));
+        }
 
         internal static ProbeRateLimiter Instance
         {
@@ -31,35 +42,39 @@ namespace Datadog.Trace.Debugger.RateLimiting
                 return LazyInitializer.EnsureInitialized(
                     ref _instance,
                     ref _globalInstanceInitialized,
-                    ref _globalInstanceLock);
+                    ref _globalInstanceLock,
+                    () => new ProbeRateLimiter());
             }
         }
 
-        private static AdaptiveSampler CreateSampler(int samplesPerSecond = DefaultSamplesPerSecond) =>
-            new(TimeSpan.FromSeconds(1), samplesPerSecond, 180, 16, null);
-
         public IAdaptiveSampler GerOrAddSampler(string probeId)
         {
-            // Avoid ConcurrentDictionary.GetOrAdd(factory): its factory can run more than once
-            // under contention, leaking the losing sampler's Timer (rooted by the runtime).
-            if (_samplers.TryGetValue(probeId, out var sampler))
+            while (true)
             {
-                return sampler;
-            }
+                if (_samplers.TryGetValue(probeId, out var sampler))
+                {
+                    return sampler;
+                }
 
-            var candidate = CreateSampler();
-            sampler = _samplers.GetOrAdd(probeId, candidate);
-            if (!ReferenceEquals(sampler, candidate))
-            {
-                candidate.Dispose();
-            }
+                var candidate = _samplerFactory(DefaultSamplesPerSecond);
+                if (_samplers.TryAdd(probeId, candidate))
+                {
+                    return candidate;
+                }
 
-            return sampler;
+                AdaptiveSamplerLifetime.Dispose(candidate);
+            }
         }
 
         public bool TryAddSampler(string probeId, IAdaptiveSampler sampler)
         {
-            return _samplers.TryAdd(probeId, sampler);
+            if (_samplers.TryAdd(probeId, sampler))
+            {
+                return true;
+            }
+
+            AdaptiveSamplerLifetime.Dispose(sampler);
+            return false;
         }
 
         public void SetRate(string probeId, int samplesPerSecond)
@@ -70,7 +85,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
                 return;
             }
 
-            var candidate = CreateSampler(samplesPerSecond);
+            var candidate = _samplerFactory(samplesPerSecond);
             if (_samplers.TryAdd(probeId, candidate))
             {
                 return;
@@ -82,7 +97,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
                 UpdateExistingRate(probeId, existing, samplesPerSecond);
             }
 
-            candidate.Dispose();
+            AdaptiveSamplerLifetime.Dispose(candidate);
         }
 
         public void ResetRate(string probeId)
@@ -90,7 +105,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
             // Must dispose: AdaptiveSampler's Timer is rooted by the runtime until disposed.
             if (_samplers.TryRemove(probeId, out var removed))
             {
-                removed.Dispose();
+                AdaptiveSamplerLifetime.Dispose(removed);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
@@ -49,21 +49,21 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         public IAdaptiveSampler GerOrAddSampler(string probeId)
         {
-            while (true)
+            if (_samplers.TryGetValue(probeId, out var existing))
             {
-                if (_samplers.TryGetValue(probeId, out var sampler))
-                {
-                    return sampler;
-                }
+                return existing;
+            }
 
-                var candidate = _samplerFactory(DefaultSamplesPerSecond);
-                if (_samplers.TryAdd(probeId, candidate))
-                {
-                    return candidate;
-                }
-
+            // Use GetOrAdd's value overload: the factory overload can run more than once
+            // under contention, leaking the losing sampler's Timer.
+            var candidate = _samplerFactory(DefaultSamplesPerSecond);
+            var sampler = _samplers.GetOrAdd(probeId, candidate);
+            if (!ReferenceEquals(sampler, candidate))
+            {
                 AdaptiveSamplerLifetime.Dispose(candidate);
             }
+
+            return sampler;
         }
 
         public bool TryAddSampler(string probeId, IAdaptiveSampler sampler)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="ConfigurationUpdaterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Debugger.Configurations;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.RateLimiting;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ConfigurationUpdaterTests
+{
+    [Fact]
+    public void AcceptAdded_ServiceConfigurationOnly_UpdatesGlobalRateLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
+
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new Datadog.Trace.Debugger.Configurations.Models.Sampling { SnapshotsPerSecond = 42 }
+                }
+            });
+
+        Assert.Equal(1, globalRateLimiter.SetRateCallCount);
+        Assert.Equal(42, globalRateLimiter.LastRate);
+    }
+
+    [Fact]
+    public void AcceptAdded_ProbeOnlyChange_DoesNotResetGlobalRateLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new Datadog.Trace.Debugger.Configurations.Models.Sampling { SnapshotsPerSecond = 42 }
+                }
+            });
+        globalRateLimiter.ResetCounters();
+
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new Datadog.Trace.Debugger.Configurations.Models.Sampling { SnapshotsPerSecond = 42 }
+                },
+                LogProbes =
+                [
+                    new LogProbe
+                    {
+                        Id = "log-probe",
+                        Where = new Where { MethodName = "TestMethod" },
+                        Tags = [],
+                    }
+                ]
+            });
+
+        Assert.Equal(0, globalRateLimiter.SetRateCallCount);
+        Assert.Equal(0, globalRateLimiter.ResetRateCallCount);
+    }
+
+    [Fact]
+    public void AcceptRemoved_ServiceConfiguration_ResetsGlobalRateLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new Datadog.Trace.Debugger.Configurations.Models.Sampling { SnapshotsPerSecond = 42 }
+                }
+            });
+        globalRateLimiter.ResetCounters();
+
+        updater.AcceptRemoved([RemoteConfigurationPath.FromPath("datadog/123/LIVE_DEBUGGING/serviceConfig_/config")]);
+
+        Assert.Equal(0, globalRateLimiter.SetRateCallCount);
+        Assert.Equal(1, globalRateLimiter.ResetRateCallCount);
+    }
+
+    private sealed class GlobalRateLimiterMock : IDebuggerGlobalRateLimiter
+    {
+        public double? LastRate { get; private set; }
+
+        public int SetRateCallCount { get; private set; }
+
+        public int ResetRateCallCount { get; private set; }
+
+        public bool ShouldSample(ProbeType probeType, string probeId) => true;
+
+        public void SetRate(double? samplesPerSecond)
+        {
+            SetRateCallCount++;
+            LastRate = samplesPerSecond;
+        }
+
+        public void ResetRate()
+        {
+            ResetRateCallCount++;
+        }
+
+        public void ResetCounters()
+        {
+            SetRateCallCount = 0;
+            ResetRateCallCount = 0;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
-using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
@@ -286,7 +285,7 @@ public class ConfigurationUpdaterTests
 
         public int ResetRateCallCount { get; private set; }
 
-        public bool ShouldSample(ProbeType probeType, string probeId) => true;
+        public bool ShouldSampleSnapshot(string probeId) => true;
 
         public void Initialize()
         {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
@@ -176,6 +176,34 @@ public class ConfigurationUpdaterTests
     }
 
     [Fact]
+    public void AcceptAdded_ServiceConfigurationAndProbe_UpdatesGlobalRateLimiterBeforeAddingProbe()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
+        double? rateWhenAddingProbe = null;
+        updater.SetProbeInstrumentationHandlers(
+            probes =>
+            {
+                rateWhenAddingProbe = globalRateLimiter.LastRate;
+                return probes.Select(probe => new ConfigurationUpdater.UpdateResult(probe.Id, null)).ToList();
+            },
+            _ => { });
+
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new DebuggerSampling { SnapshotsPerSecond = 42 }
+                },
+                LogProbes = [CreateLogProbe("log-probe")]
+            });
+
+        globalRateLimiter.SetRateCallCount.Should().Be(1);
+        rateWhenAddingProbe.Should().Be(42);
+    }
+
+    [Fact]
     public void AcceptAdded_ProbeOnlyChange_DoesNotResetGlobalRateLimiter()
     {
         var globalRateLimiter = new GlobalRateLimiterMock();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
@@ -288,6 +288,10 @@ public class ConfigurationUpdaterTests
 
         public bool ShouldSample(ProbeType probeType, string probeId) => true;
 
+        public void Initialize()
+        {
+        }
+
         public void SetRate(double? samplesPerSecond)
         {
             SetRateCallCount++;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ConfigurationUpdaterTests.cs
@@ -10,10 +10,13 @@ using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using FluentAssertions;
 using Xunit;
+using DebuggerSampling = Datadog.Trace.Debugger.Configurations.Models.Sampling;
 
 namespace Datadog.Trace.Tests.Debugger;
 
@@ -154,6 +157,75 @@ public class ConfigurationUpdaterTests
         GetCurrentConfiguration(updater).LogProbes.Should().ContainSingle().Which.Template.Should().Be("From RCM again");
     }
 
+    [Fact]
+    public void AcceptAdded_ServiceConfigurationOnly_UpdatesGlobalRateLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
+
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new DebuggerSampling { SnapshotsPerSecond = 42 }
+                }
+            });
+
+        globalRateLimiter.SetRateCallCount.Should().Be(1);
+        globalRateLimiter.LastRate.Should().Be(42);
+    }
+
+    [Fact]
+    public void AcceptAdded_ProbeOnlyChange_DoesNotResetGlobalRateLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new DebuggerSampling { SnapshotsPerSecond = 42 }
+                }
+            });
+        globalRateLimiter.ResetCounters();
+
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new DebuggerSampling { SnapshotsPerSecond = 42 }
+                },
+                LogProbes = [CreateLogProbe("log-probe")]
+            });
+
+        globalRateLimiter.SetRateCallCount.Should().Be(0);
+        globalRateLimiter.ResetRateCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void AcceptRemoved_ServiceConfiguration_ResetsGlobalRateLimiterToDefaultRate()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new DebuggerSampling { SnapshotsPerSecond = 42 }
+                }
+            });
+        globalRateLimiter.ResetCounters();
+
+        updater.AcceptRemoved([RemoteConfigurationPath.FromPath("datadog/123/LIVE_DEBUGGING/serviceConfig_/config")]);
+
+        globalRateLimiter.SetRateCallCount.Should().Be(1);
+        globalRateLimiter.LastRate.Should().BeNull();
+    }
+
     private static ConfigurationUpdater CreateUpdater(
         out List<IReadOnlyList<ProbeDefinition>> addedProbes,
         out List<string> removedProbeIds)
@@ -204,5 +276,37 @@ public class ConfigurationUpdaterTests
         var field = typeof(ConfigurationUpdater).GetField("_currentConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
         field.Should().NotBeNull();
         return (ProbeConfiguration)field!.GetValue(updater)!;
+    }
+
+    private sealed class GlobalRateLimiterMock : IDebuggerGlobalRateLimiter
+    {
+        public double? LastRate { get; private set; }
+
+        public int SetRateCallCount { get; private set; }
+
+        public int ResetRateCallCount { get; private set; }
+
+        public bool ShouldSample(ProbeType probeType, string probeId) => true;
+
+        public void SetRate(double? samplesPerSecond)
+        {
+            SetRateCallCount++;
+            LastRate = samplesPerSecond;
+        }
+
+        public void ResetRate()
+        {
+            ResetRateCallCount++;
+        }
+
+        public void ResetCounters()
+        {
+            SetRateCallCount = 0;
+            ResetRateCallCount = 0;
+        }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerGlobalRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerGlobalRateLimiterTests.cs
@@ -1,0 +1,164 @@
+// <copyright file="DebuggerGlobalRateLimiterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.RateLimiting;
+using Datadog.Trace.Logging;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class DebuggerGlobalRateLimiterTests
+{
+    [Fact]
+    public void Constructor_UsesFallbackRates()
+    {
+        var factory = new RecordingSamplerFactory();
+
+        _ = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+
+        Assert.Equal(
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            factory.RequestedRates);
+    }
+
+    [Fact]
+    public void SetRate_UsesConfiguredRateForSnapshotAndLogSamplers()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+
+        limiter.SetRate(42);
+
+        Assert.Equal(
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond, 42, 42],
+            factory.RequestedRates);
+    }
+
+    [Fact]
+    public void SetRate_DisposesPreviousSamplers()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+        var initialSnapshotSampler = factory.Samplers[0];
+        var initialLogSampler = factory.Samplers[1];
+
+        limiter.SetRate(42);
+
+        Assert.Equal(1, initialSnapshotSampler.DisposeCallCount);
+        Assert.Equal(1, initialLogSampler.DisposeCallCount);
+    }
+
+    [Fact]
+    public void ResetRate_RestoresFallbackRates()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+        limiter.SetRate(42);
+
+        limiter.ResetRate();
+
+        Assert.Equal(
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond, 42, 42, DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            factory.RequestedRates);
+    }
+
+    [Fact]
+    public void Dispose_DisposesCurrentSamplers()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+        limiter.SetRate(42);
+        var currentSnapshotSampler = factory.Samplers[2];
+        var currentLogSampler = factory.Samplers[3];
+
+        limiter.Dispose();
+
+        Assert.Equal(1, currentSnapshotSampler.DisposeCallCount);
+        Assert.Equal(1, currentLogSampler.DisposeCallCount);
+    }
+
+    [Fact]
+    public void SnapshotProbesShareOneGlobalBudget()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+        factory.Samplers[0].SetResults(true, false);
+
+        var firstResult = limiter.ShouldSample(ProbeType.Snapshot, "snapshot-1");
+        var secondResult = limiter.ShouldSample(ProbeType.Snapshot, "snapshot-2");
+
+        Assert.True(firstResult);
+        Assert.False(secondResult);
+        Assert.Equal(2, factory.Samplers[0].SampleCallCount);
+        Assert.Equal(0, factory.Samplers[1].SampleCallCount);
+    }
+
+    [Fact]
+    public void NonPayloadProbesAreUnaffected()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+
+        var metricResult = limiter.ShouldSample(ProbeType.Metric, "metric");
+        var spanDecorationResult = limiter.ShouldSample(ProbeType.SpanDecoration, "span");
+
+        Assert.True(metricResult);
+        Assert.True(spanDecorationResult);
+        Assert.Equal(0, factory.Samplers[0].SampleCallCount);
+        Assert.Equal(0, factory.Samplers[1].SampleCallCount);
+    }
+
+    private sealed class RecordingSamplerFactory
+    {
+        public List<int> RequestedRates { get; } = [];
+
+        public List<TestAdaptiveSampler> Samplers { get; } = [];
+
+        public IAdaptiveSampler Create(int samplesPerSecond)
+        {
+            RequestedRates.Add(samplesPerSecond);
+            var sampler = new TestAdaptiveSampler();
+            Samplers.Add(sampler);
+            return sampler;
+        }
+    }
+
+    private sealed class TestAdaptiveSampler : IAdaptiveSampler
+    {
+        private readonly Queue<bool> _results = new();
+
+        public int DisposeCallCount { get; private set; }
+
+        public int SampleCallCount { get; private set; }
+
+        public void SetResults(params bool[] results)
+        {
+            _results.Clear();
+            foreach (var result in results)
+            {
+                _results.Enqueue(result);
+            }
+        }
+
+        public bool Sample()
+        {
+            SampleCallCount++;
+            return _results.Count == 0 || _results.Dequeue();
+        }
+
+        public bool Keep() => true;
+
+        public bool Drop() => false;
+
+        public double NextDouble() => 0;
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerGlobalRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerGlobalRateLimiterTests.cs
@@ -82,6 +82,34 @@ public class DebuggerGlobalRateLimiterTests
     }
 
     [Fact]
+    public void SetRate_AfterDispose_DoesNotCreateNewSamplers()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+
+        limiter.Dispose();
+        limiter.SetRate(42);
+
+        Assert.Equal(
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            factory.RequestedRates);
+    }
+
+    [Fact]
+    public void Initialize_AfterDispose_RecreatesDefaultSamplers()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
+
+        limiter.Dispose();
+        limiter.Initialize();
+
+        Assert.Equal(
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            factory.RequestedRates);
+    }
+
+    [Fact]
     public void SnapshotProbesShareOneGlobalBudget()
     {
         var factory = new RecordingSamplerFactory();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerGlobalRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerGlobalRateLimiterTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System.Collections.Generic;
-using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Logging;
 using Xunit;
@@ -21,12 +20,12 @@ public class DebuggerGlobalRateLimiterTests
         _ = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
 
         Assert.Equal(
-            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond],
             factory.RequestedRates);
     }
 
     [Fact]
-    public void SetRate_UsesConfiguredRateForSnapshotAndLogSamplers()
+    public void SetRate_UsesConfiguredRateForSnapshotSampler()
     {
         var factory = new RecordingSamplerFactory();
         var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
@@ -34,7 +33,7 @@ public class DebuggerGlobalRateLimiterTests
         limiter.SetRate(42);
 
         Assert.Equal(
-            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond, 42, 42],
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, 42],
             factory.RequestedRates);
     }
 
@@ -44,12 +43,10 @@ public class DebuggerGlobalRateLimiterTests
         var factory = new RecordingSamplerFactory();
         var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
         var initialSnapshotSampler = factory.Samplers[0];
-        var initialLogSampler = factory.Samplers[1];
 
         limiter.SetRate(42);
 
         Assert.Equal(1, initialSnapshotSampler.DisposeCallCount);
-        Assert.Equal(1, initialLogSampler.DisposeCallCount);
     }
 
     [Fact]
@@ -62,7 +59,7 @@ public class DebuggerGlobalRateLimiterTests
         limiter.ResetRate();
 
         Assert.Equal(
-            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond, 42, 42, DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, 42, DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond],
             factory.RequestedRates);
     }
 
@@ -72,13 +69,11 @@ public class DebuggerGlobalRateLimiterTests
         var factory = new RecordingSamplerFactory();
         var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
         limiter.SetRate(42);
-        var currentSnapshotSampler = factory.Samplers[2];
-        var currentLogSampler = factory.Samplers[3];
+        var currentSnapshotSampler = factory.Samplers[1];
 
         limiter.Dispose();
 
         Assert.Equal(1, currentSnapshotSampler.DisposeCallCount);
-        Assert.Equal(1, currentLogSampler.DisposeCallCount);
     }
 
     [Fact]
@@ -91,7 +86,7 @@ public class DebuggerGlobalRateLimiterTests
         limiter.SetRate(42);
 
         Assert.Equal(
-            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond],
             factory.RequestedRates);
     }
 
@@ -105,7 +100,7 @@ public class DebuggerGlobalRateLimiterTests
         limiter.Initialize();
 
         Assert.Equal(
-            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultLogSamplesPerSecond],
+            [DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond, DebuggerGlobalRateLimiter.DefaultSnapshotSamplesPerSecond],
             factory.RequestedRates);
     }
 
@@ -116,28 +111,22 @@ public class DebuggerGlobalRateLimiterTests
         var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
         factory.Samplers[0].SetResults(true, false);
 
-        var firstResult = limiter.ShouldSample(ProbeType.Snapshot, "snapshot-1");
-        var secondResult = limiter.ShouldSample(ProbeType.Snapshot, "snapshot-2");
+        var firstResult = limiter.ShouldSampleSnapshot("snapshot-1");
+        var secondResult = limiter.ShouldSampleSnapshot("snapshot-2");
 
         Assert.True(firstResult);
         Assert.False(secondResult);
         Assert.Equal(2, factory.Samplers[0].SampleCallCount);
-        Assert.Equal(0, factory.Samplers[1].SampleCallCount);
     }
 
     [Fact]
-    public void NonPayloadProbesAreUnaffected()
+    public void Constructor_DoesNotSampleUntilAsked()
     {
         var factory = new RecordingSamplerFactory();
-        var limiter = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
 
-        var metricResult = limiter.ShouldSample(ProbeType.Metric, "metric");
-        var spanDecorationResult = limiter.ShouldSample(ProbeType.SpanDecoration, "span");
+        _ = new DebuggerGlobalRateLimiter(factory.Create, new NullLogRateLimiter());
 
-        Assert.True(metricResult);
-        Assert.True(spanDecorationResult);
         Assert.Equal(0, factory.Samplers[0].SampleCallCount);
-        Assert.Equal(0, factory.Samplers[1].SampleCallCount);
     }
 
     private sealed class RecordingSamplerFactory

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -13,8 +13,10 @@ using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.ProbeStatuses;
+using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.RemoteConfigurationManagement;
@@ -29,6 +31,57 @@ namespace Datadog.Trace.Tests.Debugger;
 public class DynamicInstrumentationTests
 {
     [Fact]
+    public void DynamicInstrumentation_ResetsGlobalRateLimiterOnConstruction()
+    {
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "0" }, }),
+            NullConfigurationTelemetry.Instance);
+
+        var globalRateLimiter = new GlobalRateLimiterMock();
+
+        _ = new DynamicInstrumentation(
+            settings,
+            new DiscoveryServiceMock(),
+            new RcmSubscriptionManagerMock(),
+            new LineProbeResolverMock(),
+            new SnapshotUploaderMock(),
+            new LogUploaderMock(),
+            new UploaderMock(),
+            new ProbeStatusPollerMock(),
+            ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter),
+            NoOpStatsd.Instance,
+            globalRateLimiter);
+
+        globalRateLimiter.ResetRateCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void DynamicInstrumentation_DisposesGlobalRateLimiterOnDispose()
+    {
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "0" }, }),
+            NullConfigurationTelemetry.Instance);
+
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var debugger = new DynamicInstrumentation(
+            settings,
+            new DiscoveryServiceMock(),
+            new RcmSubscriptionManagerMock(),
+            new LineProbeResolverMock(),
+            new SnapshotUploaderMock(),
+            new LogUploaderMock(),
+            new UploaderMock(),
+            new ProbeStatusPollerMock(),
+            ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter),
+            NoOpStatsd.Instance,
+            globalRateLimiter);
+
+        debugger.Dispose();
+
+        globalRateLimiter.DisposeCallCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task DynamicInstrumentationEnabled_ServicesCalled()
     {
         var settings = DebuggerSettings.FromSource(
@@ -42,9 +95,10 @@ public class DynamicInstrumentationTests
         var logUploader = new LogUploaderMock();
         var diagnosticsUploader = new UploaderMock();
         var probeStatusPoller = new ProbeStatusPollerMock();
-        var updater = ConfigurationUpdater.Create("env", "version", 0);
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
 
-        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance);
+        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance, globalRateLimiter);
         debugger.Initialize();
 
         // Wait for async initialization to complete
@@ -79,9 +133,10 @@ public class DynamicInstrumentationTests
         var logUploader = new LogUploaderMock();
         var diagnosticsUploader = new UploaderMock();
         var probeStatusPoller = new ProbeStatusPollerMock();
-        var updater = ConfigurationUpdater.Create(string.Empty, string.Empty, 0);
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter);
 
-        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance);
+        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance, globalRateLimiter);
         debugger.Initialize();
         lineProbeResolver.Called.Should().BeFalse();
         probeStatusPoller.Called.Should().BeFalse();
@@ -255,6 +310,29 @@ public class DynamicInstrumentationTests
 
         public void Dispose()
         {
+        }
+    }
+
+    private class GlobalRateLimiterMock : IDebuggerGlobalRateLimiter
+    {
+        internal int DisposeCallCount { get; private set; }
+
+        internal int ResetRateCallCount { get; private set; }
+
+        public bool ShouldSample(ProbeType probeType, string probeId) => true;
+
+        public void SetRate(double? samplesPerSecond)
+        {
+        }
+
+        public void ResetRate()
+        {
+            ResetRateCallCount++;
+        }
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -1461,7 +1461,7 @@ public class DynamicInstrumentationTests
 
         internal int SetRateCallCount { get; private set; }
 
-        public bool ShouldSample(ProbeType probeType, string probeId) => true;
+        public bool ShouldSampleSnapshot(string probeId) => true;
 
         public void Initialize()
         {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
@@ -26,6 +27,7 @@ using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using FluentAssertions;
 using Xunit;
+using DebuggerSampling = Datadog.Trace.Debugger.Configurations.Models.Sampling;
 
 #nullable enable
 
@@ -55,7 +57,7 @@ public class DynamicInstrumentationTests
             NoOpStatsd.Instance,
             globalRateLimiter);
 
-        globalRateLimiter.ResetRateCallCount.Should().Be(1);
+        globalRateLimiter.InitializeCallCount.Should().Be(1);
     }
 
     [Fact]
@@ -66,13 +68,14 @@ public class DynamicInstrumentationTests
             NullConfigurationTelemetry.Instance);
 
         var globalRateLimiter = new GlobalRateLimiterMock();
+        var logUploader = new LogUploaderMock();
         var debugger = new DynamicInstrumentation(
             settings,
             new DiscoveryServiceMock(),
             new RcmSubscriptionManagerMock(),
             new LineProbeResolverMock(),
             new SnapshotUploaderMock(),
-            new LogUploaderMock(),
+            logUploader,
             new UploaderMock(),
             new ProbeStatusPollerMock(),
             ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter),
@@ -82,6 +85,99 @@ public class DynamicInstrumentationTests
         debugger.Dispose();
 
         globalRateLimiter.DisposeCallCount.Should().Be(1);
+        logUploader.DisposeCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DynamicInstrumentation_IgnoresAddedConfigurationAfterDispose()
+    {
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "0" }, }),
+            NullConfigurationTelemetry.Instance);
+
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var subscriptionManager = new RcmSubscriptionManagerMock();
+        var updater = ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter);
+        var debugger = new DynamicInstrumentation(
+            settings,
+            new DiscoveryServiceMock(),
+            subscriptionManager,
+            new LineProbeResolverMock(),
+            new SnapshotUploaderMock(),
+            new LogUploaderMock(),
+            new UploaderMock(),
+            new ProbeStatusPollerMock(),
+            updater,
+            NoOpStatsd.Instance,
+            globalRateLimiter);
+
+        debugger.Dispose();
+        subscriptionManager.LastSubscription.Should().NotBeNull();
+        var subscription = subscriptionManager.LastSubscription!;
+
+        await subscription.Invoke(
+            new Dictionary<string, List<RemoteConfiguration>>
+            {
+                ["service-config"] =
+                [
+                    CreateRemoteConfiguration(
+                        "datadog/123/LIVE_DEBUGGING/serviceConfig_/config",
+                        """{"service_configuration":{"sampling":{"snapshots_per_second":42}}}""")
+                ]
+            },
+            null);
+
+        globalRateLimiter.SetRateCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DynamicInstrumentation_IgnoresRemovedConfigurationAfterDispose()
+    {
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "0" }, }),
+            NullConfigurationTelemetry.Instance);
+
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var subscriptionManager = new RcmSubscriptionManagerMock();
+        var updater = ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter);
+        var debugger = new DynamicInstrumentation(
+            settings,
+            new DiscoveryServiceMock(),
+            subscriptionManager,
+            new LineProbeResolverMock(),
+            new SnapshotUploaderMock(),
+            new LogUploaderMock(),
+            new UploaderMock(),
+            new ProbeStatusPollerMock(),
+            updater,
+            NoOpStatsd.Instance,
+            globalRateLimiter);
+
+        updater.AcceptAdded(
+            new ProbeConfiguration
+            {
+                ServiceConfiguration = new ServiceConfiguration
+                {
+                    Sampling = new DebuggerSampling { SnapshotsPerSecond = 42 }
+                }
+            });
+        globalRateLimiter.ResetCounters();
+
+        debugger.Dispose();
+        subscriptionManager.LastSubscription.Should().NotBeNull();
+        var subscription = subscriptionManager.LastSubscription!;
+
+        await subscription.Invoke(
+            [],
+            new Dictionary<string, List<RemoteConfigurationPath>>
+            {
+                ["service-config"] =
+                [
+                    RemoteConfigurationPath.FromPath("datadog/123/LIVE_DEBUGGING/serviceConfig_/config")
+                ]
+            });
+
+        globalRateLimiter.SetRateCallCount.Should().Be(0);
     }
 
     [Fact]
@@ -202,6 +298,12 @@ public class DynamicInstrumentationTests
         {
             await Task.Delay(50);
         }
+    }
+
+    private static RemoteConfiguration CreateRemoteConfiguration(string path, string json)
+    {
+        var content = Encoding.UTF8.GetBytes(json);
+        return new RemoteConfiguration(RemoteConfigurationPath.FromPath(path), content, content.Length, [], version: 1);
     }
 
     public class ProbeFileLoadingTests : IDisposable
@@ -1212,6 +1314,7 @@ public class DynamicInstrumentationTests
 
         public void Unsubscribe(ISubscription subscription)
         {
+            LastSubscription = subscription;
             foreach (var productKey in subscription.ProductKeys)
             {
                 ProductKeys.Remove(productKey);
@@ -1274,6 +1377,8 @@ public class DynamicInstrumentationTests
     {
         internal bool Called { get; private set; }
 
+        internal int DisposeCallCount { get; private set; }
+
         public Task StartFlushingAsync()
         {
             Called = true;
@@ -1282,6 +1387,7 @@ public class DynamicInstrumentationTests
 
         public void Dispose()
         {
+            DisposeCallCount++;
         }
     }
 
@@ -1347,19 +1453,35 @@ public class DynamicInstrumentationTests
 
     private class GlobalRateLimiterMock : IDebuggerGlobalRateLimiter
     {
+        internal int InitializeCallCount { get; private set; }
+
         internal int DisposeCallCount { get; private set; }
 
         internal int ResetRateCallCount { get; private set; }
 
+        internal int SetRateCallCount { get; private set; }
+
         public bool ShouldSample(ProbeType probeType, string probeId) => true;
+
+        public void Initialize()
+        {
+            InitializeCallCount++;
+        }
 
         public void SetRate(double? samplesPerSecond)
         {
+            SetRateCallCount++;
         }
 
         public void ResetRate()
         {
             ResetRateCallCount++;
+        }
+
+        public void ResetCounters()
+        {
+            SetRateCallCount = 0;
+            ResetRateCallCount = 0;
         }
 
         public void Dispose()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -16,8 +16,10 @@ using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.ProbeStatuses;
+using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.RemoteConfigurationManagement;
@@ -32,6 +34,57 @@ namespace Datadog.Trace.Tests.Debugger;
 public class DynamicInstrumentationTests
 {
     [Fact]
+    public void DynamicInstrumentation_ResetsGlobalRateLimiterOnConstruction()
+    {
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "0" }, }),
+            NullConfigurationTelemetry.Instance);
+
+        var globalRateLimiter = new GlobalRateLimiterMock();
+
+        _ = new DynamicInstrumentation(
+            settings,
+            new DiscoveryServiceMock(),
+            new RcmSubscriptionManagerMock(),
+            new LineProbeResolverMock(),
+            new SnapshotUploaderMock(),
+            new LogUploaderMock(),
+            new UploaderMock(),
+            new ProbeStatusPollerMock(),
+            ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter),
+            NoOpStatsd.Instance,
+            globalRateLimiter);
+
+        globalRateLimiter.ResetRateCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void DynamicInstrumentation_DisposesGlobalRateLimiterOnDispose()
+    {
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "0" }, }),
+            NullConfigurationTelemetry.Instance);
+
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var debugger = new DynamicInstrumentation(
+            settings,
+            new DiscoveryServiceMock(),
+            new RcmSubscriptionManagerMock(),
+            new LineProbeResolverMock(),
+            new SnapshotUploaderMock(),
+            new LogUploaderMock(),
+            new UploaderMock(),
+            new ProbeStatusPollerMock(),
+            ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter),
+            NoOpStatsd.Instance,
+            globalRateLimiter);
+
+        debugger.Dispose();
+
+        globalRateLimiter.DisposeCallCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task DynamicInstrumentationEnabled_ServicesCalled()
     {
         var settings = DebuggerSettings.FromSource(
@@ -45,9 +98,10 @@ public class DynamicInstrumentationTests
         var logUploader = new LogUploaderMock();
         var diagnosticsUploader = new UploaderMock();
         var probeStatusPoller = new ProbeStatusPollerMock();
-        var updater = ConfigurationUpdater.Create("env", "version", 0);
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0, globalRateLimiter);
 
-        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance);
+        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance, globalRateLimiter);
         debugger.Initialize();
         await WaitForInitializationAsync(debugger);
 
@@ -115,9 +169,10 @@ public class DynamicInstrumentationTests
         var logUploader = new LogUploaderMock();
         var diagnosticsUploader = new UploaderMock();
         var probeStatusPoller = new ProbeStatusPollerMock();
-        var updater = ConfigurationUpdater.Create(string.Empty, string.Empty, 0);
+        var globalRateLimiter = new GlobalRateLimiterMock();
+        var updater = ConfigurationUpdater.Create(string.Empty, string.Empty, 0, globalRateLimiter);
 
-        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance);
+        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance, globalRateLimiter);
         debugger.Initialize();
         lineProbeResolver.Called.Should().BeFalse();
         probeStatusPoller.Called.Should().BeFalse();
@@ -1287,6 +1342,29 @@ public class DynamicInstrumentationTests
 
         public void Dispose()
         {
+        }
+    }
+
+    private class GlobalRateLimiterMock : IDebuggerGlobalRateLimiter
+    {
+        internal int DisposeCallCount { get; private set; }
+
+        internal int ResetRateCallCount { get; private set; }
+
+        public bool ShouldSample(ProbeType probeType, string probeId) => true;
+
+        public void SetRate(double? samplesPerSecond)
+        {
+        }
+
+        public void ResetRate()
+        {
+            ResetRateCallCount++;
+        }
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -61,7 +61,7 @@ public class DynamicInstrumentationTests
     }
 
     [Fact]
-    public void DynamicInstrumentation_DisposesGlobalRateLimiterOnDispose()
+    public void DynamicInstrumentation_DoesNotDisposeGlobalRateLimiterOnDispose()
     {
         var settings = DebuggerSettings.FromSource(
             new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "0" }, }),
@@ -84,7 +84,7 @@ public class DynamicInstrumentationTests
 
         debugger.Dispose();
 
-        globalRateLimiter.DisposeCallCount.Should().Be(1);
+        globalRateLimiter.DisposeCallCount.Should().Be(0);
         logUploader.DisposeCallCount.Should().Be(1);
     }
 
@@ -1050,7 +1050,7 @@ public class DynamicInstrumentationTests
                 probeStatusPoller,
                 ConfigurationUpdater.Create("env", "version", 0),
                 global::Datadog.Trace.DogStatsd.NoOpStatsd.Instance,
-                (_, _, _, _) => { });
+                instrumentProbes: (_, _, _, _) => { });
             _debuggers.Add(debugger);
             return debugger;
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
@@ -76,7 +76,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -230,7 +230,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -263,7 +263,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
@@ -202,7 +202,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
@@ -77,7 +77,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -165,7 +165,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -257,7 +257,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -268,7 +268,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -290,7 +290,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]
@@ -301,7 +301,7 @@ public class ProbeConfigurationComparerTests
 
         var comparer = new ProbeConfigurationComparer(current, incoming);
         comparer.HasProbeRelatedChanges.Should().BeTrue();
-        comparer.HasRateLimitChanged.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeFalse();
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -1,0 +1,237 @@
+// <copyright file="ProbeProcessorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Reflection;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.Helpers;
+using Datadog.Trace.Debugger.Instrumentation.Collections;
+using Datadog.Trace.Debugger.RateLimiting;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ProbeProcessorTests
+{
+    private const string FalseConditionJson = @"{ ""eq"": [1, 0] }";
+    private const string TrueConditionJson = @"{ ""eq"": [1, 1] }";
+
+    [Fact]
+    public void ShouldProcess_UnconditionalLogProbe_SamplesGlobalBeforePerProbe()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new AdaptiveSamplerMock(true);
+        var probe = CreateLogProbe("log-probe", captureSnapshot: false);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.ShouldProcess(in probeData);
+
+        Assert.False(shouldProcess);
+        Assert.Equal(1, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(ProbeType.Log, globalRateLimiter.LastProbeType);
+        Assert.Equal("log-probe", globalRateLimiter.LastProbeId);
+        Assert.Equal(0, perProbeSampler.SampleCallCount);
+    }
+
+    [Fact]
+    public void Process_ConditionalProbe_EvaluatesConditionBeforeRateLimiting()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new AdaptiveSamplerMock(true);
+        var probe = CreateConditionalLogProbe("conditional-false", FalseConditionJson, captureSnapshot: true);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+        var snapshotCreator = processor.CreateSnapshotCreator();
+        var captureInfo = CreateAsyncEvaluateCaptureInfo();
+
+        var result = processor.Process(ref captureInfo, snapshotCreator, in probeData);
+
+        Assert.False(result);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(0, perProbeSampler.SampleCallCount);
+    }
+
+    [Fact]
+    public void Process_ConditionalProbe_SamplesGlobalBeforePerProbe()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new AdaptiveSamplerMock(true);
+        var probe = CreateConditionalLogProbe("conditional-true", TrueConditionJson, captureSnapshot: true);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+        var snapshotCreator = processor.CreateSnapshotCreator();
+        var captureInfo = CreateAsyncEvaluateCaptureInfo();
+
+        var result = processor.Process(ref captureInfo, snapshotCreator, in probeData);
+
+        Assert.False(result);
+        Assert.Equal(1, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(ProbeType.Snapshot, globalRateLimiter.LastProbeType);
+        Assert.Equal("conditional-true", globalRateLimiter.LastProbeId);
+        Assert.Equal(0, perProbeSampler.SampleCallCount);
+    }
+
+    [Fact]
+    public void ShouldProcess_MetricProbe_DoesNotUseGlobalLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new AdaptiveSamplerMock(true);
+        var probe = new MetricProbe
+        {
+            Id = "metric-probe",
+            MetricName = "metric",
+            Kind = MetricKind.COUNT,
+            Where = new Where { MethodName = nameof(TestMethod) },
+            Tags = [],
+        };
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.ShouldProcess(in probeData);
+
+        Assert.True(shouldProcess);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(1, perProbeSampler.SampleCallCount);
+    }
+
+    [Fact]
+    public void ShouldProcess_SpanDecorationProbe_DoesNotUseGlobalLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new AdaptiveSamplerMock(true);
+        var probe = new SpanDecorationProbe
+        {
+            Id = "span-probe",
+            Decorations = [],
+            TargetSpan = TargetSpan.Active,
+            Where = new Where { MethodName = nameof(TestMethod) },
+            Tags = [],
+        };
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.ShouldProcess(in probeData);
+
+        Assert.True(shouldProcess);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(1, perProbeSampler.SampleCallCount);
+    }
+
+    private static CaptureInfo<object> CreateAsyncEvaluateCaptureInfo()
+    {
+        return new CaptureInfo<object>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.EntryAsync,
+            value: new object(),
+            method: typeof(ProbeProcessorTests).GetMethod(nameof(TestMethod), BindingFlags.NonPublic | BindingFlags.Static)!,
+            invocationTargetType: typeof(ProbeProcessorTests),
+            memberKind: ScopeMemberKind.Argument,
+            type: typeof(object),
+            name: "argument",
+            localsCount: 0,
+            argumentsCount: 0,
+            asyncCaptureInfo: new AsyncCaptureInfo(
+                moveNextInvocationTarget: new object(),
+                kickoffInvocationTarget: new object(),
+                kickoffInvocationTargetType: typeof(object),
+                hoistedArgs: [],
+                hoistedLocals: []));
+    }
+
+    private static LogProbe CreateLogProbe(string probeId, bool captureSnapshot)
+    {
+        return new LogProbe
+        {
+            Id = probeId,
+            CaptureSnapshot = captureSnapshot,
+            EvaluateAt = EvaluateAt.Entry,
+            Where = new Where { MethodName = nameof(TestMethod) },
+            Tags = [],
+        };
+    }
+
+    private static LogProbe CreateConditionalLogProbe(string probeId, string conditionJson, bool captureSnapshot)
+    {
+        var probe = CreateLogProbe(probeId, captureSnapshot);
+        probe.When = new SnapshotSegment(dsl: string.Empty, json: conditionJson, str: null);
+        return probe;
+    }
+
+    private static void TestMethod()
+    {
+    }
+
+    private sealed class GlobalRateLimiterMock : IDebuggerGlobalRateLimiter
+    {
+        private readonly Queue<bool> _results = new();
+
+        public GlobalRateLimiterMock(params bool[] results)
+        {
+            foreach (var result in results)
+            {
+                _results.Enqueue(result);
+            }
+        }
+
+        public int ShouldSampleCallCount { get; private set; }
+
+        public string LastProbeId { get; private set; } = string.Empty;
+
+        public ProbeType? LastProbeType { get; private set; }
+
+        public bool ShouldSample(ProbeType probeType, string probeId)
+        {
+            ShouldSampleCallCount++;
+            LastProbeType = probeType;
+            LastProbeId = probeId;
+            return _results.Count == 0 || _results.Dequeue();
+        }
+
+        public void SetRate(double? samplesPerSecond)
+        {
+        }
+
+        public void ResetRate()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class AdaptiveSamplerMock : IAdaptiveSampler
+    {
+        private readonly Queue<bool> _results = new();
+
+        public AdaptiveSamplerMock(params bool[] results)
+        {
+            foreach (var result in results)
+            {
+                _results.Enqueue(result);
+            }
+        }
+
+        public int SampleCallCount { get; private set; }
+
+        public bool Sample()
+        {
+            SampleCallCount++;
+            return _results.Count == 0 || _results.Dequeue();
+        }
+
+        public bool Keep() => true;
+
+        public bool Drop() => false;
+
+        public double NextDouble() => 0;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations.Models;
@@ -23,6 +24,8 @@ public class ProbeProcessorTests
       2
     ]
 }";
+
+    private const string FalseConditionJson = @"{ ""eq"": [1, 0] }";
 
     [Fact]
     public void ConditionEvaluationErrorsAreDroppedWhenSamplerRejects()
@@ -149,6 +152,91 @@ public class ProbeProcessorTests
         Assert.Equal("probe-id", snapshotCreator.ProbeProcessorState.ProbeInfo.ProbeId);
     }
 
+    [Fact]
+    public void TryBeginProcess_UnconditionalLogProbe_SamplesGlobalBeforePerProbe()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new TestAdaptiveSampler(true);
+        var probe = CreateLogProbe("log-probe", captureSnapshot: false);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.TryBeginProcess(in probeData, out var snapshotCreator);
+
+        Assert.False(shouldProcess);
+        Assert.Null(snapshotCreator);
+        Assert.Equal(1, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(ProbeType.Log, globalRateLimiter.LastProbeType);
+        Assert.Equal("log-probe", globalRateLimiter.LastProbeId);
+        Assert.Equal(0, perProbeSampler.SampleCalls);
+    }
+
+    [Fact]
+    public void Process_ConditionalProbe_EvaluatesConditionBeforeRateLimiting()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new TestAdaptiveSampler(true);
+        var probe = CreateConditionalLogProbe("conditional-false", FalseConditionJson, captureSnapshot: true);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        var captureInfo = CreateAsyncEvaluateCaptureInfo();
+
+        var result = processor.Process(ref captureInfo, snapshotCreator, in probeData);
+
+        Assert.False(result);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(0, perProbeSampler.SampleCalls);
+    }
+
+    [Fact]
+    public void TryBeginProcess_MetricProbe_DoesNotUseGlobalLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new TestAdaptiveSampler(true);
+        var probe = new MetricProbe
+        {
+            Id = "metric-probe",
+            MetricName = "metric",
+            Kind = MetricKind.COUNT,
+            Where = new Where { MethodName = nameof(SampleTarget.Execute) },
+            Tags = [],
+        };
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.TryBeginProcess(in probeData, out var snapshotCreator);
+
+        Assert.True(shouldProcess);
+        Assert.NotNull(snapshotCreator);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(1, perProbeSampler.SampleCalls);
+    }
+
+    [Fact]
+    public void TryBeginProcess_SpanDecorationProbe_DoesNotUseGlobalLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new TestAdaptiveSampler(true);
+        var probe = new SpanDecorationProbe
+        {
+            Id = "span-probe",
+            Decorations = [],
+            TargetSpan = TargetSpan.Active,
+            Where = new Where { MethodName = nameof(SampleTarget.Execute) },
+            Tags = [],
+        };
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.TryBeginProcess(in probeData, out var snapshotCreator);
+
+        Assert.True(shouldProcess);
+        Assert.NotNull(snapshotCreator);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(1, perProbeSampler.SampleCalls);
+    }
+
     private static ProbeProcessor CreateConditionalProbeProcessor()
     {
         return new ProbeProcessor(
@@ -196,6 +284,50 @@ public class ProbeProcessorTests
     private static ProbeProcessor CreateVersionedCaptureExpressionProbeProcessor(string probeId, int version, string captureName)
     {
         return new ProbeProcessor(CreateVersionedCaptureExpressionProbe(probeId, version, captureName));
+    }
+
+    private static LogProbe CreateLogProbe(string probeId, bool captureSnapshot)
+    {
+        return new LogProbe
+        {
+            Id = probeId,
+            CaptureSnapshot = captureSnapshot,
+            EvaluateAt = EvaluateAt.Entry,
+            Where = new Where
+            {
+                TypeName = typeof(SampleTarget).FullName!,
+                MethodName = nameof(SampleTarget.Execute)
+            },
+            Tags = [],
+        };
+    }
+
+    private static LogProbe CreateConditionalLogProbe(string probeId, string conditionJson, bool captureSnapshot)
+    {
+        var probe = CreateLogProbe(probeId, captureSnapshot);
+        probe.When = new SnapshotSegment(dsl: string.Empty, json: conditionJson, str: null);
+        return probe;
+    }
+
+    private static CaptureInfo<object> CreateAsyncEvaluateCaptureInfo()
+    {
+        return new CaptureInfo<object>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.EntryAsync,
+            value: new object(),
+            method: typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!,
+            invocationTargetType: typeof(object),
+            memberKind: ScopeMemberKind.Argument,
+            type: typeof(object),
+            name: "argument",
+            localsCount: 0,
+            argumentsCount: 0,
+            asyncCaptureInfo: new AsyncCaptureInfo(
+                moveNextInvocationTarget: new object(),
+                kickoffInvocationTarget: new object(),
+                kickoffInvocationTargetType: typeof(SampleTarget),
+                hoistedArgs: [],
+                hoistedLocals: []));
     }
 
     private static LogProbe CreateVersionedCaptureExpressionProbe(string probeId, int version, string captureName)
@@ -377,6 +509,45 @@ public class ProbeProcessorTests
         public bool Drop() => !Sample();
 
         public double NextDouble() => 0;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class GlobalRateLimiterMock : IDebuggerGlobalRateLimiter
+    {
+        private readonly Queue<bool> _results = new();
+
+        public GlobalRateLimiterMock(params bool[] results)
+        {
+            foreach (var result in results)
+            {
+                _results.Enqueue(result);
+            }
+        }
+
+        public int ShouldSampleCallCount { get; private set; }
+
+        public string LastProbeId { get; private set; } = string.Empty;
+
+        public ProbeType? LastProbeType { get; private set; }
+
+        public bool ShouldSample(ProbeType probeType, string probeId)
+        {
+            ShouldSampleCallCount++;
+            LastProbeType = probeType;
+            LastProbeId = probeId;
+            return _results.Count == 0 || _results.Dequeue();
+        }
+
+        public void SetRate(double? samplesPerSecond)
+        {
+        }
+
+        public void ResetRate()
+        {
+        }
 
         public void Dispose()
         {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -153,7 +153,7 @@ public class ProbeProcessorTests
     }
 
     [Fact]
-    public void TryBeginProcess_UnconditionalSnapshotProbe_SamplesPerProbeBeforeGlobal()
+    public void TryBeginProcess_UnconditionalSnapshotProbe_SamplesGlobalBeforePerProbe()
     {
         var globalRateLimiter = new GlobalRateLimiterMock(false);
         var perProbeSampler = new TestAdaptiveSampler(true);
@@ -167,11 +167,11 @@ public class ProbeProcessorTests
         Assert.Null(snapshotCreator);
         Assert.Equal(1, globalRateLimiter.ShouldSampleCallCount);
         Assert.Equal("snapshot-probe", globalRateLimiter.LastProbeId);
-        Assert.Equal(1, perProbeSampler.SampleCalls);
+        Assert.Equal(0, perProbeSampler.SampleCalls);
     }
 
     [Fact]
-    public void TryBeginProcess_UnconditionalSnapshotProbe_DoesNotSpendGlobalBudgetWhenPerProbeRejects()
+    public void TryBeginProcess_UnconditionalSnapshotProbe_CalibratesGlobalSamplerWhenPerProbeRejects()
     {
         var globalRateLimiter = new GlobalRateLimiterMock(true);
         var perProbeSampler = new TestAdaptiveSampler(false);
@@ -183,8 +183,9 @@ public class ProbeProcessorTests
 
         Assert.False(shouldProcess);
         Assert.Null(snapshotCreator);
+        Assert.Equal(1, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal("snapshot-probe", globalRateLimiter.LastProbeId);
         Assert.Equal(1, perProbeSampler.SampleCalls);
-        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -541,6 +541,10 @@ public class ProbeProcessorTests
             return _results.Count == 0 || _results.Dequeue();
         }
 
+        public void Initialize()
+        {
+        }
+
         public void SetRate(double? samplesPerSecond)
         {
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -153,7 +153,42 @@ public class ProbeProcessorTests
     }
 
     [Fact]
-    public void TryBeginProcess_UnconditionalLogProbe_SamplesGlobalBeforePerProbe()
+    public void TryBeginProcess_UnconditionalSnapshotProbe_SamplesPerProbeBeforeGlobal()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var perProbeSampler = new TestAdaptiveSampler(true);
+        var probe = CreateLogProbe("snapshot-probe", captureSnapshot: true);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.TryBeginProcess(in probeData, out var snapshotCreator);
+
+        Assert.False(shouldProcess);
+        Assert.Null(snapshotCreator);
+        Assert.Equal(1, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal("snapshot-probe", globalRateLimiter.LastProbeId);
+        Assert.Equal(1, perProbeSampler.SampleCalls);
+    }
+
+    [Fact]
+    public void TryBeginProcess_UnconditionalSnapshotProbe_DoesNotSpendGlobalBudgetWhenPerProbeRejects()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(true);
+        var perProbeSampler = new TestAdaptiveSampler(false);
+        var probe = CreateLogProbe("snapshot-probe", captureSnapshot: true);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, perProbeSampler, processor);
+
+        var shouldProcess = processor.TryBeginProcess(in probeData, out var snapshotCreator);
+
+        Assert.False(shouldProcess);
+        Assert.Null(snapshotCreator);
+        Assert.Equal(1, perProbeSampler.SampleCalls);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+    }
+
+    [Fact]
+    public void TryBeginProcess_UnconditionalLogProbe_DoesNotUseGlobalLimiter()
     {
         var globalRateLimiter = new GlobalRateLimiterMock(false);
         var perProbeSampler = new TestAdaptiveSampler(true);
@@ -163,12 +198,10 @@ public class ProbeProcessorTests
 
         var shouldProcess = processor.TryBeginProcess(in probeData, out var snapshotCreator);
 
-        Assert.False(shouldProcess);
-        Assert.Null(snapshotCreator);
-        Assert.Equal(1, globalRateLimiter.ShouldSampleCallCount);
-        Assert.Equal(ProbeType.Log, globalRateLimiter.LastProbeType);
-        Assert.Equal("log-probe", globalRateLimiter.LastProbeId);
-        Assert.Equal(0, perProbeSampler.SampleCalls);
+        Assert.True(shouldProcess);
+        Assert.NotNull(snapshotCreator);
+        Assert.Equal(1, perProbeSampler.SampleCalls);
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
     }
 
     [Fact]
@@ -531,12 +564,9 @@ public class ProbeProcessorTests
 
         public string LastProbeId { get; private set; } = string.Empty;
 
-        public ProbeType? LastProbeType { get; private set; }
-
-        public bool ShouldSample(ProbeType probeType, string probeId)
+        public bool ShouldSampleSnapshot(string probeId)
         {
             ShouldSampleCallCount++;
-            LastProbeType = probeType;
             LastProbeId = probeId;
             return _results.Count == 0 || _results.Dequeue();
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
@@ -1,0 +1,71 @@
+// <copyright file="ProbeRateLimiterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Debugger.RateLimiting;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ProbeRateLimiterTests
+{
+    [Fact]
+    public void ResetRate_DisposesRemovedSampler()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new ProbeRateLimiter(factory.Create);
+
+        _ = limiter.GerOrAddSampler("probe");
+        var sampler = factory.Samplers[0];
+
+        limiter.ResetRate("probe");
+
+        Assert.Equal(1, sampler.DisposeCallCount);
+    }
+
+    [Fact]
+    public void TryAddSampler_DisposesRejectedSampler()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new ProbeRateLimiter(factory.Create);
+        _ = limiter.GerOrAddSampler("probe");
+        var rejectedSampler = new TestAdaptiveSampler();
+
+        var added = limiter.TryAddSampler("probe", rejectedSampler);
+
+        Assert.False(added);
+        Assert.Equal(1, rejectedSampler.DisposeCallCount);
+    }
+
+    private sealed class RecordingSamplerFactory
+    {
+        public List<TestAdaptiveSampler> Samplers { get; } = [];
+
+        public IAdaptiveSampler Create(int samplesPerSecond)
+        {
+            var sampler = new TestAdaptiveSampler();
+            Samplers.Add(sampler);
+            return sampler;
+        }
+    }
+
+    private sealed class TestAdaptiveSampler : IAdaptiveSampler
+    {
+        public int DisposeCallCount { get; private set; }
+
+        public bool Sample() => true;
+
+        public bool Keep() => true;
+
+        public bool Drop() => false;
+
+        public double NextDouble() => 0;
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.Debugger.RateLimiting;
 using Xunit;
@@ -55,6 +56,34 @@ public class ProbeRateLimiterTests
     }
 
     [Fact]
+    public void ResetRate_DisposesRemovedSamplerFromFactory()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new ProbeRateLimiter(factory.Create);
+
+        _ = limiter.GerOrAddSampler("probe");
+        var sampler = factory.Samplers[0];
+
+        limiter.ResetRate("probe");
+
+        Assert.Equal(1, sampler.DisposeCallCount);
+    }
+
+    [Fact]
+    public void TryAddSampler_DisposesRejectedSampler()
+    {
+        var factory = new RecordingSamplerFactory();
+        var limiter = new ProbeRateLimiter(factory.Create);
+        _ = limiter.GerOrAddSampler("probe");
+        var rejectedSampler = new TestAdaptiveSampler();
+
+        var added = limiter.TryAddSampler("probe", rejectedSampler);
+
+        Assert.False(added);
+        Assert.Equal(1, rejectedSampler.DisposeCallCount);
+    }
+
+    [Fact]
     public void GerOrAddSampler_ReturnsExistingEntryWithoutLeakingCandidate()
     {
         var limiter = ProbeRateLimiter.Instance;
@@ -73,6 +102,36 @@ public class ProbeRateLimiterTests
         finally
         {
             limiter.ResetRate(probeId);
+        }
+    }
+
+    private sealed class RecordingSamplerFactory
+    {
+        public List<TestAdaptiveSampler> Samplers { get; } = [];
+
+        public IAdaptiveSampler Create(int samplesPerSecond)
+        {
+            var sampler = new TestAdaptiveSampler();
+            Samplers.Add(sampler);
+            return sampler;
+        }
+    }
+
+    private sealed class TestAdaptiveSampler : IAdaptiveSampler
+    {
+        public int DisposeCallCount { get; private set; }
+
+        public bool Sample() => true;
+
+        public bool Keep() => true;
+
+        public bool Drop() => false;
+
+        public double NextDouble() => 0;
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
         }
     }
 


### PR DESCRIPTION
## Summary of changes
- Add a process-wide Dynamic Instrumentation global rate limiter for snapshot probes.
- Run the global snapshot limiter before the per-probe sampler so the
  adaptive global sampler observes the full snapshot traffic and stays
  correctly calibrated.
- Leave pure log probes on their existing per-probe limiter only.
- Wire Live Debugging service sampling config through `ConfigurationUpdater`, and `DynamicInstrumentation`.
- Dispose timer-backed adaptive samplers when global or per-probe limiters are replaced, removed, or shut down.
- Add focused tests for global limiter defaults/configuration, sampling order, sampler disposal, configuration updates, and debugger lifecycle behavior.

## Reason for change
- Per-probe rate limiting protects each individual snapshot probe, but it does not protect the process from aggregate snapshot volume when many probes are active at once.
- This adds a simple local safety valve now, without trying to model the backend hourly probe budget in the tracer.
- Pure log probes are intentionally excluded.
- This also fixes sampler ownership leaks where timer-backed `AdaptiveSampler` instances could stay rooted after replacement/removal.

## Implementation details
- `DebuggerGlobalRateLimiter` owns one adaptive sampler for snapshot probes.
  - Default snapshot global cap: `100/s`.
- `ServiceConfiguration.Sampling.SnapshotsPerSecond` updates the snapshot global limiter. When no service sampling config is present, the limiter falls back to its default.
- `ProbeProcessor` samples snapshot probes in this order:
  - condition evaluation, when applicable
  - global snapshot limiter
  - per-probe sampler
- Pure log probes, metric probes, and span decoration probes are unchanged and do not consume the global limiter.
- The current limiter is intentionally a naive per-process per-second limiter. Future work can evolve this behind the same abstraction into token-bucket behavior.
- `AdaptiveSamplerLifetime` centralizes sampler creation, replacement, and disposal so losing add races and removed probes do not leak timers.

## Test coverage

- `DebuggerGlobalRateLimiterTests|ConfigurationUpdaterTests|ProbeRateLimiterTests`