### PR TITLE
Fix release note generation by adding missing permissions

### DIFF
--- a/.github/chainguard/self.github.create-draft-release.sts.yaml
+++ b/.github/chainguard/self.github.create-draft-release.sts.yaml
@@ -14,5 +14,6 @@ claim_pattern:
 permissions:
   contents: write
   issues: write
+  pull_requests: read
   statuses: read
   actions: read

--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -41,10 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: publish-debug-symbols-env
     # These permissions need to map to the ones demanded in create_normal_draft_release.yml and create_hotfix_draft_release.yml
+    # and to those in .github/chainguard/self.github.create-draft-release.sts.yaml (except id-token, which is only needed at workflow level for OIDC)
     permissions:
       contents: write # create release
       actions: read # read secrets
-      issues: write # change milestones 
+      issues: write # change milestones
+      pull-requests: read # read merged PRs for release notes
+      statuses: read # verify SSI artifact build succeeded
       id-token: write  # enable GitHub OIDC token issuance for this job
     env:
       # Have to use external token with explicit workflow permissions because we are creating

--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -40,15 +40,11 @@ jobs:
   create_draft_release:
     runs-on: ubuntu-latest
     environment: publish-debug-symbols-env
-    # These permissions need to map to the ones demanded in create_normal_draft_release.yml and create_hotfix_draft_release.yml
-    # and to those in .github/chainguard/self.github.create-draft-release.sts.yaml (except id-token, which is only needed at workflow level for OIDC)
+    # All GitHub API access goes through the dd-octo-sts token; see
+    # .github/chainguard/self.github.create-draft-release.sts.yaml
     permissions:
-      contents: write # create release
-      actions: read # read secrets
-      issues: write # change milestones
-      pull-requests: read # read merged PRs for release notes
-      statuses: read # verify SSI artifact build succeeded
-      id-token: write  # enable GitHub OIDC token issuance for this job
+      contents: read # actions/checkout uses the workflow token to clone
+      id-token: write # required for dd-octo-sts OIDC and NuGet trusted publishing
     env:
       # Have to use external token with explicit workflow permissions because we are creating
       # a release from an arbitrary SHA. For "reasons", the built-in token does not _always_

--- a/.github/workflows/create_hotfix_draft_release.yml
+++ b/.github/workflows/create_hotfix_draft_release.yml
@@ -33,6 +33,8 @@ jobs:
           contents: write # create release
           actions: read # read secrets
           issues: write # change milestones
+          pull-requests: read # read merged PRs for release notes
+          statuses: read # verify SSI artifact build succeeded
           id-token: write  # enable GitHub OIDC token issuance for this job
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}

--- a/.github/workflows/create_hotfix_draft_release.yml
+++ b/.github/workflows/create_hotfix_draft_release.yml
@@ -28,14 +28,11 @@ jobs:
     create_hotfix_draft_release:
         needs: check_branch
         uses: ./.github/workflows/_create_draft_release.yml
-        # These permissions need to map to the ones demanded in _create_draft_release.yml
+        # All GitHub API access in the reusable workflow goes through the dd-octo-sts token; see
+        # .github/chainguard/self.github.create-draft-release.sts.yaml
         permissions:
-          contents: write # create release
-          actions: read # read secrets
-          issues: write # change milestones
-          pull-requests: read # read merged PRs for release notes
-          statuses: read # verify SSI artifact build succeeded
-          id-token: write  # enable GitHub OIDC token issuance for this job
+          contents: read # actions/checkout uses the workflow token to clone
+          id-token: write # required for dd-octo-sts OIDC and NuGet trusted publishing
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}

--- a/.github/workflows/create_normal_draft_release.yml
+++ b/.github/workflows/create_normal_draft_release.yml
@@ -32,7 +32,9 @@ jobs:
         permissions:
           contents: write # create release
           actions: read # read secrets
-          issues: write # change milestones 
+          issues: write # change milestones
+          pull-requests: read # read merged PRs for release notes
+          statuses: read # verify SSI artifact build succeeded
           id-token: write  # enable GitHub OIDC token issuance for this job
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}

--- a/.github/workflows/create_normal_draft_release.yml
+++ b/.github/workflows/create_normal_draft_release.yml
@@ -28,14 +28,11 @@ jobs:
     create_normal_draft_release:
         needs: check_branch
         uses: ./.github/workflows/_create_draft_release.yml
-        # These permissions need to map to the ones demanded in _create_draft_release.yml
+        # All GitHub API access in the reusable workflow goes through the dd-octo-sts token; see
+        # .github/chainguard/self.github.create-draft-release.sts.yaml
         permissions:
-          contents: write # create release
-          actions: read # read secrets
-          issues: write # change milestones
-          pull-requests: read # read merged PRs for release notes
-          statuses: read # verify SSI artifact build succeeded
-          id-token: write  # enable GitHub OIDC token issuance for this job
+          contents: read # actions/checkout uses the workflow token to clone
+          id-token: write # required for dd-octo-sts OIDC and NuGet trusted publishing
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}


### PR DESCRIPTION
## Summary of changes

Adds `pull_requests` permission to draft-release `dd-octo-sts` chainguard file

## Reason for change

The release note generation has been silently failing since we switched to STS:

```
Fetching milestones...
Found vNext-v3 milestone: 216
Fetching previous release details
Fetching Issues assigned to vNext-v3
Found 0 issues, building release notes.
```

I think that's because we're missing the `pull_requests` permission in the dd-octo-sts file, and the issues endpoint we're using silently filters this out. This also seems to _only_ apply to _app_ permissions, which is what dd-octo-sts uses, not to fine-grained tokens, which is why we couldn't replicate it locally.

## Implementation details

- Added `pull_requests: read` to the draft release STS definition.
- Removed permissions for the "ambient" GITHUB_TOKEN, as these aren't actually used, other than for the OIDC exchange, and just add confusion

## Test coverage

Nope, we just have to wait for the next release, and hope nothing breaks 😬 

