### PR TITLE
fix(microbenchmarks): restore CI Visibility reporting to Datadog

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -106,7 +106,7 @@ run-benchmarks:
     - mkdir -p artifacts
     - export GITHUB_TOKEN=$(cat /tmp/github-token)
     # Fetch DD_API_KEY from SSM (in GitLab runner's AWS account) and export for bp-infra
-    - export DD_API_KEY=$(aws ssm get-parameter --name "ci.dd-trace-dotnet.dd_api_key" --with-decryption --query "Parameter.Value" --output text --region "${AWS_REGION}")
+    - export DD_API_KEY=$(aws ssm get-parameter --name "ci.dd-trace-dotnet.dd_api_key-prod" --with-decryption --query "Parameter.Value" --output text --region "${AWS_REGION}")
     - CLEANUP_ARG=$([[ "$CLEANUP" == "false" ]] && echo "--no-cleanup" || echo "")
     # Run benchmarks on ephemeral instance
     - |

--- a/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
@@ -114,6 +114,19 @@ $env:DD_ENV = "CI"
 $env:DD_DOTNET_TRACER_HOME = $monitoringHome
 $env:DD_TRACER_HOME = $monitoringHome
 
+# CI Visibility ships benchmark results to Datadog via the in-process tracer.
+# The ephemeral benchmarking VM does not run a Datadog Agent, so route directly
+# to intake via agentless mode. DD_API_KEY is forwarded from the GitLab job.
+if ($env:DD_API_KEY) {
+    $env:DD_CIVISIBILITY_AGENTLESS_ENABLED = "true"
+    if (-not $env:DD_SITE) {
+        $env:DD_SITE = "datadoghq.com"
+    }
+    Write-Output "CI Visibility agentless mode enabled (site: $env:DD_SITE)"
+} else {
+    Write-Warning "DD_API_KEY not set; CI Visibility data will not be sent to Datadog"
+}
+
 # Build BenchmarkDotNet arguments
 $arguments = @("-r") + $runtimes + @(
     "-m",

--- a/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
@@ -118,7 +118,7 @@ $env:DD_TRACER_HOME = $monitoringHome
 # The ephemeral benchmarking VM does not run a Datadog Agent, so route directly
 # to intake via agentless mode. DD_API_KEY is forwarded from the GitLab job.
 if ($env:DD_API_KEY) {
-    $env:DD_CIVISIBILITY_AGENTLESS_ENABLED = "true"
+    $env:DD_CIVISIBILITY_AGENTLESS_ENABLED = "1"
     if (-not $env:DD_SITE) {
         $env:DD_SITE = "datadoghq.com"
     }


### PR DESCRIPTION
## Summary of changes

- Set `DD_CIVISIBILITY_AGENTLESS_ENABLED=1` on the benchmark process in `.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1` when `DD_API_KEY` is present, and default `DD_SITE=datadoghq.com`.
- Change the SSM parameter name in `.gitlab/benchmarks/microbenchmarks.yml` from `ci.dd-trace-dotnet.dd_api_key` to `ci.dd-trace-dotnet.dd_api_key-prod` to match the key the previous pipeline was using.

## Reason for change

Microbenchmark results stopped being reported to Datadog on April 8, 2026, after #8300 moved the Windows microbenchmark runner from `benchmarking-platform@dd-trace-dotnet/micro` into this repo. The `Datadog.Trace.BenchmarkDotNet` exporter ships results to Datadog via CI Visibility, and the old flow enabled agentless mode (`DD_CIVISIBILITY_AGENTLESS_ENABLED=1`) with a production SSM key — two details that were not carried over in the rewrite, so the exporter silently failed to reach intake.

Cross-reference with the old script: `benchmarking-platform/run-benchmarks.ps1:128` (`$env:DD_CIVISIBILITY_AGENTLESS_ENABLED=1`) and `benchmarking-platform/steps/run-windows-benchmarks.sh:9` (`ci.${CI_PROJECT_NAME}.dd_api_key-prod`).

## Implementation details

- `run-benchmarks.ps1` now guards the agentless toggle on `DD_API_KEY` being set, so local/dev invocations without a key continue to behave as before (warn and skip agentless) rather than attempting — and failing — to hit intake.
- No changes to `Build.cs`, tracer code, or the benchmark projects. This is purely a CI config fix.

## Test coverage

- Verified the execution order in `bp-runner.windows.yml`: the env vars are set in `run-benchmarks.ps1` after `BuildTracerHome`/`BuildBenchmarks` and before the BDN CLI is invoked — i.e., inherited by every BDN child process.

## Other details
